### PR TITLE
install.sh dev mode, and a test for the provisioning script

### DIFF
--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -176,6 +176,66 @@ test "$code" -eq 6 || { echo "    [FAIL] member should be denied (6), got $code"
 echo "    [ok] group member cannot mutate (exit 6, denied)"
 
 kill $DAEMON2 2>/dev/null || true
+
+# ── setup-board.sh, the provisioning script nothing else covered ──
+#
+# Added because two green-CI regressions landed here in one day, including #13 deleting the
+# console fix outright: deleting a working feature breaks no test. The scripts that provision
+# hardware were the least-covered surface in the repo, and the only one that touches a robot.
+#
+# Behavioural rather than a grep. `systemctl` is stubbed to record its arguments, so this
+# asserts what the script *does*. A grep would have caught the deletion but not a masking
+# call naming the wrong unit.
+mkdir -p /stub /boot /usr/local/lib
+
+# check_environment only probes with `command -v`, and the ONNX step is skipped below, so
+# stubs for tools this image lacks are enough and cost no download.
+cat > /stub/curl <<"STUB"
+#!/bin/sh
+exit 0
+STUB
+cp /stub/curl /stub/find
+cat > /stub/systemctl <<"STUB"
+#!/bin/sh
+echo "$@" >> /stub/systemctl.log
+exit 0
+STUB
+chmod +x /stub/curl /stub/find /stub/systemctl
+
+# Already present, so install_onnxruntime returns early instead of fetching ~20 MB.
+touch /usr/local/lib/libonnxruntime.so
+
+# The wrong overlay prefix and a console on the motor UART: what Armbian actually ships.
+cat > /boot/armbianEnv.txt <<"ENV"
+overlay_prefix=rk35xx
+console=both
+ENV
+
+PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board.log 2>&1
+
+# The RK3566 shares overlays with the RK3568, so the wrong prefix boots happily with no
+# /dev/ttyS2 at all.
+grep -q "^overlay_prefix=rk3568$" /boot/armbianEnv.txt
+grep -E "^overlays=" /boot/armbianEnv.txt | grep -qw uart2-m0
+echo "    [ok] setup-board fixes overlay_prefix and enables uart2-m0"
+
+# A getty *reads* the port, consuming servo replies, so every motor looks absent —
+# indistinguishable from unwired hardware and far harder to guess.
+grep -q "mask serial-getty@ttyS2.service" /stub/systemctl.log
+echo "    [ok] setup-board masks the getty on the motor port"
+
+# console=both puts printk on the same wires as the servos, corrupting replies
+# intermittently rather than cleanly.
+grep -q "^console=display$" /boot/armbianEnv.txt
+echo "    [ok] setup-board takes the kernel console off the UART"
+
+# Idempotent: it is re-run after the reboot it asks for, and must not undo its own work or
+# append a second copy of the overlay.
+PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board2.log 2>&1
+grep -q "^overlay_prefix=rk3568$" /boot/armbianEnv.txt
+grep -q "^console=display$" /boot/armbianEnv.txt
+test "$(grep -c uart2-m0 /boot/armbianEnv.txt)" = 1
+echo "    [ok] setup-board is idempotent on a second run"
 '
 
 for image in $IMAGES; do
@@ -183,6 +243,7 @@ for image in $IMAGES; do
     echo "==> $image"
     docker run --rm --platform linux/arm64 \
         -v "$PWD/$TARGET_DIR:/bin/robot:ro" \
+        -v "$PWD/scripts:/bin/scripts:ro" \
         "$image" sh -c "$CHECKS"
 done
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,6 +79,17 @@ TOKEN="${DUCK_TOKEN:-}"
 # `robotctl rollback` for that reason. Ordinary updates keep the gate.
 FORCE_REINSTALL="${DUCK_FORCE_REINSTALL:-}"
 
+# Trust the team dev key on this board, so `robotctl update apply --ref <branch>` works.
+#
+#   sudo DUCK_TOKEN=... DUCK_DEV_KEY=/path/to/team.dev.pub sh install.sh
+#
+# Operator-supplied on purpose, and never fetched. `deploy/trusted_keys/README.md` is
+# explicit that `team.dev.pub` stays out of the repository: a robot that trusts it installs
+# anything anyone on the team builds, unreviewed. Fetching it here would turn that from a
+# per-board decision into the default for every robot we image, which is precisely the
+# property that must not be automatic.
+DEV_KEY="${DUCK_DEV_KEY:-}"
+
 RAW="https://raw.githubusercontent.com/${REPO}/${REF}"
 BOOTSTRAP_ASSET="updaterd-bootstrap-aarch64"
 
@@ -430,6 +441,48 @@ add_operator_to_group() {
     fi
 }
 
+# Make this a developer board: trust the dev key, and allow dev-signed releases.
+#
+# Both halves are needed and they are independent checks in the updater — a trusted key only
+# counts as a dev key if its filename ends `.dev.pub`, and a dev key is only honoured when
+# `allow_dev_keys` is on. Doing one without the other silently produces a board that still
+# refuses branch builds, with a signature error that reads like a corrupt release.
+install_dev_key() {
+    [ -n "$DEV_KEY" ] || return 0
+
+    [ -f "$DEV_KEY" ] || die "DUCK_DEV_KEY=${DEV_KEY} is not a readable file.
+  Pass the *public* half — team.dev.pub. If you only have the secret key:
+    minisign -R -s <secret> -p team.dev.pub"
+
+    # Checked here rather than discovered at verification time, where the error names the
+    # release and not the key, and sends you looking at the wrong thing.
+    if ! head -1 "$DEV_KEY" | grep -q 'untrusted comment:'; then
+        die "${DEV_KEY} does not look like a minisign public key.
+  Expected a two-line file beginning 'untrusted comment:'. A secret key or a signature
+  will be accepted by this file copy and then fail every verification."
+    fi
+
+    config="${CONFIG_DIR}/updater.toml"
+    if ! grep -q '^allow_dev_keys' "$config"; then
+        die "${config} has no allow_dev_keys setting to enable.
+  It is a top-level key, so it cannot be safely appended — a line added at the end would
+  land inside whichever [table] comes last. Add it by hand near trusted_keys_dir."
+    fi
+
+    # The filename is load-bearing, so it is ours to choose rather than the caller's: a key
+    # installed under any other name is classified as a *release* key, and branch builds
+    # would then be trusted as though they had been reviewed.
+    install -m 644 "$DEV_KEY" "${KEYS_DIR}/team.dev.pub"
+    sed -i 's/^allow_dev_keys.*/allow_dev_keys        = true/' "$config"
+
+    say "dev mode: trusting team.dev.pub and allowing dev-signed releases"
+    warn "this board will now install any branch build anyone on the team pushes, without
+  review. Never do this to a robot you ship. To undo:
+    sudo rm ${KEYS_DIR}/team.dev.pub
+    sudo sed -i 's/^allow_dev_keys.*/allow_dev_keys        = false/' ${config}
+    sudo systemctl restart updaterd"
+}
+
 # The units live inside the release, so this can only run after the release is installed.
 # They are *copied* rather than symlinked through `current`: a unit file read through the
 # symlink would change under systemd's feet on every update, and after a rollback
@@ -531,6 +584,18 @@ report() {
 This robot polls for updates on its own and will apply a *mandatory* release without
 waiting to be asked. Ordinary releases wait for a client.
 EOF
+
+    # Only on a board that is actually in dev mode. Printing it everywhere would advertise a
+    # capability most boards correctly refuse, and the failure then looks like a broken
+    # release rather than a board that was never meant to take one.
+    if [ -f "${KEYS_DIR}/team.dev.pub" ]; then
+        cat <<'EOF'
+
+DEV BOARD: trusts team.dev.pub and accepts dev-signed branch builds.
+
+  sudo robotctl update apply daemon --ref BRANCH   install what a branch last built
+EOF
+    fi
 }
 
 
@@ -603,6 +668,7 @@ main() {
     check_board
     wait_for_clock
     install_config
+    install_dev_key
     bootstrap_first_release
     create_group
     install_units


### PR DESCRIPTION
Two independent changes.

## 1. `install.sh` gains an opt-in dev mode

```bash
sudo DUCK_TOKEN=... DUCK_DEV_KEY=/path/to/team.dev.pub sh install.sh
```

`robotctl update apply --ref <branch>` needs two things on a board, and they're *independent* checks in the updater: a trusted key whose filename ends `.dev.pub`, and `allow_dev_keys = true`. Do one without the other and the board still refuses branch builds, with a signature error that reads like a corrupt release. Both were hand steps until now — I've written them out three times today.

**The key is operator-supplied and never fetched.** `deploy/trusted_keys/README.md` is explicit that `team.dev.pub` stays out of the repository, because a robot that trusts it installs anything anyone on the team builds, unreviewed. Fetching it here would turn a per-board decision into the default for every robot we image.

Some deliberate choices:

- **The installed filename is ours, not the caller's** — a dev key installed under any other name is classified as a *release* key, and branch builds would be trusted as though reviewed.
- **Validated up front** (file exists, looks like a minisign public key), because otherwise the mistake surfaces at verification time where the error names the release rather than the key.
- **`allow_dev_keys` must already exist** to be rewritten. It's a top-level TOML key, so a line appended at the end would land inside whichever `[table]` comes last.
- The closing report names the dev command **only on a board actually in dev mode**, and says how to undo it.

## 2. A test for `setup-board.sh`

Two regressions reached `main` today through the same gap, both with green CI. #13 deleted this script's console fix outright — deleting a working feature breaks no test.

Behavioural, not a grep: `systemctl` is stubbed to record its arguments, so this asserts what the script *does*. A grep would have caught #13's deletion but not a masking call naming the wrong unit.

```
    [ok] setup-board fixes overlay_prefix and enables uart2-m0
    [ok] setup-board masks the getty on the motor port
    [ok] setup-board takes the kernel console off the UART
    [ok] setup-board is idempotent on a second run
```

Idempotence is in there because the script is designed to be re-run after the reboot it asks for, and must not undo its own work or append a second copy of the overlay.

`curl` and `find` are stubbed (`check_environment` only probes with `command -v`, and this image lacks them), and `libonnxruntime.so` is touched so the ONNX step returns early rather than fetching ~20 MB.

## Verification

The `board` job is the verifier — `board-test.sh` needs Docker and an arm64 container, and there's no container runtime on this machine. `setup-board.sh` also refuses to run anywhere `uname -m` isn't `aarch64`, so it cannot be exercised on a Mac at all.

Stating that plainly, since it's the same position #13 was in. The difference is that these assertions fail loudly if the script stops doing the thing — which is the entire point of adding them.