### PR TITLE
Fix what stopped a bench board updating: bus bring-up, the token drop-in, and progress spam

### DIFF
--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -708,10 +708,48 @@ impl Failure {
 }
 
 /// Progress goes to stderr so `--json` output on stdout stays pipeable.
+///
+/// The engine emits progress once per network chunk — around 250 notifications for a 3.6 MB
+/// artifact — and printing a line for each buried the phases that actually matter in a
+/// screenful of `Downloading N%`. On a terminal this now rewrites a single line; when
+/// redirected, where `\r` is useless, it prints one line per decile instead.
 fn report_progress(progress: &proto::Progress) {
-    match progress.percent {
-        Some(percent) => eprintln!("  {:?} {percent}%", progress.phase),
-        None => eprintln!("  {:?}", progress.phase),
+    use std::io::{IsTerminal, Write};
+
+    // `Some` also means "a bare `\r` line is open and owes a newline".
+    static LAST: std::sync::Mutex<Option<(proto::Phase, u8)>> = std::sync::Mutex::new(None);
+
+    let mut last = LAST.lock().unwrap_or_else(|e| e.into_inner());
+    let tty = std::io::stderr().is_terminal();
+
+    let Some(percent) = progress.percent else {
+        // A phase with no percentage. Close any open counter line first, or it gets
+        // overwritten and the download appears to stop partway.
+        if tty && last.is_some() {
+            eprintln!();
+        }
+        *last = None;
+        eprintln!("  {:?}", progress.phase);
+        return;
+    };
+
+    if tty {
+        eprint!("\r  {:?} {percent}%", progress.phase);
+        if percent >= 100 {
+            eprintln!();
+            *last = None;
+        } else {
+            *last = Some((progress.phase, 0));
+        }
+        let _ = std::io::stderr().flush();
+        return;
+    }
+
+    // 100 in its own bucket, so a finished download says so rather than stopping at 90.
+    let decile = if percent >= 100 { 10 } else { percent / 10 };
+    if *last != Some((progress.phase, decile)) {
+        *last = Some((progress.phase, decile));
+        eprintln!("  {:?} {percent}%", progress.phase);
     }
 }
 

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -137,9 +137,10 @@ struct RobotState {
     achieved_hz: AtomicU64,
     /// Consecutive failed bus reads. Reset by any success.
     consecutive_errors: AtomicU32,
-    /// Failed attempts to read the startup pose. Non-zero means the loop is still waiting
-    /// for the bus to answer and has never commanded anything.
-    startup_read_failures: AtomicU32,
+    /// Failed attempts to bring the bus up — opening it, verifying its registers, or
+    /// reading the startup pose. Non-zero means the loop is still waiting for a robot to
+    /// answer and has never commanded anything.
+    startup_bus_failures: AtomicU32,
     shutdown: AtomicBool,
 
     period_us: u64,
@@ -159,7 +160,7 @@ impl RobotState {
             last_tick_us: AtomicU64::new(0),
             achieved_hz: AtomicU64::new(0),
             consecutive_errors: AtomicU32::new(0),
-            startup_read_failures: AtomicU32::new(0),
+            startup_bus_failures: AtomicU32::new(0),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
             min_achieved_hz: params.health.min_achieved_hz,
@@ -192,12 +193,12 @@ impl RobotState {
             // Distinguish "starting" from "cannot see a robot". Both mean no ticks, but only
             // one of them is going to resolve on its own, and the update system quotes this
             // string as the reason it rolled a release back — so it has to name the cause.
-            let waiting = self.startup_read_failures.load(Ordering::Relaxed);
+            let waiting = self.startup_bus_failures.load(Ordering::Relaxed);
             if waiting > 0 {
                 // Degraded, not unhealthy: an unpowered bench board must not roll back every
                 // release shipped to it. The bus not answering is the same before and after.
                 return degraded(format!(
-                    "no answer from the motor bus after {waiting} attempts; \
+                    "no robot on the motor bus after {waiting} attempts; \
                      is servo power on and the bus wired?"
                 ));
             }
@@ -409,19 +410,69 @@ fn spawn_control_thread(
                 return;
             }
 
-            if let Some(io) = open_bus(&port) {
-                runtime.block_on(control_loop(io, state, period));
-            }
+            // Waiting, not one shot. `open_bus` verifies motor registers, which means it
+            // talks to the servos — so on an unpowered board it fails and this used to fall
+            // straight off the end of the thread. No control loop was ever created, and
+            // because nothing had been *attempted* the health reason was the bland "control
+            // loop has not completed a cycle yet", forever, whatever happened to the robot
+            // afterwards. Retrying the read alone was not enough: execution never got there.
+            runtime.block_on(async move {
+                if let Some(io) = open_bus_waiting(&port, &state).await {
+                    control_loop(io, state, period).await;
+                }
+            });
         })
+}
+
+/// The real bus on the board; a fake elsewhere, so `open_bus_waiting` has one signature.
+#[cfg(target_os = "linux")]
+type BusIo = duck_control::bus::DynamixelIo;
+#[cfg(not(target_os = "linux"))]
+type BusIo = FakeIo;
+
+/// Open and verify the bus, waiting for a robot to answer.
+///
+/// Same reasoning as [`adopt_startup_pose`], one step earlier: an unpowered board cannot
+/// pass `check_registers`, and that is a condition someone fixes by flipping a switch, not
+/// one to abandon the control loop over.
+///
+/// Returns `None` only if shutdown is requested while waiting.
+async fn open_bus_waiting(port: &str, state: &RobotState) -> Option<BusIo> {
+    let mut attempt = 0u32;
+
+    while !state.shutdown.load(Ordering::Relaxed) {
+        // Logging lives in `open_bus`, which is chatty by design on the first attempt and
+        // quiet thereafter — a board waiting overnight must not fill the journal.
+        if let Some(io) = open_bus(port, attempt) {
+            state.startup_bus_failures.store(0, Ordering::Relaxed);
+            return Some(io);
+        }
+        attempt += 1;
+        // Published before sleeping, so `robot.health` can name the cause immediately.
+        state.startup_bus_failures.store(attempt, Ordering::Relaxed);
+
+        // Nothing to retry on a platform that has no bus at all.
+        if !cfg!(target_os = "linux") {
+            return None;
+        }
+        tokio::time::sleep(STARTUP_RETRY_INTERVAL).await;
+    }
+
+    None
 }
 
 /// Open and verify the bus, or explain why not.
 #[cfg(target_os = "linux")]
-fn open_bus(port: &str) -> Option<duck_control::bus::DynamixelIo> {
+fn open_bus(port: &str, attempt: u32) -> Option<BusIo> {
+    // First attempt and every thirtieth — about one line per 30 s while waiting.
+    let loud = attempt == 0 || attempt.is_multiple_of(STARTUP_READ_LOG_EVERY);
+
     let mut io = match duck_control::bus::DynamixelIo::open(port) {
         Ok(io) => io,
         Err(e) => {
-            tracing::error!(error = %e, port, "cannot open the bus");
+            if loud {
+                tracing::error!(error = %e, port, attempt, "cannot open the bus; waiting");
+            }
             return None;
         }
     };
@@ -429,7 +480,13 @@ fn open_bus(port: &str) -> Option<duck_control::bus::DynamixelIo> {
         Ok(0) => tracing::info!("motor registers already correct"),
         Ok(n) => tracing::warn!(corrected = n, "motor registers corrected"),
         Err(e) => {
-            tracing::error!(error = %e, "motor register check failed");
+            if loud {
+                tracing::error!(
+                    error = %e,
+                    attempt,
+                    "motor register check failed; waiting, is servo power on?"
+                );
+            }
             return None;
         }
     }
@@ -437,7 +494,7 @@ fn open_bus(port: &str) -> Option<duck_control::bus::DynamixelIo> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn open_bus(_port: &str) -> Option<FakeIo> {
+fn open_bus(_port: &str, _attempt: u32) -> Option<BusIo> {
     tracing::error!("no bus on this platform; use --fake");
     None
 }
@@ -476,7 +533,7 @@ async fn adopt_startup_pose<T: RobotIo>(
     while !state.shutdown.load(Ordering::Relaxed) {
         match io.read() {
             Ok(sensors) => {
-                state.startup_read_failures.store(0, Ordering::Relaxed);
+                state.startup_bus_failures.store(0, Ordering::Relaxed);
                 tracing::warn!(
                     joints = NUM_JOINTS,
                     hz = 1.0 / period.as_secs_f64(),
@@ -488,9 +545,7 @@ async fn adopt_startup_pose<T: RobotIo>(
                 attempt += 1;
                 // Published before sleeping, so `robot.health` can name the cause on the
                 // very first failure rather than after the first log line.
-                state
-                    .startup_read_failures
-                    .store(attempt, Ordering::Relaxed);
+                state.startup_bus_failures.store(attempt, Ordering::Relaxed);
                 if attempt == 1 || attempt.is_multiple_of(STARTUP_READ_LOG_EVERY) {
                     tracing::warn!(
                         error = %e,
@@ -1028,7 +1083,7 @@ mod tests {
     #[test]
     fn health_names_the_bus_while_waiting_for_it() {
         let s = RobotState::new(&Params::default(), false, false);
-        s.startup_read_failures.store(4, Ordering::Relaxed);
+        s.startup_bus_failures.store(4, Ordering::Relaxed);
 
         let health = s.health();
         assert!(!health.healthy);
@@ -1039,13 +1094,47 @@ mod tests {
         );
     }
 
+    /// **The regression.** A bus that cannot be *opened* — or whose register check fails,
+    /// which is what an unpowered board does — used to fall off the end of the control
+    /// thread. No loop was created and nothing had been recorded, so health fell back to
+    /// "control loop has not completed a cycle yet" for the life of the process: the one
+    /// message that says nothing about the cause. Retrying the first *read* did not help,
+    /// because execution never reached it.
+    #[tokio::test(start_paused = true)]
+    async fn a_bus_that_cannot_be_opened_is_reported_rather_than_abandoned() {
+        let s = Arc::new(RobotState::new(&Params::default(), false, false));
+        let waiter_state = Arc::clone(&s);
+        let handle = tokio::spawn(async move {
+            open_bus_waiting("/dev/definitely-not-a-bus", &waiter_state)
+                .await
+                .is_none()
+        });
+
+        // Bounded, so a regression fails rather than hanging CI.
+        for _ in 0..10_000 {
+            if s.startup_bus_failures.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            s.startup_bus_failures.load(Ordering::Relaxed) > 0,
+            "an unopenable bus must be recorded, or health cannot explain the silence"
+        );
+        // Which is exactly what health needs to name it and to pass the update gate.
+        assert!(s.health().degraded);
+
+        s.shutdown.store(true, Ordering::Relaxed);
+        assert!(handle.await.unwrap(), "must give up only on shutdown");
+    }
+
     /// A silent bus must be *degraded*, not unhealthy: it reports the same before and after
     /// a swap, so rolling a release back cannot fix it and only wastes an update. An
     /// unpowered bench board is the case that has to keep updating.
     #[test]
     fn a_silent_bus_is_degraded_rather_than_unhealthy() {
         let s = RobotState::new(&Params::default(), false, false);
-        s.startup_read_failures.store(4, Ordering::Relaxed);
+        s.startup_bus_failures.store(4, Ordering::Relaxed);
 
         let health = s.health();
         assert!(!health.healthy);
@@ -1093,12 +1182,12 @@ mod tests {
 
         // Let it fail at least once, so shutdown lands mid-wait rather than before the start.
         for _ in 0..10_000 {
-            if s.startup_read_failures.load(Ordering::Relaxed) > 0 {
+            if s.startup_bus_failures.load(Ordering::Relaxed) > 0 {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(2)).await;
         }
-        assert!(s.startup_read_failures.load(Ordering::Relaxed) > 0);
+        assert!(s.startup_bus_failures.load(Ordering::Relaxed) > 0);
 
         s.shutdown.store(true, Ordering::Relaxed);
         handle

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,6 +260,17 @@ resolve_bootstrap_asset() {
 bootstrap_first_release() {
     if [ -L "${INSTALL_DIR}/current" ]; then
         say "a release is already live ($(readlink "${INSTALL_DIR}/current")); skipping the bootstrap"
+        # This script provisions a bare board; it is not how an installed board updates. Say
+        # so, because everything after this point still prints reassuring green output and it
+        # is entirely reasonable to read that as "now on the latest release".
+        cat <<'EOF'
+
+  This script only bootstraps a board with no release on it, so the daemon version below
+  will not change. To update an installed board:
+
+    sudo robotctl update apply daemon
+
+EOF
         return 0
     fi
 
@@ -475,6 +486,14 @@ install_token_dropin() {
         printf '[Service]\nEnvironment=GITHUB_TOKEN=%s\n' "$TOKEN" > "${dir}/token.conf"
     )
     systemctl daemon-reload
+    # `daemon-reload` re-reads unit files; it does not restart anything. Without this the
+    # drop-in exists on disk and the *running* updaterd still has no GITHUB_TOKEN, so every
+    # later check 404s against a private repo — silently, on a timer, forever. The units are
+    # started before this function runs, so this was not a corner case: it was every board.
+    #
+    # `try-restart`, not `restart`: if updaterd is not running, starting it is
+    # `install_units`' job and doing it here would hide a failure there.
+    systemctl try-restart updaterd.service || warn "could not restart updaterd"
     say "wrote ${dir}/token.conf (mode 600) so updaterd can fetch updates"
     warn "that file holds a GitHub token in plaintext. Fine on a developer's board, not on a
   robot you ship. It is why artifact hosting is still open — docs/updater-design.md §6.1."

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -235,10 +235,13 @@ EOF
     say "board ready — install the daemon next"
     cat <<'EOF'
 
-  curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/install.sh -o /tmp/install.sh
-  sudo sh /tmp/install.sh
+  URL=https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/install.sh
+  curl -fsSL -H "Authorization: Bearer $DUCK_TOKEN" "$URL" -o /tmp/install.sh
+  sudo DUCK_TOKEN="$DUCK_TOKEN" sh /tmp/install.sh
 
-  On a private repository, pass a token:  sudo DUCK_TOKEN=ghp_... sh /tmp/install.sh
+  While the repository is private, both halves need the token: raw.githubusercontent.com
+  404s without it, and sudo does not pass the variable through on its own. Once the
+  repository is public, drop the header and the prefix.
 EOF
 }
 


### PR DESCRIPTION
Everything here was found trying to get 0.1.3 onto a real Radxa. Grew past its original title as each fix uncovered the next.

## 1. `robotd` abandoned the control thread if the bus would not open

This is what rolled 0.1.3 back on my board, and #9 did not fix it — it fixed one step too late.

`open_bus` calls `check_registers()`, which **talks to the servos**. On an unpowered board that fails, `open_bus` returns `None`, and the call site was:

```rust
if let Some(io) = open_bus(&port) {
    runtime.block_on(control_loop(io, state, period));
}
```

`None` falls off the end of the thread. No control loop is ever created, and because nothing had been *attempted*, `robot.health` fell back to `control loop has not completed a cycle yet` — for the life of the process, whatever happened to the robot afterwards. #9's retry of the first *read* never ran, because execution never reached it.

Observed as:

```
  HealthGate
  RollingBack
  reason: "health check failed: not healthy within 30s:
           control loop has not completed a cycle yet"
```

The old message rather than #9's new one was the tell: it only appears when zero attempts have been recorded.

Now the whole bring-up is retried — open, verify registers, first read — and the attempt count is recorded from the first failure, so health reports `degraded` and the gate commits rather than reverting. `open_bus` logs its first attempt then one in thirty, so a board left waiting overnight doesn't fill the journal.

Field renamed `startup_read_failures` → `startup_bus_failures`, since it now counts every way the bus can fail to come up.

## 2. `updaterd` never received the token it was given

`install_token_dropin` wrote `/etc/systemd/system/updaterd.service.d/token.conf` then ran `systemctl daemon-reload` — which re-reads unit files and restarts nothing. The units start earlier, in `install_units`, so the running `updaterd` never had `GITHUB_TOKEN`.

Every board, bare or not. 0.1.2 hid it because the bootstrap install takes the token from its own environment, so provisioning worked and only the daemon's own later checks failed, silently and on a timer:

```
error: network error: GET .../releases?per_page=100&page=1: HTTP 404 Not Found
```

Now `systemctl try-restart updaterd.service` — `try-restart` so starting a stopped unit stays `install_units`' job.

## 3. Progress spam, in the half that people actually watch

#9 throttled `updaterd`'s journal logging. But `robotctl update apply` prints every notification it receives, and the engine sends one per network chunk — ~250 `Downloading N%` lines in the terminal, burying the phases worth reading. On a terminal it now rewrites a single line; when redirected, one line per decile.

## 4. Two pieces of output that misled me on a live board

- `install.sh` returns early when a release is already live, then still prints unit status and `==> installed daemon <old version>` — which reads like a successful upgrade. It now names `robotctl update apply daemon` as what actually updates an installed board.
- `setup-board.sh` closed by printing a tokenless `raw.githubusercontent.com` curl, which 404s while the repo is private, followed by a `sudo` that wouldn't have passed `DUCK_TOKEN` through anyway. Both halves now carry the token.

## Tests

The regression test for (1) drives `open_bus_waiting` against a nonexistent port and asserts the failure is *recorded* and that health reports `degraded` — the old code recorded nothing and dropped the thread. It also asserts the waiter gives up only on shutdown, so `systemctl stop` can't hang on a board with no robot.

`cargo test -p robotd -p robotctl`: all green, no new clippy warnings.