### PR TITLE
Fix two health-check defects slice 1 shipped

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -40,10 +40,15 @@ hz = 50
 # called healthy. Raise it in step with `control.hz`.
 min_achieved_hz = 45.0
 
-# How many periods may pass with no tick at all before the loop counts as stalled. This is
-# what turns a wedged control thread into an honest "unhealthy" instead of a socket that
+# How many periods may pass with no tick at all before the loop counts as WEDGED. This is
+# what turns a hung control thread into an honest "unhealthy" instead of a socket that
 # keeps answering "healthy" on the strength of one tick it managed an hour ago.
-stall_periods = 3
+#
+# It detects a dead loop, not a slow one — min_achieved_hz above owns degradation. Keep the
+# two apart. This was originally 3 (60 ms at 50 Hz), which ordinary scheduler jitter on a
+# busy board exceeds routinely; a health check that trips on jitter rolls back good
+# releases. 25 periods is 500 ms: a loop silent that long is genuinely gone.
+stall_periods = 25
 
 # Consecutive failed bus reads tolerated. One dropped transaction is ordinary on a serial
 # bus; a run of them means the bus is gone, and a robot that cannot read its own joints is

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -686,18 +686,57 @@ mod tests {
     /// the updater's auto-rollback actually gates on.
     #[test]
     fn a_stalled_loop_reports_unhealthy() {
-        let s = state();
+        // A short window so the test does not sleep for the real 500 ms default. Two
+        // periods at 50 Hz is 40 ms.
+        let mut params = Params::default();
+        params.health.stall_periods = 2;
+        let s = RobotState::new(&params, false, false);
+
         s.ticks.store(1, Ordering::Relaxed);
         // Last tick stamped at time zero while `started` keeps advancing — the shape of a
-        // loop that stopped. Three periods at 50 Hz is 60 ms.
+        // loop that stopped.
         s.last_tick_us.store(0, Ordering::Relaxed);
-        std::thread::sleep(Duration::from_millis(70));
+        std::thread::sleep(Duration::from_millis(60));
 
         let health = s.health();
         assert!(!health.healthy);
         assert!(
             health.reason.as_deref().unwrap().contains("stalled"),
             "{:?}",
+            health.reason
+        );
+    }
+
+    /// **Regression.** The stall check must not fire on ordinary scheduler jitter.
+    ///
+    /// It was originally three periods — 60 ms at 50 Hz — which a loaded machine exceeds
+    /// routinely. That failed the gate test outright, and on a board it would report a
+    /// perfectly good release unhealthy and roll it back: exactly the false positive the
+    /// health gate exists not to produce. Stall detects a *wedged* loop; `min_achieved_hz`
+    /// owns degradation, and conflating them makes both worse.
+    #[test]
+    fn a_late_tick_is_not_a_stalled_loop() {
+        let s = state();
+        let params = Params::default();
+        s.ticks.store(100, Ordering::Relaxed);
+
+        // 100 ms late: five whole periods, far past anything the old threshold tolerated,
+        // and still nowhere near a loop that has died.
+        let late_by = Duration::from_millis(100);
+        assert!(
+            late_by.as_micros() as u64 > params.period().as_micros() as u64 * 3,
+            "the jitter under test must exceed the old three-period threshold"
+        );
+        let now_us = s.started.elapsed().as_micros() as u64;
+        s.last_tick_us.store(
+            now_us.saturating_sub(late_by.as_micros() as u64),
+            Ordering::Relaxed,
+        );
+
+        let health = s.health();
+        assert!(
+            health.healthy,
+            "a merely late loop must stay healthy, got {:?}",
             health.reason
         );
     }

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -45,7 +45,13 @@ pub struct Health {
     /// updater's auto-rollback mean something. A loop running at 60% of target is alive,
     /// answers every request, and is badly broken.
     pub min_achieved_hz: f64,
-    /// How many periods may pass with no tick before the loop counts as stalled.
+    /// How many periods may pass with no tick before the loop counts as **wedged**.
+    ///
+    /// This detects a dead loop, not a slow one — `min_achieved_hz` owns degradation. Keep
+    /// the two apart: set this near the period and it fires on ordinary scheduler jitter,
+    /// which on a loaded board would report a perfectly good release unhealthy and roll it
+    /// back. A loop that has not ticked in half a second is genuinely gone; one that
+    /// ticked 80 ms late is just late.
     pub stall_periods: u32,
     /// Consecutive bus read failures tolerated before reporting unhealthy. One dropped
     /// transaction is ordinary; a run of them means the bus is gone.
@@ -72,7 +78,10 @@ impl Default for Health {
             // 90% of the default rate. Generous enough not to trip on a slow tick, tight
             // enough that a loop losing every tenth cycle is not called healthy.
             min_achieved_hz: 45.0,
-            stall_periods: 3,
+            // 500 ms at the default rate. Deliberately far from the period: three periods
+            // is 60 ms, which ordinary scheduler jitter exceeds on a busy machine, and a
+            // health check that trips on jitter rolls back good releases.
+            stall_periods: 25,
             max_consecutive_errors: 10,
         }
     }
@@ -177,7 +186,32 @@ mod tests {
         let p = Params::load(&path, true).unwrap();
         assert_eq!(p.bus.port, "/dev/ttyUSB0");
         assert_eq!(p.control.hz, 50);
-        assert_eq!(p.health.stall_periods, 3);
+        assert_eq!(p.health.stall_periods, 25);
+    }
+
+    /// The shipped example must agree with the built-in defaults, or the file documents a
+    /// robot that does not exist — and an operator reading it would draw wrong conclusions
+    /// about what their board is actually doing.
+    #[test]
+    fn the_shipped_example_matches_the_defaults() {
+        let shipped = include_str!("../../deploy/robotd.toml");
+        let from_file: Params = toml::from_str(shipped).expect("deploy/robotd.toml must parse");
+        let built_in = Params::default();
+
+        assert_eq!(from_file.bus.port, built_in.bus.port);
+        assert_eq!(from_file.control.hz, built_in.control.hz);
+        assert_eq!(
+            from_file.health.min_achieved_hz,
+            built_in.health.min_achieved_hz
+        );
+        assert_eq!(
+            from_file.health.stall_periods,
+            built_in.health.stall_periods
+        );
+        assert_eq!(
+            from_file.health.max_consecutive_errors,
+            built_in.health.max_consecutive_errors
+        );
     }
 
     /// A typo in a key must fail loudly. Silently ignoring `min_acheived_hz` would leave

--- a/robotd/tests/updater_gate.rs
+++ b/robotd/tests/updater_gate.rs
@@ -78,6 +78,31 @@ impl Robotd {
         }
         panic!("robotd never answered on {}", self.socket.display());
     }
+
+    /// Wait until the control loop has actually started.
+    ///
+    /// Separate from [`Self::wait_until_answering`] because the socket comes up *before*
+    /// the first tick, and deliberately so: IPC has to answer even when the loop is broken,
+    /// which is the entire reason health is computed from published atomics rather than by
+    /// asking the loop. So there is a real window where a running `robotd` correctly
+    /// reports `control loop has not completed a cycle yet`.
+    ///
+    /// The updater handles that window by polling within its health-gate budget. A test
+    /// that asserts on the first answer instead races the thread scheduler — it passes on
+    /// an idle laptop and fails under a parallel `cargo test` on a loaded machine.
+    async fn wait_until_healthy(&self) {
+        let client = SocketRobotClient::new(self.socket.clone());
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut last = Health::Unreachable;
+        while Instant::now() < deadline {
+            last = client.health(Duration::from_millis(500)).await;
+            if matches!(last, Health::Healthy) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("robotd never became healthy; last answer was {last:?}");
+    }
 }
 
 impl Drop for Robotd {
@@ -193,13 +218,18 @@ async fn apply_latest(engine: &mut Engine) -> Result<ApplyResult, updater::Error
 #[tokio::test]
 async fn real_robotd_answers_every_method_the_engine_calls() {
     let fx = Fixture::new();
-    let _robotd = Robotd::spawn(fx.socket(), &[]).await;
+    let robotd = Robotd::spawn(fx.socket(), &[]).await;
+    robotd.wait_until_healthy().await;
     let client = SocketRobotClient::new(fx.socket());
     let t = Duration::from_secs(2);
 
+    // Report the verdict, not just that it was wrong: `robot.health` carries a reason
+    // precisely so a failure names its cause, and swallowing it here means every future
+    // regression in this test starts with a debugging session.
+    let health = client.health(t).await;
     assert!(
-        matches!(client.health(t).await, Health::Healthy),
-        "a running robotd must report healthy"
+        matches!(health, Health::Healthy),
+        "a running robotd must report healthy, got {health:?}"
     );
     // `Yes` specifically, not `permits_restart()`: that also returns true for
     // `Unreachable`, so it would pass even if the wire were completely broken.


### PR DESCRIPTION
Both found running the merged `main` under load, and both would bite on a real board rather than only in CI. Independent of slice 2; splitting them out so they can land on `main` on their own.

## 1. The stall threshold conflated "wedged" with "slow"

Slice 1 has two health checks with deliberately distinct jobs — `min_achieved_hz` catches a *degraded* loop, the stall check catches a *dead* one. But stall was set to 3 periods, which at 50 Hz is **60 ms**, and ordinary scheduler jitter exceeds that on a busy machine.

That is the false positive the health gate must never produce: on a loaded board a single hiccup would report a perfectly good release unhealthy and roll it back.

Now 25 periods (500 ms), with the distinction written into both the type docs and `deploy/robotd.toml` so it does not get re-tightened by someone who reads the two checks as redundant.

## 2. The gate test raced the thread scheduler

`wait_until_answering` returns as soon as the socket replies — but the socket is served *before* the control loop's first tick, deliberately, because IPC must answer when the loop is broken. That is the entire reason health is computed from published atomics rather than by asking the loop.

So there is a genuine window in which a healthy `robotd` correctly reports `control loop has not completed a cycle yet`. The updater handles it by polling inside its health-gate budget. The test asserted on the first answer instead, so it passed on an idle laptop and failed under a parallel `cargo test`.

Added an explicit `wait_until_healthy`, used by the tests that need a started robot. The `--unhealthy` test deliberately does not use it.

## Two smaller things found on the way

- **The health assertion discarded the reason.** A failure said only *"a running robotd must report healthy"*. It now prints the verdict — which is how defect 2 was identified at all, rather than being written off as flake.
- **`deploy/robotd.toml` could drift from the built-in defaults silently**, leaving an operator reading a file that documents a robot that does not exist. A test now parses the shipped file and compares every field.

## Testing

274 passing (up from 272 — the two new tests are the jitter regression and the shipped-defaults check), `cargo fmt --check` and `cargo clippy --all-targets` clean.

The gate test previously failed roughly one run in two under load; it now passes 5 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)