### PR TITLE
ci: stop paying zstd level 19 for a throwaway smoke-test artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,10 @@ jobs:
           # workspace member in an unspecified order, so the old form read whichever
           # sorted first and passed only because they all share one version today.
           version="$(cargo metadata --format-version 1 --no-deps | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"] == "updater"))')"
-          cargo run -p xtask -- package --version "$version" --bin-dir /tmp/bin --out /tmp/dist
+          # --zstd-level 1: this artifact is asserted on and thrown away, never downloaded.
+          # The default 19 on unstripped debug binaries took ~400s — most of this job — to
+          # save bytes nothing reads. Every other code path is exercised unchanged.
+          cargo run -p xtask -- package --version "$version" --bin-dir /tmp/bin --out /tmp/dist --zstd-level 1
           test -f /tmp/dist/manifest.json
           test -f "/tmp/dist/${version}.manifest.json"
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -91,6 +91,12 @@ enum Command {
         /// Skip the crate-version match. Only for testing the tool itself.
         #[arg(long)]
         allow_version_drift: bool,
+
+        /// zstd compression level. The default is what a release should ship; lower it
+        /// only when the artifact is thrown away, as CI's smoke test does — see the
+        /// encoder below for why that one constant dominates the run.
+        #[arg(long, default_value_t = 19)]
+        zstd_level: i32,
     },
 
     /// Sign the artifact and manifest in `--dir` with a minisign secret key.
@@ -203,6 +209,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             min_supported,
             includes,
             allow_version_drift,
+            zstd_level,
         } => package(PackageArgs {
             version,
             channel,
@@ -214,6 +221,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             min_supported,
             includes,
             allow_version_drift,
+            zstd_level,
         }),
         Command::Keygen {
             kind,
@@ -256,6 +264,7 @@ struct PackageArgs {
     min_supported: Option<semver::Version>,
     includes: Vec<String>,
     allow_version_drift: bool,
+    zstd_level: i32,
 }
 
 fn package(args: PackageArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -295,8 +304,13 @@ fn package(args: PackageArgs) -> Result<(), Box<dyn std::error::Error>> {
     // ── build the artifact ──
     {
         let file = std::fs::File::create(&artifact)?;
-        // Level 19: publishing is a one-off, download bandwidth is not.
-        let encoder = zstd::Encoder::new(file, 19)?.auto_finish();
+        // Level 19 by default: publishing is a one-off, download bandwidth is not.
+        //
+        // But this is single-threaded, and the cost is set by what you feed it. A release
+        // packs stripped aarch64 binaries in ~15s; CI's smoke test packs unstripped debug
+        // ones and took ~400s at the same level — over half of that job, for an artifact
+        // it deletes. Hence `--zstd-level`, so the throwaway case can pay level 1.
+        let encoder = zstd::Encoder::new(file, args.zstd_level)?.auto_finish();
         let mut builder = tar::Builder::new(encoder);
 
         let mut shipped = Vec::new();


### PR DESCRIPTION
## What

The `xtask smoke test` step is the critical path of every CI run: ~400s of the `check` job's 8.5 minutes. Across the last 25 runs it ranged 174–423s, on every branch including `main`.

Almost all of it is one call. From the step log:

```
12:05:59 → 12:06:11   cargo build --workspace --bins        12s
12:06:11 → 12:12:47   cargo run -p xtask -- package        396s
```

## Why

`xtask package` compresses at zstd level 19 — and `zstd::Encoder::new` is single-threaded, unlike the `zstd` CLI. Fed unstripped debug binaries, that dominates. The shipping path is not affected: `release.yml` packages stripped aarch64 *release* binaries and its `Package` step takes **15s**, same code.

Meanwhile the smoke test's only assertions are `test -f manifest.json` and `test -f <version>.manifest.json`. It was spending 6.6 minutes per push to save bytes nothing ever downloads.

## Change

Add `--zstd-level` to `package`, `default_value_t = 19` so `release.yml`, `dev.yml` and `promote.yml` keep shipping at 19 untouched, and pass `--zstd-level 1` from `ci.yml`. Every other code path — version-drift guard, tar assembly, `version.toml`, sha256, both manifests — is exercised exactly as before.

## Measured

Running the same command CI runs, on 46MB of debug binaries:

| | artifact | wall |
|---|---|---|
| default (19) | 10,240,646 B | 38.5s |
| `--zstd-level 1` | 14,458,675 B | 1.8s |

Both manifests written in both cases. The default run sat at 99% CPU, confirming the single-threaded encoder — the `zstd` CLI does the same input in 7.3s at 157%.

Expected effect: `check` drops from ~8.5 min to ~2 min, leaving `board` (~3.3 min) as the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)