### PR TITLE
Slice 1: robotd holds a pose, and health means something

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -404,6 +410,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "duck-control"
+version = "0.1.0"
+dependencies = [
+ "rustypot",
+ "serde",
+ "serialport",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "duck-ipc-proto"
 version = "0.1.0"
 dependencies = [
@@ -425,6 +442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -623,6 +653,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -886,10 +922,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -986,6 +1043,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1085,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1066,12 +1152,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1091,6 +1210,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -1127,6 +1252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1237,6 +1371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1473,7 @@ name = "robotd"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "duck-control",
  "duck-ipc-proto",
  "libc",
  "minisign",
@@ -1337,7 +1484,9 @@ dependencies = [
  "tar",
  "tempfile",
  "test-support",
+ "thiserror",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "updater",
@@ -1386,7 +1535,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1475,6 +1624,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rustypot"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaf51a0dc05b5a2023ec70791fba4909af8944f86d1eb293f4988573a105244"
+dependencies = [
+ "clap",
+ "env_logger",
+ "log",
+ "num_enum",
+ "paste",
+ "proc-macro2",
+ "serialport",
+ "signal-hook",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,7 +1695,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1627,6 +1798,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialport"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libudev",
+ "mach2",
+ "nix",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1852,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1796,6 +1996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-support"
 version = "0.1.0"
 dependencies = [
@@ -1915,6 +2124,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
@@ -1922,10 +2146,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1938,12 +2171,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1974,7 +2219,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -2073,6 +2318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,7 +2363,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "zstd",
@@ -2381,9 +2635,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"
@@ -2412,7 +2675,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tar",
- "toml",
+ "toml 1.1.3+spec-1.1.0",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,26 +1043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,7 +1788,6 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # docs/architecture.md §1. `robotd`, `btd` and `mediad` join as siblings.
 [workspace]
 resolver = "3"
-members = ["duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
+members = ["duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the robot is aarch64 Linux.
 cargo test --workspace
 ```
 
-246 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+272 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
 
 The fastest way to actually *see* the update engine work is the playground, which drives
 the real engine — real signatures, real atomic swaps, real rollback — against a fake remote
@@ -56,7 +56,8 @@ to watch the boot counter undo a release that never confirmed healthy.
 
 | | |
 |---|---|
-| `robotd` | motor control, kinematics, gait model, **safety authority**. Currently a skeleton: a heartbeat plus the four `robot.*` methods the updater needs. |
+| `robotd` | motor control, kinematics, gait model, **safety authority**. Currently holds the pose it starts in: a real 50 Hz loop on the Dynamixel bus, plus the four `robot.*` methods the updater needs. Walking arrives in slice 2 ([`docs/robotd-design.md`](docs/robotd-design.md)). |
+| `duck-control` | the control core — robot model, bus, sensing. A library, not a service: no tokio, no sockets, no systemd. |
 | `updaterd` | the update engine. Resident, and deliberately independent of `robotd` — it is the recovery path, so it must work when the robot does not. |
 | `mediad` | camera, audio, WebRTC gateway. **Not built yet.** |
 | `btd` | BLE: wifi provisioning, naming, update trigger from the phone. **Not built yet.** |
@@ -67,13 +68,14 @@ never inherit the update engine's http/tar/crypto tree.
 
 ```
 duck-ipc-proto/ the wire contract
+duck-control/   the control core: robot model · Dynamixel bus · IMU · the RobotIo seam
 updater/        engine + updaterd
 robotd/         control daemon
 robotctl/       the local CLI
 xtask/          package · sign · promote — build tooling, never shipped
-deploy/         what a robot is configured with: updater.toml, trust anchor, journald
+deploy/         what a robot is configured with: updater.toml, robotd.toml, trust anchor, journald
 scripts/        install.sh (provisioning) · board-test.sh (aarch64 checks)
-docs/           architecture · update design · roadmap · CI setup
+docs/           architecture · update design · robotd design · roadmap · CI setup
 ```
 
 ## Working on the robot
@@ -226,7 +228,9 @@ Honest version, kept current in [`docs/roadmap.md`](docs/roadmap.md):
 - **Open:** artifact hosting. This repo is private, and a robot without a token cannot
   download from it (§6.1). Dev boards have tokens; the fleet will need a public
   artifact-only repository or an object store. Blocks hardware bring-up, not development.
-- **Skeleton:** `robotd`.
+- **`robotd` holds a pose.** A real 50 Hz loop on the Dynamixel bus, and `robot.health`
+  now means *the loop is meeting its deadline* rather than *it ticked once* — which is what
+  makes the updater's auto-rollback gate on something real. Walking is slice 2.
 - **Not started:** `mediad`, `btd`, the phone app, the SDK, safety authority.
 - **Runs on aarch64 Linux, emulated.** `scripts/board-test.sh` runs in CI: it
   cross-compiles for the board and executes 13 checks — rollback, tampered-artifact

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -1,0 +1,51 @@
+# robotd — per-robot parameters.
+#
+# Installed to /etc/robot/robotd.toml. Read once at startup, not watched: changing
+# anything here needs `systemctl restart robotd`. Live reload is deferred
+# (docs/robotd-design.md §7.2).
+#
+# It lives here, and not under /opt/robot/daemon/releases/<ver>/, on purpose: this is
+# per-robot configuration rather than a shipped default, so it must survive an update
+# *and* a rollback (docs/architecture.md §3). The installer never overwrites it.
+#
+# Every value below is the built-in default. The file may be deleted entirely — an
+# unprovisioned board comes up on these same numbers rather than refusing to start, which
+# is far easier to diagnose remotely than a daemon that will not run.
+
+[bus]
+# Serial port the 15 servos and the imu_to_dxl board share. /dev/ttyS2 is the Radxa
+# Zero 3W's wiring; a board wired differently can also be overridden per-invocation with
+# `robotd --port`, which is the dev escape hatch rather than the thing to edit here.
+port = "/dev/ttyS2"
+
+[control]
+# Control loop rate, Hz.
+#
+# 50 is inherited from the prototype, where it was chosen on a Raspberry Pi Zero 2W. It
+# has never been re-derived on the Radxa. Before trusting it, measure: `bench_dynamixel_bus`
+# in microduck_runtime reports achieved rate, jitter, bus utilisation and error counts at a
+# given rate, and the loop's own five-minute summary reports the same from inside robotd.
+hz = 50
+
+[health]
+# What `robot.health` means, and therefore what the update system rolls back on.
+#
+# This is the whole point of the daemon in its current form: the updater's auto-rollback is
+# only meaningful if health is a real measurement. A loop running at 60% of target is
+# alive, answers every request, and is badly broken — these three thresholds are what
+# distinguish that from a healthy robot.
+
+# Achieved rate floor. Below this, unhealthy. 45 is 90% of the default 50 Hz: loose enough
+# not to trip on one slow tick, tight enough that a loop dropping every tenth cycle is not
+# called healthy. Raise it in step with `control.hz`.
+min_achieved_hz = 45.0
+
+# How many periods may pass with no tick at all before the loop counts as stalled. This is
+# what turns a wedged control thread into an honest "unhealthy" instead of a socket that
+# keeps answering "healthy" on the strength of one tick it managed an hour ago.
+stall_periods = 3
+
+# Consecutive failed bus reads tolerated. One dropped transaction is ordinary on a serial
+# bus; a run of them means the bus is gone, and a robot that cannot read its own joints is
+# not healthy whatever rate the loop is spinning at.
+max_consecutive_errors = 10

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,16 +11,18 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | | |
 |---|---|
 | `updater/` | engine, verification, store, journal, hooks, preflight, GitHub/HF/local sources, IPC server, systemd unit — **done** |
+| `duck-control/` | robot model · Dynamixel bus · IMU · the `RobotIo` seam — **slice 1 done**. A library: no tokio, no sockets, no systemd |
 | `duck-ipc-proto/` | wire contract for `update.*` and `robot.*` — **done**; serde/serde_json/semver only, so nothing on the recovery path pulls the engine's tree |
-| `robotd/` | heartbeat + the four `robot.*` methods, systemd unit — **skeleton done**; no control, no kinematics |
+| `robotd/` | a real 50 Hz loop on the Dynamixel bus holding the startup pose, health from deadline adherence, the four `robot.*` methods, systemd unit — **slice 1 done**, untested on a board; no policy, no kinematics |
 | `robotctl/` | CLI over the update socket — **done** for the `update` namespace; depends on `duck-ipc-proto`, not `updater` |
 | `xtask/` | package · sign · promote — **done**, byte-identical promotion verified |
 | `.github/` | ci · release · promote — **ci passing**; release/promote still unrun (needs secrets + the `release` environment) |
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
-| `deploy/` | shipped `updater.toml`, trust anchor, journald retention drop-in |
+| `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
 | tests | **272 passing**, including the health gate against a real `robotd` process |
-| missing | `mediad`, `btd`, `robot-config`, app, SDK, hardware |
+| missing | `mediad`, `btd`, `robot-config`, app, SDK |
+| never run on hardware | every claim above is from CI and a laptop. Slice 1's whole purpose is to change that |
 
 ## The framing
 
@@ -113,18 +115,39 @@ over the network, and a customer-robot config refused the same build.
 **Open, and it blocks M4:** a private repo's release assets need a token, and a customer robot
 has none. See `updater-design.md` §6.1.
 
-### M3 — `robotd` for real  ·  sim first
+### M3 — `robotd` for real  ·  hardware first, in two slices
 
-Port control into the new architecture. The MuJoCo setup in `microduck_brain` means
-most of this needs no hardware — worth building the seam early: a `RobotBackend` trait
-with `Mujoco` and `Hardware` impls, the same shape as `RobotClient` in the updater.
+Designed in [`robotd-design.md`](robotd-design.md). `robotd` **replaces**
+`microduck_runtime`, by extracting its control core into `duck-control` rather than
+reimplementing it — so the prototype keeps running while the daemon grows, and parity
+arrives as a consequence of the extraction instead of as a race against a moving target.
+Only the alpha variant on the Radxa survives; the other three variants, four IMUs and two
+boards are dropped.
 
-**Safety authority belongs here, not in M6.** `architecture.md` §6 designs it and
-nothing implements it. It's the one thing that can hurt someone, and retrofitting
-authority arbitration into a working control loop is far worse than designing it in.
+**Hardware first, sim after.** An earlier draft of this milestone said the reverse. It was
+wrong on the facts: there are boards, and correctness gets settled on them. The simulator's
+job is a clean laptop dev environment, not a validation oracle, so it lands after slice 2
+and never becomes a second definition of what the robot is. Tests run against a `FakeIo`
+backend — no hardware, no network, no Docker, no Python.
 
-**Done when:** it walks in sim through the new architecture, and `robotd` enforces
-joint/thermal/fall limits regardless of what any client asks for.
+**Slice 1 — hold the pose · done, pending a board.** A real 50 Hz loop on the Dynamixel
+bus, holding whatever pose it starts in. No policy. It exists so `robot.health` means *the
+loop is meeting its deadline* rather than *it ticked once* — until now the updater's
+auto-rollback has been gating on a placeholder. Holding a pose is also what makes it safe to
+hammer install/rollback/power-cut cycles at a bench for a day.
+
+**Slice 2 — walk and stand.** One 61-D observation builder (every alpha policy is
+`obs[1,61] → actions[1,14]`), the main-plus-standing policy shaped as it is in the runtime,
+`move`/`head`/`stop`/`enable` intents, and a gamepad client that goes through them.
+
+**Safety authority belongs here, not in M6** — `architecture.md` §6 designs it and nothing
+implements it. It lands in slice 2, holding the only write handle to the bus, so no policy
+and no client *can* command a motor around it. Joint clamp, fall → limp, and an intent
+deadman; thermal waits for a measured threshold rather than a guessed one.
+
+**Done when:** it walks on a board driven through the intent API, an update applied with
+`robotctl` restarts it cleanly with the gate passing, and a release built to come up
+unhealthy is automatically rolled back.
 
 ### M4 — Hardware bring-up
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| tests | **246 passing**, including the health gate against a real `robotd` process |
+| tests | **272 passing**, including the health gate against a real `robotd` process |
 | missing | `mediad`, `btd`, `robot-config`, app, SDK, hardware |
 
 ## The framing

--- a/docs/robotd-design.md
+++ b/docs/robotd-design.md
@@ -1,0 +1,412 @@
+# `robotd` — design, slices 1 and 2
+
+Status: draft · Date: 2026-07-29 · Owner: pierre
+
+Implements the `robotd` row of [`architecture.md`](architecture.md) §1 and covers
+[`roadmap.md`](roadmap.md) M3. Scoped deliberately to the first two increments; everything
+beyond them is in §10.
+
+The prototype being absorbed is
+[`apirrone/microduck_runtime`](https://github.com/apirrone/microduck_runtime), referred to
+throughout as *the runtime*.
+
+## 1. The goal, which is not "a good `robotd`"
+
+Two things are wanted, and the second is the one that reorders the work:
+
+1. **Iterate fast on the control core.**
+2. **Actually test the updater.**
+
+The update engine is finished and has never run on hardware. Its most important paths are
+therefore unproven: `systemctl restart` in `on_apply` has never met real systemd, the 30 s
+health-gate timeout is an admitted guess, and — worst — **auto-rollback is only meaningful
+if `robot.health` means something.** Today it means "the control loop ticked once", so
+every rollback tested so far has been tested against a placeholder.
+
+That is why slice 1 does not walk. It exists to be a truthful health signal on a real
+board.
+
+## 2. What `robotd` replaces, and over what span
+
+`robotd` replaces the runtime, but not in one step — the runtime does five separable jobs
+and only one of them is `robotd`'s:
+
+| runtime job | destination | when |
+|---|---|---|
+| control loop, policies, motors, IMU | `robotd` | now |
+| gamepad | an intent client | slice 2 |
+| camera, ball/laser/pet detection, JPEG | `mediad` | M5 |
+| web hub, PWA, brain command socket | `mediad` / the app | M5+ |
+| maploc — mapping, MCL, planning | unowned | — |
+
+So the two run side by side for a while. They cannot run *simultaneously* — one serial bus,
+one owner — so a board is running one or the other, and the systemd units should say so
+with `Conflicts=`.
+
+The remote/app layer is not designed here. It is the `reachy_mini` architecture — WebRTC
+for media, JSON-RPC 2.0 over the DataChannel for control — ported to Rust, and out of scope
+for this document. Its one requirement on `robotd` is in §7.4.
+
+**Only the alpha variant, only the Radxa, only the v2 `imu_to_dxl` board.** v1/v1.5/v1.6,
+the four other IMUs, the three cameras, the Pi, and the wheeled configuration are all
+dropped. Every shipped policy is already `alpha_*`.
+
+## 3. Crate layout
+
+```
+duck-ipc-proto/  wire contract                                  (exists)
+duck-control/    robot model · bus · RobotIo · obs · policy · safety   NEW
+updater/         engine + updaterd                              (exists)
+robotd/          the daemon process                             (skeleton exists)
+robotctl/        CLI                                            (exists)
+padd/            gamepad → intents                              NEW, slice 2
+xtask/ test-support/                                            (exist)
+```
+
+`duck-control` holds everything between reading the bus and writing it. `robotd` is the
+process around it: socket, JSON-RPC, systemd, health reporting. The compiler enforces that
+boundary, which is what stops daemon concerns leaking into control code — and it means the
+crate can be lifted into its own repo later if the runtime needs to consume it during the
+transition, without that being a rewrite.
+
+(`padd` is a placeholder name.)
+
+## 4. Slice 1 — hold the pose
+
+A daemon that drives the real bus at the real rate and tells the truth about itself. No
+observations, no ONNX, no intents, no safety layer.
+
+### 4.1 The tick
+
+50 Hz, one `tokio` task on its own runtime so IPC work cannot sit in front of it:
+
+```
+read()               one sync_read: IMU board + 15 motors, one transaction
+publish(state)       atomics for health; snapshot for telemetry
+write(held_pose)     sync_write goal positions
+```
+
+`held_pose` is a constant, adopted at startup (§4.4). Nothing computes anything. That is
+the point: it puts the real load on the bus at the real rate, so loop timing and health are
+honest, and **nothing falls over when a deliberately broken release lands.** You can hammer
+install / rollback / power-cut cycles at a bench all day. With a walking policy you would
+spend the day picking the robot up instead.
+
+The loop stays a `tokio` task with `interval`. It is not being made real-time. Two changes
+from the runtime, both small: `MissedTickBehavior::Delay` rather than `Burst` — after an
+overrun, burst fires the backlog back to back and stacks motor commands on top of each
+other — and moving perception out to `mediad`, which removes most of what competes with the
+loop today for free.
+
+### 4.2 The bus
+
+A thin layer over `rustypot`: open, one combined `sync_read`, `sync_write` goal positions,
+torque enable, and the startup register check. Roughly what `bench_dynamixel_bus` already
+exercises.
+
+Written fresh rather than lifted, but **the numbers are borrowed from the runtime**, each
+with a comment saying so:
+
+- `RADS_PER_SEC_PER_COUNT = 0.229 × 2π/60`, and the position count↔radian conversion.
+- The register expectations from `check_and_fix_config`, asserted and corrected at startup:
+  `return_delay_time=0`, `baud_rate=3`, `pwm_slope=255`, `shutdown=52`. The first is
+  load-bearing — at the XL330 default of 250, sixteen devices cost ~8 ms of pure bus
+  turnaround per tick, 40% of the budget.
+
+The IMU is folded into the same `sync_read` as the motors, because that is what the
+hardware does — the v2 board sits on the Dynamixel bus and ships an on-chip SFLP quaternion,
+so the host only decodes. One board, one code path, no IMU abstraction.
+
+### 4.3 `RobotIo`
+
+```rust
+trait RobotIo {
+    fn read(&mut self) -> Result<Sensors>;              // joints + IMU, one sample
+    fn write(&mut self, targets: &JointTargets) -> Result<()>;
+}
+```
+
+Two implementations: `DynamixelIo` and `FakeIo` (scripted samples). `FakeIo` is what the
+test suite runs against, and it is why `cargo test` still needs no hardware, no network and
+no Docker. A MuJoCo backend comes after slice 2.
+
+**Neither is `cfg`-gated off macOS**, contrary to an earlier draft of this document. The
+gate was meant to keep `serialport` out of a laptop's dependency tree, but `rustypot` and
+`serialport` both build cleanly there, so it bought nothing and cost the ability to
+type-check the bus layer without a board — which is exactly the code most likely to be
+edited by someone who does not have one. Only the entry points that open a real port are
+gated, so a Mac build still refuses to pretend it has a robot: `robotd --fake` is the
+laptop path, and it must be asked for explicitly rather than fallen back to.
+
+### 4.4 Startup, and what an update restart does to the robot
+
+**`robotd` never moves the robot on its own.** On start it reads current positions, adopts
+them as targets, and does not touch torque.
+
+This is what makes update testing safe on a robot that is standing up. Dynamixels hold
+their last commanded goal while the process is dead, so a restart leaves the pose unchanged
+and there is no gap — the robot stands through an update without noticing. Interpolating to
+the default pose on start, which is what `init` does today, would make every update restart
+move a standing robot: a fall risk, and a confounder when the thing under test is the
+updater.
+
+Moving to the default pose is therefore explicit — `robotctl init`, in the maintenance
+namespace (§7.4).
+
+### 4.5 What `updaterd` finally gets
+
+| method | slice 1 |
+|---|---|
+| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count |
+| `robot.safeToRestart` | `true` (a constant pose is always safe to interrupt) |
+| `robot.modelApi` | unchanged constant |
+| `robot.remoteSessionActive` | `false` — `mediad` owns the real answer |
+
+Health is computed by the IPC side from atomics the loop publishes — a last-tick timestamp
+plus counters — never by asking the loop. That is what lets a *wedged* loop report itself
+unhealthy instead of hanging the caller, and it is the property the existing skeleton was
+already built around.
+
+A loop running at 60% of target is alive, answers every request, and is badly broken. That
+distinction is the whole reason slice 1 exists.
+
+### 4.6 Done when
+
+On a board: `robotd` holds the pose for an hour with no bus errors; `robotctl update apply`
+installs a release, restarts it, passes the gate, and the robot does not move; a release
+built to come up unhealthy is **automatically rolled back**; and a power cut mid-update
+recovers via the boot counter. That last three are the updater's real first test.
+
+## 5. Slice 2 — walk and stand
+
+### 5.1 What it adds
+
+Observations, the ONNX policy, the walk/stand pair, the safety layer, intents, and the
+gamepad client.
+
+### 5.2 One observation builder
+
+Every alpha policy is `obs[1,61] → actions[1,14]` — verified across walking, standing,
+ground pick, ball kick and sit. So there is exactly one layout:
+
+```
+[ gyro(3) | projected_gravity(3) | joint_pos(14) | joint_vel(14) | last_action(14) | command(13) ]
+                                                                    command = vel(3) + head(4) + body(6)
+```
+
+Joints exclude the mouth throughout; actions map back into 15 motor slots with index 9 left
+at zero. The 51/54D legacy, 49D wheeled and 85D tracking layouts go away with the variants.
+
+⚠ **How the 13 command floats are filled is unresolved — see §11.2 before implementing this.**
+Slice 2 intends to send zeros for the 6 body slots (there is no `pose` intent yet), but
+whether all-zero is the nominal-pose encoding these policies were trained against is not
+known, nor is whether head offsets still apply on top of policy output under this layout.
+The other 48 floats are unambiguous.
+
+### 5.3 The policy stays shaped like Antoine's
+
+No skill abstraction. Lift `policy.rs`'s main-plus-standing path: two ONNX sessions, and
+`command_magnitude ≤ 0.05` selects standing. Drop the other six modes and the priority
+if-chain with them. The abstraction can arrive when the third skill does.
+
+Policy files come from a path in the params file, defaulting into the release directory — so
+a normal update carries the policy, and a dev points the path at their own `.onnx` and
+iterates without cutting a release.
+
+Two hot-path fixes worth doing while the code is being moved, both cheap: pre-bind the ONNX
+input/output tensors, since the current path does `to_vec()` on the observation and again on
+the output, allocating several times per inference; and run one warm-up inference before the
+loop starts, because the first is always an outlier.
+
+**Carried over from the runtime because it works** — head and leg low-pass filters, action
+scale, voltage-adaptive scaling, the standing-transition gain change. These are tunables
+(§8), not decisions to revisit. The rule is not to regress what already runs.
+
+### 5.4 Safety
+
+`safety` owns the only `RobotIo` write handle. No policy and no client has one, so nothing
+above it *can* command a motor — the invariant is structural rather than remembered.
+
+Three rules, unconditional:
+
+- **Joint clamp** — targets clipped to the model's range every tick, whatever the policy asked.
+- **Fall → limp** — projected gravity in the body frame, debounced (0.2 s in the runtime).
+  In the runtime this is `--fall-detect`, a flag, evaluated inline among the gamepad handling
+  and *skipped while a scripted skill is active*. Here it is always on and preempts anything.
+- **Intent deadman** — if intents stop arriving, velocity goes to zero.
+
+**Stop is not limp**, and the distinction matters: losing comms makes the robot *stand
+still*, because standing is the safe state for a biped. Losing balance makes it limp. Two
+events, two responses, written down rather than inferred from whichever got implemented
+first.
+
+### 5.5 Intents
+
+Two vocabularies — intents in, state out — and JSON-RPC's two message families map onto
+them exactly:
+
+```jsonc
+// continuous: notifications, no id, no reply, last-writer-wins
+{"jsonrpc":"2.0","method":"robot.move","params":{"vx":0.2,"vy":0.0,"vyaw":0.4}}
+{"jsonrpc":"2.0","method":"robot.head","params":{"neck_pitch":0.35,"head_pitch":0.35,
+                                                 "head_yaw":0.0,"head_roll":0.0}}
+
+// discrete: requests, answered
+{"jsonrpc":"2.0","id":7,"method":"robot.stop"}
+{"jsonrpc":"2.0","id":8,"method":"robot.enable","params":{"on":true}}
+```
+
+That is the whole slice-2 surface. `look` (gaze direction), `pose` and `do` come later; both
+gaze forms will be exposed, and arbitration between them is last-writer-wins with no
+blending.
+
+Everything is radians, trunk frame, right-handed, signs fixed in the protocol definition.
+The runtime carries `--laser-track-yaw-sign`, `--laser-track-pitch-sign`,
+`--laser-fk-pitch-sign`, `--laser-fk-neck-sign` and `--imu-z-rotation-deg` because that
+convention was never written down and each consumer rediscovered it empirically. Writing it
+into the protocol deletes the category.
+
+At 50 Hz, continuous intents as notifications means no response traffic. When they later
+travel over WebRTC, notifications route to the unreliable `teleop` channel and requests to
+the reliable `control` one — which is what §5.2 of `architecture.md` asks for, falling out of
+the message family rather than a rule anyone has to remember.
+
+### 5.6 State out
+
+One stream, subscribable, decimated per subscriber. It must report what was **refused**, not
+just what happened — a teleop UI showing the stick forward and the robot still, with no
+explanation, is unusable, and safety clamps things constantly:
+
+```jsonc
+{"method":"robot.state","params":{
+  "t":1234.567,
+  "move":{"requested":[0.4,0,0],"applied":[0.15,0,0],"limited_by":["max_velocity"]},
+  "policy":"walk", "safety":{"fallen":false,"limp":false},
+  "loop":{"hz":49.8,"missed":0}
+}}
+```
+
+Same payload for `robotctl monitor` and, later, the app. This is what replaces the runtime's
+180-byte frame on 9870, the JPEG stream on 9871, the UDP command socket on 9872, the maploc
+ports on 9874/9875 and the web hub's `/state.json`. Adding a field today means editing four
+places that can silently disagree; here it means one struct, and older clients ignore what
+they do not know.
+
+### 5.7 The gamepad is a client
+
+`padd` reads `gilrs` and sends intents over `robotd`'s socket. Its own crate, so a gamepad
+stack stays out of `robotctl` — the tool that has to work on a broken robot.
+
+One socket hop, tens of microseconds. What it buys: the input path used by the app, the SDK
+and any remote client is the one a developer exercises every day, so it cannot quietly rot.
+For dev, `ssh -L /tmp/robotd.sock:/run/robotd.sock` gives pad-on-laptop, robot-on-board with
+no code.
+
+### 5.8 `safeToRestart` becomes real
+
+False while the policy is enabled and the robot is moving. Restarting motor control
+mid-stride is how a robot falls over (`updater-design.md` §7.2), and slice 2 is the first
+time that can happen.
+
+### 5.9 Done when
+
+It walks on a board, driven by `padd` through the intent API; an update applied with
+`robotctl` restarts it cleanly with the gate passing; and `--unhealthy` still rolls back.
+
+## 6. The robot model
+
+Rust consts for alpha only: 15 joints, Dynamixel IDs `20–24 / 30–34 / 10–14`, names,
+`ALPHA_DEFAULT_POSITION`, and per-joint limits. Same tables as the runtime's `motor.rs`,
+minus the three dead variants. There is exactly one robot; a second revision can be a second
+table.
+
+## 7. Cross-cutting
+
+### 7.1 The control loop reads snapshots, never waits
+
+Intents and params are published by IPC threads and read by the loop as a single atomic
+load. Nothing can apply backpressure to the loop and no request enters it synchronously.
+Telemetry goes out through a bounded broadcast where a slow subscriber gets a gap, never
+backpressure — the pattern the updater's IPC layer already uses and documents.
+
+### 7.2 Params
+
+A TOML file read at startup, **not watched** — live reload comes later. It lives outside
+`releases/<ver>/` so it survives update *and* rollback, next to the updater's own config at
+`/etc/robot/robotd.toml`.
+
+Roughly ten values, not 142: control rate, gains, action scale, low-pass alphas, deadzone,
+max velocities, deadman timeout, policy paths. The flag explosion in the runtime was mostly
+variants, dead skills and dead sensors, all of which are gone.
+
+### 7.3 Not regressing is the acceptance criterion
+
+The measurement already exists: `bench_dynamixel_bus` reports achieved rate, jitter, read
+time, bus time, utilisation, errors and IMU sample freshness at 50 and 100 Hz. Record
+today's numbers as the baseline; `robotd` must match them. This is deliberately not an RT
+engineering project — no `SCHED_FIFO`, no pinning, no `mlockall`. The loop is reliable today
+and the job is to keep it that way while the code around it gets simpler.
+
+Worth keeping permanently: the IMU-freshness check. "The read succeeded but the board handed
+back the same sample" feeds dead data to the policy and is known to happen.
+
+### 7.4 Maintenance is a separate namespace
+
+`init`, emergency torque-off, calibration and raw joint writes are not intents. They live in
+their own namespace so the relay's per-transport allow-list can keep them off remote
+transports. Signaling gating decides *who connects*; it does not say a teleoperator is also
+a mechanic — and `update.*` reaching a DataChannel would mean a remote peer can trigger a
+rollback.
+
+## 8. Testing
+
+`FakeIo` with scripted samples, no hardware:
+
+- health goes false when deadlines are missed;
+- startup adopts the current pose and never commands motion;
+- safety clamps a policy output past a joint limit, and fall → limp preempts a running policy;
+- deadman zeroes velocity when intents stop;
+- **golden observation vectors** — `(inputs, expected 61-float array)` pairs exported from
+  mjlab and committed. A wrong index in the observation does not fail loudly; it produces a
+  plausible robot that falls over. Depends on an export from `microduck_brain`.
+
+Each test's comment says which failure it exists to prevent, per the repo convention.
+
+## 9. Decisions recorded
+
+| | |
+|---|---|
+| `duck-control` as a workspace crate | boundary enforced by the compiler, no second repo |
+| bus layer written fresh, constants borrowed | thin code, but the tuned numbers are not re-derived |
+| Rust consts for the model | one robot exists |
+| params file, not watched | establishes the file and its location; the watcher is later |
+| policy path in params, default = release dir | updates carry the policy; devs override it |
+| adopt current pose on start | an update must not move a standing robot |
+| no odometry | nothing in slice 1 or 2 reads it; one 50 Hz rate instead of 50/100 |
+| walk/stand keep the runtime's shape | abstraction waits for the third skill |
+| gamepad as its own crate | keeps `gilrs` out of the recovery CLI |
+| sim after slice 2 | hardware is the validation path; `FakeIo` covers laptop development |
+
+## 10. Deferred, deliberately
+
+MuJoCo backend and the `RemoteIo` protocol · the remaining six skills · the skill
+abstraction · policy bundle manifests and `model_api` gating · `look`/`pose`/`do` intents ·
+gaze IK · live params reload and the config store · odometry · thermal limits · rate limits ·
+per-device IMU calibration.
+
+## 11. Open
+
+1. **Control rate on the Radxa.** 50 Hz is inherited from a Pi Zero 2W. Measurable now
+   that boards exist.
+2. ⚠ **The 61D command encoding is not settled, and it blocks slice 2 being correct.**
+   Two unknowns (§5.2): whether an all-zero body command is the nominal-pose encoding these
+   policies expect, and whether head offsets are still applied on top of policy output under
+   the 61D layout or only through the command slots — the runtime does both in different
+   places and marks one path "legacy". Nobody currently knows. Getting either wrong produces
+   a robot that walks badly for reasons that look like a timing problem, so this needs
+   settling against the training env (`microduck_brain`) rather than guessed from the
+   runtime's behaviour.
+3. **Golden vectors** need an export from `microduck_brain`. This is the highest-value test
+   in the plan and the only item here that depends on another repo.
+4. **Where the alpha MJCF lives** if a sim/real agreement test is ever wanted — 31 KB of
+   XML, 19 MB of meshes, currently in the runtime's `scripts/alpha_assets/`.

--- a/duck-control/Cargo.toml
+++ b/duck-control/Cargo.toml
@@ -11,4 +11,9 @@ thiserror.workspace = true
 tracing.workspace = true
 
 rustypot = "1.4.2"
-serialport = "4.8"
+# `default-features = false` drops serialport's `libudev` feature, which exists only for
+# enumerating ports (`available_ports`). We open one by path from the params file and never
+# enumerate — and libudev-sys needs a pkg-config sysroot that the board's cross-build does
+# not have, so leaving it on breaks the aarch64 build outright. rustypot disables it for the
+# same reason; this crate has to as well, or cargo's feature unification turns it back on.
+serialport = { version = "4.8", default-features = false }

--- a/duck-control/Cargo.toml
+++ b/duck-control/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "duck-control"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Robot control core: model, bus, sensing"
+
+[dependencies]
+serde = { workspace = true }
+thiserror.workspace = true
+tracing.workspace = true
+
+rustypot = "1.4.2"
+serialport = "4.8"

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -1,0 +1,280 @@
+//! The Dynamixel bus.
+//!
+//! One combined `sync_read` per tick covering the IMU board and all 15 servos, and one
+//! `sync_write` of goal positions. The IMU is listed first so it answers before the servo
+//! burst.
+//!
+//! Written against `rustypot`, but the *numbers* — conversion factors and the EEPROM
+//! registers asserted at startup — come from `microduck_runtime`, where they were arrived
+//! at against real hardware. See [`crate::model`].
+
+use std::f64::consts::PI;
+use std::time::Duration;
+
+use rustypot::servo::dynamixel::xl330::Xl330Controller;
+
+use crate::imu::{IMU_BLOCK_LEN, SflpDecoder};
+use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors};
+use crate::model::{BAUD_RATE, EXPECTED_REGISTERS, IMU_DXL_ID, JOINT_IDS, NUM_JOINTS};
+
+/// Start of the contiguous block read every tick: `present_pwm`, `present_current`,
+/// `present_velocity`, `present_position`. Twelve bytes covers all four, and happens to be
+/// exactly what the IMU board serves at the same address.
+const READ_ADDR: u8 = 124;
+const READ_LEN: u8 = 12;
+
+/// 0.229 rev/min per count, in rad/s.
+const RAD_PER_SEC_PER_COUNT: f64 = 0.229 * (2.0 * PI / 60.0);
+
+/// A healthy 16-device read completes well inside this. Capping it means a missing device
+/// costs a bounded hiccup rather than stalling the loop on the serial driver's default.
+const READ_TIMEOUT: Duration = Duration::from_millis(30);
+
+pub struct DynamixelIo {
+    controller: Xl330Controller,
+    /// IMU first, then the servos in [`JOINT_IDS`] order — the order blocks come back in.
+    ids: Vec<u8>,
+    imu: SflpDecoder,
+    last_imu_block: [u8; IMU_BLOCK_LEN],
+    /// Blocks identical to their predecessor. The read succeeded but the board handed back
+    /// the same sample, which means the policy is being fed dead orientation data — a
+    /// failure that is invisible unless someone counts it. Known to happen.
+    stale_imu_blocks: u64,
+}
+
+impl DynamixelIo {
+    pub fn open(port: &str) -> Result<Self> {
+        let serial = serialport::new(port, BAUD_RATE)
+            .timeout(READ_TIMEOUT)
+            .open()
+            .map_err(|e| IoError::Port {
+                path: port.to_owned(),
+                source: std::io::Error::other(e),
+            })?;
+
+        let controller = Xl330Controller::new()
+            .with_protocol_v2()
+            .with_serial_port(serial);
+
+        let mut ids = Vec::with_capacity(NUM_JOINTS + 1);
+        ids.push(IMU_DXL_ID);
+        ids.extend_from_slice(&JOINT_IDS);
+
+        Ok(Self {
+            controller,
+            ids,
+            imu: SflpDecoder::default(),
+            last_imu_block: [0; IMU_BLOCK_LEN],
+            stale_imu_blocks: 0,
+        })
+    }
+
+    /// Assert — and correct — the EEPROM registers the control loop depends on.
+    ///
+    /// Returns how many needed fixing. A servo that has been factory-reset or swapped in
+    /// arrives with `return_delay_time = 250`, which alone would eat 40% of the tick
+    /// budget across the bus. Checking costs one read per register at startup and removes
+    /// a whole class of "why is it slow on this robot".
+    pub fn check_registers(&mut self) -> Result<usize> {
+        let mut fixed = 0;
+        for &id in &JOINT_IDS {
+            for &(name, want) in EXPECTED_REGISTERS {
+                // rustypot returns a Vec even for a single-id read. An empty one means the
+                // servo did not answer, which must not be read as "register is fine".
+                let raw = match name {
+                    "return_delay_time" => self.controller.read_return_delay_time(id),
+                    "baud_rate" => self.controller.read_baud_rate(id),
+                    "pwm_slope" => self.controller.read_pwm_slope(id),
+                    "shutdown" => self.controller.read_shutdown(id),
+                    other => unreachable!("unhandled register {other}"),
+                }
+                .map_err(|e| IoError::Bus(format!("read {name} on {id}: {e}")))?;
+
+                let got = *raw.first().ok_or(IoError::ShortRead {
+                    what: "register read",
+                    expected: 1,
+                    got: 0,
+                })?;
+
+                if got == want {
+                    continue;
+                }
+                tracing::warn!(id, register = name, got, want, "correcting motor register");
+                match name {
+                    "return_delay_time" => self.controller.write_return_delay_time(id, want),
+                    "baud_rate" => self.controller.write_baud_rate(id, want),
+                    "pwm_slope" => self.controller.write_pwm_slope(id, want),
+                    "shutdown" => self.controller.write_shutdown(id, want),
+                    other => unreachable!("unhandled register {other}"),
+                }
+                .map_err(|e| IoError::Bus(format!("write {name} on {id}: {e}")))?;
+                fixed += 1;
+            }
+        }
+        Ok(fixed)
+    }
+
+    /// Present positions only — a lighter read than [`RobotIo::read`], used once at startup
+    /// to adopt the pose the robot is already in.
+    pub fn present_positions(&mut self) -> Result<[f64; NUM_JOINTS]> {
+        let values = self
+            .controller
+            .sync_read_present_position(&JOINT_IDS)
+            .map_err(|e| IoError::Bus(format!("read present positions: {e}")))?;
+        if values.len() != NUM_JOINTS {
+            return Err(IoError::ShortRead {
+                what: "present positions",
+                expected: NUM_JOINTS,
+                got: values.len(),
+            });
+        }
+        let mut out = [0.0; NUM_JOINTS];
+        out.copy_from_slice(&values);
+        Ok(out)
+    }
+
+    /// Torque on every servo. Not used by the control loop, which deliberately never
+    /// touches torque so that a restart mid-update leaves a standing robot standing.
+    pub fn set_torque(&mut self, on: bool) -> Result<()> {
+        for &id in &JOINT_IDS {
+            self.controller
+                .write_torque_enable(id, on)
+                .map_err(|e| IoError::Bus(format!("torque {on} on {id}: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Ramp every joint from where it is now to `target`, linearly.
+    ///
+    /// Only ever called by an explicit `init` — the control loop must never move the robot
+    /// on its own, because that would make an update restart a fall risk. Blocking, and
+    /// deliberately so: nothing else should be talking to the bus while this runs.
+    pub fn interpolate_to(
+        &mut self,
+        target: &[f64; NUM_JOINTS],
+        duration: Duration,
+        step: Duration,
+    ) -> Result<()> {
+        let start = self.present_positions()?;
+        let steps = (duration.as_secs_f64() / step.as_secs_f64())
+            .ceil()
+            .max(1.0) as u32;
+        for i in 1..=steps {
+            let t = i as f64 / steps as f64;
+            let mut next = [0.0; NUM_JOINTS];
+            for j in 0..NUM_JOINTS {
+                next[j] = start[j] + (target[j] - start[j]) * t;
+            }
+            self.write(&JointTargets::new(next))?;
+            std::thread::sleep(step);
+        }
+        Ok(())
+    }
+
+    /// Blocks identical to their predecessor since startup. Non-zero means the IMU board
+    /// is answering without refreshing.
+    pub fn stale_imu_blocks(&self) -> u64 {
+        self.stale_imu_blocks
+    }
+
+    pub fn imu_ready(&self) -> bool {
+        self.imu.ready()
+    }
+}
+
+impl RobotIo for DynamixelIo {
+    fn read(&mut self) -> Result<Sensors> {
+        let blocks = self
+            .controller
+            .sync_read_raw_data(&self.ids, READ_ADDR, READ_LEN)
+            .map_err(|e| IoError::Bus(format!("combined imu+motor sync_read: {e}")))?;
+
+        if blocks.len() != self.ids.len() {
+            return Err(IoError::ShortRead {
+                what: "sync_read blocks",
+                expected: self.ids.len(),
+                got: blocks.len(),
+            });
+        }
+
+        let mut sensors = Sensors::default();
+
+        // Slot 0 is the IMU board.
+        if blocks[0].len() == IMU_BLOCK_LEN {
+            let mut raw = [0u8; IMU_BLOCK_LEN];
+            raw.copy_from_slice(&blocks[0]);
+            if raw == self.last_imu_block {
+                self.stale_imu_blocks = self.stale_imu_blocks.saturating_add(1);
+            }
+            self.last_imu_block = raw;
+            sensors.imu = self.imu.decode(&raw);
+        } else {
+            return Err(IoError::ShortRead {
+                what: "imu block",
+                expected: IMU_BLOCK_LEN,
+                got: blocks[0].len(),
+            });
+        }
+
+        for (joint, block) in blocks[1..].iter().enumerate() {
+            if block.len() != READ_LEN as usize {
+                return Err(IoError::ShortRead {
+                    what: "motor block",
+                    expected: READ_LEN as usize,
+                    got: block.len(),
+                });
+            }
+            // [0..2] present_pwm, unused · [2..4] current · [4..8] velocity · [8..12] position
+            sensors.currents_ma[joint] = (i16::from_le_bytes([block[2], block[3]]) as f64).abs();
+            let velocity = i32::from_le_bytes([block[4], block[5], block[6], block[7]]);
+            sensors.velocities[joint] = velocity as f64 * RAD_PER_SEC_PER_COUNT;
+            let position = i32::from_le_bytes([block[8], block[9], block[10], block[11]]);
+            sensors.positions[joint] = (2.0 * PI * position as f64 / 4096.0) - PI;
+        }
+
+        Ok(sensors)
+    }
+
+    fn write(&mut self, targets: &JointTargets) -> Result<()> {
+        self.controller
+            .sync_write_goal_position(&JOINT_IDS, &targets.positions)
+            .map_err(|e| IoError::Bus(format!("sync_write goal positions: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The block parsed per servo must cover current, velocity and position without
+    /// overrunning. If `READ_LEN` and the offsets below ever disagree, joints get each
+    /// other's values — which reads as a wiring fault, not a code bug.
+    #[test]
+    fn read_block_is_long_enough_for_every_field() {
+        assert_eq!(READ_LEN as usize, IMU_BLOCK_LEN);
+        // Highest offset touched by the parser below is position at 8..12.
+        const { assert!(READ_LEN >= 12) };
+    }
+
+    /// The conversion must agree with rustypot's own `AnglePosition`, which is what
+    /// `sync_write_goal_position` uses on the way out. A mismatch would mean the loop
+    /// commands a different angle than it believes it read back.
+    #[test]
+    fn position_conversion_round_trips_through_rustypot() {
+        for raw in [0i32, 1024, 2048, 3072, 4095] {
+            let ours = (2.0 * PI * raw as f64 / 4096.0) - PI;
+            let theirs = (4096.0 * (PI + ours) / (2.0 * PI)) as i32;
+            assert_eq!(theirs, raw, "raw {raw} did not survive the round trip");
+        }
+    }
+
+    /// 0.229 rev/min per count. Getting this wrong scales every joint velocity in the
+    /// observation vector by a constant, which a policy tolerates just well enough to walk
+    /// badly.
+    #[test]
+    fn velocity_scale_matches_the_datasheet_figure() {
+        let one_count = RAD_PER_SEC_PER_COUNT;
+        let expected_rpm = 0.229;
+        assert!((one_count * 60.0 / (2.0 * PI) - expected_rpm).abs() < 1e-12);
+    }
+}

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -204,7 +204,17 @@ impl RobotIo for DynamixelIo {
             let mut raw = [0u8; IMU_BLOCK_LEN];
             raw.copy_from_slice(&blocks[0]);
             if raw == self.last_imu_block {
-                self.stale_imu_blocks = self.stale_imu_blocks.saturating_add(1);
+                let n = self.stale_imu_blocks.saturating_add(1);
+                self.stale_imu_blocks = n;
+                // Say so, or the counter is a number nobody ever reads. Rate-limited
+                // because a board that has stopped refreshing produces one of these every
+                // single tick, and 50 Hz of identical warnings would evict the journal.
+                if n == 1 || n.is_multiple_of(500) {
+                    tracing::warn!(
+                        stale_blocks = n,
+                        "imu board returned the same sample as last tick — orientation may be dead"
+                    );
+                }
             }
             self.last_imu_block = raw;
             sensors.imu = self.imu.decode(&raw);

--- a/duck-control/src/imu.rs
+++ b/duck-control/src/imu.rs
@@ -1,0 +1,355 @@
+//! The `imu_to_dxl` v2 board (LSM6DSV16X), decoded.
+//!
+//! One IMU, one code path. The board rides the Dynamixel bus and its 12-byte block is
+//! fetched in the same `sync_read` as the servos, so there is no separate sensor to poll
+//! and no fusion to run on the host — the chip's SFLP block ships a game-rotation
+//! quaternion and estimates its own gyro bias.
+//!
+//! Block layout at address 124:
+//!
+//! | bytes | contents |
+//! |---|---|
+//! | 0..6  | gyro x/y/z, `i16` LE raw counts, ±500 dps |
+//! | 6..12 | SFLP quaternion x/y/z as IEEE half-precision; `w = √(1 − x² − y² − z²)` |
+//!
+//! The board's full diagnostic block is 20 bytes (it also carries raw accelerometer, a
+//! sample counter and status flags). The control loop consumes only the first 12 so the
+//! read fits alongside the servos in one transaction.
+
+use crate::model::NUM_JOINTS;
+
+/// Bytes of the v2 board's block consumed per tick.
+pub const IMU_BLOCK_LEN: usize = 12;
+
+/// What the control loop knows about the robot's orientation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuData {
+    /// Angular velocity in the trunk frame, rad/s.
+    pub gyro: [f64; 3],
+    /// Projected gravity in the trunk frame, unit vector. Upright is `[0, 0, -1]`.
+    ///
+    /// This is what the policy observes, and what fall detection thresholds on.
+    pub gravity: [f64; 3],
+    /// Orientation, trunk→world, scalar-first `[w, x, y, z]`.
+    pub quat: [f64; 4],
+}
+
+impl Default for ImuData {
+    fn default() -> Self {
+        Self {
+            gyro: [0.0; 3],
+            gravity: [0.0, 0.0, -1.0],
+            quat: [1.0, 0.0, 0.0, 0.0],
+        }
+    }
+}
+
+/// ±500 dps at 17.5 mdps/LSB, in rad/s.
+const GYRO_RAD_PER_LSB: f64 = 0.0175 * std::f64::consts::PI / 180.0;
+
+/// Decodes the board's block into [`ImuData`].
+///
+/// Stateful only for spike rejection and for holding the last good quaternion — there is
+/// no filter here. Keeping the state explicit means [`crate::io::FakeIo`] can drive the
+/// same decoder in tests.
+pub struct SflpDecoder {
+    /// Sensor→trunk mounting rotation, scalar-first.
+    mount: [f64; 4],
+    /// Last quaternion the board actually produced. Held across blocks that arrive before
+    /// SFLP has written its table — snapping to identity would report a robot as upright
+    /// when its orientation is simply unknown, which is the worst possible lie to tell
+    /// fall detection.
+    last_quat: [f64; 4],
+    /// Blocks carrying a live quaternion. Gates [`SflpDecoder::ready`].
+    quat_samples: u32,
+    gyro_history: [[f64; 3]; 2],
+    gravity_history: [[f64; 3]; 2],
+}
+
+impl Default for SflpDecoder {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MOUNT)
+    }
+}
+
+impl SflpDecoder {
+    /// The board is mounted so that trunk = `[+raw_z, +raw_y, −raw_x]`, a +90° rotation
+    /// about Y.
+    pub const DEFAULT_MOUNT: [f64; 4] = [
+        std::f64::consts::FRAC_1_SQRT_2,
+        0.0,
+        std::f64::consts::FRAC_1_SQRT_2,
+        0.0,
+    ];
+
+    pub fn new(mount: [f64; 4]) -> Self {
+        Self {
+            mount,
+            last_quat: [1.0, 0.0, 0.0, 0.0],
+            quat_samples: 0,
+            gyro_history: [[0.0; 3]; 2],
+            gravity_history: [[0.0, 0.0, -1.0]; 2],
+        }
+    }
+
+    /// Whether the chip has demonstrably produced fused output — roughly 0.25 s at 100 Hz.
+    ///
+    /// Until this is true the orientation is a default, not a measurement. Slice 2's fall
+    /// detection must not run before it.
+    pub fn ready(&self) -> bool {
+        self.quat_samples >= 25
+    }
+
+    pub fn decode(&mut self, raw: &[u8; IMU_BLOCK_LEN]) -> ImuData {
+        let gyro_sensor = [
+            i16::from_le_bytes([raw[0], raw[1]]) as f64 * GYRO_RAD_PER_LSB,
+            i16::from_le_bytes([raw[2], raw[3]]) as f64 * GYRO_RAD_PER_LSB,
+            i16::from_le_bytes([raw[4], raw[5]]) as f64 * GYRO_RAD_PER_LSB,
+        ];
+        let gyro = rotate(self.mount, gyro_sensor);
+
+        // All-zero quaternion bytes mean SFLP has not written its table yet — the board
+        // just powered up, or its init failed. Keep the last good value.
+        let packed = [
+            u16::from_le_bytes([raw[6], raw[7]]),
+            u16::from_le_bytes([raw[8], raw[9]]),
+            u16::from_le_bytes([raw[10], raw[11]]),
+        ];
+        if packed != [0, 0, 0] {
+            let (x, y, z) = (half(packed[0]), half(packed[1]), half(packed[2]));
+            let norm_sq = x * x + y * y + z * z;
+            // A quaternion the chip never produced would fail this; ≤ 1.02 allows for
+            // half-precision rounding at full scale.
+            if x.is_finite() && y.is_finite() && z.is_finite() && norm_sq <= 1.02 {
+                let w = (1.0 - norm_sq).max(0.0).sqrt();
+                let mount_inv = [
+                    self.mount[0],
+                    -self.mount[1],
+                    -self.mount[2],
+                    -self.mount[3],
+                ];
+                let q = mul([w, x, y, z], mount_inv);
+                let norm = (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]).sqrt();
+                if norm > 0.5 {
+                    self.last_quat = [q[0] / norm, q[1] / norm, q[2] / norm, q[3] / norm];
+                    self.quat_samples = self.quat_samples.saturating_add(1);
+                }
+            }
+        }
+
+        // Normalise *before* the median, matching the runtime. Note the consequence: a
+        // component-wise median across three unit vectors is not itself unit-norm, so
+        // during a transient the policy sees a slightly short vector. Steady state is
+        // exact. Whether the training env expects strict unit norm is worth settling when
+        // slice 2 wires up observations — normalising after the median would guarantee it,
+        // but that is a behaviour change to a path that currently walks.
+        let gravity = normalise(rotate_inverse(self.last_quat, [0.0, 0.0, -1.0]));
+
+        let out = ImuData {
+            gyro: median3_each(&self.gyro_history, gyro),
+            gravity: median3_each(&self.gravity_history, gravity),
+            quat: self.last_quat,
+        };
+        self.gyro_history = [self.gyro_history[1], gyro];
+        self.gravity_history = [self.gravity_history[1], gravity];
+        out
+    }
+}
+
+/// Single-sample spike rejection. A dropped or corrupted block shows up as one wild value;
+/// a median over three discards it without the lag of an average.
+fn median3_each(history: &[[f64; 3]; 2], now: [f64; 3]) -> [f64; 3] {
+    let m = |a: f64, b: f64, c: f64| a.max(b).min(c).max(a.min(b));
+    [
+        m(history[0][0], history[1][0], now[0]),
+        m(history[0][1], history[1][1], now[1]),
+        m(history[0][2], history[1][2], now[2]),
+    ]
+}
+
+/// IEEE 754 binary16 → f64. The LSM6DSV16X ships quaternion components in this format.
+fn half(bits: u16) -> f64 {
+    let sign = if bits & 0x8000 != 0 { -1.0 } else { 1.0 };
+    let exp = ((bits >> 10) & 0x1F) as i32;
+    let frac = (bits & 0x3FF) as f64;
+    match exp {
+        0 => sign * frac * 2.0_f64.powi(-24),
+        0x1F if frac == 0.0 => sign * f64::INFINITY,
+        0x1F => f64::NAN,
+        _ => sign * (1.0 + frac / 1024.0) * 2.0_f64.powi(exp - 15),
+    }
+}
+
+/// Hamilton product, scalar-first.
+fn mul(a: [f64; 4], b: [f64; 4]) -> [f64; 4] {
+    let ([aw, ax, ay, az], [bw, bx, by, bz]) = (a, b);
+    [
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    ]
+}
+
+/// `q · v · q⁻¹`
+fn rotate(q: [f64; 4], v: [f64; 3]) -> [f64; 3] {
+    let (t, c) = cross_terms(q, v);
+    [
+        v[0] + q[0] * t[0] + c[0],
+        v[1] + q[0] * t[1] + c[1],
+        v[2] + q[0] * t[2] + c[2],
+    ]
+}
+
+/// `q⁻¹ · v · q` — world vector expressed in the body frame.
+fn rotate_inverse(q: [f64; 4], v: [f64; 3]) -> [f64; 3] {
+    let (t, c) = cross_terms(q, v);
+    [
+        v[0] - q[0] * t[0] + c[0],
+        v[1] - q[0] * t[1] + c[1],
+        v[2] - q[0] * t[2] + c[2],
+    ]
+}
+
+fn cross_terms(q: [f64; 4], v: [f64; 3]) -> ([f64; 3], [f64; 3]) {
+    let (x, y, z) = (q[1], q[2], q[3]);
+    let t = [
+        (y * v[2] - z * v[1]) * 2.0,
+        (z * v[0] - x * v[2]) * 2.0,
+        (x * v[1] - y * v[0]) * 2.0,
+    ];
+    let c = [
+        y * t[2] - z * t[1],
+        z * t[0] - x * t[2],
+        x * t[1] - y * t[0],
+    ];
+    (t, c)
+}
+
+/// Unit vector, falling back to "upright" rather than dividing by ~zero.
+fn normalise(v: [f64; 3]) -> [f64; 3] {
+    let mag = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    if mag > 0.1 {
+        [v[0] / mag, v[1] / mag, v[2] / mag]
+    } else {
+        [0.0, 0.0, -1.0]
+    }
+}
+
+/// Compile-time assurance that the joint count and this module stay independent — the IMU
+/// block is fixed-size regardless of how many servos share the bus.
+const _: () = assert!(NUM_JOINTS > 0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Half-precision decoding is hand-rolled, so pin the cases that matter: zero, one,
+    /// a negative, and a subnormal. A wrong exponent bias here silently tilts the horizon.
+    #[test]
+    fn half_precision_decodes_known_values() {
+        assert_eq!(half(0x0000), 0.0);
+        assert_eq!(half(0x3C00), 1.0);
+        assert_eq!(half(0xBC00), -1.0);
+        assert_eq!(half(0x3800), 0.5);
+        assert!((half(0x3555) - 0.333).abs() < 1e-3);
+    }
+
+    /// A block of zeroes is the board saying "SFLP has not started". Reporting identity —
+    /// i.e. perfectly upright — would tell fall detection the robot is fine when its
+    /// orientation is simply unknown.
+    #[test]
+    fn all_zero_quaternion_bytes_hold_the_last_good_value() {
+        let mut d = SflpDecoder::default();
+        assert!(!d.ready());
+
+        let zero = d.decode(&[0u8; IMU_BLOCK_LEN]);
+        assert_eq!(zero.quat, [1.0, 0.0, 0.0, 0.0]);
+        assert!(!d.ready(), "a zero block must not count as a live sample");
+
+        // 0x3C00 = 1.0 in the x slot would exceed unit norm on its own; use a modest
+        // rotation the chip could actually emit.
+        let mut block = [0u8; IMU_BLOCK_LEN];
+        block[6..8].copy_from_slice(&0x3000u16.to_le_bytes()); // x = 0.125
+        let live = d.decode(&block);
+        assert_ne!(live.quat, [1.0, 0.0, 0.0, 0.0]);
+
+        let held = d.decode(&[0u8; IMU_BLOCK_LEN]);
+        assert_eq!(held.quat, live.quat, "zero block must hold, not reset");
+    }
+
+    /// `ready()` gates fall detection in slice 2. If it were true from the first block,
+    /// the robot would be judged on a default orientation for the first quarter second.
+    #[test]
+    fn not_ready_until_the_chip_has_produced_output() {
+        let mut d = SflpDecoder::default();
+        let mut block = [0u8; IMU_BLOCK_LEN];
+        block[6..8].copy_from_slice(&0x3000u16.to_le_bytes());
+        for _ in 0..24 {
+            d.decode(&block);
+        }
+        assert!(!d.ready());
+        d.decode(&block);
+        assert!(d.ready());
+    }
+
+    /// In steady state gravity must be a unit vector at any orientation — the policy
+    /// observes it directly and was trained on normalised input.
+    ///
+    /// Three identical blocks per orientation so the median settles. Mid-transient the
+    /// median blends three different unit vectors component-wise and the result is
+    /// slightly short; that is the runtime's behaviour and is deliberately preserved (see
+    /// the note in `decode`).
+    #[test]
+    fn gravity_is_a_unit_vector_in_steady_state() {
+        let mut d = SflpDecoder::default();
+        let mut block = [0u8; IMU_BLOCK_LEN];
+        for packed in [0x0000u16, 0x3000, 0x3800, 0xB000] {
+            block[6..8].copy_from_slice(&packed.to_le_bytes());
+            d.decode(&block);
+            d.decode(&block);
+            let g = d.decode(&block).gravity;
+            let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
+            assert!(
+                (mag - 1.0).abs() < 1e-9,
+                "gravity magnitude {mag} for {packed:#06x}"
+            );
+        }
+    }
+
+    /// The transient case, pinned so the bound is known rather than assumed: switching
+    /// orientation between ticks blends three vectors and shortens the result. If this
+    /// ever gets far from 1.0 the policy is being fed something training never saw.
+    #[test]
+    fn gravity_stays_close_to_unit_through_a_transient() {
+        let mut d = SflpDecoder::default();
+        let mut block = [0u8; IMU_BLOCK_LEN];
+        block[6..8].copy_from_slice(&0x0000u16.to_le_bytes());
+        d.decode(&block);
+        block[6..8].copy_from_slice(&0x3800u16.to_le_bytes());
+        let g = d.decode(&block).gravity;
+        let mag = (g[0] * g[0] + g[1] * g[1] + g[2] * g[2]).sqrt();
+        assert!(mag > 0.5, "transient gravity collapsed to {mag}");
+        assert!(mag <= 1.0 + 1e-9);
+    }
+
+    /// Gyro counts are signed. Reading them as unsigned would turn every negative rate
+    /// into a large positive one, which reads as a robot spinning.
+    #[test]
+    fn gyro_counts_are_signed() {
+        let mut d = SflpDecoder::default();
+        let mut block = [0u8; IMU_BLOCK_LEN];
+        block[0..2].copy_from_slice(&(-1000i16).to_le_bytes());
+        // Three identical blocks so the median settles on this sample.
+        d.decode(&block);
+        d.decode(&block);
+        let out = d.decode(&block);
+        let magnitude: f64 = out.gyro.iter().map(|v| v.abs()).sum();
+        assert!(magnitude > 0.0);
+        let expected = 1000.0 * GYRO_RAD_PER_LSB;
+        assert!(
+            (magnitude - expected).abs() < 1e-9,
+            "expected |gyro| {expected}, got {magnitude}"
+        );
+    }
+}

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -1,0 +1,198 @@
+//! The seam between the control loop and the physical world.
+//!
+//! Everything between [`RobotIo::read`] and [`RobotIo::write`] is pure computation over
+//! plain data, which is what makes the loop testable without a robot.
+//!
+//! [`Sensors`] carries joints *and* IMU together because that is what the hardware does:
+//! the IMU board sits on the Dynamixel bus and is fetched in the same transaction as the
+//! servos. A trait that split them would invent a distinction the bus does not have, and
+//! would double the bus traffic to honour it.
+
+use crate::imu::ImuData;
+use crate::model::NUM_JOINTS;
+
+/// One atomic sample of the robot.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Sensors {
+    /// Joint angles in radians, indexed as [`crate::model::JOINT_NAMES`].
+    pub positions: [f64; NUM_JOINTS],
+    /// Joint velocities, rad/s.
+    pub velocities: [f64; NUM_JOINTS],
+    /// Present current magnitude, mA. Sign is dropped — direction is inferable from
+    /// velocity, and every consumer so far wants load, not direction.
+    pub currents_ma: [f64; NUM_JOINTS],
+    pub imu: ImuData,
+}
+
+impl Default for Sensors {
+    fn default() -> Self {
+        Self {
+            positions: [0.0; NUM_JOINTS],
+            velocities: [0.0; NUM_JOINTS],
+            currents_ma: [0.0; NUM_JOINTS],
+            imu: ImuData::default(),
+        }
+    }
+}
+
+/// What the loop commands. Position control only — alpha has no velocity-mode joints.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct JointTargets {
+    pub positions: [f64; NUM_JOINTS],
+}
+
+impl JointTargets {
+    pub fn new(positions: [f64; NUM_JOINTS]) -> Self {
+        Self { positions }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IoError {
+    #[error("serial port {path}: {source}")]
+    Port {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("bus transaction failed: {0}")]
+    Bus(String),
+    /// A `sync_read` that returns the wrong number of blocks, or a block of the wrong
+    /// length, means a device did not answer. Reported rather than papered over: a
+    /// silently short read would leave stale values in half the joint array.
+    #[error("{what}: expected {expected}, got {got}")]
+    ShortRead {
+        what: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    #[error("simulated failure")]
+    Simulated,
+}
+
+pub type Result<T> = std::result::Result<T, IoError>;
+
+pub trait RobotIo {
+    /// One transaction: joints and IMU together.
+    fn read(&mut self) -> Result<Sensors>;
+    fn write(&mut self, targets: &JointTargets) -> Result<()>;
+}
+
+/// A robot made of nothing, for tests.
+///
+/// Always compiled — it is what the test suite runs against, and it is why `cargo test`
+/// needs no hardware, no network and no Docker. Positions echo back whatever was last
+/// written, so a loop driving it behaves like a servo that tracks perfectly.
+pub struct FakeIo {
+    sensors: Sensors,
+    /// Set to make the next [`RobotIo::read`] fail, then cleared. For exercising the
+    /// loop's error path without a flaky bus.
+    pub fail_next_read: bool,
+    pub last_written: Option<JointTargets>,
+    pub reads: usize,
+    pub writes: usize,
+    /// When true, `read` reports the last written targets as the present positions.
+    track_targets: bool,
+}
+
+impl Default for FakeIo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FakeIo {
+    pub fn new() -> Self {
+        Self {
+            sensors: Sensors::default(),
+            fail_next_read: false,
+            last_written: None,
+            reads: 0,
+            writes: 0,
+            track_targets: true,
+        }
+    }
+
+    /// Start from a known pose — typically [`crate::model::DEFAULT_POSITION`].
+    pub fn at(positions: [f64; NUM_JOINTS]) -> Self {
+        let mut io = Self::new();
+        io.sensors.positions = positions;
+        io
+    }
+
+    /// Freeze reported positions so they ignore what is written. Models a robot whose
+    /// servos are limp, or one being pushed around by hand.
+    pub fn frozen(mut self) -> Self {
+        self.track_targets = false;
+        self
+    }
+
+    pub fn set_imu(&mut self, imu: ImuData) {
+        self.sensors.imu = imu;
+    }
+
+    pub fn positions(&self) -> [f64; NUM_JOINTS] {
+        self.sensors.positions
+    }
+}
+
+impl RobotIo for FakeIo {
+    fn read(&mut self) -> Result<Sensors> {
+        if self.fail_next_read {
+            self.fail_next_read = false;
+            return Err(IoError::Simulated);
+        }
+        self.reads += 1;
+        Ok(self.sensors)
+    }
+
+    fn write(&mut self, targets: &JointTargets) -> Result<()> {
+        self.writes += 1;
+        self.last_written = Some(*targets);
+        if self.track_targets {
+            self.sensors.positions = targets.positions;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::DEFAULT_POSITION;
+
+    /// The loop's whole contract in slice 1: whatever it writes, it reads back. A FakeIo
+    /// that ignored writes would make every hold-pose test pass vacuously.
+    #[test]
+    fn fake_io_tracks_what_was_written() {
+        let mut io = FakeIo::at(DEFAULT_POSITION);
+        assert_eq!(io.read().unwrap().positions, DEFAULT_POSITION);
+
+        let mut moved = DEFAULT_POSITION;
+        moved[0] = 0.5;
+        io.write(&JointTargets::new(moved)).unwrap();
+        assert_eq!(io.read().unwrap().positions, moved);
+        assert_eq!(io.writes, 1);
+    }
+
+    /// A limp or hand-held robot does not follow commands. Slice 2's safety work needs to
+    /// be testable against that, so the divergence has to be expressible.
+    #[test]
+    fn frozen_fake_io_ignores_writes() {
+        let mut io = FakeIo::at(DEFAULT_POSITION).frozen();
+        let mut moved = DEFAULT_POSITION;
+        moved[0] = 0.5;
+        io.write(&JointTargets::new(moved)).unwrap();
+        assert_eq!(io.read().unwrap().positions, DEFAULT_POSITION);
+    }
+
+    /// A read failure must be a one-shot, or a test that injects one can never recover and
+    /// the loop's retry path is untestable.
+    #[test]
+    fn simulated_read_failure_clears_itself() {
+        let mut io = FakeIo::new();
+        io.fail_next_read = true;
+        assert!(io.read().is_err());
+        assert!(io.read().is_ok());
+    }
+}

--- a/duck-control/src/lib.rs
+++ b/duck-control/src/lib.rs
@@ -1,0 +1,17 @@
+//! The robot control core: everything between reading the bus and writing it.
+//!
+//! Deliberately not a daemon. There is no tokio here, no socket, no systemd — `robotd`
+//! owns all of that. The boundary is enforced by the compiler rather than by discipline,
+//! which is what stops process concerns leaking into the code that drives motors.
+//!
+//! Slice 1 (`docs/robotd-design.md` §4) is the model, the bus, and the [`io::RobotIo`]
+//! seam. Observations, the policy runner and the safety layer arrive with slice 2.
+
+pub mod bus;
+pub mod imu;
+pub mod io;
+pub mod model;
+
+pub use imu::ImuData;
+pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors};
+pub use model::{DEFAULT_POSITION, JOINT_IDS, JOINT_NAMES, NUM_JOINTS};

--- a/duck-control/src/model.rs
+++ b/duck-control/src/model.rs
@@ -1,0 +1,149 @@
+//! The robot, as data.
+//!
+//! One variant — **alpha** — because that is the only robot that exists. Every shipped
+//! policy is `alpha_*`; v1/v1.5/v1.6 are history. A second revision becomes a second set
+//! of tables, which is honest until there is a second robot to generalise from.
+//!
+//! The numeric values here are lifted from `microduck_runtime`'s `motor.rs`, where they
+//! were measured against hardware rather than derived. Re-deriving them from a datasheet
+//! is exactly the kind of change that looks right and walks wrong.
+
+/// Left leg (5) · neck/head/mouth (5) · right leg (5).
+pub const NUM_JOINTS: usize = 15;
+
+/// Dynamixel IDs, indexed as [`JOINT_NAMES`].
+pub const JOINT_IDS: [u8; NUM_JOINTS] = [
+    20, 21, 22, 23, 24, // left leg
+    30, 31, 32, 33, 34, // neck, head, mouth
+    10, 11, 12, 13, 14, // right leg
+];
+
+pub const JOINT_NAMES: [&str; NUM_JOINTS] = [
+    "left_hip_yaw",
+    "left_hip_roll",
+    "left_hip_pitch",
+    "left_knee",
+    "left_ankle",
+    "neck_pitch",
+    "head_pitch",
+    "head_yaw",
+    "head_roll",
+    "mouth",
+    "right_hip_yaw",
+    "right_hip_roll",
+    "right_hip_pitch",
+    "right_knee",
+    "right_ankle",
+];
+
+/// The mouth is absent from every alpha policy — they are all 61-D observation, 14-action,
+/// and the action vector skips this index. Named so that omission is deliberate rather
+/// than an off-by-one someone has to rediscover.
+pub const MOUTH_INDEX: usize = 9;
+
+/// Home pose. The trunk sits ~5 mm further forward than the v1.5 pose so the CoM is over
+/// the ankle axis; the old pose biased the robot backwards.
+///
+/// Must match `HOME_FRAME` in the training env — a policy is trained against these angles
+/// and observes joint positions *relative* to them, so a discrepancy here is a constant
+/// offset on 14 observation slots.
+pub const DEFAULT_POSITION: [f64; NUM_JOINTS] = [
+    0.0,     // left_hip_yaw
+    -0.0873, // left_hip_roll
+    -0.4579, // left_hip_pitch
+    -0.0049, // left_knee
+    0.4530,  // left_ankle
+    0.3491,  // neck_pitch
+    0.3491,  // head_pitch
+    0.0,     // head_yaw
+    0.0,     // head_roll
+    0.0,     // mouth
+    0.0,     // right_hip_yaw
+    0.0873,  // right_hip_roll
+    0.4579,  // right_hip_pitch
+    0.0049,  // right_knee
+    -0.4530, // right_ankle
+];
+
+/// The `imu_to_dxl` v2 board's Dynamixel ID. It rides the motor bus and is read in the
+/// same transaction as the servos ([`crate::bus`]).
+pub const IMU_DXL_ID: u8 = 200;
+
+pub const BAUD_RATE: u32 = 1_000_000;
+
+/// EEPROM registers asserted (and corrected) at startup.
+///
+/// `return_delay_time` is the load-bearing one: the XL330 ships at 250, which is 500 µs of
+/// turnaround *per device*. Across 16 devices that is 8 ms per tick — 40% of a 20 ms budget
+/// — spent waiting for servos to get around to answering. The rest are here because the
+/// runtime found them worth pinning; `shutdown = 52` is the error mask that latches on
+/// overload, overheating and input-voltage faults.
+pub const EXPECTED_REGISTERS: &[(&str, u8)] = &[
+    ("return_delay_time", 0),
+    ("baud_rate", 3), // 3 = 1 Mbps, must agree with BAUD_RATE
+    ("pwm_slope", 255),
+    ("shutdown", 52),
+];
+
+/// Index of a joint by name. Linear scan over 15 entries, used at startup and in tests.
+pub fn joint_index(name: &str) -> Option<usize> {
+    JOINT_NAMES.iter().position(|n| *n == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three tables are indexed by the same integer everywhere in the crate. If they
+    /// ever diverge in length, every lookup silently reads the wrong joint.
+    #[test]
+    fn tables_agree_on_length() {
+        assert_eq!(JOINT_IDS.len(), NUM_JOINTS);
+        assert_eq!(JOINT_NAMES.len(), NUM_JOINTS);
+        assert_eq!(DEFAULT_POSITION.len(), NUM_JOINTS);
+    }
+
+    /// A duplicated Dynamixel ID makes a `sync_read` return blocks that cannot be matched
+    /// back to joints, and a `sync_write` command two joints at once. Both fail in ways
+    /// that look like a wiring fault.
+    #[test]
+    fn ids_are_unique() {
+        let mut seen = JOINT_IDS;
+        seen.sort_unstable();
+        seen.windows(2)
+            .for_each(|w| assert_ne!(w[0], w[1], "duplicate Dynamixel ID {}", w[0]));
+    }
+
+    /// The IMU board shares the bus with the servos, so its ID must not collide with one.
+    #[test]
+    fn imu_id_does_not_collide_with_a_joint() {
+        assert!(!JOINT_IDS.contains(&IMU_DXL_ID));
+    }
+
+    /// `MOUTH_INDEX` is used to skip a slot when mapping 14 policy actions onto 15 joints.
+    /// Pointing it at the wrong joint would shift every action after it by one.
+    #[test]
+    fn mouth_index_names_the_mouth() {
+        assert_eq!(JOINT_NAMES[MOUTH_INDEX], "mouth");
+        assert_eq!(joint_index("mouth"), Some(MOUTH_INDEX));
+    }
+
+    /// The legs are mirrored: the roll/pitch/ankle pairs are equal and opposite. A sign
+    /// typo in the home pose is invisible by inspection and makes the robot stand crooked.
+    #[test]
+    fn home_pose_legs_are_mirrored() {
+        for (left, right) in [
+            ("left_hip_roll", "right_hip_roll"),
+            ("left_hip_pitch", "right_hip_pitch"),
+            ("left_knee", "right_knee"),
+            ("left_ankle", "right_ankle"),
+        ] {
+            let l = DEFAULT_POSITION[joint_index(left).unwrap()];
+            let r = DEFAULT_POSITION[joint_index(right).unwrap()];
+            assert!(
+                (l + r).abs() < 1e-9,
+                "{left} ({l}) and {right} ({r}) should be equal and opposite"
+            );
+        }
+    }
+}

--- a/robotd/Cargo.toml
+++ b/robotd/Cargo.toml
@@ -7,6 +7,7 @@ description = "Robot control daemon — skeleton"
 
 [dependencies]
 duck-ipc-proto = { path = "../duck-ipc-proto" }
+duck-control = { path = "../duck-control" }
 clap = { workspace = true, features = ["derive"] }
 serde.workspace = true
 serde_json.workspace = true
@@ -22,6 +23,8 @@ tokio = { workspace = true, features = [
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libc = "0.2"
+thiserror.workspace = true
+toml = "0.9"
 
 # Test-only. `tests/updater_gate.rs` drives the real update engine against this binary,
 # which is why `updater` appears here: the test asserts that robotd upholds the contract

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -1,38 +1,40 @@
 //! `robotd` — the robot control daemon.
 //!
-//! **This is a skeleton.** It logs a heartbeat and answers the four questions
-//! `updaterd` asks. No motors, no kinematics, no gait. Motor control arrives in M3
-//! (`docs/roadmap.md`), developed against the MuJoCo sim before hardware.
+//! **Slice 1** (`docs/robotd-design.md` §4): a control loop that drives the real bus at the
+//! real rate and holds the pose it started in. No observations, no policy, no intents.
 //!
-//! It exists now for one reason: without it, `updaterd` has nothing to health-gate
-//! against, so `updater.example.toml` had to ship with `health = none` and **no
-//! auto-rollback** (`updater-design.md` §16.5). That is the weakest the update design
-//! gets, and this removes it.
+//! It is not walking yet because that is not what it is for yet. The update engine is
+//! finished and has never run on hardware, and its auto-rollback is only meaningful if
+//! `robot.health` means something — today it means "the loop ticked once", so every
+//! rollback tested so far tested a placeholder. Slice 1 makes health honest: **the loop is
+//! meeting its deadline**. A loop running at 60% of target is alive, answers every request,
+//! and is badly broken.
 //!
-//! The four methods are deliberately the whole API surface:
+//! Holding a pose is also the right thing to be doing while someone deliberately breaks
+//! releases at a bench: the bus sees the real load at the real rate, and nothing falls over
+//! when a bad build lands.
 //!
-//! | method | why `updaterd` asks |
-//! |---|---|
-//! | `robot.safeToRestart` | don't restart motor control mid-motion |
-//! | `robot.health` | the post-update gate — did the new release come up? |
-//! | `robot.modelApi` | can this daemon load a given model bundle? |
-//! | `robot.remoteSessionActive` | don't drop a telepresence session |
-//!
-//! Every one of them must be answerable *while the robot is in a bad state*, since that
-//! is exactly when it is being asked. So this server holds no locks, does no IO beyond
-//! the socket, and never blocks on the control loop — a wedged control loop must show up
-//! as `healthy: false`, not as a hung socket.
+//! Every one of the four methods must be answerable *while the robot is in a bad state*,
+//! since that is exactly when it is asked. So the IPC side reads atomics the control loop
+//! publishes and never calls into the loop — a wedged loop reports itself unhealthy rather
+//! than hanging the caller.
+
+mod params;
 
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use duck_control::io::RobotIo;
+use duck_control::{DEFAULT_POSITION, FakeIo, JointTargets, NUM_JOINTS};
 use duck_ipc_proto as proto;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+
+use params::Params;
 
 /// Model API version this build implements (`updater-design.md` §5.5). Bump when the
 /// sensor-input / actuator-output contract a model sees changes.
@@ -43,16 +45,36 @@ const SOCKET_MODE: u32 = 0o660;
 
 const MAX_LINE: usize = 64 * 1024;
 
+/// How often the loop logs a summary at `info`.
+///
+/// Per-tick logging would be ~4.3M lines a day at 50 Hz. That is not merely noise: under a
+/// journal size cap it is what *evicts* the logs support needs.
+const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Window over which the achieved rate is measured, and therefore how quickly a degraded
+/// loop becomes visible to the health gate.
+const RATE_WINDOW: Duration = Duration::from_secs(1);
+
 #[derive(Parser, Debug)]
-#[command(name = "robotd", about = "Robot control daemon (skeleton)", version)]
+#[command(name = "robotd", about = "Robot control daemon", version)]
 struct Args {
     /// Socket to serve the `robot.*` API on. `updaterd --robot-socket` must match.
     #[arg(long, default_value = "/run/robotd.sock")]
     socket: PathBuf,
 
-    /// Heartbeat interval.
-    #[arg(long, default_value = "1s", value_parser = parse_duration)]
-    heartbeat: Duration,
+    /// Params file. Defaults to `/etc/robot/robotd.toml`, which may be absent — an
+    /// unprovisioned board comes up on defaults. A path given here must exist.
+    #[arg(long)]
+    params: Option<PathBuf>,
+
+    /// Serial port override, for a board wired differently from the shipped default.
+    #[arg(long)]
+    port: Option<String>,
+
+    /// Run against a robot made of nothing. For laptop development and tests — there is no
+    /// simulator yet, and this is what stands in for one.
+    #[arg(long)]
+    fake: bool,
 
     /// Report unhealthy. For exercising the updater's rollback path on a bench robot
     /// without having to break a real build.
@@ -62,6 +84,23 @@ struct Args {
     /// Report that it is not safe to restart, as if the robot were moving.
     #[arg(long)]
     busy: bool,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Enable torque and move to the home pose, then exit.
+    ///
+    /// Explicit, and separate from running the daemon, because the control loop must never
+    /// move the robot on its own: `robotd` restarting during an update would otherwise make
+    /// a standing robot lurch, which is both a fall risk and a confounder when the thing
+    /// under test is the updater.
+    Init {
+        #[arg(long, default_value = "2s", value_parser = parse_duration)]
+        duration: Duration,
+    },
 }
 
 fn parse_duration(raw: &str) -> Result<Duration, String> {
@@ -80,38 +119,90 @@ fn parse_duration(raw: &str) -> Result<Duration, String> {
 
 /// What the control loop publishes about itself.
 ///
-/// Atomics rather than a mutex on purpose: the IPC side must never be able to block on
-/// the control loop. A robot whose control loop is wedged still has to be able to say
-/// "I am not healthy" — if answering required the loop's lock, the one situation where
-/// `updaterd` needs an answer is the situation it would hang in.
+/// Atomics rather than a mutex on purpose: the IPC side must never be able to block on the
+/// control loop. A robot whose loop is wedged still has to be able to say "I am not
+/// healthy" — if answering required the loop's lock, the one situation where `updaterd`
+/// needs an answer is the situation it would hang in.
 struct RobotState {
-    /// Set once the loop has completed a cycle; the health gate's basic question.
-    running: AtomicBool,
-    /// Heartbeats since start. Lets a caller see progress, not just liveness.
+    /// Epoch for every timestamp below. `Instant` so the clock cannot go backwards.
+    started: Instant,
     ticks: AtomicU64,
-    /// Forced-unhealthy, for testing rollback.
+    /// Ticks whose work overran the period. Cumulative, for diagnosis; the rate check is
+    /// what catches a sustained problem.
+    missed: AtomicU64,
+    /// Microseconds since `started` at the last completed tick.
+    last_tick_us: AtomicU64,
+    /// Achieved rate over the last window, as `f64::to_bits`. Zero until the first window
+    /// closes, which is why the stall check carries the first second.
+    achieved_hz: AtomicU64,
+    /// Consecutive failed bus reads. Reset by any success.
+    consecutive_errors: AtomicU32,
+    shutdown: AtomicBool,
+
+    period_us: u64,
+    min_achieved_hz: f64,
+    stall_periods: u32,
+    max_consecutive_errors: u32,
     force_unhealthy: bool,
-    /// Forced-busy, for testing the safe-to-restart refusal.
     force_busy: bool,
 }
 
 impl RobotState {
+    fn new(params: &Params, force_unhealthy: bool, force_busy: bool) -> Self {
+        Self {
+            started: Instant::now(),
+            ticks: AtomicU64::new(0),
+            missed: AtomicU64::new(0),
+            last_tick_us: AtomicU64::new(0),
+            achieved_hz: AtomicU64::new(0),
+            consecutive_errors: AtomicU32::new(0),
+            shutdown: AtomicBool::new(false),
+            period_us: params.period().as_micros() as u64,
+            min_achieved_hz: params.health.min_achieved_hz,
+            stall_periods: params.health.stall_periods,
+            max_consecutive_errors: params.health.max_consecutive_errors,
+            force_unhealthy,
+            force_busy,
+        }
+    }
+
     fn health(&self) -> proto::HealthResult {
+        let unhealthy = |reason: String| proto::HealthResult {
+            healthy: false,
+            reason: Some(reason),
+        };
+
         if self.force_unhealthy {
-            return proto::HealthResult {
-                healthy: false,
-                reason: Some("forced unhealthy by --unhealthy".into()),
-            };
+            return unhealthy("forced unhealthy by --unhealthy".into());
         }
-        // A loop that has not completed a cycle yet is not healthy. During the health
-        // gate this is the honest answer — "starting" is not "started" — and the gate
-        // polls, so it will see the transition.
-        if !self.running.load(Ordering::Relaxed) {
-            return proto::HealthResult {
-                healthy: false,
-                reason: Some("control loop has not completed a cycle yet".into()),
-            };
+
+        // "Starting" is not "started". The gate polls, so it will see the transition.
+        if self.ticks.load(Ordering::Relaxed) == 0 {
+            return unhealthy("control loop has not completed a cycle yet".into());
         }
+
+        let errors = self.consecutive_errors.load(Ordering::Relaxed);
+        if errors >= self.max_consecutive_errors {
+            return unhealthy(format!("{errors} consecutive bus read failures"));
+        }
+
+        // A wedged loop stops stamping. This is what turns a hung control thread into an
+        // honest answer instead of a socket that keeps saying "healthy" forever.
+        let now_us = self.started.elapsed().as_micros() as u64;
+        let stale_us = now_us.saturating_sub(self.last_tick_us.load(Ordering::Relaxed));
+        let stall_limit_us = self.period_us.saturating_mul(self.stall_periods as u64);
+        if stale_us > stall_limit_us {
+            return unhealthy(format!("control loop stalled for {} ms", stale_us / 1000));
+        }
+
+        let hz = f64::from_bits(self.achieved_hz.load(Ordering::Relaxed));
+        if hz > 0.0 && hz < self.min_achieved_hz {
+            return unhealthy(format!(
+                "control loop at {hz:.1} Hz, below the {:.1} Hz floor",
+                self.min_achieved_hz
+            ));
+        }
+
         proto::HealthResult {
             healthy: true,
             reason: None,
@@ -125,9 +216,9 @@ impl RobotState {
                 reason: Some("forced busy by --busy".into()),
             };
         }
-        // The skeleton never moves, so it is always safe. When real control lands this
-        // must consult actual motion state — restarting mid-stride is how a robot falls
-        // over (`updater-design.md` §7.2).
+        // Slice 1 holds a constant pose, so interrupting it cannot put the robot anywhere it
+        // was not already. Slice 2 must consult actual motion state: restarting motor
+        // control mid-stride is how a robot falls over (`updater-design.md` §7.2).
         proto::SafeToRestartResult {
             safe: true,
             reason: None,
@@ -170,12 +261,27 @@ async fn main() -> ExitCode {
 
     log_startup_identity("robotd");
 
-    let state = Arc::new(RobotState {
-        running: AtomicBool::new(false),
-        ticks: AtomicU64::new(0),
-        force_unhealthy: args.unhealthy,
-        force_busy: args.busy,
-    });
+    let explicit = args.params.is_some();
+    let params_path = args
+        .params
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(params::DEFAULT_PATH));
+    let mut params = match Params::load(&params_path, explicit) {
+        Ok(params) => params,
+        Err(e) => {
+            tracing::error!(error = %e, "bad params");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Some(port) = args.port.clone() {
+        params.bus.port = port;
+    }
+
+    if let Some(Command::Init { duration }) = args.command {
+        return run_init(&params, duration);
+    }
+
+    let state = Arc::new(RobotState::new(&params, args.unhealthy, args.busy));
 
     if args.unhealthy {
         tracing::warn!("--unhealthy: will report unhealthy, so updates will roll back");
@@ -184,82 +290,215 @@ async fn main() -> ExitCode {
         tracing::warn!("--busy: will refuse restarts, so updates will be held off");
     }
 
-    let control = tokio::spawn(control_loop(Arc::clone(&state), args.heartbeat));
+    let control = match spawn_control_thread(&args, &params, Arc::clone(&state)) {
+        Ok(handle) => handle,
+        Err(e) => {
+            tracing::error!(error = %e, "cannot start the control loop");
+            return ExitCode::FAILURE;
+        }
+    };
 
     let serving = serve(Arc::clone(&state), args.socket.clone());
+    let mut code = ExitCode::SUCCESS;
     tokio::select! {
         result = serving => {
             if let Err(e) = result {
                 tracing::error!(error = %e, "IPC server stopped");
-                return ExitCode::FAILURE;
+                code = ExitCode::FAILURE;
             }
         }
         _ = shutdown() => tracing::info!("shutting down"),
     }
 
-    control.abort();
+    // Ask the loop to stop and let it finish the tick it is in, rather than aborting
+    // mid-transaction and leaving a half-written packet on the bus.
+    state.shutdown.store(true, Ordering::Relaxed);
+    let _ = control.join();
     let _ = std::fs::remove_file(&args.socket);
+    code
+}
+
+/// Enable torque and ramp to the home pose.
+#[cfg(target_os = "linux")]
+fn run_init(params: &Params, duration: Duration) -> ExitCode {
+    let mut io = match duck_control::bus::DynamixelIo::open(&params.bus.port) {
+        Ok(io) => io,
+        Err(e) => {
+            tracing::error!(error = %e, port = %params.bus.port, "cannot open the bus");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(e) = io.check_registers() {
+        tracing::error!(error = %e, "motor register check failed");
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = io.set_torque(true) {
+        tracing::error!(error = %e, "cannot enable torque");
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = io.interpolate_to(&DEFAULT_POSITION, duration, Duration::from_millis(20)) {
+        tracing::error!(error = %e, "interpolation to the home pose failed");
+        return ExitCode::FAILURE;
+    }
+    tracing::warn!(?duration, "at home pose, torque enabled");
     ExitCode::SUCCESS
 }
 
-/// Stands in for the control loop. M3 replaces the body, not the shape.
-/// How often the loop logs a summary at `info`.
-///
-/// The per-tick line is at `debug`, because the shipped unit runs at `info` and a 1s
-/// heartbeat would be ~86k journal lines a day from an idle robot. That is not merely
-/// noise: under a journal size cap it is what *evicts* the logs support needs. One summary
-/// every five minutes is ~288 lines a day and says strictly more.
-const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
-
-/// How the control loop is actually keeping up, as a percentage of its target rate.
-///
-/// Separated out to be testable, and because it is the number M4 needs: on a non-RT kernel
-/// the interesting question is not "is the loop running" but "is it running *on time*".
-/// A loop at 60% of target is alive, passing its health check, and badly broken.
-fn achieved_percent(ticks: u64, elapsed: Duration, interval: Duration) -> Option<u32> {
-    let expected = elapsed.as_secs_f64() / interval.as_secs_f64();
-    if expected < 1.0 {
-        return None;
-    }
-    Some((ticks as f64 / expected * 100.0).round() as u32)
+#[cfg(not(target_os = "linux"))]
+fn run_init(_params: &Params, _duration: Duration) -> ExitCode {
+    tracing::error!("init needs a real bus; this build is not on the robot");
+    ExitCode::FAILURE
 }
 
-async fn control_loop(state: Arc<RobotState>, interval: Duration) {
-    let mut ticker = tokio::time::interval(interval);
-    // Skipped ticks must not be replayed in a burst: a loop that fell behind should
-    // continue at its target rate, not sprint to catch up.
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+/// Start the control loop on its own OS thread, with its own current-thread runtime.
+///
+/// Its own thread because the bus read is *blocking* serial I/O — on a shared runtime it
+/// would occupy a worker for the duration of every transaction. Its own runtime so IPC work
+/// can never be scheduled in front of a tick. This mirrors the prototype, where the loop
+/// likewise had a runtime to itself and everything else lived on threads.
+fn spawn_control_thread(
+    args: &Args,
+    params: &Params,
+    state: Arc<RobotState>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
+    let period = params.period();
+    let fake = args.fake;
+    let port = params.bus.port.clone();
 
-    let mut last_summary = tokio::time::Instant::now();
-    let mut ticks_at_last_summary = 0u64;
+    std::thread::Builder::new()
+        .name("control".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(e) => {
+                    tracing::error!(error = %e, "cannot build the control runtime");
+                    return;
+                }
+            };
 
-    loop {
-        ticker.tick().await;
-        let n = state.ticks.fetch_add(1, Ordering::Relaxed) + 1;
-        // Only after a cycle completes, so `health` cannot claim readiness before the
-        // loop has actually run once.
-        state.running.store(true, Ordering::Relaxed);
-        tracing::debug!(tick = n, "hello from robotd");
-        if n == 1 {
-            // One line at `info` the moment the loop is alive. Without it, a developer
-            // running robotd by hand at the default level sees nothing between "starting"
-            // and the first five-minute summary, which reads like a hang.
-            tracing::info!(interval = ?interval, "control loop running");
+            if fake {
+                tracing::warn!("--fake: no bus, no robot");
+                runtime.block_on(control_loop(FakeIo::at(DEFAULT_POSITION), state, period));
+                return;
+            }
+
+            if let Some(io) = open_bus(&port) {
+                runtime.block_on(control_loop(io, state, period));
+            }
+        })
+}
+
+/// Open and verify the bus, or explain why not.
+#[cfg(target_os = "linux")]
+fn open_bus(port: &str) -> Option<duck_control::bus::DynamixelIo> {
+    let mut io = match duck_control::bus::DynamixelIo::open(port) {
+        Ok(io) => io,
+        Err(e) => {
+            tracing::error!(error = %e, port, "cannot open the bus");
+            return None;
         }
-
-        let elapsed = last_summary.elapsed();
-        if elapsed >= LOOP_SUMMARY_INTERVAL {
-            let ticks = n - ticks_at_last_summary;
-            tracing::info!(
-                ticks,
-                total = n,
-                achieved_percent = achieved_percent(ticks, elapsed, interval),
-                "control loop"
-            );
-            last_summary = tokio::time::Instant::now();
-            ticks_at_last_summary = n;
+    };
+    match io.check_registers() {
+        Ok(0) => tracing::info!("motor registers already correct"),
+        Ok(n) => tracing::warn!(corrected = n, "motor registers corrected"),
+        Err(e) => {
+            tracing::error!(error = %e, "motor register check failed");
+            return None;
         }
     }
+    Some(io)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_bus(_port: &str) -> Option<FakeIo> {
+    tracing::error!("no bus on this platform; use --fake");
+    None
+}
+
+/// The tick.
+///
+/// Slice 1 reads, publishes, and writes back the pose adopted at startup. The sensor sample
+/// is read every tick even though nothing consumes it yet — it is what makes the bus load,
+/// and therefore the timing, representative of what slice 2 will do.
+async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Duration) {
+    // Adopt the pose the robot is already in. Never move on start: the servos hold their
+    // last commanded goal while this process is dead, so a restart mid-update leaves a
+    // standing robot standing, with no gap.
+    let targets = match io.read() {
+        Ok(sensors) => JointTargets::new(sensors.positions),
+        Err(e) => {
+            tracing::error!(error = %e, "first bus read failed; not commanding anything");
+            return;
+        }
+    };
+    tracing::warn!(
+        joints = NUM_JOINTS,
+        hz = 1.0 / period.as_secs_f64(),
+        "holding the pose found at startup"
+    );
+
+    let mut ticker = tokio::time::interval(period);
+    // Skipped ticks must not be replayed in a burst: a loop that fell behind should continue
+    // at its target rate, not fire the backlog back to back and stack motor commands.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut window_start = Instant::now();
+    let mut window_ticks = 0u64;
+    let mut last_summary = Instant::now();
+
+    while !state.shutdown.load(Ordering::Relaxed) {
+        ticker.tick().await;
+        let tick_start = Instant::now();
+
+        match io.read() {
+            Ok(_sensors) => state.consecutive_errors.store(0, Ordering::Relaxed),
+            Err(e) => {
+                let n = state.consecutive_errors.fetch_add(1, Ordering::Relaxed) + 1;
+                // One dropped transaction is ordinary on a serial bus; a run of them is not.
+                // Log the first and then every tenth, so a persistent fault is visible
+                // without a wall of identical lines.
+                if n == 1 || n.is_multiple_of(10) {
+                    tracing::warn!(error = %e, consecutive = n, "bus read failed");
+                }
+            }
+        }
+
+        if let Err(e) = io.write(&targets) {
+            tracing::warn!(error = %e, "bus write failed");
+        }
+
+        let ticks = state.ticks.fetch_add(1, Ordering::Relaxed) + 1;
+        state.last_tick_us.store(
+            state.started.elapsed().as_micros() as u64,
+            Ordering::Relaxed,
+        );
+        if tick_start.elapsed() > period {
+            state.missed.fetch_add(1, Ordering::Relaxed);
+        }
+
+        window_ticks += 1;
+        let window = window_start.elapsed();
+        if window >= RATE_WINDOW {
+            let hz = window_ticks as f64 / window.as_secs_f64();
+            state.achieved_hz.store(hz.to_bits(), Ordering::Relaxed);
+            window_start = Instant::now();
+            window_ticks = 0;
+
+            if last_summary.elapsed() >= LOOP_SUMMARY_INTERVAL {
+                tracing::info!(
+                    total = ticks,
+                    hz = format!("{hz:.1}"),
+                    missed = state.missed.load(Ordering::Relaxed),
+                    "control loop"
+                );
+                last_summary = Instant::now();
+            }
+        }
+    }
+    tracing::info!("control loop stopped");
 }
 
 async fn serve(state: Arc<RobotState>, socket_path: PathBuf) -> std::io::Result<()> {
@@ -346,8 +585,8 @@ async fn handle(state: Arc<RobotState>, stream: UnixStream) -> std::io::Result<(
 
 /// Answer one request.
 ///
-/// Synchronous and allocation-light on purpose: these answers must be available even
-/// when everything else is broken.
+/// Synchronous and allocation-light on purpose: these answers must be available even when
+/// everything else is broken.
 fn dispatch(state: &RobotState, id: proto::Id, call: &proto::Call) -> proto::Response {
     match call {
         proto::Call::RobotHealth => proto::Response::ok(Some(id), &state.health()),
@@ -358,9 +597,9 @@ fn dispatch(state: &RobotState, id: proto::Id, call: &proto::Call) -> proto::Res
                 model_api: MODEL_API,
             },
         ),
-        // The skeleton has no media stack, so no session can be live. `mediad` owns the
-        // real answer (architecture.md §5.2); reporting `false` here is honest for now,
-        // and the updater treats unknown as false anyway.
+        // No media stack, so no session can be live. `mediad` owns the real answer
+        // (architecture.md §5.2); reporting `false` here is honest for now, and the updater
+        // treats unknown as false anyway.
         proto::Call::RobotRemoteSessionActive => {
             proto::Response::ok(Some(id), &proto::SessionActiveResult { active: false })
         }
@@ -419,39 +658,121 @@ async fn shutdown() {
 mod tests {
     use super::*;
 
-    fn state(unhealthy: bool, busy: bool) -> RobotState {
-        RobotState {
-            running: AtomicBool::new(false),
-            ticks: AtomicU64::new(0),
-            force_unhealthy: unhealthy,
-            force_busy: busy,
-        }
+    fn state() -> RobotState {
+        RobotState::new(&Params::default(), false, false)
     }
 
-    /// Before the loop has run, health must be false. Claiming readiness early would let
-    /// an update commit against a robot that never actually started.
+    /// Mark the loop as having just ticked, `ticks` times.
+    fn ticked(s: &RobotState, ticks: u64) {
+        s.ticks.store(ticks, Ordering::Relaxed);
+        s.last_tick_us
+            .store(s.started.elapsed().as_micros() as u64, Ordering::Relaxed);
+    }
+
+    /// Before the loop has run, health must be false. Claiming readiness early would let an
+    /// update commit against a robot that never actually started.
     #[test]
     fn not_healthy_until_the_loop_has_ticked() {
-        let s = state(false, false);
+        let s = state();
         assert!(!s.health().healthy);
         assert!(s.health().reason.unwrap().contains("not completed a cycle"));
 
-        s.running.store(true, Ordering::Relaxed);
+        ticked(&s, 1);
         assert!(s.health().healthy);
-        assert!(s.health().reason.is_none());
+    }
+
+    /// **The point of slice 1.** A loop that ticked once and then wedged must report
+    /// unhealthy, not stay healthy forever on the strength of that one tick. This is what
+    /// the updater's auto-rollback actually gates on.
+    #[test]
+    fn a_stalled_loop_reports_unhealthy() {
+        let s = state();
+        s.ticks.store(1, Ordering::Relaxed);
+        // Last tick stamped at time zero while `started` keeps advancing — the shape of a
+        // loop that stopped. Three periods at 50 Hz is 60 ms.
+        s.last_tick_us.store(0, Ordering::Relaxed);
+        std::thread::sleep(Duration::from_millis(70));
+
+        let health = s.health();
+        assert!(!health.healthy);
+        assert!(
+            health.reason.as_deref().unwrap().contains("stalled"),
+            "{:?}",
+            health.reason
+        );
+    }
+
+    /// A loop running at 60% of target is alive and answers every request. Rate is the only
+    /// thing that distinguishes it from a healthy one.
+    #[test]
+    fn a_slow_loop_reports_unhealthy() {
+        let s = state();
+        ticked(&s, 100);
+        s.achieved_hz.store(30.0f64.to_bits(), Ordering::Relaxed);
+
+        let health = s.health();
+        assert!(!health.healthy);
+        let reason = health.reason.unwrap();
+        assert!(reason.contains("30.0"), "{reason}");
+        assert!(reason.contains("45.0"), "{reason}");
+    }
+
+    /// The rate is unknown until the first window closes, and unknown must not read as
+    /// failing — otherwise every startup would report unhealthy for its first second and the
+    /// update gate would roll back a perfectly good release.
+    #[test]
+    fn an_unmeasured_rate_is_not_treated_as_a_slow_one() {
+        let s = state();
+        ticked(&s, 5);
+        assert_eq!(s.achieved_hz.load(Ordering::Relaxed), 0);
+        assert!(s.health().healthy);
+    }
+
+    /// One dropped transaction is ordinary; a sustained run of them means the bus is gone,
+    /// and a robot that cannot read its own joints is not healthy whatever the loop rate.
+    #[test]
+    fn sustained_bus_failures_report_unhealthy() {
+        let s = state();
+        ticked(&s, 100);
+        s.consecutive_errors.store(9, Ordering::Relaxed);
+        assert!(
+            s.health().healthy,
+            "9 errors is under the default floor of 10"
+        );
+
+        s.consecutive_errors.store(10, Ordering::Relaxed);
+        let health = s.health();
+        assert!(!health.healthy);
+        assert!(health.reason.unwrap().contains("consecutive"));
+    }
+
+    /// `--unhealthy` must win over a healthy loop: it exists to exercise rollback.
+    #[test]
+    fn forced_unhealthy_overrides_a_running_loop() {
+        let s = RobotState::new(&Params::default(), true, false);
+        ticked(&s, 100);
+        assert!(!s.health().healthy);
+        assert!(s.health().reason.unwrap().contains("--unhealthy"));
+    }
+
+    #[test]
+    fn safe_to_restart_unless_forced_busy() {
+        assert!(state().safe_to_restart().safe);
+        let busy = RobotState::new(&Params::default(), false, true).safe_to_restart();
+        assert!(!busy.safe);
+        assert!(busy.reason.unwrap().contains("--busy"));
     }
 
     /// Every method must come back off `dispatch` in the shape the updater parses.
     ///
-    /// The other health tests call `state.health()` directly, which type-checks but says
-    /// nothing about what goes over the socket — `dispatch` could answer with a completely
-    /// different JSON shape and they would all still pass. `tests/updater_gate.rs` catches
-    /// that against a live process; this runs in microseconds and fails on the exact
-    /// method, so it is the first line of defence.
+    /// The health tests call `state.health()` directly, which type-checks but says nothing
+    /// about what goes over the socket — `dispatch` could answer with a completely different
+    /// JSON shape and they would all still pass. `tests/updater_gate.rs` catches that
+    /// against a live process; this runs in microseconds and fails on the exact method.
     #[test]
     fn dispatch_answers_every_method_in_the_typed_shape() {
-        let s = state(false, false);
-        s.running.store(true, Ordering::Relaxed);
+        let s = state();
+        ticked(&s, 1);
         let id = || proto::Id::Number(1);
 
         let health: proto::HealthResult = dispatch(&s, id(), &proto::Call::RobotHealth)
@@ -471,28 +792,11 @@ mod tests {
         assert!(!session.active);
     }
 
-    /// `--unhealthy` must win over a running loop: it exists to exercise rollback.
-    #[test]
-    fn forced_unhealthy_overrides_a_running_loop() {
-        let s = state(true, false);
-        s.running.store(true, Ordering::Relaxed);
-        assert!(!s.health().healthy);
-        assert!(s.health().reason.unwrap().contains("--unhealthy"));
-    }
-
-    #[test]
-    fn safe_to_restart_unless_forced_busy() {
-        assert!(state(false, false).safe_to_restart().safe);
-        let busy = state(false, true).safe_to_restart();
-        assert!(!busy.safe);
-        assert!(busy.reason.unwrap().contains("--busy"));
-    }
-
-    /// `update.*` is a valid call that this daemon does not serve. It must be refused with
-    /// a message naming the right daemon, not answered with something invented.
+    /// `update.*` is a valid call that this daemon does not serve. It must be refused with a
+    /// message naming the right daemon, not answered with something invented.
     #[test]
     fn calls_belonging_to_updaterd_are_refused() {
-        let s = state(false, false);
+        let s = state();
         let response = dispatch(&s, proto::Id::Number(1), &proto::Call::Status);
         let error = response.error.expect("update.status must be refused");
         assert_eq!(error.code, proto::code::METHOD_NOT_FOUND);
@@ -501,34 +805,10 @@ mod tests {
 
     #[test]
     fn model_api_is_reported() {
-        let s = state(false, false);
+        let s = state();
         let response = dispatch(&s, proto::Id::Number(1), &proto::Call::RobotModelApi);
         let result: proto::ModelApiResult = response.result_as().unwrap();
         assert_eq!(result.model_api, MODEL_API);
-    }
-
-    /// The summary must report a *late* loop as late. A loop that runs at 60% of its
-    /// target rate is alive and passes its health check, so this number is the only thing
-    /// that would show it.
-    #[test]
-    fn achieved_percent_reports_a_slow_loop() {
-        let interval = Duration::from_millis(100);
-
-        // 300 ticks in 30s at 100ms = exactly on time.
-        assert_eq!(
-            achieved_percent(300, Duration::from_secs(30), interval),
-            Some(100)
-        );
-        // Half the ticks it should have managed.
-        assert_eq!(
-            achieved_percent(150, Duration::from_secs(30), interval),
-            Some(50)
-        );
-        // Too early to say anything: less than one interval has passed.
-        assert_eq!(
-            achieved_percent(0, Duration::from_millis(50), interval),
-            None
-        );
     }
 
     #[test]
@@ -537,5 +817,54 @@ mod tests {
         assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
         assert_eq!(parse_duration("3").unwrap(), Duration::from_secs(3));
         assert!(parse_duration("soon").is_err());
+    }
+
+    /// **The startup invariant.** The loop must command the pose it *found*, not the home
+    /// pose and nothing interpolated — an update restarting `robotd` while the robot stands
+    /// must not move it.
+    ///
+    /// `frozen()` so the fake robot does not follow commands: if the loop were re-reading
+    /// and re-adopting each tick, a tracking fake would hide the bug.
+    #[tokio::test]
+    async fn the_loop_holds_the_pose_it_started_in() {
+        let mut resting = DEFAULT_POSITION;
+        resting[0] = 0.42; // deliberately not the home pose
+        let io = FakeIo::at(resting).frozen();
+
+        let s = Arc::new(RobotState::new(&Params::default(), false, false));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let loop_state = Arc::clone(&s);
+        let handle = tokio::spawn(async move {
+            let mut io = io;
+            control_loop_probe(&mut io, loop_state, Duration::from_millis(2)).await;
+            tx.send(io.last_written).unwrap();
+        });
+
+        while s.ticks.load(Ordering::Relaxed) < 5 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle.await.unwrap();
+
+        let written = rx.recv().unwrap().expect("the loop must command something");
+        assert_eq!(
+            written.positions, resting,
+            "the loop moved the robot instead of holding where it found it"
+        );
+    }
+
+    /// `control_loop` takes its IO by value, which makes the fake unreachable afterwards.
+    /// This borrows instead so a test can inspect what was written.
+    async fn control_loop_probe<T: RobotIo>(io: &mut T, state: Arc<RobotState>, period: Duration) {
+        struct Borrowed<'a, T>(&'a mut T);
+        impl<T: RobotIo> RobotIo for Borrowed<'_, T> {
+            fn read(&mut self) -> duck_control::io::Result<duck_control::Sensors> {
+                self.0.read()
+            }
+            fn write(&mut self, t: &JointTargets) -> duck_control::io::Result<()> {
+                self.0.write(t)
+            }
+        }
+        control_loop(Borrowed(io), state, period).await
     }
 }

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -1,0 +1,201 @@
+//! Startup parameters.
+//!
+//! A file rather than a wall of CLI flags — the prototype grew 142 of them and most were
+//! variants, dead skills and dead sensors, all of which are gone. **Read once at startup,
+//! not watched**; live reload is deferred (`docs/robotd-design.md` §7.2).
+//!
+//! It lives outside `releases/<ver>/` so it survives an update *and* a rollback: this is
+//! per-robot configuration, not shipped defaults (`architecture.md` §3).
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Where a provisioned robot keeps it, alongside the updater's own config.
+pub const DEFAULT_PATH: &str = "/etc/robot/robotd.toml";
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Params {
+    pub bus: Bus,
+    pub control: Control,
+    pub health: Health,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Bus {
+    /// Serial port the servos and the IMU board share. The Radxa Zero 3W wires them to
+    /// `/dev/ttyS2`.
+    pub port: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Control {
+    /// Control loop rate. 50 Hz is inherited from the prototype, where it was chosen on a
+    /// Pi Zero 2W — re-derive it on the Radxa rather than trusting it.
+    pub hz: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Health {
+    /// Below this achieved rate the robot reports unhealthy, which is what makes the
+    /// updater's auto-rollback mean something. A loop running at 60% of target is alive,
+    /// answers every request, and is badly broken.
+    pub min_achieved_hz: f64,
+    /// How many periods may pass with no tick before the loop counts as stalled.
+    pub stall_periods: u32,
+    /// Consecutive bus read failures tolerated before reporting unhealthy. One dropped
+    /// transaction is ordinary; a run of them means the bus is gone.
+    pub max_consecutive_errors: u32,
+}
+
+impl Default for Bus {
+    fn default() -> Self {
+        Self {
+            port: "/dev/ttyS2".into(),
+        }
+    }
+}
+
+impl Default for Control {
+    fn default() -> Self {
+        Self { hz: 50 }
+    }
+}
+
+impl Default for Health {
+    fn default() -> Self {
+        Self {
+            // 90% of the default rate. Generous enough not to trip on a slow tick, tight
+            // enough that a loop losing every tenth cycle is not called healthy.
+            min_achieved_hz: 45.0,
+            stall_periods: 3,
+            max_consecutive_errors: 10,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParamsError {
+    #[error("reading {path}: {source}")]
+    Read {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("parsing {path}: {source}")]
+    Parse {
+        path: String,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("{path}: control.hz must be between 1 and 1000, got {got}")]
+    Rate { path: String, got: u32 },
+}
+
+impl Params {
+    /// Load from `path`. A missing file at the *default* location is not an error — an
+    /// unprovisioned board should still come up on defaults rather than refuse to start,
+    /// and a daemon that will not start is much harder to diagnose remotely than one
+    /// running on known defaults. A file explicitly named on the command line must exist.
+    pub fn load(path: &Path, explicit: bool) -> Result<Self, ParamsError> {
+        let text = match std::fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !explicit => {
+                tracing::warn!(path = %path.display(), "no params file; using defaults");
+                return Ok(Self::default());
+            }
+            Err(source) => {
+                return Err(ParamsError::Read {
+                    path: path.display().to_string(),
+                    source,
+                });
+            }
+        };
+
+        let params: Params = toml::from_str(&text).map_err(|source| ParamsError::Parse {
+            path: path.display().to_string(),
+            source,
+        })?;
+        params.validate(path)?;
+        Ok(params)
+    }
+
+    /// Reject values that would produce a loop that cannot work, at startup rather than as
+    /// a division by zero three seconds later.
+    fn validate(&self, path: &Path) -> Result<(), ParamsError> {
+        if self.control.hz == 0 || self.control.hz > 1000 {
+            return Err(ParamsError::Rate {
+                path: path.display().to_string(),
+                got: self.control.hz,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn period(&self) -> std::time::Duration {
+        std::time::Duration::from_secs_f64(1.0 / self.control.hz as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+        let path = dir.join("robotd.toml");
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// An unprovisioned board must still come up. A daemon that refuses to start because a
+    /// config file is absent is far harder to diagnose on a robot than one running on
+    /// documented defaults.
+    #[test]
+    fn a_missing_default_file_falls_back_to_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = Params::load(&dir.path().join("absent.toml"), false).unwrap();
+        assert_eq!(p.control.hz, 50);
+    }
+
+    /// But a file named explicitly on the command line must exist — silently ignoring
+    /// `--params /path/typo.toml` would run the robot on settings nobody chose.
+    #[test]
+    fn an_explicitly_named_missing_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(Params::load(&dir.path().join("absent.toml"), true).is_err());
+    }
+
+    /// Partial files are the normal case — a board overrides the port and nothing else.
+    #[test]
+    fn absent_sections_take_their_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "[bus]\nport = \"/dev/ttyUSB0\"\n");
+        let p = Params::load(&path, true).unwrap();
+        assert_eq!(p.bus.port, "/dev/ttyUSB0");
+        assert_eq!(p.control.hz, 50);
+        assert_eq!(p.health.stall_periods, 3);
+    }
+
+    /// A typo in a key must fail loudly. Silently ignoring `min_acheived_hz` would leave
+    /// the health gate at a threshold the operator believes they changed.
+    #[test]
+    fn an_unknown_key_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "[health]\nmin_acheived_hz = 10.0\n");
+        assert!(Params::load(&path, true).is_err());
+    }
+
+    /// Zero would divide by zero when computing the period; absurdly high would spin.
+    #[test]
+    fn an_impossible_rate_is_rejected_at_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        for hz in ["0", "5000"] {
+            let path = write(dir.path(), &format!("[control]\nhz = {hz}\n"));
+            assert!(Params::load(&path, true).is_err(), "hz = {hz} was accepted");
+        }
+    }
+}

--- a/robotd/systemd/robotd.service
+++ b/robotd/systemd/robotd.service
@@ -25,6 +25,11 @@ After=local-fs.target
 Type=exec
 ExecStart=/opt/robot/daemon/current/bin/robotd --socket /run/robotd.sock
 
+# Parameters come from /etc/robot/robotd.toml, which is robotd's default path and is not
+# named here on purpose: the file is optional, and a missing one means built-in defaults
+# rather than a daemon that refuses to start. Naming it with --params would make it
+# mandatory. See deploy/robotd.toml.
+
 # --unhealthy and --busy are deliberately absent. They exist to exercise the updater's
 # rollback path on a bench robot and are added by hand for that, never shipped: a robot
 # started with --unhealthy reverts every update it is offered.
@@ -63,10 +68,9 @@ RestrictSUIDSGID=yes
 
 # stderr → journal; level via RUST_LOG.
 #
-# `info` is safe to ship: the per-tick heartbeat is at `debug`, and the loop logs one
-# summary line every five minutes. `debug` on a long-running board would write a line per
-# control cycle and evict older logs under journald's size cap — use it while debugging,
-# not as a standing setting.
+# `info` is safe to ship: the control loop logs one summary line every five minutes and
+# nothing per tick. At 50 Hz a per-tick line would be ~4.3M entries a day, which under
+# journald's size cap is what *evicts* the logs support actually needs.
 #
 # The startup identity line (version, revision, exe path) is at `warn`, so it survives even
 # RUST_LOG=warn. See deploy/README.md for log retention.

--- a/robotd/tests/updater_gate.rs
+++ b/robotd/tests/updater_gate.rs
@@ -48,11 +48,11 @@ impl Robotd {
     async fn spawn(socket: PathBuf, extra_args: &[&str]) -> Self {
         let mut command = Command::new(robotd_bin());
         command.arg("--socket").arg(&socket);
-        // Fast heartbeat: `robot.health` reports unhealthy until the control loop has
-        // ticked at least once, so a 1s default would add a second to every test.
-        command.arg("--heartbeat").arg("50ms");
+        // No Dynamixel bus here, and there must never need to be: this test runs in CI and
+        // on a laptop. `--fake` is the whole reason `RobotIo` is a trait.
+        command.arg("--fake");
         command.args(extra_args);
-        // Quiet the heartbeat, which would otherwise bury the test output. `error` rather
+        // Quiet the loop summary, which would otherwise bury the test output. `error` rather
         // than `off` so a real startup failure still shows up.
         command.env("RUST_LOG", "error");
         let child = command.spawn().expect("spawn robotd");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -177,6 +177,16 @@ install_config() {
     if grep -q '"ORG/' "${CONFIG_DIR}/updater.toml"; then
         die "${CONFIG_DIR}/updater.toml still names a placeholder repository"
     fi
+
+    # Same rule: never overwritten, because it is where a bench robot's loop rate and
+    # health thresholds get tuned. robotd runs on built-in defaults if it is missing, so
+    # this is documentation as much as configuration.
+    if [ -f "${CONFIG_DIR}/robotd.toml" ]; then
+        warn "keeping the existing ${CONFIG_DIR}/robotd.toml"
+    else
+        fetch "${RAW}/deploy/robotd.toml" "${CONFIG_DIR}/robotd.toml"
+        chmod 644 "${CONFIG_DIR}/robotd.toml"
+    fi
 }
 
 # Land the first release through the real engine. `--config` is the config installed


### PR DESCRIPTION
First of two slices toward M3. Design lives in `docs/robotd-design.md`, added here.

## Why this and not walking

The update engine is finished and has never run on hardware. Its auto-rollback is only meaningful if `robot.health` is a real measurement — and until now it meant *"the control loop ticked once"*. Every rollback tested so far was tested against a placeholder.

So slice 1 makes health honest rather than making the robot walk. `robotd` holds the pose it starts in, which puts the real load on the bus at the real rate — so timing and health are representative — while nothing falls over when a deliberately broken release lands. Install / rollback / power-cut cycles can be hammered at a bench all day. Walking is slice 2.

## What health means now

Three thresholds, all in `/etc/robot/robotd.toml`:

| check | catches |
|---|---|
| achieved rate below a floor | a loop at 60% of target — alive, answering, badly broken |
| no tick for N periods | a wedged control thread |
| consecutive bus read failures | a bus that has gone away |

Computed by the IPC side from atomics the loop publishes, never by calling into the loop — so a wedged loop reports itself unhealthy instead of hanging the caller.

## New crate: `duck-control`

Everything between reading the bus and writing it — robot model, Dynamixel bus, IMU, the `RobotIo` seam. No tokio, no sockets, no systemd, so the boundary against daemon concerns is enforced by the compiler rather than by discipline.

## Decisions worth reviewing

- **`robotd` never moves the robot on its own.** It adopts the pose it finds and does not touch torque, so an update restart leaves a standing robot standing — the servos hold their goal while the process is dead, so there is no gap. Going to the home pose is an explicit `robotd init`. This is the decision that makes update testing safe on a robot that is standing up.
- **New bus code, borrowed numbers.** Conversion factors and the EEPROM registers asserted at startup come from `microduck_runtime`, where they were arrived at against hardware — each with a comment saying so. `return_delay_time = 0` is load-bearing: the XL330 ships at 250, which is ~8 ms of pure turnaround per tick across 16 devices, 40% of the budget.
- **The loop gets its own thread and its own current-thread runtime.** The bus read is blocking serial I/O; on a shared runtime it would occupy a worker for every transaction. Not an RT project — no `SCHED_FIFO`, no pinning. The acceptance criterion is *do not regress* against today's `bench_dynamixel_bus` numbers.
- **`DynamixelIo` is not `cfg`-gated off macOS.** The design originally said gate it; `rustypot` and `serialport` both build there, so the gate bought nothing and cost type-checking the bus layer on a laptop. Only the entry points that open a real port are gated — `--fake` must be asked for, never fallen back to.
- **Params are a file, not more flags.** Read once at startup, not watched. Outside the release dir so it survives update *and* rollback.

## Two things flagged rather than fixed

- Component-wise median over three unit gravity vectors is not itself unit-norm during a transient. Kept parity with the runtime (normalise, then median) rather than silently changing a path that currently walks. Commented, pinned by two tests, and flagged for slice 2 — if training expects strict unit norm, normalising *after* the median is the fix.
- The XL330 has a `bus_watchdog` register (addr 98). I had earlier claimed there was no bus-timeout failsafe; that was wrong. Whether it helps is still open — on X-series it zeroes goal velocity rather than cutting torque, so a position-held biped may just freeze.

## Testing

**272 passing** (up from 246), no hardware, no network, no Docker. `cargo fmt --check` and `cargo clippy --all-targets` both clean.

The existing gate test now drives a real control loop via `FakeIo` instead of a heartbeat — same assertions, real loop underneath. Smoke-tested the binary over its socket: `{"healthy":true}`, `{"safe":true}`.

Untouched deliberately: the two unresolved 61D command-encoding questions in `docs/robotd-design.md` §11.2 — slice 1 has no observations, so they do not bite yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)