### PR TITLE
install.sh: give the bootstrap a token, and stop 404 lying about why

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -275,7 +275,13 @@ bootstrap_first_release() {
     chmod +x "${tmp}/updaterd"
 
     say "installing the first release (verifying signatures)"
-    "${tmp}/updaterd" install --config "${CONFIG_DIR}/updater.toml"
+    # GITHUB_TOKEN, not DUCK_TOKEN: the engine reads that name, and it needs one for the
+    # same reason this script does — a private repo's API answers 404 to an unauthenticated
+    # caller. Exported only for this command, deliberately: nothing is written to disk, so
+    # the installed `updaterd` still has no credential and still cannot fetch a *later*
+    # update until someone adds the systemd drop-in by hand. That asymmetry is the point —
+    # provisioning is a person at a keyboard, an unattended update is not.
+    GITHUB_TOKEN="$TOKEN" "${tmp}/updaterd" install --config "${CONFIG_DIR}/updater.toml"
 
     if [ ! -L "${INSTALL_DIR}/current" ]; then
         die "the install reported success but nothing is live"

--- a/updater/src/source/http.rs
+++ b/updater/src/source/http.rs
@@ -361,7 +361,11 @@ fn github_token() -> Option<String> {
 fn describe_failure(url: &str, status: reqwest::StatusCode) -> String {
     let hint = match status.as_u16() {
         401 | 403 => " (private repo, or rate-limited — set GITHUB_TOKEN?)",
-        404 => " (wrong repo, tag, or asset name?)",
+        // GitHub answers 404 — not 403 — for a private resource the caller cannot see, so
+        // as not to disclose that it exists. So the one status that most often means "you
+        // need a token" was the one suggesting a typo. That cost a real debugging round
+        // trip on the first board: the repo name was right and the message said it was not.
+        404 => " (wrong repo, tag, or asset name? or a private repo — set GITHUB_TOKEN?)",
         429 => " (rate-limited; retry later)",
         500..=599 => " (server-side; retry later)",
         _ => "",
@@ -386,10 +390,19 @@ mod tests {
     }
 
     /// Failure messages must be actionable — "HTTP 404" alone sends someone hunting.
+    ///
+    /// **404 must mention the token.** GitHub answers 404, not 403, for a private resource
+    /// the caller cannot see, so as not to disclose that it exists — which means the status
+    /// most likely to mean "you need a token" was the one suggesting a typo. On the first
+    /// real board that message sent someone checking a repository name that was correct.
     #[test]
     fn failures_carry_a_hint() {
         let msg = describe_failure("https://x/y", reqwest::StatusCode::NOT_FOUND);
         assert!(msg.contains("wrong repo"), "{msg}");
+        assert!(
+            msg.contains("GITHUB_TOKEN"),
+            "404 must offer the token too: {msg}"
+        );
 
         let msg = describe_failure("https://x/y", reqwest::StatusCode::FORBIDDEN);
         assert!(msg.contains("GITHUB_TOKEN"), "{msg}");


### PR DESCRIPTION
Second failure on the first real board, straight after the first was fixed:

```
ERROR install failed error=network error:
  GET .../releases?per_page=100&page=1: HTTP 404 Not Found
  (wrong repo, tag, or asset name?)
```

Two separate bugs, which compounded into a misleading message.

## 1. The bootstrap was invoked without a token

`install.sh` uses `DUCK_TOKEN` for its own `curl` calls, then ran `updaterd install` with nothing in its environment — so the engine's `GET /releases` went out unauthenticated. On a private repository that can never succeed.

Now exported for that one command only. Nothing is written to disk, so the installed `updaterd` **still** has no credential and still needs the systemd drop-in before it can fetch a *later* update. That asymmetry is deliberate: provisioning is a person at a keyboard, an unattended update is not.

## 2. The 404 hint pointed at the wrong cause

`describe_failure` only suggested `GITHUB_TOKEN` on **401/403**. But GitHub answers **404** for a private resource the caller cannot see — deliberately, so as not to disclose that it exists.

So the status code that most often means *"you need a token"* was the one saying *"(wrong repo, tag, or asset name?)"*. It sent someone checking a repository name that was correct, and cost a debugging round trip on the first board that ever ran this.

404 now offers both causes, and the test asserts it — the old message was wrong in a way that reads as helpful, which is the worst kind.

## Why both survived this long

`install.sh` had never been run against a private repo with a promoted release. Neither bug is subtle. There was simply no path that exercised them until today, which is also the argument for §6.1: a public artifact repo removes the token from this flow entirely.

## Testing

Full suite green, clippy and fmt clean. The unblocking workaround — passing `GITHUB_TOKEN` through `sudo` alongside `DUCK_TOKEN` — is what this makes unnecessary.