### PR TITLE
ci: measure coverage, and put a floor under it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,32 @@ jobs:
           platforms: arm64
 
       - run: ./scripts/board-test.sh
+
+  coverage:
+    # Its own job rather than another step in `check`: coverage needs a full
+    # instrumented rebuild, which shares no artifacts with the ordinary one, so bolting it
+    # onto `check` would roughly double the time to the signal everyone actually waits for.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      # `xtask` is excluded because it is build tooling that never ships. It is exercised
+      # by CI actually packaging a release — the `check` job runs `xtask package` — not by
+      # unit tests, so counting it would only ever measure the wrong thing.
+      #
+      # Everything else stays in, including code that cannot be covered without hardware
+      # (`duck-control/src/bus.rs` is the Dynamixel driver, and `FakeIo` deliberately
+      # covers the trait rather than the driver). Those are honest zeroes and the floor
+      # below is set with them included, rather than hidden by widening the exclusion until
+      # the number looks good.
+      #
+      # The floor is a ratchet, not a target: raise it when the real number rises. It sits
+      # a few points under today's ~77% so ordinary work does not trip it, while a genuine
+      # collapse still fails. Lowering it should be a deliberate, explained commit.
+      - name: Coverage
+        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines 72

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,6 @@ jobs:
               echo "**${head_pct}% lines** on this branch. No base measurement to compare against."
             fi
             echo
-            echo "Floor is 72; \`xtask\` is excluded as build tooling. Code that needs hardware is *not* excluded and counts against the total."
-            echo
             echo "<details><summary>Per-file</summary>"
             echo
             echo '```'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
     # instrumented rebuild, which shares no artifacts with the ordinary one, so bolting it
     # onto `check` would roughly double the time to the signal everyone actually waits for.
     runs-on: ubuntu-latest
+    # To leave a comment on the pull request. Everything else here is read-only.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -129,4 +133,67 @@ jobs:
       # a few points under today's ~77% so ordinary work does not trip it, while a genuine
       # collapse still fails. Lowering it should be a deliberate, explained commit.
       - name: Coverage
-        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines 72
+        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines 72 | tee "$RUNNER_TEMP/head.txt"
+
+      # The base branch, built separately, purely to get a number to subtract. Only on
+      # pull requests: a push to main has nothing to compare against, and paying for a
+      # second instrumented build there would be waste.
+      #
+      # A second checkout rather than a git worktree, so the two builds keep separate
+      # target directories and cannot poison each other's incremental state.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Coverage on the base branch
+        if: github.event_name == 'pull_request'
+        working-directory: base
+        # No `--fail-under-lines`: the base is a measurement, not a gate. If main is
+        # already below the floor that is main's problem, and failing here would block an
+        # unrelated pull request from merging.
+        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' | tee "$RUNNER_TEMP/base.txt"
+
+      # Column 10 of the TOTAL row is line coverage. The whole table goes in the run
+      # summary, where it renders without anyone opening a log; the comment carries the
+      # numbers that matter.
+      - name: Report
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pct() { awk '/^TOTAL/ {gsub("%","",$10); print $10}' "$1" 2>/dev/null; }
+          head_pct=$(pct "$RUNNER_TEMP/head.txt")
+          base_pct=$(pct "$RUNNER_TEMP/base.txt")
+          : "${head_pct:=unknown}"
+
+          {
+            echo "## Coverage"
+            echo
+            if [ "$head_pct" = "unknown" ]; then
+              echo "The coverage run did not produce a total — it most likely failed before finishing."
+            elif [ -n "$base_pct" ]; then
+              delta=$(awk -v a="$head_pct" -v b="$base_pct" 'BEGIN { printf "%+.2f", a - b }')
+              echo "**${head_pct}% lines** on this branch, ${base_pct}% on \`${{ github.base_ref }}\` — **${delta}**."
+            else
+              echo "**${head_pct}% lines** on this branch. No base measurement to compare against."
+            fi
+            echo
+            echo "Floor is 72; \`xtask\` is excluded as build tooling. Code that needs hardware is *not* excluded and counts against the total."
+            echo
+            echo "<details><summary>Per-file</summary>"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/head.txt" 2>/dev/null || echo "no report"
+            echo '```'
+            echo
+            echo "</details>"
+          } > "$RUNNER_TEMP/comment.md"
+
+          cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+          # Edit the previous comment rather than adding one per push, so a long-running
+          # branch does not accumulate a wall of near-identical coverage reports.
+          gh pr comment "${{ github.event.number }}" --body-file "$RUNNER_TEMP/comment.md" --edit-last \
+            || gh pr comment "${{ github.event.number }}" --body-file "$RUNNER_TEMP/comment.md"


### PR DESCRIPTION
Low priority, as asked. Adds a `coverage` job to `ci.yml` so the number is tracked rather than being a thing someone measures by hand once.

## Where coverage actually is today

**77.3% lines** excluding build tooling (73.0% including it). The aggregate is less interesting than the split:

| | lines |
|---|---|
| `duck-control/obs.rs` — the 61-D layout | **100%** |
| `duck-control/model.rs` | **100%** |
| `duck-control/imu.rs` | **97%** |
| `robotd/params.rs` | **100%** |
| `duck-ipc-proto` | **94%** |
| `updater` engine · journal · store · verify · hooks | **82–98%** |
| `robotd/main.rs` | 56% |
| `robotctl/main.rs` | 44% |
| `updater/source/github.rs` | 62% |
| `updater/source/http.rs` | 66% |
| `updater/source/hf_hub.rs` | **47%** |
| `updater/source/mod.rs` | **17%** |
| `duck-control/bus.rs` — Dynamixel driver | **8%** |
| `xtask` | 0% (excluded) |

The code most worth covering — the observation layout, the health logic, the engine's commit and rollback paths — is in the 82–100% band. The genuinely weak spots are the **network source paths**, which is the code that runs when a robot pulls a release.

## Choices worth reviewing

**Separate job, not another `check` step.** Coverage needs a full instrumented rebuild sharing no artifacts with the ordinary one. Adding it to `check` would roughly double the time to the signal people actually wait for.

**`xtask` excluded.** Build tooling that never ships, exercised by CI packaging a real release rather than by unit tests. It reads 0% and costs four points of the total while telling us nothing.

**`bus.rs` deliberately *not* excluded**, despite being uncoverable without a Dynamixel bus. It is an honest 8%, and the floor is set with it included — rather than widening the exclusion until the number looks respectable. Same will apply to the ONNX policy runner in slice 2.

**The floor is 72 against a current 77.3, and it is a ratchet, not a target.** Raise it as the real number rises; lowering it should be a deliberate commit that says why. Slice 2 adds inference paths that cannot run in CI, so it may legitimately dip — that should be a conscious decision rather than a silent slide.

I verified the gate actually gates: the exact command exits 0 at `--fail-under-lines 72` and 1 at 90. A coverage job that cannot fail is decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)