### PR TITLE
Forced clean re-install, for a board the updater has stranded

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,6 +59,26 @@ REF="${DUCK_REF:-main}"
 # release download, which needs auth on a private repo.
 TOKEN="${DUCK_TOKEN:-}"
 
+# Re-install a release onto a board that already has one, using the release's *own*
+# updaterd rather than the one installed.
+#
+# The escape hatch for a board whose installed updaterd is too old to accept the release you
+# are trying to give it. Not hypothetical: 0.1.4 taught the health gate to commit on a
+# `degraded` robot, and a board on 0.1.2 rolls 0.1.4 back for reporting exactly that — it
+# cannot install the version that fixes it. Every future change to health semantics or
+# manifest format has the same shape.
+#
+# `updaterd install` refuses when a release is live, and it is right to: it forces
+# `on_apply = none` and `health = none`, which on a *running* robot would silently disable
+# auto-rollback. So this stops the daemons first. With nothing running there is no robot to
+# mislead anyone about, which is the same position a bare board is in — and that is a path
+# this script already takes. `install_units` starts them again afterwards.
+#
+# What is genuinely given up is auto-rollback *for this one install*: with no gate, a bad
+# release stays live. `verify_install` reports health at the end and `report` names
+# `robotctl rollback` for that reason. Ordinary updates keep the gate.
+FORCE_REINSTALL="${DUCK_FORCE_REINSTALL:-}"
+
 RAW="https://raw.githubusercontent.com/${REPO}/${REF}"
 BOOTSTRAP_ASSET="updaterd-bootstrap-aarch64"
 
@@ -257,8 +277,25 @@ resolve_bootstrap_asset() {
     BOOTSTRAP_URL="https://api.github.com/repos/${REPO}/releases/assets/${id}"
 }
 
+# Stop the daemons so a forced re-install is operating on an inert board.
+#
+# Deliberately not `try-restart`-style politeness: the point is that nothing is live while
+# the swap happens with no health gate behind it. Motors stop; on this robot that is
+# acceptable and is the price of the escape hatch.
+stop_for_reinstall() {
+    say "stopping the daemons for a clean re-install"
+    for unit in robotd.service updaterd.service; do
+        systemctl stop "$unit" 2>/dev/null || warn "could not stop ${unit}"
+    done
+}
+
 bootstrap_first_release() {
-    if [ -L "${INSTALL_DIR}/current" ]; then
+    if [ -L "${INSTALL_DIR}/current" ] && [ -n "$FORCE_REINSTALL" ]; then
+        say "forcing a clean re-install over $(readlink "${INSTALL_DIR}/current")"
+        warn "the health gate does not apply to a forced re-install, so this one cannot
+  auto-roll-back. If the robot misbehaves afterwards:  sudo robotctl rollback daemon"
+        stop_for_reinstall
+    elif [ -L "${INSTALL_DIR}/current" ]; then
         say "a release is already live ($(readlink "${INSTALL_DIR}/current")); skipping the bootstrap"
         # This script provisions a bare board; it is not how an installed board updates. Say
         # so, because everything after this point still prints reassuring green output and it
@@ -269,6 +306,12 @@ bootstrap_first_release() {
   will not change. To update an installed board:
 
     sudo robotctl update apply daemon
+
+  If that rolls back because the installed updaterd is too old to accept the new release,
+  re-install through the release's own updaterd. This stops the daemons and runs without a
+  health gate, so it cannot auto-roll-back — signatures and hashes are still verified:
+
+    sudo DUCK_TOKEN="$DUCK_TOKEN" DUCK_FORCE_REINSTALL=1 sh /tmp/install.sh
 
 EOF
         return 0
@@ -292,7 +335,17 @@ EOF
     # the installed `updaterd` still has no credential and still cannot fetch a *later*
     # update until someone adds the systemd drop-in by hand. That asymmetry is the point —
     # provisioning is a person at a keyboard, an unattended update is not.
-    GITHUB_TOKEN="$TOKEN" "${tmp}/updaterd" install --config "${CONFIG_DIR}/updater.toml"
+    # `--force` only on the forced path, where the daemons have just been stopped. updaterd
+    # verifies that itself — it refuses --force while robotd still answers — so this cannot
+    # quietly swap a release under a running robot.
+    force_flag=""
+    if [ -n "$FORCE_REINSTALL" ]; then
+        force_flag="--force"
+    fi
+
+    # shellcheck disable=SC2086 # unquoted so an empty force_flag passes no argument at all
+    GITHUB_TOKEN="$TOKEN" "${tmp}/updaterd" install \
+        --config "${CONFIG_DIR}/updater.toml" $force_flag
 
     if [ ! -L "${INSTALL_DIR}/current" ]; then
         die "the install reported success but nothing is live"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -391,6 +391,43 @@ create_group() {
     if ! getent group robot >/dev/null; then
         die "the robot group could not be created; updaterd.service will not start without it"
     fi
+
+    add_operator_to_group
+}
+
+# Put the person doing the install in the `robot` group.
+#
+# The socket is mode 0660, root:robot, and `Group=robot` in the unit is load-bearing for
+# exactly this reason: group membership is how a non-root client reaches robotd. But the group
+# was only ever created, never populated — so on every board provisioned so far, no
+# unprivileged user could talk to the robot at all:
+#
+#   $ robotctl health
+#   error: cannot reach robotd at /run/robotd.sock: Permission denied (os error 13)
+#
+# which reads like a crashed daemon rather than a missing group.
+#
+# Read-only access, not a privilege grant: mutations are refused to non-root peers regardless
+# of group, so this permits asking and not commanding.
+add_operator_to_group() {
+    # The human who ran sudo, not `whoami` — that is root, which is already able to connect
+    # and would make this a silent no-op.
+    operator="${SUDO_USER:-}"
+    if [ -z "$operator" ] || [ "$operator" = root ]; then
+        return 0
+    fi
+
+    if id -nG "$operator" 2>/dev/null | tr ' ' '\n' | grep -qx robot; then
+        return 0
+    fi
+
+    if usermod -aG robot "$operator"; then
+        say "added ${operator} to the robot group"
+        warn "${operator} must log out and back in before that takes effect. Until then,
+  read-only commands need sudo:  sudo robotctl health"
+    else
+        warn "could not add ${operator} to the robot group; robotctl will need sudo"
+    fi
 }
 
 # The units live inside the release, so this can only run after the release is installed.

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -106,7 +106,33 @@ enum Command {
         /// installable without committing to it.
         #[arg(long)]
         dry_run: bool,
+
+        /// Install over a release that is already live, with `robotd` stopped.
+        ///
+        /// For a board whose installed `updaterd` is too old to accept the release you are
+        /// trying to give it — it will roll the new release back and can never install the
+        /// version that fixes that. `robotctl update apply` cannot help, because the old
+        /// binary is the one running the gate.
+        ///
+        /// Refused unless `robotd` is silent, so the reason plain `install` refuses — no
+        /// health gate on a *working* robot — cannot apply. Stop it first:
+        /// `systemctl stop robotd`. Signatures, hashes and compatibility are still checked;
+        /// what is given up is auto-rollback for this one install.
+        #[arg(long)]
+        force: bool,
     },
+}
+
+/// Is a `robotd` answering the socket?
+///
+/// Short timeout: this asks whether anything is *there*, not whether it is well. Anything
+/// other than `Unreachable` means a robot is running and must not have the release swapped
+/// out from under it without a gate.
+async fn robot_is_answering(robot: &dyn updater::robot::RobotClient) -> bool {
+    !matches!(
+        robot.health(std::time::Duration::from_secs(2)).await,
+        updater::robot::Health::Unreachable
+    )
 }
 
 /// The first line each daemon logs, before anything that can fail.
@@ -147,7 +173,8 @@ async fn main() -> ExitCode {
             ref from,
             ref component,
             dry_run,
-        }) => install(&args, from.clone(), component, dry_run).await,
+            force,
+        }) => install(&args, from.clone(), component, dry_run, force).await,
         None => serve(args).await,
     }
 }
@@ -227,7 +254,13 @@ fn load(args: &Args) -> Option<Loaded> {
 ///
 /// See [`Command::Install`] for why this exists and why it refuses to run on a robot
 /// that already has a release live.
-async fn install(args: &Args, from: Option<PathBuf>, component: &str, dry_run: bool) -> ExitCode {
+async fn install(
+    args: &Args,
+    from: Option<PathBuf>,
+    component: &str,
+    dry_run: bool,
+    force: bool,
+) -> ExitCode {
     use updater::config::{ApplyAction, HealthCheck, SourceConfig};
 
     let Some(mut loaded) = load(args) else {
@@ -267,6 +300,29 @@ async fn install(args: &Args, from: Option<PathBuf>, component: &str, dry_run: b
     let store = updater::store::Store::new(cfg.install_dir.clone());
     match store.current() {
         Ok(None) => {}
+        // `--force`, and only with a silent robot. The objection to installing over a live
+        // release is about a *working robot* losing auto-rollback, so the honest guard is
+        // "is a robot answering", not "is a release live" — a stopped robotd cannot be
+        // misled about its own health, which is the same position a bare board is in.
+        Ok(Some(live)) if force => {
+            if robot_is_answering(loaded.robot.as_ref()).await {
+                tracing::error!(
+                    component,
+                    live = %live,
+                    "refusing --force: robotd is still answering, so this would swap the \
+                     release under a running robot with no health gate behind it. Stop it \
+                     first: systemctl stop robotd"
+                );
+                return ExitCode::FAILURE;
+            }
+            tracing::warn!(
+                component,
+                live = %live,
+                "--force: installing over a live release with robotd stopped. No health \
+                 gate, so this install cannot auto-roll-back — `robotctl rollback` is the \
+                 recovery path if the new release misbehaves."
+            );
+        }
         Ok(Some(live)) => {
             tracing::error!(
                 component,
@@ -274,7 +330,9 @@ async fn install(args: &Args, from: Option<PathBuf>, component: &str, dry_run: b
                 "refusing: this component already has a release live. `install` forces \
                  on_apply and health off, which on a working robot would silently disable \
                  auto-rollback. Use `robotctl update apply` — it goes through the daemon, \
-                 with the real health gate."
+                 with the real health gate. If that rolls back because the installed \
+                 updaterd is too old to accept the release, stop robotd and re-run with \
+                 --force."
             );
             return ExitCode::FAILURE;
         }
@@ -583,6 +641,7 @@ mod tests {
             from,
             component,
             dry_run,
+            force,
         }) = args.command
         else {
             panic!("expected install, got {:?}", args.command);
@@ -590,6 +649,7 @@ mod tests {
         assert_eq!(from.as_deref(), Some(Path::new("/var/tmp/rel")));
         assert_eq!(component, "daemon");
         assert!(!dry_run);
+        assert!(!force, "a plain install must never force");
     }
 
     /// The one-liner installer's path: no `--from`, so the configured source resolves
@@ -619,6 +679,26 @@ mod tests {
         .unwrap();
         assert_eq!(args.config, PathBuf::from("/etc/robot/updater.toml"));
         assert!(matches!(args.command, Some(Command::Install { .. })));
+    }
+
+    /// `--force` must be opt-in. Defaulting it on would let any bootstrap install swap a
+    /// release under a running robot with no health gate.
+    #[test]
+    fn install_does_not_force_by_default() {
+        let args = Args::try_parse_from(["updaterd", "install"]).unwrap();
+        match args.command {
+            Some(Command::Install { force, .. }) => assert!(!force),
+            other => panic!("expected Install, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn install_accepts_force() {
+        let args = Args::try_parse_from(["updaterd", "install", "--force"]).unwrap();
+        match args.command {
+            Some(Command::Install { force, .. }) => assert!(force),
+            other => panic!("expected Install, got {other:?}"),
+        }
     }
 
     /// The engine emits progress once per network chunk, so a single 3.6 MB download wrote

--- a/updater/tests/install.rs
+++ b/updater/tests/install.rs
@@ -317,6 +317,42 @@ fn refuses_once_a_release_is_live_and_says_what_to_use_instead() {
         Some("1.0.0"),
         "a refused install must not disturb the live release"
     );
+    assert!(
+        stderr.contains("--force"),
+        "the refusal must name the escape hatch, got: {stderr}"
+    );
+}
+
+/// The escape hatch, and the reason it exists: a board whose installed `updaterd` is too
+/// old to accept the release that fixes it. `robotctl update apply` cannot help, because the
+/// old binary is the one running the gate.
+///
+/// No `robotd` answers in this fixture, which is the condition `--force` requires — the
+/// objection to installing over a live release is about a *working* robot losing
+/// auto-rollback, and there is no robot here.
+#[test]
+fn force_installs_over_a_live_release_when_no_robot_answers() {
+    let fresh = FreshRobot::new();
+    fresh.publish("1.0.0");
+    assert!(fresh.install(&[]).status.success());
+    fresh.publish("1.1.0");
+
+    let out = fresh.install(&["--force"]);
+    assert!(
+        out.status.success(),
+        "--force must install over a live release: {}",
+        stderr(&out)
+    );
+    assert_eq!(
+        fresh.live().as_deref(),
+        Some("1.1.0"),
+        "the forced install must actually move the live release"
+    );
+    let stderr = stderr(&out);
+    assert!(
+        stderr.contains("cannot auto-roll-back"),
+        "a forced install must say what it gave up, got: {stderr}"
+    );
 }
 
 /// `--dry-run` proves a downloaded release is installable without committing to it,


### PR DESCRIPTION
Recording the capability discussed on the board bring-up: a way to force a clean re-install.

## The problem

A board cannot install the release that fixes the gate rejecting it.

The health gate is run by the **installed** `updaterd`. 0.1.2 has never heard of `degraded`, so it sees `healthy: false` from an unpowered bench board and rolls 0.1.4 back — the very release that teaches the gate to accept that state. `robotctl update apply` can't help, because the old binary is the one judging. Every future change to health semantics or manifest format has this shape.

## Why `install` refused, and why that was slightly wrong

`updaterd install` refused whenever a release was live:

> refusing: this component already has a release live. `install` forces on_apply and health off, which on a working robot would silently disable auto-rollback.

The reasoning is right, but the condition was keyed on the wrong thing: it asks whether a **release** is live, while the objection it describes is about a **working robot** losing auto-rollback. Those two come apart exactly when someone stops the robot — which on this machine is an acceptable thing to ask for.

## What this adds

`updaterd install --force`, permitted only while `robotd` is silent:

```
$ sudo updaterd install --force          # robotd still running
refusing --force: robotd is still answering, so this would swap the release under a
running robot with no health gate behind it. Stop it first: systemctl stop robotd
```

`updaterd` probes the socket itself rather than trusting the caller. A stopped `robotd` cannot be misled about its own health — the same position a bare board is in, and installing onto a bare board is a path this code already takes and trusts.

What is genuinely given up is auto-rollback **for that one install**, so the warning and `report` both name `robotctl rollback` as the recovery path. Signatures, hashes and compatibility checks are untouched.

`install.sh` exposes it as:

```bash
sudo DUCK_TOKEN="$DUCK_TOKEN" DUCK_FORCE_REINSTALL=1 sh /tmp/install.sh
```

which stops both daemons first; `install_units` starts them again afterwards. The "a release is already live; skipping the bootstrap" message now names it too.

## Tests

`force_installs_over_a_live_release_when_no_robot_answers` installs 1.0.0, publishes 1.1.0, and requires `--force` to actually move the live release — through the real binary, not a mock. The existing refusal test sits beside it and now also asserts the refusal names the escape hatch. `--force` is asserted off by default, since defaulting it on would make every bootstrap install a gateless one.

## Scope note

This does **not** help the 0.1.2 → 0.1.4 hop on my board: 0.1.4's bootstrap binary predates the flag. That hop still needs `probe = "none"` once. From 0.1.5 onward the escape hatch exists for every future occurrence — which is the point.