### PR TITLE
setup-board: configure what a gamepad needs

### DIFF
--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -211,6 +211,14 @@ chmod +x /stub/curl /stub/find /stub/systemctl
 touch /usr/local/lib/libonnxruntime.so.9.9.9
 ln -sf libonnxruntime.so.9.9.9 /usr/local/lib/libonnxruntime.so
 
+# A BlueZ config with [General] but no Privacy key — the insert-after-[General] branch, which
+# is the one a stock Armbian image takes.
+mkdir -p /etc/bluetooth
+cat > /etc/bluetooth/main.conf <<"BTCONF"
+[General]
+Name = radxa
+BTCONF
+
 # The wrong overlay prefix and a console on the motor UART: what Armbian actually ships.
 cat > /boot/armbianEnv.txt <<"ENV"
 overlay_prefix=rk35xx
@@ -242,6 +250,16 @@ grep -q "^overlay_prefix=rk3568$" /boot/armbianEnv.txt
 grep -q "^console=display$" /boot/armbianEnv.txt
 test "$(grep -c uart2-m0 /boot/armbianEnv.txt)" = 1
 echo "    [ok] setup-board is idempotent on a second run"
+
+# The gamepad settings, which are the kind that fail silently: a pad that pairs and drops, or
+# a padd that reads nothing because the user is not in `input`.
+grep -qE "^Privacy = device$" /etc/bluetooth/main.conf
+echo "    [ok] setup-board sets Privacy = device for gamepad pairing"
+
+# Idempotent too: the second run above must not have added a duplicate key, which BlueZ
+# would read as a conflicting setting.
+test "$(grep -cE "^[[:space:]]*Privacy[[:space:]]*=" /etc/bluetooth/main.conf)" = 1
+echo "    [ok] Privacy is set exactly once"
 
 # ── the generated preinstall hook ──
 #

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -391,8 +391,16 @@ report() {
     fi
 
     # The device node is what gilrs opens, so this is the only claim that matters.
-    if ls /dev/input/js* >/dev/null 2>&1; then
-        printf '  %-22s %s\n' "gamepad" "$(ls /dev/input/js* | tr '\n' ' ')"
+    #
+    # A glob rather than `ls`: an unmatched glob stays literal in sh, so the `-e` test is what
+    # distinguishes "no pad" from a device actually being there.
+    pads=""
+    for node in /dev/input/js*; do
+        [ -e "$node" ] || continue
+        pads="${pads}${node} "
+    done
+    if [ -n "$pads" ]; then
+        printf '  %-22s %s\n' "gamepad" "$pads"
     else
         printf '  %-22s %s\n' "gamepad" "none connected"
     fi

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -41,6 +41,17 @@ MOTOR_PORT="${MOTOR_PORT:-/dev/ttyS2}"
 
 ENV_TXT=/boot/armbianEnv.txt
 
+BT_CONF=/etc/bluetooth/main.conf
+
+# Optionally pair a gamepad, e.g. PAD_MAC=78:86:2E:BB:13:28 sh setup-board.sh
+#
+# An environment variable rather than a flag, matching MOTOR_PORT and ONNX_VERSION above —
+# this script is usually run through `curl | sh`, where flags are awkward to pass.
+#
+# Optional because the MAC is per-pad and most of the value here is the two settings that
+# apply to every board regardless: the BlueZ privacy mode, and the `input` group.
+PAD_MAC="${PAD_MAC:-}"
+
 # Where this script puts itself so it is still around after the reboot it asks for.
 SELF=/usr/local/sbin/robot-setup-board
 
@@ -258,6 +269,94 @@ free_motor_port() {
     fi
 }
 
+# Bluetooth settings a gamepad needs, and the group that lets a human read one.
+#
+# `Privacy = device` is the fix for an Xbox controller that pairs and then drops straight back
+# out — it presents as an endless connect/disconnect loop, or as
+# `disconnected with reason 3` / `AuthenticationCanceled` during pairing. Taken from
+# microduck_runtime, whose installer sets exactly this and whose notes record the same
+# symptom; several hours went into rediscovering it as a supposed BR/EDR or ERTM problem,
+# which it is not. BLE is fine.
+#
+# The change sets `needs_reboot` rather than restarting bluetooth. Restarting the daemon on
+# this board left the kernel holding hci0 while bluetoothd reported "No default controller
+# available", which needs a reboot to clear — so a reboot is the honest instruction, not an
+# extra step.
+configure_bluetooth() {
+    if [ ! -f "$BT_CONF" ]; then
+        warn "no ${BT_CONF}; skipping the gamepad Bluetooth settings"
+        return 0
+    fi
+
+    if grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
+        say "bluetooth Privacy already set to device"
+    else
+        say "setting Privacy = device in ${BT_CONF}"
+        if grep -Eq '^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=' "$BT_CONF"; then
+            sed -i -E 's|^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=.*|Privacy = device|' "$BT_CONF"
+        elif grep -q '^\[General\]' "$BT_CONF"; then
+            sed -i '/^\[General\]/a Privacy = device' "$BT_CONF"
+        else
+            printf '\n[General]\nPrivacy = device\n' >> "$BT_CONF"
+        fi
+        needs_reboot=1
+    fi
+
+    add_operator_to_input_group
+    pair_pad
+}
+
+# A gamepad is read through /dev/input/event*, which is root:input mode 0660. Without this
+# `padd` starts, reports nothing, and silently sees no pad at all — the same shape of failure
+# as the `robot` group, and just as hard to guess from the outside.
+add_operator_to_input_group() {
+    operator="${SUDO_USER:-}"
+    if [ -z "$operator" ] || [ "$operator" = root ]; then
+        return 0
+    fi
+    if id -nG "$operator" 2>/dev/null | tr ' ' '\n' | grep -qx input; then
+        return 0
+    fi
+    if usermod -aG input "$operator"; then
+        say "added ${operator} to the input group"
+        warn "${operator} must log out and back in before padd can read a gamepad."
+    else
+        warn "could not add ${operator} to the input group; padd will see no gamepad"
+    fi
+}
+
+# Trust and connect a known pad, when its MAC was supplied.
+#
+# Deliberately not a scan: discovery needs the pad held in pairing mode at the right moment,
+# which a provisioning script cannot arrange. Supplying the MAC of a pad already in pairing
+# mode is the part that can be automated; the rest stays a human at a keyboard.
+pair_pad() {
+    [ -n "$PAD_MAC" ] || return 0
+
+    if ! command -v bluetoothctl >/dev/null 2>&1; then
+        warn "bluetoothctl is not installed; cannot pair ${PAD_MAC}"
+        return 0
+    fi
+
+    say "pairing gamepad ${PAD_MAC} (hold it in pairing mode)"
+    # Discovery has to be running for a first-time connect to resolve the address.
+    bluetoothctl --timeout 15 scan on >/dev/null 2>&1 || true
+
+    # `connect` before `pair`, which is the order microduck_runtime's notes give and the one
+    # that works; leading with `pair` returns AuthenticationCanceled.
+    if bluetoothctl connect "$PAD_MAC" >/dev/null 2>&1; then
+        bluetoothctl trust "$PAD_MAC" >/dev/null 2>&1 || true
+        say "gamepad ${PAD_MAC} connected and trusted"
+    else
+        warn "could not connect ${PAD_MAC}. If Privacy was just changed, reboot first — it
+  does not take effect until then. Otherwise pair by hand:
+    sudo bluetoothctl
+    scan on            (hold the pad in pairing mode until it is listed by: devices)
+    connect ${PAD_MAC}
+    trust ${PAD_MAC}"
+    fi
+}
+
 # What the board looks like now. Printed whether or not anything was changed, because "is
 # this board ready" is a question worth being able to ask on its own.
 report() {
@@ -273,6 +372,29 @@ report() {
   is wrong. Check:  dmesg | grep -iE 'ttyS|serial'
   robotd will start, fail to open the bus, and report unhealthy — which is honest, but it
   will not drive anything."
+    fi
+
+    # Gamepad readiness, which is three separate things that each fail silently.
+    if [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
+        printf '  %-22s %s\n' "bluetooth privacy" "device"
+    else
+        printf '  %-22s %s\n' "bluetooth privacy" "NOT SET — a pad will drop on connect"
+    fi
+
+    operator="${SUDO_USER:-}"
+    if [ -z "$operator" ] || [ "$operator" = root ]; then
+        printf '  %-22s %s\n' "input group" "not applicable (no sudo user)"
+    elif id -nG "$operator" 2>/dev/null | tr ' ' '\n' | grep -qx input; then
+        printf '  %-22s %s\n' "input group" "${operator} is a member"
+    else
+        printf '  %-22s %s\n' "input group" "${operator} NOT a member — padd sees no pad"
+    fi
+
+    # The device node is what gilrs opens, so this is the only claim that matters.
+    if ls /dev/input/js* >/dev/null 2>&1; then
+        printf '  %-22s %s\n' "gamepad" "$(ls /dev/input/js* | tr '\n' ' ')"
+    else
+        printf '  %-22s %s\n' "gamepad" "none connected"
     fi
 
     # Named explicitly, because "the port exists" and "the port is usable" are different
@@ -359,6 +481,7 @@ main() {
     persist_self
     configure_overlay
     free_motor_port
+    configure_bluetooth
     install_onnxruntime
     report
 }


### PR DESCRIPTION
Three settings a gamepad needs, each of which fails silently.

## `Privacy = device`

The fix for an Xbox controller that pairs and immediately drops:

```
hci0 78:86:2E:BB:13:28 type LE Public disconnected with reason 3
Failed to pair: org.bluez.Error.AuthenticationCanceled
```

Taken from `microduck_runtime` — its installer sets exactly this, and `rpi_setup/setup.md` records the same symptom as a "connect/disconnect loop". I spent several rounds treating it as a BR/EDR transport problem and then an ERTM problem. It is neither, and BLE was always fine. The answer was in a section headed "Xbox controller pairing" in the reference repo.

## The `input` group

A gamepad is read through `/dev/input/event*`, which is `root:input` mode `0660`. Without membership `padd` starts, logs nothing, and sees no pad — the same failure shape as the `robot` group.

## Optional `PAD_MAC`

```bash
sudo PAD_MAC=78:86:2E:BB:13:28 sh setup-board.sh
```

An environment variable rather than a flag, matching `MOTOR_PORT` and `ONNX_VERSION`, since this script is usually run through `curl | sh`.

Deliberately **not** a scan. Discovery needs the pad held in pairing mode at the right moment, which a provisioning script can't arrange — so the part that can be automated is connecting a MAC someone already has, and the rest stays a human at a keyboard. It uses `connect` before `pair`, which is the order that works; leading with `pair` returns `AuthenticationCanceled`.

## Reboot, not restart

A changed `main.conf` sets `needs_reboot` instead of restarting `bluetooth`. Restarting the daemon on this board left the kernel holding `hci0` while `bluetoothd` reported `No default controller available` — recoverable only by rebooting. So a reboot is the honest instruction rather than something you discover after a failure I caused.

## Reporting and tests

```
  bluetooth privacy      device
  input group            pierre is a member
  gamepad                /dev/input/js0
```

Three lines because they're three different claims — "paired" and "`padd` can read it" are not the same, and only the `js` device settles the second.

`board-test.sh` asserts the key is set, and set **exactly once** across the idempotent second run; a duplicate would leave BlueZ with a conflicting setting. The container starts from a `main.conf` with `[General]` and no `Privacy`, which is the insert-after-section branch a stock Armbian image takes.