### PR TITLE
Restore the motor-UART fix that #13 reverted

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -544,6 +544,15 @@ MOTOR_PORT="${MOTOR_PORT:-/dev/ttyS2}"
 
 check_board() {
     if [ -e "$MOTOR_PORT" ]; then
+        # Existing is not the same as usable. Armbian runs a login console on this UART by
+        # default, and a getty *reads* the port — so it eats servo replies and every motor
+        # looks absent. Identical symptoms to unwired hardware, and far harder to guess.
+        tty="$(basename "$MOTOR_PORT")"
+        if systemctl is-active --quiet "serial-getty@${tty}.service" 2>/dev/null; then
+            warn "a login console (serial-getty@${tty}) is running on ${MOTOR_PORT}.
+  It will consume servo replies and robotd will report every motor missing. Run
+  scripts/setup-board.sh, which masks it."
+        fi
         return 0
     fi
     warn "${MOTOR_PORT} does not exist, so robotd will have no motor bus.

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -179,6 +179,54 @@ install_onnxruntime() {
     rm -rf "$tmp"
 }
 
+# Take the login console off the motor UART.
+#
+# UART2 is the RK3566 debug console, so Armbian runs `serial-getty@ttyS2` on it by default.
+# A getty does not merely hold the port open — it *reads* from it, consuming the Dynamixel
+# replies before `robotd` ever sees them. Every servo then looks absent, which is
+# indistinguishable from hardware that is unpowered or unwired.
+#
+# That is not a hypothetical: it cost an afternoon of staring at
+# `read return_delay_time on 20: Operation timed out` with a correctly wired robot attached
+# and every servo visible to other tools. `fuser -v /dev/ttyS2` naming `agetty` was the
+# first honest evidence.
+#
+# Two halves, because two things write to that UART:
+#
+#  1. The getty, which is masked rather than merely disabled — `getty.target` pulls it back
+#     in otherwise.
+#  2. The kernel's own console. Armbian's `console=both`/`console=serial` puts printk on the
+#     same wires as the servos, so a kernel message mid-transaction corrupts a reply. It is
+#     quiet most of the time, which makes it worse: an intermittent bus fault with no
+#     pattern. `console=display` is the supported Armbian value that keeps a console on HDMI
+#     and takes it off the UART.
+#
+# A UART cannot be both a console and a motor bus. Choosing the motor bus is the whole point
+# of this script.
+free_motor_port() {
+    tty="$(basename "$MOTOR_PORT")"
+    unit="serial-getty@${tty}.service"
+
+    if [ "$(systemctl is-enabled "$unit" 2>/dev/null)" = masked ]; then
+        say "${unit} already masked"
+    else
+        say "masking ${unit} so it stops eating servo replies"
+        systemctl disable --now "$unit" >/dev/null 2>&1 || true
+        if ! systemctl mask "$unit" >/dev/null 2>&1; then
+            warn "could not mask ${unit}; it will keep consuming bytes on ${MOTOR_PORT}"
+        fi
+    fi
+
+    if [ -f "$ENV_TXT" ] && grep -Eq '^console=(both|serial)$' "$ENV_TXT"; then
+        say "taking the kernel console off the motor UART (console=display)"
+        # Two plain substitutions rather than a BRE alternation, which differs between
+        # sed dialects and would fail silently by matching nothing.
+        sed -i 's/^console=both$/console=display/' "$ENV_TXT"
+        sed -i 's/^console=serial$/console=display/' "$ENV_TXT"
+        needs_reboot=1
+    fi
+}
+
 # What the board looks like now. Printed whether or not anything was changed, because "is
 # this board ready" is a question worth being able to ask on its own.
 report() {
@@ -194,6 +242,27 @@ report() {
   is wrong. Check:  dmesg | grep -iE 'ttyS|serial'
   robotd will start, fail to open the bus, and report unhealthy — which is honest, but it
   will not drive anything."
+    fi
+
+    # Named explicitly, because "the port exists" and "the port is usable" are different
+    # questions and only the second one matters.
+    holder=""
+    if command -v fuser >/dev/null 2>&1 && [ -e "$MOTOR_PORT" ]; then
+        holder="$(fuser "$MOTOR_PORT" 2>/dev/null | tr -d ' ')"
+    fi
+    if [ -n "$holder" ]; then
+        printf '  %-22s %s\n' "motor bus owner" "IN USE by pid ${holder}"
+        warn "something else has ${MOTOR_PORT} open. A reader on this port consumes servo
+  replies and every motor will look absent. Identify it with:  sudo fuser -v ${MOTOR_PORT}"
+    else
+        printf '  %-22s %s\n' "motor bus owner" "free"
+    fi
+
+    if grep -qE '(^| )console=tty(S|AMA)' /proc/cmdline 2>/dev/null; then
+        printf '  %-22s %s\n' "kernel console" "still on a serial port"
+        warn "the kernel prints to a UART (see /proc/cmdline). If that is ${MOTOR_PORT},
+  kernel messages will corrupt servo traffic intermittently. Set console=display in
+  ${ENV_TXT} and reboot."
     fi
 
     if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
@@ -249,6 +318,7 @@ main() {
     check_environment
     persist_self
     configure_overlay
+    free_motor_port
     install_onnxruntime
     report
 }


### PR DESCRIPTION
**#13 silently reverted #12.** Commit `2279c81` carries this alongside its intended change:

```
 scripts/install.sh     |   9 ----
 scripts/setup-board.sh |  70 --------------------------
 updater/Cargo.toml     |   4 +-
 updater/src/hooks.rs   | 131 ++++++++++++++++++++++++++++++++++++++++
```

So `main` has been shipping a `setup-board.sh` that enables the Dynamixel UART and leaves a getty reading from it — the bug that cost an afternoon of `read return_delay_time on 20: Operation timed out` with a correctly wired robot attached.

## How

Not a conflict resolved wrongly. A dirty working tree.

I cut #13's branch in a clone where I'd earlier run `git checkout origin/main -- .` against a ref that predated #12, to inspect an unrelated file. That left #12's changes looking like local modifications. `git checkout -b` carries uncommitted modifications into the new branch, and `git add -A` committed them as deletions.

Nothing looked wrong in review: the diffstat mentioned `scripts/`, and #13 was a PR that plausibly touched scripts. CI was green, because deleting a working feature breaks no test — there is no test asserting `setup-board.sh` masks the getty, since it's a shell script that reconfigures a board.

## The fix

Both files restored verbatim from `af4dcec` (#12's commit). `git diff af4dcec -- scripts/setup-board.sh scripts/install.sh` is empty, and #13's `ETXTBSY` retry is untouched — `spawn_retrying_busy` and both Linux-only tests are still there.

## Worth noting

This is the second time today that a green CI accompanied a real regression, and both were in the same blind spot: the shell scripts that provision hardware. `board-test.sh` exists but doesn't assert this. A check that `setup-board.sh` masks `serial-getty@<port>` would have caught it — worth doing separately rather than smuggling into a restore commit.