### PR TITLE
Fix three defects found installing 0.1.2 on a real board

### DIFF
--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -104,6 +104,11 @@ units  = ["robotd"]
 # The gate that makes auto-rollback real. 30s is still the placeholder M4 is meant to
 # replace with a measured boot time plus margin; too short reverts a healthy release that
 # merely starts slowly.
+#
+# The gate rolls back on *unhealthy*, not on *degraded*. A robot that cannot see its servos
+# reports degraded, and passes: it said the same thing before the swap, so reverting cannot
+# fix it and would revert every release ever shipped to a bench board. A release that broke
+# the control loop still reverts. `robotctl health` prints which one it is.
 [component.daemon.health]
 probe   = "socket"
 timeout = "30s"

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -88,6 +88,9 @@ pub struct FakeIo {
     /// Set to make the next [`RobotIo::read`] fail, then cleared. For exercising the
     /// loop's error path without a flaky bus.
     pub fail_next_read: bool,
+    /// Reads still to fail before this one starts answering, decremented per read. Models a
+    /// robot whose servos are not powered yet, and then are.
+    pub fail_reads: u32,
     pub last_written: Option<JointTargets>,
     pub reads: usize,
     pub writes: usize,
@@ -106,6 +109,7 @@ impl FakeIo {
         Self {
             sensors: Sensors::default(),
             fail_next_read: false,
+            fail_reads: 0,
             last_written: None,
             reads: 0,
             writes: 0,
@@ -127,6 +131,13 @@ impl FakeIo {
         self
     }
 
+    /// Fail the next `n` reads, then behave normally. Models a board that comes up before
+    /// its servo power does.
+    pub fn failing_reads(mut self, n: u32) -> Self {
+        self.fail_reads = n;
+        self
+    }
+
     pub fn set_imu(&mut self, imu: ImuData) {
         self.sensors.imu = imu;
     }
@@ -140,6 +151,10 @@ impl RobotIo for FakeIo {
     fn read(&mut self) -> Result<Sensors> {
         if self.fail_next_read {
             self.fail_next_read = false;
+            return Err(IoError::Simulated);
+        }
+        if self.fail_reads > 0 {
+            self.fail_reads -= 1;
             return Err(IoError::Simulated);
         }
         self.reads += 1;

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -653,6 +653,19 @@ pub struct SafeToRestartResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HealthResult {
     pub healthy: bool,
+    /// Set when the reason is a property of the *board*, not of the running release.
+    ///
+    /// The whole point of the health gate is to answer "did this release break the robot?".
+    /// A robot with no servo power answers nothing about the release: it reported exactly
+    /// the same before the swap, and reverting cannot change it — so rolling back only
+    /// wastes an update and churns the boot counter. Such conditions are reported here so
+    /// the gate can commit anyway, while a release that genuinely broke the control loop
+    /// still reverts.
+    ///
+    /// Only meaningful when `healthy` is false. Defaults to false, so an older `robotd`
+    /// that does not send it keeps the previous strict behaviour.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub degraded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
@@ -950,6 +963,7 @@ mod tests {
     #[test]
     fn robot_results_round_trip() {
         let healthy = HealthResult {
+            degraded: false,
             healthy: true,
             reason: None,
         };
@@ -961,11 +975,41 @@ mod tests {
         );
 
         let sick = HealthResult {
+            degraded: false,
             healthy: false,
             reason: Some("motors not responding".into()),
         };
         let line = serde_json::to_string(&sick).unwrap();
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), sick);
+    }
+
+    /// `degraded` must default to false, so an older `robotd` that never sends the field
+    /// keeps the strict behaviour: unhealthy means roll back.
+    #[test]
+    fn health_without_the_degraded_field_is_not_degraded() {
+        let answer: HealthResult =
+            serde_json::from_str(r#"{"healthy":false,"reason":"motors not responding"}"#).unwrap();
+        assert!(!answer.degraded);
+    }
+
+    /// And it is absent from the wire when false, so the common answers stay small.
+    #[test]
+    fn degraded_is_omitted_when_false_and_present_when_true() {
+        let plain = HealthResult {
+            healthy: true,
+            degraded: false,
+            reason: None,
+        };
+        assert!(!serde_json::to_string(&plain).unwrap().contains("degraded"));
+
+        let bench = HealthResult {
+            healthy: false,
+            degraded: true,
+            reason: Some("no answer from the motor bus".into()),
+        };
+        let line = serde_json::to_string(&bench).unwrap();
+        assert!(line.contains(r#""degraded":true"#), "{line}");
+        assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), bench);
     }
 
     /// A local build must say so, rather than looking like a release whose revision was

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -413,8 +413,16 @@ fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
     } else if health.healthy {
         println!("healthy");
     } else {
+        // "degraded" reads as what it is: this release is fine, this board cannot move.
+        // Still a non-zero exit — `install.sh` and anyone else scripting this should hear
+        // about an unpowered robot rather than see a silent success.
         println!(
-            "unhealthy: {}",
+            "{}: {}",
+            if health.degraded {
+                "degraded"
+            } else {
+                "unhealthy"
+            },
             health.reason.as_deref().unwrap_or("no reason given")
         );
     }

--- a/robotd/Cargo.toml
+++ b/robotd/Cargo.toml
@@ -39,6 +39,10 @@ toml = "0.9"
 # already.
 [dev-dependencies]
 updater = { path = "../updater" }
+# `start_paused` for the startup-retry tests: the retry interval is a second of real time,
+# which is right on a robot and far too slow in a test. Dev-only — `cargo build` does not
+# pull dev-dependencies, so the shipped binary has no test-util in it.
+tokio = { workspace = true, features = ["test-util"] }
 test-support = { path = "../test-support" }
 minisign = "0.9.1"
 semver.workspace = true

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -137,6 +137,9 @@ struct RobotState {
     achieved_hz: AtomicU64,
     /// Consecutive failed bus reads. Reset by any success.
     consecutive_errors: AtomicU32,
+    /// Failed attempts to read the startup pose. Non-zero means the loop is still waiting
+    /// for the bus to answer and has never commanded anything.
+    startup_read_failures: AtomicU32,
     shutdown: AtomicBool,
 
     period_us: u64,
@@ -156,6 +159,7 @@ impl RobotState {
             last_tick_us: AtomicU64::new(0),
             achieved_hz: AtomicU64::new(0),
             consecutive_errors: AtomicU32::new(0),
+            startup_read_failures: AtomicU32::new(0),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
             min_achieved_hz: params.health.min_achieved_hz,
@@ -178,6 +182,16 @@ impl RobotState {
 
         // "Starting" is not "started". The gate polls, so it will see the transition.
         if self.ticks.load(Ordering::Relaxed) == 0 {
+            // Distinguish "starting" from "cannot see a robot". Both mean no ticks, but only
+            // one of them is going to resolve on its own, and the update system quotes this
+            // string as the reason it rolled a release back — so it has to name the cause.
+            let waiting = self.startup_read_failures.load(Ordering::Relaxed);
+            if waiting > 0 {
+                return unhealthy(format!(
+                    "no answer from the motor bus after {waiting} attempts; \
+                     is servo power on and the bus wired?"
+                ));
+            }
             return unhealthy("control loop has not completed a cycle yet".into());
         }
 
@@ -418,28 +432,79 @@ fn open_bus(_port: &str) -> Option<FakeIo> {
     None
 }
 
+/// How long to wait between attempts to read the startup pose.
+///
+/// A second, not a control period: the read itself already carries a 30 ms bus timeout, and
+/// a board waiting for someone to switch servo power on is not in a hurry. Fast enough that
+/// powering the robot brings it up while your hand is still on the switch.
+const STARTUP_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Log one waiting line, then one every this many attempts — about one per 30 s.
+const STARTUP_READ_LOG_EVERY: u32 = 30;
+
+/// Adopt the pose the robot is already in, waiting for the bus to answer.
+///
+/// Never move on start: the servos hold their last commanded goal while this process is
+/// dead, so a restart mid-update leaves a standing robot standing, with no gap. That
+/// requires a successful read, so there is nothing to command until one lands.
+///
+/// This used to be a single read that logged and returned on failure — which killed the
+/// control thread for the life of the process. `robotd` stayed up and kept answering the
+/// socket, so a board booted before its servos were powered was permanently inert: powering
+/// them changed nothing and only `systemctl restart robotd` helped, with no hint anywhere
+/// that a restart was what was needed. Retrying makes the ordinary order of operations —
+/// power the board, then power the servos — just work.
+///
+/// Returns `None` only if shutdown is requested while waiting.
+async fn adopt_startup_pose<T: RobotIo>(
+    io: &mut T,
+    state: &RobotState,
+    period: Duration,
+) -> Option<JointTargets> {
+    let mut attempt = 0u32;
+
+    while !state.shutdown.load(Ordering::Relaxed) {
+        match io.read() {
+            Ok(sensors) => {
+                state.startup_read_failures.store(0, Ordering::Relaxed);
+                tracing::warn!(
+                    joints = NUM_JOINTS,
+                    hz = 1.0 / period.as_secs_f64(),
+                    "holding the pose found at startup"
+                );
+                return Some(JointTargets::new(sensors.positions));
+            }
+            Err(e) => {
+                attempt += 1;
+                // Published before sleeping, so `robot.health` can name the cause on the
+                // very first failure rather than after the first log line.
+                state
+                    .startup_read_failures
+                    .store(attempt, Ordering::Relaxed);
+                if attempt == 1 || attempt.is_multiple_of(STARTUP_READ_LOG_EVERY) {
+                    tracing::warn!(
+                        error = %e,
+                        attempt,
+                        "no answer from the motor bus; waiting, not commanding anything"
+                    );
+                }
+                tokio::time::sleep(STARTUP_RETRY_INTERVAL).await;
+            }
+        }
+    }
+
+    None
+}
+
 /// The tick.
 ///
 /// Slice 1 reads, publishes, and writes back the pose adopted at startup. The sensor sample
 /// is read every tick even though nothing consumes it yet — it is what makes the bus load,
 /// and therefore the timing, representative of what slice 2 will do.
 async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Duration) {
-    // Adopt the pose the robot is already in. Never move on start: the servos hold their
-    // last commanded goal while this process is dead, so a restart mid-update leaves a
-    // standing robot standing, with no gap.
-    let targets = match io.read() {
-        Ok(sensors) => JointTargets::new(sensors.positions),
-        Err(e) => {
-            tracing::error!(error = %e, "first bus read failed; not commanding anything");
-            return;
-        }
+    let Some(targets) = adopt_startup_pose(&mut io, &state, period).await else {
+        return;
     };
-    tracing::warn!(
-        joints = NUM_JOINTS,
-        hz = 1.0 / period.as_secs_f64(),
-        "holding the pose found at startup"
-    );
-
     let mut ticker = tokio::time::interval(period);
     // `Skip`, not `Burst` and not `Delay`.
     //
@@ -901,6 +966,108 @@ mod tests {
         assert_eq!(
             written.positions, resting,
             "the loop moved the robot instead of holding where it found it"
+        );
+    }
+
+    /// **The regression.** A board powered on before its servos gets no answer from the bus.
+    /// That used to kill the control thread outright — `robotd` stayed up, kept serving the
+    /// socket, and never ticked again no matter what happened to the robot afterwards. Only
+    /// `systemctl restart robotd` recovered it, and nothing said so.
+    ///
+    /// So: fail the first few reads, then answer, and require the loop to be running.
+    #[tokio::test(start_paused = true)]
+    async fn the_loop_waits_for_the_bus_rather_than_giving_up() {
+        let mut resting = DEFAULT_POSITION;
+        resting[0] = 0.42;
+        // Three failures is arbitrary; one is enough to have broken the old code.
+        let io = FakeIo::at(resting).failing_reads(3).frozen();
+
+        let s = Arc::new(RobotState::new(&Params::default(), false, false));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let loop_state = Arc::clone(&s);
+        let handle = tokio::spawn(async move {
+            let mut io = io;
+            control_loop_probe(&mut io, loop_state, Duration::from_millis(2)).await;
+            tx.send(io.last_written).unwrap();
+        });
+
+        // Bounded, so a regression fails the test instead of hanging CI forever.
+        for _ in 0..10_000 {
+            if s.ticks.load(Ordering::Relaxed) >= 3 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(
+            s.ticks.load(Ordering::Relaxed) >= 3,
+            "the loop never started ticking; it gave up on the bus instead of waiting"
+        );
+
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle.await.unwrap();
+
+        // And it still adopted the pose it found rather than the home pose — waiting must
+        // not cost the startup invariant.
+        let written = rx.recv().unwrap().expect("the loop must command something");
+        assert_eq!(written.positions, resting);
+    }
+
+    /// While waiting, health must say *why*. The update system quotes this string as the
+    /// reason it rolled a release back, and "control loop has not completed a cycle yet"
+    /// describes a robot that is about to start, not one that cannot see its servos.
+    #[test]
+    fn health_names_the_bus_while_waiting_for_it() {
+        let s = RobotState::new(&Params::default(), false, false);
+        s.startup_read_failures.store(4, Ordering::Relaxed);
+
+        let health = s.health();
+        assert!(!health.healthy);
+        let reason = health.reason.unwrap();
+        assert!(
+            reason.contains("motor bus") && reason.contains("servo power"),
+            "unactionable reason: {reason}"
+        );
+    }
+
+    /// Before any read is attempted there is nothing to blame, so the plain starting-up
+    /// message is still the honest one.
+    #[test]
+    fn health_says_merely_starting_before_the_first_read_fails() {
+        let s = RobotState::new(&Params::default(), false, false);
+        let reason = s.health().reason.unwrap();
+        assert!(reason.contains("not completed a cycle"), "{reason}");
+    }
+
+    /// A robot whose bus never answers must still shut down promptly. Waiting forever is
+    /// correct; ignoring `systemctl stop` while doing it is not.
+    #[tokio::test(start_paused = true)]
+    async fn waiting_for_the_bus_still_honours_shutdown() {
+        let io = FakeIo::at(DEFAULT_POSITION).failing_reads(u32::MAX);
+
+        let s = Arc::new(RobotState::new(&Params::default(), false, false));
+        let loop_state = Arc::clone(&s);
+        let handle = tokio::spawn(async move {
+            let mut io = io;
+            control_loop_probe(&mut io, loop_state, Duration::from_millis(2)).await;
+        });
+
+        // Let it fail at least once, so shutdown lands mid-wait rather than before the start.
+        for _ in 0..10_000 {
+            if s.startup_read_failures.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(s.startup_read_failures.load(Ordering::Relaxed) > 0);
+
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle
+            .await
+            .expect("the loop must exit when asked, even with no bus");
+        assert_eq!(
+            s.ticks.load(Ordering::Relaxed),
+            0,
+            "nothing should have been commanded without a successful read"
         );
     }
 

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -173,6 +173,13 @@ impl RobotState {
     fn health(&self) -> proto::HealthResult {
         let unhealthy = |reason: String| proto::HealthResult {
             healthy: false,
+            degraded: false,
+            reason: Some(reason),
+        };
+        // Not healthy, but not the release's fault either — see `HealthResult::degraded`.
+        let degraded = |reason: String| proto::HealthResult {
+            healthy: false,
+            degraded: true,
             reason: Some(reason),
         };
 
@@ -187,7 +194,9 @@ impl RobotState {
             // string as the reason it rolled a release back — so it has to name the cause.
             let waiting = self.startup_read_failures.load(Ordering::Relaxed);
             if waiting > 0 {
-                return unhealthy(format!(
+                // Degraded, not unhealthy: an unpowered bench board must not roll back every
+                // release shipped to it. The bus not answering is the same before and after.
+                return degraded(format!(
                     "no answer from the motor bus after {waiting} attempts; \
                      is servo power on and the bus wired?"
                 ));
@@ -219,6 +228,7 @@ impl RobotState {
 
         proto::HealthResult {
             healthy: true,
+            degraded: false,
             reason: None,
         }
     }
@@ -1027,6 +1037,36 @@ mod tests {
             reason.contains("motor bus") && reason.contains("servo power"),
             "unactionable reason: {reason}"
         );
+    }
+
+    /// A silent bus must be *degraded*, not unhealthy: it reports the same before and after
+    /// a swap, so rolling a release back cannot fix it and only wastes an update. An
+    /// unpowered bench board is the case that has to keep updating.
+    #[test]
+    fn a_silent_bus_is_degraded_rather_than_unhealthy() {
+        let s = RobotState::new(&Params::default(), false, false);
+        s.startup_read_failures.store(4, Ordering::Relaxed);
+
+        let health = s.health();
+        assert!(!health.healthy);
+        assert!(
+            health.degraded,
+            "an unpowered board would roll back releases"
+        );
+    }
+
+    /// The other unhealthy states *are* evidence about the release, so they must not be
+    /// degraded — otherwise auto-rollback stops working for the cases it exists for.
+    #[test]
+    fn a_broken_control_loop_is_not_degraded() {
+        let s = RobotState::new(&Params::default(), false, false);
+        s.ticks.store(1, Ordering::Relaxed);
+        s.consecutive_errors
+            .store(s.max_consecutive_errors, Ordering::Relaxed);
+
+        let health = s.health();
+        assert!(!health.healthy);
+        assert!(!health.degraded, "this must still roll back");
     }
 
     /// Before any read is attempted there is nothing to blame, so the plain starting-up

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -410,7 +410,9 @@ verify_install() {
         :
     else
         warn "robotd is up but not healthy. That is the honest answer, not necessarily a
-  failed install — a board with no motor bus reports exactly this. Look at:
+  failed install — a bench board reports exactly this until its servos are powered, and
+  the reason above says which. robotd keeps retrying, so powering the servos brings it up
+  without reinstalling or restarting anything. Look at:
     journalctl -u robotd -b --no-pager"
     fi
 }

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1228,6 +1228,17 @@ impl Engine {
                 while tokio::time::Instant::now() < deadline {
                     match self.robot.health(ROBOT_QUERY_TIMEOUT).await {
                         crate::robot::Health::Healthy => return Ok(()),
+                        // Passes. Logged at warn, not swallowed: committing a release onto a
+                        // robot that cannot move is the right call, but nobody should have to
+                        // guess afterwards that that is what happened.
+                        crate::robot::Health::Degraded(reason) => {
+                            tracing::warn!(
+                                reason = %reason,
+                                "committing: the robot is degraded for a reason this release \
+                                 cannot have caused and a rollback cannot fix"
+                            );
+                            return Ok(());
+                        }
                         crate::robot::Health::Unhealthy(reason) => last = reason,
                         crate::robot::Health::Unreachable => {
                             last = "unreachable".into();

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -318,12 +318,32 @@ async fn install(args: &Args, from: Option<PathBuf>, component: &str, dry_run: b
 
     // Progress is advisory and the channel unbounded, so this cannot slow the install
     // down — it just makes a long download visible in the journal.
+    //
+    // Logged in deciles, not per callback. The engine emits progress per network chunk, so
+    // a single 3.6 MB download produced ~250 journal lines — 13 of them at "percent=0",
+    // before the first whole percent had even accrued. That is not merely noise: under
+    // journald's size cap it is what evicts the logs someone actually needs, and this runs
+    // on a robot whose logs may be all anyone has.
+    //
+    // Deciles because the point of the line is "is it moving", which ten lines answer as
+    // well as two hundred and fifty.
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<updater::proto::Progress>();
     tokio::spawn(async move {
+        let mut last_logged: Option<(updater::proto::Phase, u8)> = None;
         while let Some(p) = rx.recv().await {
             match p.percent {
-                Some(percent) => tracing::info!(phase = ?p.phase, percent, "installing"),
-                None => tracing::info!(phase = ?p.phase, "installing"),
+                Some(percent) => {
+                    let decile = progress_decile(percent);
+                    if last_logged == Some((p.phase, decile)) {
+                        continue;
+                    }
+                    last_logged = Some((p.phase, decile));
+                    tracing::info!(phase = ?p.phase, percent, "installing");
+                }
+                None => {
+                    last_logged = None;
+                    tracing::info!(phase = ?p.phase, "installing");
+                }
             }
         }
     });
@@ -511,6 +531,13 @@ async fn shutdown() {
     }
 }
 
+/// Which decile a percentage falls in, for throttling progress logs.
+///
+/// 100 gets its own bucket so a finished download reports 100 rather than stopping at 90.
+fn progress_decile(percent: u8) -> u8 {
+    if percent >= 100 { 10 } else { percent / 10 }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -592,5 +619,52 @@ mod tests {
         .unwrap();
         assert_eq!(args.config, PathBuf::from("/etc/robot/updater.toml"));
         assert!(matches!(args.command, Some(Command::Install { .. })));
+    }
+
+    /// The engine emits progress once per network chunk, so a single 3.6 MB download wrote
+    /// ~250 journal lines — 13 of them before the first whole percent had even accrued.
+    /// That is not just noise: under journald's size cap it evicts the logs someone needs,
+    /// on a robot where the journal may be all anyone has to go on.
+    #[test]
+    fn a_full_download_logs_eleven_lines_not_hundreds() {
+        // The shape a chunked download really reports: repeated zeros, then every percent
+        // more than once.
+        let mut reported = vec![0u8; 13];
+        for percent in 0..=100u8 {
+            reported.push(percent);
+            reported.push(percent);
+        }
+        assert!(
+            reported.len() > 200,
+            "the flood this throttling exists to fix"
+        );
+
+        let mut logged = 0;
+        let mut last = None;
+        for percent in reported {
+            let decile = progress_decile(percent);
+            if last != Some(decile) {
+                last = Some(decile);
+                logged += 1;
+            }
+        }
+        // 0, 10, ... 90, then completion.
+        assert_eq!(logged, 11, "one line per decile plus completion");
+    }
+
+    /// 100 must not share a bucket with 90, or a finished download looks stalled at 90%.
+    #[test]
+    fn completion_is_its_own_bucket() {
+        assert_eq!(progress_decile(90), 9);
+        assert_eq!(progress_decile(99), 9);
+        assert_eq!(progress_decile(100), 10);
+    }
+
+    /// The start of a phase is worth exactly one line, not thirteen.
+    #[test]
+    fn the_leading_zeros_collapse() {
+        assert_eq!(progress_decile(0), 0);
+        assert_eq!(progress_decile(9), 0);
+        assert_ne!(progress_decile(10), progress_decile(9));
     }
 }

--- a/updater/src/robot.rs
+++ b/updater/src/robot.rs
@@ -36,6 +36,10 @@ impl SafeToRestart {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Health {
     Healthy,
+    /// Came up and reported a problem, but one belonging to the board rather than to the
+    /// release — no servo power, no motor bus. Passes the gate: see
+    /// [`crate::proto::HealthResult::degraded`].
+    Degraded(String),
     /// Came up and reported a problem.
     Unhealthy(String),
     /// Did not answer within the timeout — includes crash-looping and hung
@@ -157,6 +161,11 @@ impl RobotClient for SocketRobotClient {
         };
         match serde_json::from_value::<crate::proto::HealthResult>(result) {
             Ok(answer) if answer.healthy => Health::Healthy,
+            Ok(answer) if answer.degraded => Health::Degraded(
+                answer
+                    .reason
+                    .unwrap_or_else(|| "robot reports degraded".into()),
+            ),
             Ok(answer) => Health::Unhealthy(
                 answer
                     .reason

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -68,6 +68,26 @@ impl RobotClient for DeadThenHealthy {
     }
 }
 
+/// A robot that came up fine but cannot see its servos — a bench board with the motor
+/// supply off, which is exactly the configuration the update system gets tested on.
+struct DegradedRobot;
+
+#[async_trait::async_trait]
+impl RobotClient for DegradedRobot {
+    async fn safe_to_restart(&self, _t: std::time::Duration) -> SafeToRestart {
+        SafeToRestart::Yes
+    }
+    async fn health(&self, _t: std::time::Duration) -> Health {
+        Health::Degraded("no answer from the motor bus after 12 attempts".into())
+    }
+    async fn model_api(&self, _t: std::time::Duration) -> Option<u32> {
+        None
+    }
+    async fn remote_session_active(&self, _t: std::time::Duration) -> bool {
+        false
+    }
+}
+
 #[async_trait::async_trait]
 impl RobotClient for FakeRobot {
     async fn safe_to_restart(&self, _t: std::time::Duration) -> SafeToRestart {
@@ -560,6 +580,30 @@ async fn rolls_back_when_the_new_release_is_unhealthy() {
     // The robot must be running the *old* release, content and all.
     assert_eq!(fx.live_version().as_deref(), Some("1.0.0"));
     assert_eq!(fx.live_marker().as_deref(), Some("version=1.0.0\n"));
+}
+
+/// The counterpart to `rolls_back_when_the_new_release_is_unhealthy`. Rollback answers
+/// "did this release break the robot?", and a board with no servo power answers nothing
+/// about the release — it said the same before the swap, and reverting cannot change it.
+/// Rolling back there would revert every release shipped to a bench board and churn the
+/// boot counter doing it.
+#[tokio::test]
+async fn commits_when_the_robot_is_degraded_rather_than_broken() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+
+    let mut engine = fx.engine_healthy();
+    apply_latest(&mut engine).await.unwrap();
+
+    fx.publish("1.1.0", None);
+    let mut engine = fx.engine(Box::new(DegradedRobot), Faults::none(), "");
+    let result = apply_latest(&mut engine).await.unwrap();
+
+    assert!(
+        matches!(result, ApplyResult::Applied { .. }),
+        "a degraded board must still take the update, got {result:?}"
+    );
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Three things, all on the path from a freshly flashed board to a running robot. The first is what was asked for; the other two came from looking ahead down the same path.

## 1. The download log flooded the journal

Installing 0.1.2 wrote roughly **250** `installing phase=Downloading percent=N` lines for one 3.6 MB artifact — 13 of them at `percent=0`, before the first whole percent had accrued. The engine emits progress once per network chunk and the handler logged every callback.

Not only unreadable: journald has a size cap, so a chatty install is what evicts the logs someone needs afterwards, on a machine where the journal is often all there is.

Now one line per decile per phase — eleven for a full download. 100 gets its own bucket so a finished download doesn't appear to stall at 90%, and a phase reporting no percentage resets the filter so `Verifying`, `Swapping`, `HealthGate` and friends still log exactly once each.

## 2. `robotd` gave up on the motor bus permanently

`control_loop` read the startup pose **once** and `return`ed on failure. That killed the control thread for the life of the process, while `robotd` stayed active and kept serving its socket.

So a board powered on before its servos was permanently inert. Powering them changed nothing; only `systemctl restart robotd` recovered it, and nothing in the health output suggested a restart was what was needed. This is what my board was doing — `unhealthy: control loop has not completed a cycle yet`, forever, with `/dev/ttyS2` present.

It now retries the startup read every second, indefinitely. The startup invariant is untouched — nothing is commanded until a read succeeds, so a restart still never moves a standing robot — but power the board, then power the servos, and it comes up.

Health also distinguishes the two no-tick states. "Control loop has not completed a cycle yet" describes a robot that is about to start; one that cannot see its servos now says so and says to check servo power. That string is what the update system quotes as its reason for rolling a release back, so it has to name a cause someone can act on.

The regression test fails against the old code with *"the loop never started ticking; it gave up on the bus instead of waiting"*.

## 3. …which meant every update to a bench board would have reverted

Found while checking the blast radius of (2). `deploy/updater.toml` sets `probe = "socket"`, and the gate rolled back on anything not healthy. A bench board with servo power off is legitimately not healthy — so it would download, swap, wait 30s, revert, and churn the boot counter, every release, forever. Testing the updater on a board with no motors attached is exactly what we want to do.

Rollback answers one question: *did this release break the robot?* A silent motor bus answers nothing about it — same before the swap, and reverting cannot change it. So `robot.health` now separates conditions that are evidence about the release from conditions that belong to the board:

```
healthy               -> commit
degraded (no bus)     -> commit, logged at warn
unhealthy (loop dead) -> roll back
```

`degraded` defaults to false on the wire and is omitted when false, so an older `robotd` that never sends it keeps the strict behaviour. `robotctl health` prints `degraded:` rather than `unhealthy:` and still exits non-zero, so `install.sh` still reports an unpowered robot rather than showing a silent success.

The two tests that matter are opposites: a degraded robot must commit, and a control loop failing its bus reads must still roll back. Breaking the second while fixing the first would quietly disable auto-rollback for the cases it exists for.

## Notes

- 0.1.2 *did* commit on my board, which means `robotd` was healthy during the gate and isn't now — so something restarted it after the install. `journalctl -u robotd -b` would settle that; it doesn't change any of the above.
- `FakeIo` grows `failing_reads(n)` to model a board whose servo power arrives late, and `robotd` takes tokio's `test-util` as a **dev**-dependency so the one-second retry is tested without waiting for it. `cargo build` doesn't pull dev-dependencies, so the shipped binary is unaffected.
- Binary changes in `robotd`, `robotctl` and `updaterd`, so this wants a release to be worth anything.

`cargo test --workspace`: 287 passed. No new clippy warnings.