### PR TITLE
ci: prune dev releases whose branch is gone

### DIFF
--- a/.github/workflows/prune-dev-releases.yml
+++ b/.github/workflows/prune-dev-releases.yml
@@ -1,0 +1,79 @@
+# Delete the dev-channel prerelease belonging to a branch that no longer exists.
+#
+# `dev.yml` publishes every branch push to a moving tag `daemon-dev-<branch>`. Nothing ever
+# removed those, so each merged branch left a prerelease and ~11 MB of signed binaries
+# behind for good.
+#
+# Tidiness is the least of it. **A dead tag stays installable**: months later
+# `robotctl update apply daemon --ref some-old-branch` still resolves, verifies and
+# installs, because the artifact is genuinely signed with the team dev key. It looks like a
+# valid install and it is arbitrary stale code from a branch nobody remembers.
+#
+# What this cannot break: the release stream. Dev versions are semver prereleases and
+# `latest` resolves to the highest *stable* version, so a customer robot could never have
+# been on one of these — and `allow_dev_keys = false` is a second, independent barrier.
+name: prune-dev-releases
+
+on:
+  # The immediate path: a branch is deleted, its prerelease goes with it.
+  delete:
+  # The sweeper. Catches branches deleted before this workflow existed, deleted through the
+  # API without an event reaching us, or missed for any other reason. Without it the
+  # `delete` trigger can only ever keep up with the future.
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted, delete nothing"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # One implementation for all three triggers. The `delete` event could be handled with
+      # a single targeted call, but then the common path and the sweeper would be different
+      # code, and the one that runs rarely would be the one that rots.
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          branches="$(gh api --paginate repos/${{ github.repository }}/branches --jq '.[].name')"
+          echo "live branches:"
+          echo "$branches" | sed 's/^/  /'
+          echo
+
+          deleted=0
+          for tag in $(gh release list --limit 200 --json tagName --jq '.[].tagName' \
+                       | grep '^daemon-dev-' || true); do
+              branch="${tag#daemon-dev-}"
+
+              # `grep -x` so a branch named `foo` does not keep `daemon-dev-foo-bar` alive.
+              if echo "$branches" | grep -qx -- "$branch"; then
+                  echo "keep   $tag"
+                  continue
+              fi
+
+              if [ "${DRY_RUN:-false}" = "true" ]; then
+                  echo "would delete $tag"
+              else
+                  # --cleanup-tag, or the tag survives the release and `--ref <branch>`
+                  # keeps resolving to it — which is the actual hazard here.
+                  gh release delete "$tag" --cleanup-tag --yes
+                  echo "delete $tag"
+                  deleted=$((deleted + 1))
+              fi
+          done
+
+          echo
+          echo "pruned ${deleted} dev release(s)"


### PR DESCRIPTION
You spotted that every merged branch leaves its dev release behind forever. It does, and five had already accumulated — three of them dead.

I deleted those three by hand (`ci-coverage`, `fix-health-thresholds`, `slice-1-hold-pose`, tags included). This stops it recurring.

## Why it matters beyond tidiness

Clutter and ~11 MB per dead release are the small part. **A dead tag stays installable.** Months from now `robotctl update apply daemon --ref some-old-branch` still resolves, verifies and installs — the artifact genuinely is signed with the team dev key. It looks like a valid install and it's arbitrary stale code from a branch nobody remembers.

That's also why `--cleanup-tag` is load-bearing: deleting the release alone leaves the tag, and the tag is what `--ref` resolves.

## What this cannot affect

The release stream. I checked `version_from_tag` rather than trusting the docs: `latest` resolves to the highest **stable** semver, and dev versions are prereleases (`0.1.0-dev.20.da64000`), so a customer robot could never have been on one. `allow_dev_keys = false` is a second, independent barrier. **This is hygiene, not a fix for a safety hole.**

## Design

Three triggers, one implementation:

- **`delete`** — the common case, immediate.
- **weekly `schedule`** — the sweeper. Catches branches deleted before this workflow existed, or removed via the API without an event reaching us. Without it the `delete` trigger can only keep up with the future, never the backlog.
- **`workflow_dispatch`** with a `dry_run` input, for checking by hand.

Handling `delete` with its own targeted call would have been shorter, but then the rarely-run sweeper would be different code from the common path — and the rarely-run path is the one that rots.

Branch matching is `grep -qx`, so a branch named `foo` cannot keep `daemon-dev-foo-bar` alive. I tested that case explicitly, along with running the exact shell against the live repo: it correctly keeps `daemon-dev-main` and `daemon-dev-slice-2-walk-stand` and would delete nothing else.

## One thing for you

`deleteBranchOnMerge` is **off** on this repo. You're deleting branches by hand, which works and does fire the `delete` trigger — but turning the setting on would make the immediate path reliable rather than dependent on remembering. That's a repo setting, so yours to flip.