### PR TITLE
Assert board prerequisites in a preinstall hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,17 @@
 resolver = "3"
 members = ["duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
 
+# ONNX Runtime, which robotd dlopens to run a policy. One source of truth: `xtask package`
+# bakes these into the release's preinstall hook, and a test asserts scripts/setup-board.sh
+# agrees with them. Two copies drifting apart is exactly how a board ended up with 1.20.1
+# against an `ort` that panics below 1.23.
+#
+# `floor` is the minimum `ort` accepts — raise it in step with the `ort` dependency.
+# `target` is what we install when a board is below the floor.
+[workspace.metadata.onnxruntime]
+floor  = "1.23"
+target = "1.28.0"
+
 [workspace.package]
 version = "0.1.4"
 edition = "2024"

--- a/hooks/preinstall.in
+++ b/hooks/preinstall.in
@@ -1,0 +1,131 @@
+#!/bin/sh
+# Make sure this board can actually run the release being installed.
+#
+# TEMPLATE. `xtask package` substitutes @ONNX_FLOOR@ and @ONNX_TARGET@ from
+# [workspace.metadata.onnxruntime] in Cargo.toml and ships the result as `hooks/preinstall`.
+# Edit this file, never the generated one — and there is no copy of the version to keep in
+# step, because the hook is built from the same constant the release is.
+#
+# Runs after the artifact is downloaded, verified and extracted, but *before* the swap. That
+# placement is the whole value: failing here aborts the update with the old release still
+# live, no rollback, and no boot-counter churn. Compare the alternative, which is what
+# actually happened on a board — full download, swap, restart, a 30s health gate, a rollback,
+# and `control loop has not completed a cycle yet` as the only explanation.
+#
+# The environment is cleared by the updater apart from PATH and the hook context, so there is
+# no token here. That is fine: ONNX Runtime comes from microsoft/onnxruntime, which is public.
+set -eu
+
+ONNX_FLOOR="@ONNX_FLOOR@"
+ONNX_TARGET="@ONNX_TARGET@"
+ONNX_LIB_DIR=/usr/local/lib
+
+# Below the updater's 120s ceiling on a hook, so a slow network produces our message naming
+# the fix rather than a bare "timed out after 120s".
+CURL_MAX_TIME=90
+
+say() { printf 'preinstall: %s\n' "$*"; }
+die() { printf 'preinstall: %s\n' "$*" >&2; exit 1; }
+
+# The version ONNX Runtime is installed at, or empty.
+#
+# The tarball lays down `libonnxruntime.so.<version>` with the bare name as a symlink, so the
+# resolved target names the version without running anything. Asking the library itself would
+# mean dlopening it, which is what we are trying to avoid doing unsafely.
+installed_onnx() {
+    resolved="$(readlink -f "${ONNX_LIB_DIR}/libonnxruntime.so" 2>/dev/null || true)"
+    case "$resolved" in
+        */libonnxruntime.so.*) printf '%s' "${resolved##*/libonnxruntime.so.}" ;;
+        *) printf '' ;;
+    esac
+}
+
+# Is $1 at least $2, comparing major.minor numerically?
+#
+# Numeric rather than string: "1.9" sorts above "1.23" lexically, which would pass a board
+# that cannot run the release. Patch is ignored — `ort` cares about the API version, which
+# moves with the minor.
+at_least() {
+    [ -n "$1" ] || return 1
+
+    have_major="${1%%.*}"
+    have_rest="${1#*.}"
+    have_minor="${have_rest%%.*}"
+    want_major="${2%%.*}"
+    want_rest="${2#*.}"
+    want_minor="${want_rest%%.*}"
+
+    # Guard against a version that is not numeric at all, rather than letting `test` fail
+    # noisily on it.
+    case "${have_major}${have_minor}${want_major}${want_minor}" in
+        *[!0-9]*) return 1 ;;
+    esac
+
+    if [ "$have_major" -gt "$want_major" ]; then
+        return 0
+    elif [ "$have_major" -lt "$want_major" ]; then
+        return 1
+    elif [ "$have_minor" -ge "$want_minor" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Install ONNX Runtime, replacing whatever is there.
+#
+# This writes to /usr/local/lib before the swap, so the change outlives an aborted update.
+# Deliberate and safe in this direction: `ort` asks the dylib for *at least* its
+# ORT_API_VERSION and ONNX Runtime keeps the C API backward compatible, so the release we are
+# about to abandon still works against the newer runtime.
+install_onnx() {
+    url="https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_TARGET}/onnxruntime-linux-aarch64-${ONNX_TARGET}.tgz"
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064 # expand $tmp now, deliberately
+    trap "rm -rf '$tmp'" EXIT INT TERM
+
+    say "fetching ONNX Runtime ${ONNX_TARGET}"
+    curl -fsSL --max-time "$CURL_MAX_TIME" -o "${tmp}/ort.tgz" "$url" \
+        || die "cannot download ONNX Runtime ${ONNX_TARGET} from ${url}
+  This board needs it to run a policy, and this release cannot start without one. With
+  network access, re-running the update will retry. Otherwise install it by hand, or run
+  scripts/setup-board.sh."
+
+    tar -xzf "${tmp}/ort.tgz" -C "$tmp" || die "cannot unpack ONNX Runtime"
+
+    found="$(find "$tmp" -name 'libonnxruntime.so.*' -type f | head -1)"
+    [ -n "$found" ] || die "no libonnxruntime.so.* in the ONNX Runtime tarball"
+
+    install -m 0644 "$found" "${ONNX_LIB_DIR}/$(basename "$found")"
+    ln -sf "$(basename "$found")" "${ONNX_LIB_DIR}/libonnxruntime.so"
+
+    # ldconfig lives in /usr/sbin, which a hook's minimal PATH does include — but check
+    # anyway, because a freshly copied library that dlopen cannot find is the same failure
+    # this hook exists to prevent.
+    if command -v ldconfig >/dev/null 2>&1; then
+        ldconfig
+    elif [ -x /usr/sbin/ldconfig ]; then
+        /usr/sbin/ldconfig
+    else
+        say "no ldconfig; robotd may need ORT_DYLIB_PATH=${ONNX_LIB_DIR}/libonnxruntime.so"
+    fi
+}
+
+have="$(installed_onnx)"
+
+if at_least "$have" "$ONNX_FLOOR"; then
+    say "ONNX Runtime ${have} satisfies >= ${ONNX_FLOOR}"
+    exit 0
+fi
+
+say "ONNX Runtime ${have:-absent} is below ${ONNX_FLOOR}, which this release requires"
+install_onnx
+
+# Verified rather than assumed: an install that reported success but left the symlink wrong
+# would otherwise be discovered by robotd's control thread panicking, which is the failure
+# mode this hook was written to remove.
+have="$(installed_onnx)"
+at_least "$have" "$ONNX_FLOOR" \
+    || die "installed ONNX Runtime ${have:-none}, still below ${ONNX_FLOOR}"
+
+say "ONNX Runtime now ${have}"

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -242,6 +242,50 @@ grep -q "^overlay_prefix=rk3568$" /boot/armbianEnv.txt
 grep -q "^console=display$" /boot/armbianEnv.txt
 test "$(grep -c uart2-m0 /boot/armbianEnv.txt)" = 1
 echo "    [ok] setup-board is idempotent on a second run"
+
+# ── the generated preinstall hook ──
+#
+# The hook that asserts a board can run the release being installed. Exercised here because
+# the alternative is discovering on a robot that it rejects every update, and because the
+# whole point of moving this check into a hook was to stop relying on someone remembering to
+# re-run a script.
+#
+# Rendered from the template the way xtask does, so this covers the shipped shape rather than
+# a hand-written approximation.
+sed -e "s/@ONNX_FLOOR@/1.23/" -e "s/@ONNX_TARGET@/1.28.0/" \
+    /bin/hooks/preinstall.in > /tmp/preinstall
+chmod +x /tmp/preinstall
+if grep -q "@ONNX_" /tmp/preinstall; then
+    echo "    [FAIL] placeholders left in the rendered hook"
+    exit 1
+fi
+
+# Satisfied: a runtime at or above the floor must pass, touching nothing.
+rm -f /usr/local/lib/libonnxruntime.so*
+touch /usr/local/lib/libonnxruntime.so.1.28.0
+ln -sf libonnxruntime.so.1.28.0 /usr/local/lib/libonnxruntime.so
+PATH="/stub:$PATH" /tmp/preinstall > /tmp/hook1.log 2>&1
+grep -q "satisfies" /tmp/hook1.log
+echo "    [ok] preinstall accepts a runtime at the floor"
+
+# Too old, and unfixable: curl fails, so the hook must exit non-zero *before* the swap rather
+# than let a release install that cannot load a policy. This is the case that used to reach a
+# board and panic robotd control thread.
+mkdir -p /stubfail
+cat > /stubfail/curl <<"STUB"
+#!/bin/sh
+exit 22
+STUB
+chmod +x /stubfail/curl
+rm -f /usr/local/lib/libonnxruntime.so*
+touch /usr/local/lib/libonnxruntime.so.1.20.1
+ln -sf libonnxruntime.so.1.20.1 /usr/local/lib/libonnxruntime.so
+code=0
+PATH="/stubfail:$PATH" /tmp/preinstall > /tmp/hook2.log 2>&1 || code=$?
+test "$code" -ne 0 || { echo "    [FAIL] hook passed an unusable runtime"; exit 1; }
+grep -q "1.20.1 is below 1.23" /tmp/hook2.log
+grep -q "cannot download ONNX Runtime" /tmp/hook2.log
+echo "    [ok] preinstall refuses an old runtime it cannot replace, naming the fix"
 '
 
 for image in $IMAGES; do
@@ -250,6 +294,7 @@ for image in $IMAGES; do
     docker run --rm --platform linux/arm64 \
         -v "$PWD/$TARGET_DIR:/bin/robot:ro" \
         -v "$PWD/scripts:/bin/scripts:ro" \
+        -v "$PWD/hooks:/bin/hooks:ro" \
         "$image" sh -c "$CHECKS"
 done
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -332,6 +332,24 @@ fn package(args: PackageArgs) -> Result<(), Box<dyn std::error::Error>> {
             append_file(&mut builder, Path::new(src), dest, mode)?;
         }
 
+        // The preinstall hook, always, generated from its template.
+        //
+        // Not an `--include` the release workflow has to remember: the board prerequisites it
+        // asserts are a property of every release, and a check that ships only when someone
+        // adds a flag is a check that will one day be missing from the release that needed it.
+        const PREINSTALL_TEMPLATE: &str = "hooks/preinstall.in";
+        if args
+            .includes
+            .iter()
+            .any(|i| i.ends_with("=hooks/preinstall"))
+        {
+            return Err("hooks/preinstall is generated; remove the --include for it".into());
+        }
+        let template = std::fs::read_to_string(PREINSTALL_TEMPLATE)
+            .map_err(|e| format!("reading {PREINSTALL_TEMPLATE}: {e}"))?;
+        let hook = render_preinstall_hook(&template)?;
+        append_bytes(&mut builder, "hooks/preinstall", hook.as_bytes(), 0o755)?;
+
         // Recorded inside the release so a robot can identify what it is running even
         // with no network and no manifest.
         let version_toml = format!(
@@ -706,6 +724,44 @@ fn promote(
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+/// ONNX Runtime floor and target from `[workspace.metadata.onnxruntime]`.
+///
+/// One source of truth for a value that has to agree in three places — the preinstall hook,
+/// `scripts/setup-board.sh`, and whatever `ort` requires. Two of those drifted apart once
+/// already, and the board that resulted could install a release and then only load a policy
+/// far enough to panic.
+fn onnxruntime_versions() -> Result<(String, String), Box<dyn std::error::Error>> {
+    let manifest: toml::Value = toml::from_str(&std::fs::read_to_string("Cargo.toml")?)?;
+    let table = manifest
+        .get("workspace")
+        .and_then(|w| w.get("metadata"))
+        .and_then(|m| m.get("onnxruntime"))
+        .ok_or("Cargo.toml has no [workspace.metadata.onnxruntime]")?;
+    let get = |key: &str| -> Result<String, Box<dyn std::error::Error>> {
+        Ok(table
+            .get(key)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("[workspace.metadata.onnxruntime] has no {key}"))?
+            .to_owned())
+    };
+    Ok((get("floor")?, get("target")?))
+}
+
+/// Fill in the preinstall hook from its template.
+///
+/// Generated rather than committed so the hook cannot disagree with the release it ships
+/// inside: both come from the same `Cargo.toml` in the same build.
+fn render_preinstall_hook(template: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let (floor, target) = onnxruntime_versions()?;
+    let rendered = template
+        .replace("@ONNX_FLOOR@", &floor)
+        .replace("@ONNX_TARGET@", &target);
+    if rendered.contains("@ONNX_") {
+        return Err("preinstall template still has unsubstituted @ONNX_...@ placeholders".into());
+    }
+    Ok(rendered)
+}
+
 fn workspace_version() -> Result<semver::Version, Box<dyn std::error::Error>> {
     let manifest: toml::Value = toml::from_str(&std::fs::read_to_string("Cargo.toml")?)?;
     let raw = manifest
@@ -753,4 +809,50 @@ fn sha256_hex(bytes: &[u8]) -> String {
             let _ = write!(s, "{b:02x}");
             s
         })
+}
+
+#[cfg(test)]
+mod tests {
+    /// `scripts/setup-board.sh` is fetched standalone with `curl`, so it cannot read
+    /// Cargo.toml and has to carry a literal version. This is what stops that literal
+    /// drifting from the value the preinstall hook is generated with — the exact failure that
+    /// left 1.20.1 on a board against an `ort` that requires 1.23 and panics below it.
+    #[test]
+    fn setup_board_pins_the_same_onnx_target() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let manifest: toml::Value =
+            toml::from_str(&std::fs::read_to_string(root.join("Cargo.toml")).unwrap()).unwrap();
+        let target = manifest["workspace"]["metadata"]["onnxruntime"]["target"]
+            .as_str()
+            .unwrap();
+
+        let script = std::fs::read_to_string(root.join("scripts/setup-board.sh")).unwrap();
+        let expected = format!("ONNX_VERSION=\"${{ONNX_VERSION:-{target}}}\"");
+        assert!(
+            script.contains(&expected),
+            "setup-board.sh must pin ONNX_VERSION to {target}; expected the line {expected:?}"
+        );
+    }
+
+    /// The shipped hook must be fully substituted. A placeholder reaching a board would be
+    /// compared against a version number and silently fail every board the same way.
+    #[test]
+    fn the_preinstall_template_renders_completely() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let template = std::fs::read_to_string(root.join("hooks/preinstall.in")).unwrap();
+        assert!(
+            template.contains("@ONNX_FLOOR@") && template.contains("@ONNX_TARGET@"),
+            "the template should carry both placeholders"
+        );
+
+        let rendered = template
+            .replace("@ONNX_FLOOR@", "1.23")
+            .replace("@ONNX_TARGET@", "1.28.0");
+        assert!(
+            !rendered.contains("@ONNX_"),
+            "nothing may remain unsubstituted"
+        );
+        assert!(rendered.contains("ONNX_FLOOR=\"1.23\""));
+        assert!(rendered.contains("ONNX_TARGET=\"1.28.0\""));
+    }
 }


### PR DESCRIPTION
Your suggestion, built. The hook mechanism was fully implemented and had **never run anything** — no `hooks/` directory existed, so `RunningPreHook` and `RunningPostHook` were phases that always did nothing.

## Why this is the right home for it

The requirement — an ONNX Runtime new enough for `ort` — is a property of the **release** (it's set by `ort` in `Cargo.toml`). It lived in `setup-board.sh`, an artifact with its own lifecycle and no coupling to the release. That decoupling is exactly why a board ran 1.20.1 against an `ort` needing 1.23: installed fine, then killed `robotd`'s control thread the moment it loaded a policy.

Now it travels with the release that needs it.

## A correction to what I offered you

You picked "assert + self-heal in postinstall". That combination can't work, and the option text was mine to get right: `preinstall` runs *before* `postinstall`, so an assert that hard-fails means the heal never runs.

Resolved by **healing in `preinstall`**, which keeps what you wanted and improves on it. `preinstall` runs after verify/extract but *before the swap*, so:

- it heals what it can — no manual `setup-board` re-run
- when it can't (no network, failed download) it **fails before the swap**: old release still live, no rollback, no boot-counter churn

Healing in `postinstall` would put every failure after the swap, costing a rollback.

What today's failure would have looked like:

```
  Extracting
  RunningPreHook
error: hooks/preinstall failed: ONNX Runtime 1.20.1 is below 1.23, which this
       release requires ... cannot download ONNX Runtime 1.28.0
```

versus what it did: full download, swap, restart, 30 s gate, rollback, and `control loop has not completed a cycle yet` as the only explanation.

## No room for drift

`[workspace.metadata.onnxruntime]` holds `floor` and `target`. `xtask package` renders `hooks/preinstall.in` from them, so **the hook cannot disagree with the release it ships inside** — same `Cargo.toml`, same build.

It ships unconditionally rather than via `--include`: a check that only ships when someone remembers a flag will one day be missing from the release that needed it.

`setup-board.sh` is fetched standalone with `curl` and cannot read `Cargo.toml`, so it keeps a literal and a test asserts the two agree. I verified that test **fails** when they're changed apart rather than trusting it.

## Verified, not assumed

- `xtask package` really puts `hooks/preinstall` in the artifact at mode 0755 with both values substituted — checked by unpacking a real tarball.
- The comparison is numeric on major.minor, because `"1.9"` sorts *above* `"1.23"` as a string and would pass a board that cannot run the release. Truth table checked against `1.20.1`, `1.23.0`, `1.28.0`, `1.9`, `2.0.0`, empty, and non-numeric.
- `board-test.sh` renders the template the way `xtask` does and exercises both paths: accepted at the floor, and refused with an actionable message when it cannot replace an old runtime.
- The playground builds its own tarballs and doesn't include hooks, so existing board tests are unaffected — checked, because a hook running inside those containers would have tried to download 20 MB.

## Note

`HOOK_TIMEOUT` is 120 s and the download is ~20 MB, so `curl` gets `--max-time 90` — a slow board then produces our message naming the fix rather than a bare `timed out after 120s`. If board networks turn out slower than that, the ceiling is the thing to raise.