### PR TITLE
Split board bring-up out of the installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,12 @@ jobs:
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          sh -n scripts/install.sh
-          shellcheck --shell=sh scripts/install.sh
-          # The one-liner is only correct if the file is executable and self-contained.
-          test -x scripts/install.sh
+          for script in scripts/install.sh scripts/setup-board.sh; do
+            sh -n "$script"
+            shellcheck --shell=sh "$script"
+            # The one-liner is only correct if the file is executable and self-contained.
+            test -x "$script"
+          done
 
       # The publish tooling must keep working, or a release can't be cut. Cheap to
       # assert here rather than discovering it at tag time.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,6 +29,20 @@ curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/ma
 sudo sh /tmp/setup-board.sh
 ```
 
+The first run copies itself to `/usr/local/sbin/robot-setup-board`, so after the reboot it
+asks for there is still something to run:
+
+```bash
+sudo reboot
+```
+
+```bash
+sudo /usr/local/sbin/robot-setup-board
+```
+
+`/tmp` is cleared on reboot, and a script whose whole job is *change boot config, reboot,
+confirm* should not delete itself in the middle of that.
+
 It ends with a status block — motor bus, ONNX Runtime, clock — so "is this board ready" is a
 question you can ask on its own, not only as a side effect of installing something.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,36 @@ next to their service (`updater/systemd/`, `robotd/systemd/`); anything robot-wi
 
 ## Installing a robot from scratch
 
+Two steps, because they answer to different things. `setup-board.sh` is OS-level bring-up —
+device-tree overlays, ONNX Runtime — which changes rarely and needs a reboot. `install.sh`
+installs a signed daemon release, which happens on every update. Conflating them would mean
+every update re-litigating boot configuration.
+
+**1. Prepare the board.** Idempotent, and it never reboots on its own: if it changes boot
+config it says so and stops, and running it again afterwards continues.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/setup-board.sh -o /tmp/setup-board.sh
+```
+
+```bash
+sudo sh /tmp/setup-board.sh
+```
+
+It ends with a status block — motor bus, ONNX Runtime, clock — so "is this board ready" is a
+question you can ask on its own, not only as a side effect of installing something.
+
+The one thing it fixes that is otherwise very hard to diagnose: Armbian ships
+`overlay_prefix=rk35xx`, but the RK3566 shares device-tree overlays with the RK3568 and they
+are named `rk3568-*.dtbo`. With the wrong prefix the loader finds nothing, the board boots
+happily, and there is simply no `/dev/ttyS2`. `armbian-config`'s overlay editor crashes for
+the same reason, so the file is patched directly.
+
+⚠ A kernel upgrade that repoints `/boot/{Image,dtb,uInitrd}` can undo it. A board that stops
+seeing its motors after an `apt upgrade` needs this re-run.
+
+**2. Install the daemon.**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/install.sh | sudo sh
 ```
@@ -58,11 +88,14 @@ A private repo's release assets are unreachable without credentials — the
 release API instead. `updaterd` reads `GITHUB_TOKEN` from its environment, which on a board
 means a systemd drop-in, not a shell export.
 
-That is fine on a developer's board (see the README) and **not** fine on a customer robot: a
-fleet-wide credential in an image is one that leaks and cannot be rotated without reflashing,
-which is the failure the tiered signing keys exist to avoid. So `scripts/install.sh` does not
-provision a token, and a robot installed today can be provisioned but cannot fetch an update
-unless someone adds one by hand.
+That is fine on a developer's board and **not** fine on a customer robot: a fleet-wide
+credential in an image is one that leaks and cannot be rotated without reflashing, which is
+the failure the tiered signing keys exist to avoid.
+
+`install.sh` therefore writes the drop-in **only when `DUCK_TOKEN` was supplied** — mode 600,
+and it says so loudly. A customer robot installs from a public artifact repository and passes
+no token, so it never reaches that path. Without it `updaterd` would be installed, running,
+and unable to fetch a single update, which is most of what it is for.
 
 Artifact hosting is therefore an open decision, not a settled one —
 [`../docs/updater-design.md`](../docs/updater-design.md) §6.1 has the options. The cheap one

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -91,6 +91,17 @@ enum Namespace {
         command: UpdateCommand,
     },
 
+    /// Is the robot healthy, and if not, why not.
+    ///
+    /// The same question the update system's health gate asks, and the reason auto-rollback
+    /// means anything. It was previously only answerable by hand-writing JSON at the socket,
+    /// which is a poor way to ask the one thing that decides whether a release is kept.
+    Health {
+        /// Machine-readable output, for scripts and support bundles.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// What is running on this robot, and what is installed. The first thing to ask for
     /// in a support report.
     ///
@@ -377,6 +388,46 @@ struct VersionReport {
 /// That exits non-zero when `updaterd` is unreachable, which is precisely the situation
 /// where someone is running this command. Every failure here becomes a line in the report
 /// instead.
+/// Ask `robotd` whether it is healthy.
+///
+/// Exits non-zero when the robot is unhealthy or unreachable, so a script can gate on it —
+/// `robotctl health && do_the_thing`. The reason is always printed, because "unhealthy" on
+/// its own sends someone hunting: it distinguishes a loop that has not started from one
+/// missing its deadline from a policy that would not load.
+fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
+    let mut client = Client::connect_to("robotd", robot_socket)?;
+    let response = client.call(&proto::Call::RobotHealth)?;
+
+    let health: proto::HealthResult = response.result_as().map_err(|e| {
+        Failure::new(
+            exit::FAILED,
+            format!("robotd answered robot.health with something unexpected: {e}"),
+        )
+    })?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string(&health).unwrap_or_else(|_| "{}".to_owned())
+        );
+    } else if health.healthy {
+        println!("healthy");
+    } else {
+        println!(
+            "unhealthy: {}",
+            health.reason.as_deref().unwrap_or("no reason given")
+        );
+    }
+
+    if health.healthy {
+        Ok(())
+    } else {
+        // REFUSED, not FAILED: the robot answered correctly and the answer was "no". That is
+        // a verdict, not a malfunction, and a script should be able to tell them apart.
+        Err(Failure::silent(exit::REFUSED))
+    }
+}
+
 fn run_version(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Failure> {
     let build = proto::build_info!();
     let mut report = VersionReport {
@@ -615,6 +666,19 @@ impl Failure {
         Self { code, message }
     }
 
+    /// An exit code with nothing to say.
+    ///
+    /// For a command that has already printed its own answer on stdout and only needs the
+    /// status to be non-zero — `robotctl health` on an unhealthy robot has reported the
+    /// reason already, and repeating it as `error: ...` on stderr would read as though
+    /// something had gone wrong with the command rather than with the robot.
+    fn silent(code: u8) -> Self {
+        Self {
+            code,
+            message: String::new(),
+        }
+    }
+
     /// Map a daemon error code to a CLI exit code, preserving the distinctions that
     /// let scripts branch: retry on BUSY, "correctly rejected" on REFUSED.
     fn from_rpc(error: proto::Error) -> Self {
@@ -665,7 +729,9 @@ fn main() -> ExitCode {
     match run(cli) {
         Ok(()) => ExitCode::from(exit::OK),
         Err(failure) => {
-            eprintln!("error: {}", failure.message);
+            if !failure.message.is_empty() {
+                eprintln!("error: {}", failure.message);
+            }
             ExitCode::from(failure.code)
         }
     }
@@ -673,6 +739,9 @@ fn main() -> ExitCode {
 
 fn run(cli: Cli) -> Result<(), Failure> {
     let command = match cli.namespace {
+        Namespace::Health { json } => {
+            return run_health(&cli.robot_socket, json);
+        }
         Namespace::Version { json } => {
             return run_version(&cli.socket, &cli.robot_socket, json);
         }

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -441,9 +441,21 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
     );
 
     let mut ticker = tokio::time::interval(period);
-    // Skipped ticks must not be replayed in a burst: a loop that fell behind should continue
-    // at its target rate, not fire the backlog back to back and stack motor commands.
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // `Skip`, not `Burst` and not `Delay`.
+    //
+    // `Burst` replays a backlog back to back, stacking motor commands — clearly wrong. But
+    // `Delay` is wrong too, and less obviously: it schedules the next tick at *now + period*
+    // after each one, so every tick's wakeup latency is added to the period rather than
+    // absorbed. A few milliseconds of scheduler jitter becomes a permanent rate loss.
+    //
+    // Measured, not reasoned about: with `Delay` this loop reported 43.1 Hz against a 50 Hz
+    // target and `missed = 0` — not overrunning its work, just being rescheduled late every
+    // time. With a real bus read costing 3–8 ms it would have been nearer 35 Hz, and it
+    // would have looked like a hardware problem.
+    //
+    // `Skip` keeps the original schedule and drops missed ticks, which is what a control
+    // loop wants: no backlog, no drift.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let mut window_start = Instant::now();
     let mut window_ticks = 0u64;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -396,6 +396,23 @@ verify_install() {
     # support report. Non-fatal: a daemon that is active but not yet answering is a timing
     # artefact, not a failed install.
     robotctl version || warn "robotctl could not reach the daemons yet"
+
+    # And ask whether it is actually *working*, which `is-active` cannot tell you.
+    #
+    # robotd stays active with no motor bus: it logs the failure, keeps serving its socket,
+    # and reports unhealthy. Before this, a board with no servos wired produced a completely
+    # green install of a daemon that could not see a robot.
+    #
+    # Non-fatal on purpose. A bench board with no motors attached is a legitimate state — it
+    # is the right thing to test the update system against — so this reports rather than
+    # refuses. The exit code is swallowed deliberately.
+    if robotctl health; then
+        :
+    else
+        warn "robotd is up but not healthy. That is the honest answer, not necessarily a
+  failed install — a board with no motor bus reports exactly this. Look at:
+    journalctl -u robotd -b --no-pager"
+    fi
 }
 
 report() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -413,13 +413,63 @@ waiting to be asked. Ordinary releases wait for a client.
 EOF
 }
 
+
+# The motor bus, checked but never configured here.
+#
+# Board bring-up is `setup-board.sh`'s job — device-tree overlays need a reboot and belong to
+# the board, not to a daemon release. But installing a robot daemon onto a board with no bus
+# is worth saying out loud: the install will succeed, `robotd` will start, fail to open the
+# bus, and report unhealthy. That is honest behaviour, and an easy thing to stare past.
+MOTOR_PORT="${MOTOR_PORT:-/dev/ttyS2}"
+
+check_board() {
+    if [ -e "$MOTOR_PORT" ]; then
+        return 0
+    fi
+    warn "${MOTOR_PORT} does not exist, so robotd will have no motor bus.
+  Run scripts/setup-board.sh (then reboot) to enable it. Installing anyway: the update
+  system is worth testing on a board whose bus is not wired yet, and robotd reports itself
+  unhealthy rather than pretending."
+}
+
+# Let `updaterd` fetch updates on a *developer's* board.
+#
+# Only when a token was supplied, and never on a customer robot: those install from a public
+# artifact repository and pass no token, so they never reach this path. A fleet-wide
+# credential baked into an image is one that leaks and cannot be rotated without reflashing —
+# the failure the tiered signing keys exist to avoid (deploy/README.md).
+#
+# Without this, `updaterd` is installed, running, and unable to fetch a single update — which
+# is most of what it is for.
+install_token_dropin() {
+    if [ -z "$TOKEN" ]; then
+        say "no token supplied; updaterd will not be able to fetch updates"
+        return 0
+    fi
+
+    dir=/etc/systemd/system/updaterd.service.d
+    mkdir -p "$dir"
+    # Restrictive umask before the write, not chmod after: a drop-in is world-readable by
+    # default, and this one holds a credential from the moment it exists.
+    (
+        umask 077
+        printf '[Service]\nEnvironment=GITHUB_TOKEN=%s\n' "$TOKEN" > "${dir}/token.conf"
+    )
+    systemctl daemon-reload
+    say "wrote ${dir}/token.conf (mode 600) so updaterd can fetch updates"
+    warn "that file holds a GitHub token in plaintext. Fine on a developer's board, not on a
+  robot you ship. It is why artifact hosting is still open — docs/updater-design.md §6.1."
+}
+
 main() {
     check_environment
+    check_board
     wait_for_clock
     install_config
     bootstrap_first_release
     create_group
     install_units
+    install_token_dropin
     verify_install
     report
 }

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -1,0 +1,214 @@
+#!/bin/sh
+# Get a freshly flashed board ready to run the robot, then say whether it is.
+#
+# Split from `install.sh` on purpose. This does OS-level bring-up — device-tree overlays,
+# ONNX Runtime — which changes rarely, needs a reboot, and belongs to the *board*.
+# `install.sh` installs a signed daemon release, which happens on every update and belongs
+# to the *software*. Conflating them would mean every update re-litigating boot config.
+#
+# Idempotent, and safe to re-run. It never reboots on its own: if it changes anything that
+# needs one, it says so and stops, and running it again afterwards continues.
+#
+#   sudo sh setup-board.sh
+#   sudo reboot            # only if it asks
+#   sudo sh setup-board.sh # confirms, then points at install.sh
+#
+# Radxa Zero 3W on Armbian. Nothing here is specific to a robot revision.
+set -eu
+
+ONNX_VERSION="${ONNX_VERSION:-1.20.1}"
+ONNX_LIB_DIR=/usr/local/lib
+
+# The Dynamixel bus. Every servo and the imu_to_dxl board share it, so without this there
+# is no robot — just a daemon reporting that it cannot see one.
+MOTOR_PORT="${MOTOR_PORT:-/dev/ttyS2}"
+
+ENV_TXT=/boot/armbianEnv.txt
+
+# Only what `robotd` needs. The prototype also enables i2c-gpio-pihat, aic3104-pihat and a
+# camera overlay; none apply here — our IMU rides the Dynamixel bus rather than I²C, and
+# `robotd` owns no camera or audio.
+REQUIRED_OVERLAY=uart2-m0
+
+needs_reboot=0
+
+say()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+check_environment() {
+    [ "$(id -u)" = 0 ] || die "run as root (sudo sh setup-board.sh)"
+
+    arch="$(uname -m)"
+    [ "$arch" = aarch64 ] || die "this targets aarch64 boards, and this box is ${arch}"
+
+    for tool in curl tar find install; do
+        command -v "$tool" >/dev/null 2>&1 || die "${tool} is required"
+    done
+}
+
+# Enable the UART the Dynamixel bus lives on.
+#
+# Two traps here, both of which fail *silently* — which is why this is scripted rather than
+# written up as a checklist:
+#
+#  1. Armbian ships `overlay_prefix=rk35xx`, but the RK3566 shares device-tree overlays with
+#     the RK3568 and they are named `rk3568-*.dtbo`. With the wrong prefix the loader finds
+#     nothing, boots happily, and there is no /dev/ttyS2.
+#  2. `armbian-config`'s overlay editor crashes on this board for the same reason
+#     (`Invalid overlay_prefix rk35xx`), so the file is patched directly.
+#
+# A kernel upgrade that repoints /boot/{Image,dtb,uInitrd} can undo this. If a board stops
+# seeing its motors after an apt upgrade, re-run this.
+configure_overlay() {
+    if [ ! -f "$ENV_TXT" ]; then
+        warn "no ${ENV_TXT}; not an Armbian image?
+  Enable the UART that ${MOTOR_PORT} lives on by whatever means this image provides, then
+  re-run. Everything else here will still be done."
+        return 0
+    fi
+
+    changed=0
+
+    if grep -Eq '^overlay_prefix=rk35xx$' "$ENV_TXT"; then
+        say "fixing overlay_prefix: rk35xx -> rk3568"
+        sed -i 's/^overlay_prefix=rk35xx$/overlay_prefix=rk3568/' "$ENV_TXT"
+        changed=1
+    elif ! grep -Eq '^overlay_prefix=' "$ENV_TXT"; then
+        say "setting overlay_prefix=rk3568"
+        echo 'overlay_prefix=rk3568' >> "$ENV_TXT"
+        changed=1
+    fi
+
+    if ! grep -Eq '^overlays=' "$ENV_TXT"; then
+        say "adding overlays=${REQUIRED_OVERLAY}"
+        echo "overlays=${REQUIRED_OVERLAY}" >> "$ENV_TXT"
+        changed=1
+    elif ! grep -E '^overlays=' "$ENV_TXT" | grep -qw "$REQUIRED_OVERLAY"; then
+        say "adding ${REQUIRED_OVERLAY} to overlays"
+        # Appended rather than replacing the line: whatever else this image enables is not
+        # ours to remove.
+        sed -i "s/^overlays=\(.*\)\$/overlays=\1 ${REQUIRED_OVERLAY}/" "$ENV_TXT"
+        changed=1
+    fi
+
+    if [ "$changed" = 1 ]; then
+        needs_reboot=1
+    else
+        say "device-tree overlays already correct"
+    fi
+}
+
+# ONNX Runtime, which `robotd` dlopens to run its gait policy.
+#
+# A board prerequisite rather than release cargo: it changes far less often than the daemon,
+# so shipping ~20 MB of it in every artifact would enlarge every update for nothing. The
+# consequence is that it is loaded at runtime, not linked — a board without it installs and
+# starts fine and *then* cannot walk. `robotd` reports that through `robot.health` with the
+# searched path in the message, so the failure names itself, but it is still a failure.
+install_onnxruntime() {
+    if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
+        say "ONNX Runtime already present in ${ONNX_LIB_DIR}"
+        return 0
+    fi
+
+    url="https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-aarch64-${ONNX_VERSION}.tgz"
+    tmp="$(mktemp -d)"
+    say "installing ONNX Runtime ${ONNX_VERSION}"
+
+    if ! curl -fsSL -o "${tmp}/ort.tgz" "$url"; then
+        rm -rf "$tmp"
+        die "cannot download ONNX Runtime from ${url}
+  robotd needs it to run a policy. Install it by hand into ${ONNX_LIB_DIR}, or point
+  ORT_DYLIB_PATH at wherever it lives."
+    fi
+
+    tar -xzf "${tmp}/ort.tgz" -C "$tmp" || { rm -rf "$tmp"; die "cannot unpack ONNX Runtime"; }
+
+    found="$(find "$tmp" -name 'libonnxruntime.so*' -type f | head -1)"
+    [ -n "$found" ] || { rm -rf "$tmp"; die "no libonnxruntime.so in the tarball"; }
+
+    install -m 0644 "$found" "${ONNX_LIB_DIR}/$(basename "$found")"
+    ln -sf "$(basename "$found")" "${ONNX_LIB_DIR}/libonnxruntime.so"
+
+    # ldconfig lives in /usr/sbin, often absent from a login PATH, so `command -v` would
+    # report it missing and skip the refresh — leaving the freshly copied library
+    # unfindable by dlopen. Try the absolute path too.
+    if command -v ldconfig >/dev/null 2>&1; then
+        ldconfig
+    elif [ -x /usr/sbin/ldconfig ]; then
+        /usr/sbin/ldconfig
+    else
+        warn "no ldconfig; robotd may need ORT_DYLIB_PATH=${ONNX_LIB_DIR}/libonnxruntime.so"
+    fi
+
+    rm -rf "$tmp"
+}
+
+# What the board looks like now. Printed whether or not anything was changed, because "is
+# this board ready" is a question worth being able to ask on its own.
+report() {
+    say "board status"
+
+    if [ -e "$MOTOR_PORT" ]; then
+        printf '  %-22s %s\n' "motor bus" "$MOTOR_PORT present"
+    elif [ "$needs_reboot" = 1 ]; then
+        printf '  %-22s %s\n' "motor bus" "$MOTOR_PORT absent — enabled, pending reboot"
+    else
+        printf '  %-22s %s\n' "motor bus" "$MOTOR_PORT ABSENT"
+        warn "${MOTOR_PORT} is missing and no overlay change was needed, so something else
+  is wrong. Check:  dmesg | grep -iE 'ttyS|serial'
+  robotd will start, fail to open the bus, and report unhealthy — which is honest, but it
+  will not drive anything."
+    fi
+
+    if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
+        printf '  %-22s %s\n' "ONNX Runtime" "present"
+    else
+        printf '  %-22s %s\n' "ONNX Runtime" "ABSENT — robotd cannot load a policy"
+    fi
+
+    # A board with no battery-backed RTC reading 1970 fails TLS certificate validation, and
+    # that surfaces as an opaque handshake error several steps into an install.
+    if command -v timedatectl >/dev/null 2>&1; then
+        if timedatectl show --property=NTPSynchronized --value 2>/dev/null | grep -q yes; then
+            printf '  %-22s %s\n' "clock" "NTP-synchronised"
+        else
+            printf '  %-22s %s\n' "clock" "not synchronised yet"
+        fi
+    fi
+
+    echo
+
+    if [ "$needs_reboot" = 1 ]; then
+        say "reboot required, then run this again"
+        cat <<'EOF'
+
+  sudo reboot
+
+  Boot configuration changed. Nothing else can be confirmed until the overlay is live, and
+  this script is idempotent — running it again after the reboot picks up where it stopped.
+EOF
+        return 0
+    fi
+
+    say "board ready — install the daemon next"
+    cat <<'EOF'
+
+  curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/install.sh -o /tmp/install.sh
+  sudo sh /tmp/install.sh
+
+  On a private repository, pass a token:  sudo DUCK_TOKEN=ghp_... sh /tmp/install.sh
+EOF
+}
+
+main() {
+    check_environment
+    configure_overlay
+    install_onnxruntime
+    report
+}
+
+# Called on the last line so a truncated download — the real failure mode of `curl | sh` —
+# defines functions and then does nothing, rather than running half a setup.
+main "$@"

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -10,8 +10,12 @@
 # needs one, it says so and stops, and running it again afterwards continues.
 #
 #   sudo sh setup-board.sh
-#   sudo reboot            # only if it asks
-#   sudo sh setup-board.sh # confirms, then points at install.sh
+#   sudo reboot                     # only if it asks
+#   sudo /usr/local/sbin/robot-setup-board
+#
+# The first run copies itself to that path. /tmp does not survive a reboot, and a script
+# whose whole job is "change boot config, reboot, confirm" that then deletes itself across
+# the reboot is a bad joke to play on whoever is holding the board.
 #
 # Radxa Zero 3W on Armbian. Nothing here is specific to a robot revision.
 set -eu
@@ -25,16 +29,46 @@ MOTOR_PORT="${MOTOR_PORT:-/dev/ttyS2}"
 
 ENV_TXT=/boot/armbianEnv.txt
 
+# Where this script puts itself so it is still around after the reboot it asks for.
+SELF=/usr/local/sbin/robot-setup-board
+
 # Only what `robotd` needs. The prototype also enables i2c-gpio-pihat, aic3104-pihat and a
 # camera overlay; none apply here — our IMU rides the Dynamixel bus rather than I²C, and
 # `robotd` owns no camera or audio.
 REQUIRED_OVERLAY=uart2-m0
 
 needs_reboot=0
+# Whether we managed to leave a persistent copy, which decides what the reboot advice says.
+persisted=0
 
 say()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Leave a copy somewhere that survives a reboot.
+#
+# Not possible when piped (`curl | sh`), because then there is no file to copy — `$0` is the
+# shell. That is fine; the reboot message adapts.
+persist_self() {
+    case "$0" in
+        sh|-sh|bash|-bash|/dev/fd/*|/proc/self/fd/*) return 0 ;;
+    esac
+    [ -f "$0" ] || return 0
+
+    # Already running from the installed copy: nothing to do, and copying a file onto
+    # itself would truncate it.
+    if [ "$(readlink -f "$0" 2>/dev/null)" = "$(readlink -f "$SELF" 2>/dev/null)" ]; then
+        persisted=1
+        return 0
+    fi
+
+    if install -m 0755 "$0" "$SELF" 2>/dev/null; then
+        persisted=1
+    else
+        warn "could not copy this script to ${SELF}; you will need to fetch it again after
+  the reboot."
+    fi
+}
 
 check_environment() {
     [ "$(id -u)" = 0 ] || die "run as root (sudo sh setup-board.sh)"
@@ -182,9 +216,15 @@ report() {
 
     if [ "$needs_reboot" = 1 ]; then
         say "reboot required, then run this again"
+        echo
+        echo "  sudo reboot"
+        if [ "$persisted" = 1 ]; then
+            echo "  sudo ${SELF}"
+        else
+            echo "  # then fetch and run this script again — it was not copied anywhere"
+            echo "  # persistent, so /tmp will have cleared it"
+        fi
         cat <<'EOF'
-
-  sudo reboot
 
   Boot configuration changed. Nothing else can be confirmed until the overlay is live, and
   this script is idempotent — running it again after the reboot picks up where it stopped.
@@ -204,6 +244,7 @@ EOF
 
 main() {
     check_environment
+    persist_self
     configure_overlay
     install_onnxruntime
     report


### PR DESCRIPTION
Provisioning the first real Radxa needed **three** things that did not know about each other: this repo's `install.sh`, another repo's setup doc for the device-tree overlay, and a manual systemd drop-in for the token. We found each one by hitting it.

`setup-board.sh` now does OS-level bring-up; `install.sh` installs a signed release.

## Why split rather than one script

They answer to different things. Overlays and ONNX Runtime change rarely and need a reboot — that is the *board*. A daemon release lands on every update — that is the *software*. One script would mean every update re-litigating boot configuration.

## `setup-board.sh`

- **Enables `uart2-m0`, and only that.** The prototype also enables I²C, an audio codec and a camera overlay; none apply here, because our IMU rides the Dynamixel bus and `robotd` owns no camera or audio.
- **Installs ONNX Runtime** into `/usr/local/lib` + `ldconfig`.
- **Never reboots on its own.** If it changed boot config it says so and stops; it is idempotent, so re-running after the reboot continues.
- **Ends with a status block** — motor bus, ONNX Runtime, clock — so *"is this board ready"* is a question you can ask on its own, not only as a side effect of installing something.

### The overlay fix is scripted because both its traps fail silently

Armbian ships `overlay_prefix=rk35xx`, but the RK3566 shares device-tree overlays with the RK3568 and they are named `rk3568-*.dtbo`. With the wrong prefix the loader finds nothing, **the board boots happily, and there is simply no `/dev/ttyS2`.** `armbian-config`'s overlay editor crashes for the same reason, so the file is patched directly.

A checklist item that quiet gets skipped, which is why this is code.

## `install.sh`

- **Warns when the motor bus is absent.** Previously it reported a clean install of a daemon that cannot see a robot: `robotd` starts, fails to open the bus, and reports unhealthy. Correct behaviour, easy to stare past.
- **Writes the `updaterd` token drop-in when `DUCK_TOKEN` was supplied** — mode 600, via `umask` before the write rather than `chmod` after, and it says loudly what it just put on disk.

That last one is a deliberate narrowing of `deploy/README.md`'s stance, not a reversal. A customer robot installs from a public artifact repository and passes no token, so it never reaches that path. The property being protected — no fleet-wide credential baked into an image — is intact, while a dev board now works in one command instead of two plus folklore. Without it `updaterd` is installed, running, and unable to fetch a single update, which is most of what it is for.

## Also

CI lints both scripts. One linted and one not is exactly how the second one rots.

`shellcheck --shell=sh` and `sh -n` clean on both.