### PR TITLE
setup-board: pin an ONNX Runtime that ort can actually load

### DIFF
--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -202,8 +202,14 @@ exit 0
 STUB
 chmod +x /stub/curl /stub/find /stub/systemctl
 
-# Already present, so install_onnxruntime returns early instead of fetching ~20 MB.
-touch /usr/local/lib/libonnxruntime.so
+# Already present at the version asked for, so install_onnxruntime returns early instead of
+# fetching ~20 MB. Both halves matter: the check resolves the symlink and reads the version out
+# of the target name, so a bare file would be treated as a mismatch and trigger a download.
+#
+# ONNX_VERSION is passed explicitly rather than mirroring the script default, so bumping that
+# default — which happens whenever ort moves — cannot silently break this test.
+touch /usr/local/lib/libonnxruntime.so.9.9.9
+ln -sf libonnxruntime.so.9.9.9 /usr/local/lib/libonnxruntime.so
 
 # The wrong overlay prefix and a console on the motor UART: what Armbian actually ships.
 cat > /boot/armbianEnv.txt <<"ENV"
@@ -211,7 +217,7 @@ overlay_prefix=rk35xx
 console=both
 ENV
 
-PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board.log 2>&1
+ONNX_VERSION=9.9.9 PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board.log 2>&1
 
 # The RK3566 shares overlays with the RK3568, so the wrong prefix boots happily with no
 # /dev/ttyS2 at all.
@@ -231,7 +237,7 @@ echo "    [ok] setup-board takes the kernel console off the UART"
 
 # Idempotent: it is re-run after the reboot it asks for, and must not undo its own work or
 # append a second copy of the overlay.
-PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board2.log 2>&1
+ONNX_VERSION=9.9.9 PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board2.log 2>&1
 grep -q "^overlay_prefix=rk3568$" /boot/armbianEnv.txt
 grep -q "^console=display$" /boot/armbianEnv.txt
 test "$(grep -c uart2-m0 /boot/armbianEnv.txt)" = 1

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -20,7 +20,19 @@
 # Radxa Zero 3W on Armbian. Nothing here is specific to a robot revision.
 set -eu
 
-ONNX_VERSION="${ONNX_VERSION:-1.20.1}"
+# Must satisfy `ort`'s minimum, which is a hard runtime check and not a warning: ort
+# 2.0.0-rc.11 requires >= 1.23.x and *panics* in `setup_api` when the dylib is older —
+# killing robotd's control thread rather than returning an error. 1.20.1 was pinned here and
+# every board provisioned with it could load a policy only far enough to die:
+#
+#   thread 'control' panicked at ort-2.0.0-rc.11/src/lib.rs:191:41:
+#   Failed to load ONNX Runtime dylib: ... expected version >= '1.23.x', but got '1.20.1'
+#
+# Newer is safe: ort asks for *at least* its `ORT_API_VERSION`, and ONNX Runtime keeps the C
+# API backward compatible, so a runtime above the floor serves an older API version happily.
+# Raise this in step with `ort` in Cargo.toml — the two are one decision, and only one of them
+# is checked at compile time.
+ONNX_VERSION="${ONNX_VERSION:-1.28.0}"
 ONNX_LIB_DIR=/usr/local/lib
 
 # The Dynamixel bus. Every servo and the imu_to_dxl board share it, so without this there
@@ -141,9 +153,28 @@ configure_overlay() {
 # starts fine and *then* cannot walk. `robotd` reports that through `robot.health` with the
 # searched path in the message, so the failure names itself, but it is still a failure.
 install_onnxruntime() {
-    if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
-        say "ONNX Runtime already present in ${ONNX_LIB_DIR}"
+    # Version-aware, not merely presence-aware. The old check returned early whenever the
+    # symlink existed, so a board carrying an incompatible runtime could never be fixed by
+    # re-running this script — which is exactly the situation the 1.20.1 pin created.
+    #
+    # The tarball installs `libonnxruntime.so.<version>` with the bare name as a symlink, so
+    # the resolved target names the version without needing to run anything.
+    existing=""
+    if [ -e "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
+        resolved="$(readlink -f "${ONNX_LIB_DIR}/libonnxruntime.so" 2>/dev/null || true)"
+        case "$resolved" in
+            */libonnxruntime.so.*) existing="${resolved##*/libonnxruntime.so.}" ;;
+            *) existing="unknown" ;;
+        esac
+    fi
+
+    if [ "$existing" = "$ONNX_VERSION" ]; then
+        say "ONNX Runtime ${ONNX_VERSION} already present in ${ONNX_LIB_DIR}"
         return 0
+    fi
+
+    if [ -n "$existing" ]; then
+        say "replacing ONNX Runtime ${existing} with ${ONNX_VERSION}"
     fi
 
     url="https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-aarch64-${ONNX_VERSION}.tgz"
@@ -265,8 +296,17 @@ report() {
   ${ENV_TXT} and reboot."
     fi
 
-    if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
-        printf '  %-22s %s\n' "ONNX Runtime" "present"
+    if [ -e "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
+        # The version, not just "present": an incompatible runtime is indistinguishable from
+        # a correct one until robotd tries to load a policy and its control thread dies.
+        have="$(readlink -f "${ONNX_LIB_DIR}/libonnxruntime.so" 2>/dev/null || true)"
+        have="${have##*/libonnxruntime.so.}"
+        if [ "$have" = "$ONNX_VERSION" ]; then
+            printf '  %-22s %s\n' "ONNX Runtime" "$have"
+        else
+            printf '  %-22s %s\n' "ONNX Runtime" "${have:-unknown} (expected ${ONNX_VERSION})"
+            warn "this ONNX Runtime will not load a policy. Re-run this script to replace it."
+        fi
     else
         printf '  %-22s %s\n' "ONNX Runtime" "ABSENT — robotd cannot load a policy"
     fi


### PR DESCRIPTION
`setup-board.sh` installs ONNX Runtime **1.20.1**. `ort 2.0.0-rc.11` requires **>= 1.23.x** — and it doesn't return an error when the dylib is too old, it **panics**:

```
thread 'control' panicked at ort-2.0.0-rc.11/src/lib.rs:191:41:
Failed to load ONNX Runtime dylib: Error { code: GenericFailure,
  msg: "ort 2.0.0-rc.11 is not compatible with the ONNX Runtime binary found at
  `libonnxruntime.so`; expected version >= '1.23.x', but got '1.20.1'" }
```

A panicking thread doesn't kill the process, so `robotd` stays up and keeps serving its socket while never completing a tick. Health then reports `control loop has not completed a cycle yet` — the one message that says nothing about the cause.

Found when a dev install of slice 2 rolled back on a board whose bus, servos and IMU were all working:

```
  HealthGate
  RollingBack
  reason: "health check failed: not healthy within 30s:
           control loop has not completed a cycle yet"
```

## Two changes

**The pin.** 1.28.0, verified to have a `linux-aarch64` asset. Newer than the floor is safe: `ort` asks the dylib for *at least* its `ORT_API_VERSION`, and ONNX Runtime keeps the C API backward compatible. This must be raised in step with `ort` in `Cargo.toml` — one decision, of which only one half is checked at compile time.

**The check is version-aware.** It previously returned early whenever the symlink existed:

```sh
if [ -f "${ONNX_LIB_DIR}/libonnxruntime.so" ]; then
    say "ONNX Runtime already present in ${ONNX_LIB_DIR}"
    return 0
fi
```

So every board provisioned with 1.20.1 could never be fixed by re-running the script — the fix would have been unreachable on exactly the boards needing it. It now resolves the symlink, reads the version from the target's name (`libonnxruntime.so.1.20.1`), and replaces a mismatch.

The status block reports the version rather than `present`, with a warning when it won't work, because an incompatible runtime is indistinguishable from a correct one until a policy load kills the control thread.

## Note on scope

This makes the board correct. It does **not** stop `ort` from panicking, and a panicking control thread producing a misleading health reason is a separate defect worth fixing in slice 2, where `Policy::load` lives — `ensure_runtime()` probes that the dylib *loads*, which cannot detect a version mismatch. That belongs in #4.