### PR TITLE
robotctl health reports the whole robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the robot is aarch64 Linux.
 cargo test --workspace
 ```
 
-310 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+311 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
 
 The fastest way to actually *see* the update engine work is the playground, which drives
 the real engine — real signatures, real atomic swaps, real rollback — against a fake remote

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the robot is aarch64 Linux.
 cargo test --workspace
 ```
 
-272 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+310 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
 
 The fastest way to actually *see* the update engine work is the playground, which drives
 the real engine — real signatures, real atomic swaps, real rollback — against a fake remote
@@ -82,9 +82,37 @@ docs/           architecture · update design · robotd design · roadmap · CI 
 
 Everything below assumes a **dev board**, never a customer robot.
 
-What is running, and what is installed — these are different questions, because `updaterd`
-never restarts itself during an update and so legitimately lags the installed release until
-the next reboot:
+The state of the robot, hardware and software, in one answer — control loop, motor bus, IMU,
+battery, motor temperature, then what is running, what is installed, what is pinned and how
+the last update went:
+
+```bash
+robotctl health
+```
+
+```
+robot     healthy
+  loop      50.1 of 50.0 Hz · 2834 ticks · 0 missed · last 13 ms ago
+  bus       ok
+  imu       ready
+  battery   7.62 V (64%)
+  motors    41 °C max (left_knee) · 36 °C mean
+
+software
+  updaterd  0.1.4 (rev abc1234)
+  robotd    0.1.5 (rev def5678)
+  daemon    0.1.5 installed
+            last update 0.1.4 → 0.1.5: applied
+```
+
+It exits non-zero when the robot is unhealthy or unreachable, so it can gate a script.
+Nothing else there affects the exit code: a flat pack, a hot motor and a pinned component are
+reported, not judged — a release must never be rolled back for the state of the board it
+landed on.
+
+`version` is the software half on its own, for when that is all you want. What is running and
+what is installed are different questions, because `updaterd` never restarts itself during an
+update and so legitimately lags the installed release until the next reboot:
 
 ```bash
 robotctl version

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the robot is aarch64 Linux.
 cargo test --workspace
 ```
 
-311 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+317 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
 
 The fastest way to actually *see* the update engine work is the playground, which drives
 the real engine — real signatures, real atomic swaps, real rollback — against a fake remote
@@ -83,8 +83,8 @@ docs/           architecture · update design · robotd design · roadmap · CI 
 Everything below assumes a **dev board**, never a customer robot.
 
 The state of the robot, hardware and software, in one answer — control loop, motor bus, IMU,
-battery, motor temperature, then what is running, what is installed, what is pinned and how
-the last update went:
+battery, servo and board temperatures, then what is running, what is installed, what is
+pinned and how the last update went:
 
 ```bash
 robotctl health
@@ -97,6 +97,7 @@ robot     healthy
   imu       ready
   battery   7.62 V (64%)
   motors    41 °C max (left_knee) · 36 °C mean
+  cpu       52 °C
 
 software
   updaterd  0.1.4 (rev abc1234)

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -27,13 +27,18 @@ port = "/dev/ttyS2"
 # given rate, and the loop's own five-minute summary reports the same from inside robotd.
 hz = 50
 
-[health]
-# What `robot.health` means, and therefore what the update system rolls back on.
+[update_gate]
+# What decides `healthy`, and therefore what the update system rolls back on.
 #
 # This is the whole point of the daemon in its current form: the updater's auto-rollback is
-# only meaningful if health is a real measurement. A loop running at 60% of target is
+# only meaningful if that verdict is a real measurement. A loop running at 60% of target is
 # alive, answers every request, and is badly broken — these three thresholds are what
-# distinguish that from a healthy robot.
+# distinguish that from a working robot.
+#
+# Named `update_gate` rather than `health` because `robot.health` reports much more than
+# this: battery, motor temperature, loop and bus counters. None of those may reach a verdict
+# — a release must never be rolled back for the state of the board it landed on — so none of
+# them is configured here.
 
 # Achieved rate floor. Below this, unhealthy. 45 is 90% of the default 50 Hz: loose enough
 # not to trip on one slow tick, tight enough that a loop dropping every tenth cycle is not

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| tests | **272 passing**, including the health gate against a real `robotd` process |
+| tests | **310 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
 | missing | `mediad`, `btd`, `robot-config`, app, SDK |
 | never run on hardware | every claim above is from CI and a laptop. Slice 1's whole purpose is to change that |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| tests | **311 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
+| tests | **317 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
 | missing | `mediad`, `btd`, `robot-config`, app, SDK |
 | never run on hardware | every claim above is from CI and a laptop. Slice 1's whole purpose is to change that |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| tests | **310 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
+| tests | **311 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
 | missing | `mediad`, `btd`, `robot-config`, app, SDK |
 | never run on hardware | every claim above is from CI and a laptop. Slice 1's whole purpose is to change that |
 

--- a/docs/robotd-design.md
+++ b/docs/robotd-design.md
@@ -157,7 +157,7 @@ namespace (§7.4).
 
 | method | slice 1 |
 |---|---|
-| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count |
+| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count, plus the battery as a *reported* field the verdict never consults |
 | `robot.safeToRestart` | `true` (a constant pose is always safe to interrupt) |
 | `robot.modelApi` | unchanged constant |
 | `robot.remoteSessionActive` | `false` — `mediad` owns the real answer |
@@ -169,6 +169,15 @@ already built around.
 
 A loop running at 60% of target is alive, answers every request, and is badly broken. That
 distinction is the whole reason slice 1 exists.
+
+**What may and may not reach the verdict.** `healthy` and `degraded` are the update system's
+inputs, so only conditions a *release* can be blamed for may set them — that is what
+`degraded` already exists to enforce for an unpowered bench board. The battery rides on the
+same answer without touching either, because it is the number a human wants when a robot is
+behaving oddly and this is the command they run. Gating on it would mean a robot updated on a
+low pack rolls the release back, then judges its replacement on the same low pack, and cannot
+be updated at all until someone works out why. The same rule will apply to motor temperature
+when it lands (address 146, one register past the voltage this reads).
 
 ### 4.6 Done when
 
@@ -282,9 +291,20 @@ explanation, is unusable, and safety clamps things constantly:
   "t":1234.567,
   "move":{"requested":[0.4,0,0],"applied":[0.15,0,0],"limited_by":["max_velocity"]},
   "policy":"walk", "safety":{"fallen":false,"limp":false},
-  "loop":{"hz":49.8,"missed":0}
+  "loop":{"hz":49.8,"missed":0},
+  "battery":{"volts":7.62,"percent":64}
 }}
 ```
+
+**Battery carries both volts and percent**, here and in `robot.health`. The mapping — 6.6 V
+empty, 8.2 V full under load, an NP-F550 — lives in `duck_control::model::battery_percent` and
+travels already applied. The prototype sent volts only and the app re-derived the percentage
+from constants of its own, which is how the same pack shows two different numbers on two
+screens. A client drawing a battery pill should not have to know which pack this robot ships
+with.
+
+There is no fuel gauge: the measurement is the servos' own supply voltage, read once a second
+in its own bus transaction and smoothed, so it sags under load and recovers at rest.
 
 Same payload for `robotctl monitor` and, later, the app. This is what replaces the runtime's
 180-byte frame on 9870, the JPEG stream on 9871, the UDP command socket on 9872, the maploc

--- a/docs/robotd-design.md
+++ b/docs/robotd-design.md
@@ -157,7 +157,7 @@ namespace (§7.4).
 
 | method | slice 1 |
 |---|---|
-| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count — plus a description of the robot the verdict never consults: loop, bus, IMU, battery, motor temperature |
+| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count — plus a description of the robot the verdict never consults: loop, bus, IMU, battery, servo and board temperature |
 | `robot.safeToRestart` | `true` (a constant pose is always safe to interrupt) |
 | `robot.modelApi` | unchanged constant |
 | `robot.remoteSessionActive` | `false` — `mediad` owns the real answer |
@@ -193,6 +193,15 @@ once a second in a second transaction (~1 ms) rather than widening the tick's re
 per servo at 50 Hz. Temperature is reported per joint reduced to *the hottest* one and named:
 a knee holding a squat runs far above the mouth, and a mean over fifteen servos hides the one
 approaching the overheat shutdown its error mask latches on.
+
+**Board temperature is a third source, and not on the bus at all.** The hottest of the SoC's
+thermal zones, read from `sysfs` in the same once-a-second sample (`robotd/src/soc.rs`). It
+lives in `robotd` rather than `duck-control` because it is a property of the Linux board, not
+of the robot — which is also why it keeps answering when the motor bus does not, and that is
+precisely when it earns its place: a board cooking behind a blocked vent and a robot with dead
+servos are the same symptom until you can see both numbers. Servo and board temperature are
+reported separately for the same reason. The maximum across zones rather than one zone by name,
+so a board that wires its sensors differently cannot silently omit the one that was climbing.
 
 ### 4.6 Done when
 

--- a/docs/robotd-design.md
+++ b/docs/robotd-design.md
@@ -157,7 +157,7 @@ namespace (§7.4).
 
 | method | slice 1 |
 |---|---|
-| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count, plus the battery as a *reported* field the verdict never consults |
+| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count — plus a description of the robot the verdict never consults: loop, bus, IMU, battery, motor temperature |
 | `robot.safeToRestart` | `true` (a constant pose is always safe to interrupt) |
 | `robot.modelApi` | unchanged constant |
 | `robot.remoteSessionActive` | `false` — `mediad` owns the real answer |
@@ -172,12 +172,27 @@ distinction is the whole reason slice 1 exists.
 
 **What may and may not reach the verdict.** `healthy` and `degraded` are the update system's
 inputs, so only conditions a *release* can be blamed for may set them — that is what
-`degraded` already exists to enforce for an unpowered bench board. The battery rides on the
-same answer without touching either, because it is the number a human wants when a robot is
-behaving oddly and this is the command they run. Gating on it would mean a robot updated on a
-low pack rolls the release back, then judges its replacement on the same low pack, and cannot
-be updated at all until someone works out why. The same rule will apply to motor temperature
-when it lands (address 146, one register past the voltage this reads).
+`degraded` already exists to enforce for an unpowered bench board. Everything else on the
+answer is a **description**, and no automatic decision may read it: battery, motor
+temperature, and the loop/bus/IMU counters. Gating on the battery would mean a robot updated
+on a low pack rolls the release back, then judges its replacement on the same low pack, and
+cannot be updated at all until someone works out why. Motor temperature would do the same on
+a hot afternoon.
+
+**Why they travel together anyway.** One method, because the question arrives once: a robot
+behaving oddly gets asked "what is going on", and a verdict without the numbers behind it just
+starts a second round of questions. The loop section carries the very figures the verdict was
+computed from, so `unhealthy: control loop at 43.9 Hz` can be read next to `missed = 0` —
+which distinguishes a loop being woken late from a loop doing too much, and those have
+different fixes. `robotctl health` adds the software half from `updaterd` and prints both.
+
+**Two bus transactions, not one.** The tick reads a contiguous block at 124–136 (pwm, current,
+velocity, position). Voltage and temperature sit at 144–146, eight bytes past its end, with
+twelve bytes of trajectory registers nothing wants in between — so they are sampled together
+once a second in a second transaction (~1 ms) rather than widening the tick's read to 22 bytes
+per servo at 50 Hz. Temperature is reported per joint reduced to *the hottest* one and named:
+a knee holding a squat runs far above the mouth, and a mean over fifteen servos hides the one
+approaching the overheat shutdown its error mask latches on.
 
 ### 4.6 Done when
 

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -4,6 +4,10 @@
 //! `sync_write` of goal positions. The IMU is listed first so it answers before the servo
 //! burst.
 //!
+//! Battery is the one thing that does not fit that shape: it lives at a register outside the
+//! block the tick fetches, so [`RobotIo::bus_voltage`] is a transaction of its own, meant to
+//! be called about once a second rather than every tick.
+//!
 //! Written against `rustypot`, but the *numbers* — conversion factors and the EEPROM
 //! registers asserted at startup — come from `microduck_runtime`, where they were arrived
 //! at against real hardware. See [`crate::model`].
@@ -25,6 +29,12 @@ const READ_LEN: u8 = 12;
 
 /// 0.229 rev/min per count, in rad/s.
 const RAD_PER_SEC_PER_COUNT: f64 = 0.229 * (2.0 * PI / 60.0);
+
+/// `present_input_voltage` (address 144) counts 0.1 V each. Not in the block above: it sits
+/// eight bytes past its end, so battery costs a second transaction — see
+/// [`RobotIo::bus_voltage`]. Address 146 is `present_temperature`, one byte further, if
+/// motor temperature ever wants surfacing too.
+const VOLTS_PER_COUNT: f64 = 0.1;
 
 /// A healthy 16-device read completes well inside this. Capping it means a missing device
 /// costs a bounded hiccup rather than stalling the loop on the serial driver's default.
@@ -249,6 +259,36 @@ impl RobotIo for DynamixelIo {
         self.controller
             .sync_write_goal_position(&JOINT_IDS, &targets.positions)
             .map_err(|e| IoError::Bus(format!("sync_write goal positions: {e}")))
+    }
+
+    /// Mean supply voltage across the servos.
+    ///
+    /// Averaged because all 15 sit on one pack: a single servo's reading is the same
+    /// measurement with more noise. Note that a silent servo does not produce a short
+    /// answer here — `rustypot`'s `sync_read` waits for every id and fails the whole
+    /// transaction if one does not reply — so this is all-or-nothing, and the caller is
+    /// expected to keep its previous reading rather than treat one miss as news. The zero
+    /// filter is for a device that answers with a nonsense value, which must not be
+    /// averaged in as if the pack were half flat.
+    fn bus_voltage(&mut self) -> Result<f64> {
+        let raw = self
+            .controller
+            .sync_read_present_input_voltage(&JOINT_IDS)
+            .map_err(|e| IoError::Bus(format!("read present input voltage: {e}")))?;
+
+        let answered: Vec<f64> = raw
+            .iter()
+            .map(|&counts| counts as f64 * VOLTS_PER_COUNT)
+            .filter(|&v| v > 0.0)
+            .collect();
+        if answered.is_empty() {
+            return Err(IoError::ShortRead {
+                what: "input voltage",
+                expected: NUM_JOINTS,
+                got: 0,
+            });
+        }
+        Ok(answered.iter().sum::<f64>() / answered.len() as f64)
     }
 }
 

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -4,9 +4,9 @@
 //! `sync_write` of goal positions. The IMU is listed first so it answers before the servo
 //! burst.
 //!
-//! Battery is the one thing that does not fit that shape: it lives at a register outside the
-//! block the tick fetches, so [`RobotIo::bus_voltage`] is a transaction of its own, meant to
-//! be called about once a second rather than every tick.
+//! Battery and thermals are the one thing that does not fit that shape: they live at registers
+//! outside the block the tick fetches, so [`RobotIo::slow_sensors`] is a transaction of its
+//! own, meant to be called about once a second rather than every tick.
 //!
 //! Written against `rustypot`, but the *numbers* — conversion factors and the EEPROM
 //! registers asserted at startup — come from `microduck_runtime`, where they were arrived
@@ -18,7 +18,7 @@ use std::time::Duration;
 use rustypot::servo::dynamixel::xl330::Xl330Controller;
 
 use crate::imu::{IMU_BLOCK_LEN, SflpDecoder};
-use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors};
+use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors, SlowSensors};
 use crate::model::{BAUD_RATE, EXPECTED_REGISTERS, IMU_DXL_ID, JOINT_IDS, NUM_JOINTS};
 
 /// Start of the contiguous block read every tick: `present_pwm`, `present_current`,
@@ -30,10 +30,18 @@ const READ_LEN: u8 = 12;
 /// 0.229 rev/min per count, in rad/s.
 const RAD_PER_SEC_PER_COUNT: f64 = 0.229 * (2.0 * PI / 60.0);
 
-/// `present_input_voltage` (address 144) counts 0.1 V each. Not in the block above: it sits
-/// eight bytes past its end, so battery costs a second transaction — see
-/// [`RobotIo::bus_voltage`]. Address 146 is `present_temperature`, one byte further, if
-/// motor temperature ever wants surfacing too.
+/// The second, slower block: `present_input_voltage` (144, `u16`) then `present_temperature`
+/// (146, `u8`). Three bytes covers both, so voltage and thermals cost *one* extra transaction
+/// between them rather than two — see [`RobotIo::slow_sensors`].
+///
+/// It starts eight bytes past the end of the tick's block, which is why it cannot simply be
+/// folded into [`READ_LEN`]: the gap is `velocity_trajectory`/`position_trajectory`, twelve
+/// bytes nothing here wants, and a servo answering a 22-byte read every tick would cost more
+/// bus time than the two transactions do.
+const SLOW_READ_ADDR: u8 = 144;
+const SLOW_READ_LEN: u8 = 3;
+
+/// `present_input_voltage` counts 0.1 V each.
 const VOLTS_PER_COUNT: f64 = 0.1;
 
 /// A healthy 16-device read completes well inside this. Capping it means a missing device
@@ -180,16 +188,6 @@ impl DynamixelIo {
         }
         Ok(())
     }
-
-    /// Blocks identical to their predecessor since startup. Non-zero means the IMU board
-    /// is answering without refreshing.
-    pub fn stale_imu_blocks(&self) -> u64 {
-        self.stale_imu_blocks
-    }
-
-    pub fn imu_ready(&self) -> bool {
-        self.imu.ready()
-    }
 }
 
 impl RobotIo for DynamixelIo {
@@ -261,34 +259,70 @@ impl RobotIo for DynamixelIo {
             .map_err(|e| IoError::Bus(format!("sync_write goal positions: {e}")))
     }
 
-    /// Mean supply voltage across the servos.
+    /// Supply voltage and case temperatures, in one `sync_read` over registers 144–146.
     ///
-    /// Averaged because all 15 sit on one pack: a single servo's reading is the same
-    /// measurement with more noise. Note that a silent servo does not produce a short
-    /// answer here — `rustypot`'s `sync_read` waits for every id and fails the whole
-    /// transaction if one does not reply — so this is all-or-nothing, and the caller is
-    /// expected to keep its previous reading rather than treat one miss as news. The zero
-    /// filter is for a device that answers with a nonsense value, which must not be
-    /// averaged in as if the pack were half flat.
-    fn bus_voltage(&mut self) -> Result<f64> {
-        let raw = self
+    /// Voltage is averaged because all 15 servos sit on one pack: a single reading is the
+    /// same measurement with more noise. Temperature is *not* averaged here — the caller gets
+    /// every joint, because one loaded joint running hot is the case worth seeing and a mean
+    /// over fifteen hides it.
+    ///
+    /// Note that a silent servo does not produce a short answer: `rustypot`'s `sync_read`
+    /// waits for every id and fails the whole transaction if one does not reply. So this is
+    /// all-or-nothing, and the caller is expected to keep its previous sample rather than
+    /// treat one miss as news. The zero filter on voltage guards a device that answers with a
+    /// nonsense value, which must not be averaged in as if the pack were half flat.
+    fn slow_sensors(&mut self) -> Result<SlowSensors> {
+        let blocks = self
             .controller
-            .sync_read_present_input_voltage(&JOINT_IDS)
-            .map_err(|e| IoError::Bus(format!("read present input voltage: {e}")))?;
+            .sync_read_raw_data(&JOINT_IDS, SLOW_READ_ADDR, SLOW_READ_LEN)
+            .map_err(|e| IoError::Bus(format!("voltage+temperature sync_read: {e}")))?;
 
-        let answered: Vec<f64> = raw
-            .iter()
-            .map(|&counts| counts as f64 * VOLTS_PER_COUNT)
-            .filter(|&v| v > 0.0)
-            .collect();
-        if answered.is_empty() {
+        if blocks.len() != NUM_JOINTS {
+            return Err(IoError::ShortRead {
+                what: "voltage+temperature blocks",
+                expected: NUM_JOINTS,
+                got: blocks.len(),
+            });
+        }
+
+        let mut temps_c = [0.0; NUM_JOINTS];
+        let mut volts = Vec::with_capacity(NUM_JOINTS);
+        for (joint, block) in blocks.iter().enumerate() {
+            if block.len() != SLOW_READ_LEN as usize {
+                return Err(IoError::ShortRead {
+                    what: "voltage+temperature block",
+                    expected: SLOW_READ_LEN as usize,
+                    got: block.len(),
+                });
+            }
+            // [0..2] present_input_voltage · [2] present_temperature, already in whole °C.
+            let counts = u16::from_le_bytes([block[0], block[1]]);
+            let v = counts as f64 * VOLTS_PER_COUNT;
+            if v > 0.0 {
+                volts.push(v);
+            }
+            temps_c[joint] = block[2] as f64;
+        }
+
+        if volts.is_empty() {
             return Err(IoError::ShortRead {
                 what: "input voltage",
                 expected: NUM_JOINTS,
                 got: 0,
             });
         }
-        Ok(answered.iter().sum::<f64>() / answered.len() as f64)
+        Ok(SlowSensors {
+            volts: volts.iter().sum::<f64>() / volts.len() as f64,
+            temps_c,
+        })
+    }
+
+    fn imu_stale_blocks(&self) -> u64 {
+        self.stale_imu_blocks
+    }
+
+    fn imu_ready(&self) -> bool {
+        self.imu.ready()
     }
 }
 

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -72,18 +72,51 @@ pub enum IoError {
 
 pub type Result<T> = std::result::Result<T, IoError>;
 
+/// What the servos report about their own supply and case, rather than their motion.
+///
+/// Sampled about once a second rather than every tick — see [`RobotIo::slow_sensors`]. A pack
+/// does not drain and a motor does not heat up in 20 ms, so the tick would be paying for a
+/// second bus transaction to learn nothing new.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SlowSensors {
+    /// Mean supply voltage across the servos, in volts — the only battery measurement the
+    /// robot has, since there is no fuel gauge anywhere on the hat.
+    pub volts: f64,
+    /// Per-joint case temperature in °C, indexed as [`crate::model::JOINT_NAMES`].
+    ///
+    /// Per-joint rather than an average because the interesting case is one joint carrying
+    /// the load — a knee holding a squat runs far hotter than the mouth, and a mean over
+    /// fifteen servos hides exactly the servo about to latch its overheat shutdown.
+    pub temps_c: [f64; NUM_JOINTS],
+}
+
 pub trait RobotIo {
     /// One transaction: joints and IMU together.
     fn read(&mut self) -> Result<Sensors>;
     fn write(&mut self, targets: &JointTargets) -> Result<()>;
 
-    /// Mean motor-bus voltage, in volts — the only battery measurement the robot has.
+    /// Supply voltage and case temperatures, in one extra transaction.
     ///
-    /// Its own transaction, and therefore not part of [`Sensors`]: `present_input_voltage`
-    /// lives at address 144, outside the contiguous block the tick fetches, so it cannot
-    /// ride along however much we would like it to. Costs about a millisecond, which is why
-    /// the caller is expected to ask roughly once a second rather than every tick.
-    fn bus_voltage(&mut self) -> Result<f64>;
+    /// Not part of [`Sensors`], and not on the tick's critical path: these registers sit at
+    /// 144–146, past the end of the contiguous block [`Self::read`] fetches, so reaching them
+    /// costs a transaction of its own — about a millisecond. Negligible once a second, 5% of
+    /// the budget at 50 Hz.
+    fn slow_sensors(&mut self) -> Result<SlowSensors>;
+
+    /// Diagnostics the bus keeps about itself. Default to "nothing to report" so a fake or a
+    /// future backend is not obliged to invent them.
+    ///
+    /// `sync_read` blocks identical to their predecessor: the board answered but did not
+    /// refresh, which means the policy would be fed dead orientation. Invisible unless
+    /// someone counts it, which is why it is counted.
+    fn imu_stale_blocks(&self) -> u64 {
+        0
+    }
+
+    /// Has the orientation filter converged? False for the first moments after startup.
+    fn imu_ready(&self) -> bool {
+        true
+    }
 }
 
 /// A robot made of nothing, for tests.
@@ -102,10 +135,10 @@ pub struct FakeIo {
     pub last_written: Option<JointTargets>,
     pub reads: usize,
     pub writes: usize,
-    /// What [`RobotIo::bus_voltage`] reports. Mid-pack by default so `--fake` shows a
-    /// plausible battery; set it to exercise a flat one. `None` fails the read, which is
-    /// what a robot with no bus does.
-    pub battery_v: Option<f64>,
+    /// What [`RobotIo::slow_sensors`] reports. Mid-pack and hand-warm by default so `--fake`
+    /// shows a plausible robot; set it to exercise a flat pack or a cooking servo. `None`
+    /// fails the read, which is what a robot with no bus does.
+    pub slow: Option<SlowSensors>,
     /// When true, `read` reports the last written targets as the present positions.
     track_targets: bool,
 }
@@ -125,7 +158,10 @@ impl FakeIo {
             last_written: None,
             reads: 0,
             writes: 0,
-            battery_v: Some(7.4),
+            slow: Some(SlowSensors {
+                volts: 7.4,
+                temps_c: [32.0; NUM_JOINTS],
+            }),
             track_targets: true,
         }
     }
@@ -183,8 +219,8 @@ impl RobotIo for FakeIo {
         Ok(())
     }
 
-    fn bus_voltage(&mut self) -> Result<f64> {
-        self.battery_v.ok_or(IoError::Simulated)
+    fn slow_sensors(&mut self) -> Result<SlowSensors> {
+        self.slow.ok_or(IoError::Simulated)
     }
 }
 

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -76,6 +76,14 @@ pub trait RobotIo {
     /// One transaction: joints and IMU together.
     fn read(&mut self) -> Result<Sensors>;
     fn write(&mut self, targets: &JointTargets) -> Result<()>;
+
+    /// Mean motor-bus voltage, in volts — the only battery measurement the robot has.
+    ///
+    /// Its own transaction, and therefore not part of [`Sensors`]: `present_input_voltage`
+    /// lives at address 144, outside the contiguous block the tick fetches, so it cannot
+    /// ride along however much we would like it to. Costs about a millisecond, which is why
+    /// the caller is expected to ask roughly once a second rather than every tick.
+    fn bus_voltage(&mut self) -> Result<f64>;
 }
 
 /// A robot made of nothing, for tests.
@@ -94,6 +102,10 @@ pub struct FakeIo {
     pub last_written: Option<JointTargets>,
     pub reads: usize,
     pub writes: usize,
+    /// What [`RobotIo::bus_voltage`] reports. Mid-pack by default so `--fake` shows a
+    /// plausible battery; set it to exercise a flat one. `None` fails the read, which is
+    /// what a robot with no bus does.
+    pub battery_v: Option<f64>,
     /// When true, `read` reports the last written targets as the present positions.
     track_targets: bool,
 }
@@ -113,6 +125,7 @@ impl FakeIo {
             last_written: None,
             reads: 0,
             writes: 0,
+            battery_v: Some(7.4),
             track_targets: true,
         }
     }
@@ -168,6 +181,10 @@ impl RobotIo for FakeIo {
             self.sensors.positions = targets.positions;
         }
         Ok(())
+    }
+
+    fn bus_voltage(&mut self) -> Result<f64> {
+        self.battery_v.ok_or(IoError::Simulated)
     }
 }
 

--- a/duck-control/src/lib.rs
+++ b/duck-control/src/lib.rs
@@ -14,4 +14,7 @@ pub mod model;
 
 pub use imu::ImuData;
 pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors};
-pub use model::{DEFAULT_POSITION, JOINT_IDS, JOINT_NAMES, NUM_JOINTS};
+pub use model::{
+    BATTERY_EMPTY_V, BATTERY_FULL_V, DEFAULT_POSITION, JOINT_IDS, JOINT_NAMES, NUM_JOINTS,
+    battery_percent,
+};

--- a/duck-control/src/lib.rs
+++ b/duck-control/src/lib.rs
@@ -13,7 +13,7 @@ pub mod io;
 pub mod model;
 
 pub use imu::ImuData;
-pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors};
+pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors, SlowSensors};
 pub use model::{
     BATTERY_EMPTY_V, BATTERY_FULL_V, DEFAULT_POSITION, JOINT_IDS, JOINT_NAMES, NUM_JOINTS,
     battery_percent,

--- a/duck-control/src/model.rs
+++ b/duck-control/src/model.rs
@@ -90,6 +90,36 @@ pub fn joint_index(name: &str) -> Option<usize> {
     JOINT_NAMES.iter().position(|n| *n == name)
 }
 
+// ── battery ──────────────────────────────────────────────────────────────────
+//
+// There is no fuel gauge and no ADC. The only measurement available is what the servos
+// report as their own supply (`crate::bus::DynamixelIo::bus_voltage`), which is the pack
+// seen through the bus — so it sags under load and recovers when the robot stands still.
+// That is why the span below is *usable-under-load*, not the cell chemistry's range.
+
+/// Off a full charge, under load. NP-F550, 2S Li-ion.
+pub const BATTERY_FULL_V: f64 = 8.2;
+
+/// The sag floor: below this the robot starts struggling, well before the pack's own
+/// protection trips. Empty for our purposes, not empty for the cells'.
+pub const BATTERY_EMPTY_V: f64 = 6.6;
+
+/// Fraction of a pack, 0–100, for a bus voltage.
+///
+/// Linear, and the numbers come from `microduck_runtime`'s `check_battery`, where they were
+/// arrived at by running a duck flat. It lives here rather than in `robotd` so there is one
+/// mapping: the prototype had it in a CLI *and* re-derived in the app, which is how two
+/// screens end up disagreeing about the same pack.
+///
+/// A non-finite or non-positive reading is 0 — those mean "no answer from the bus", and the
+/// caller is expected to report that as unknown rather than to display this number.
+pub fn battery_percent(volts: f64) -> f64 {
+    if !volts.is_finite() || volts <= 0.0 {
+        return 0.0;
+    }
+    ((volts - BATTERY_EMPTY_V) / (BATTERY_FULL_V - BATTERY_EMPTY_V)).clamp(0.0, 1.0) * 100.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,6 +156,33 @@ mod tests {
     fn mouth_index_names_the_mouth() {
         assert_eq!(JOINT_NAMES[MOUTH_INDEX], "mouth");
         assert_eq!(joint_index("mouth"), Some(MOUTH_INDEX));
+    }
+
+    /// The ends of the span and the middle of it. Getting the direction wrong here would
+    /// report a full pack as flat, which is the kind of thing nobody double-checks.
+    #[test]
+    fn battery_percent_spans_the_usable_range() {
+        assert_eq!(battery_percent(BATTERY_FULL_V), 100.0);
+        assert_eq!(battery_percent(BATTERY_EMPTY_V), 0.0);
+        assert!((battery_percent(7.4) - 50.0).abs() < 0.001);
+    }
+
+    /// Voltages outside the span are ordinary — a fresh pack reads over 8.2 V off the
+    /// charger, and a robot being run into the ground reads under 6.6 V. Neither may
+    /// produce a percentage outside 0–100 for a caller to display.
+    #[test]
+    fn battery_percent_clamps_rather_than_extrapolating() {
+        assert_eq!(battery_percent(9.5), 100.0);
+        assert_eq!(battery_percent(5.0), 0.0);
+    }
+
+    /// A bus that did not answer arrives here as 0.0, and NaN is what a mean over an empty
+    /// set produces. Both must be 0 rather than a wild number a caller might print.
+    #[test]
+    fn battery_percent_treats_no_reading_as_zero() {
+        assert_eq!(battery_percent(0.0), 0.0);
+        assert_eq!(battery_percent(f64::NAN), 0.0);
+        assert_eq!(battery_percent(-1.0), 0.0);
     }
 
     /// The legs are mirrored: the roll/pitch/ankle pairs are equal and opposite. A sign

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -650,7 +650,9 @@ pub struct SafeToRestartResult {
 ///
 /// A robot that is up but *not* healthy must say so rather than fail to answer: the
 /// difference decides whether an update rolls back for a known reason or for a timeout.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// No `Eq`: the battery reading is a float. Nothing compares these for exact equality
+// outside tests, where `PartialEq` is what `assert_eq!` needs anyway.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HealthResult {
     pub healthy: bool,
     /// Set when the reason is a property of the *board*, not of the running release.
@@ -668,6 +670,31 @@ pub struct HealthResult {
     pub degraded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Motor-bus voltage, when it has been read.
+    ///
+    /// **Reported, never judged.** Nothing here may influence `healthy` or `degraded`: a flat
+    /// pack is a fact about the robot, and a release rolled back over one would be replaced by
+    /// a release judged on the same flat pack — so the robot could not be updated at all until
+    /// someone charged it. It rides on this method because this is the one a human already
+    /// asks (`robotctl health`), not because the gate has any use for it.
+    ///
+    /// Absent means *not known yet* — the first second after startup, a bus that cannot
+    /// answer, or an older `robotd`. Absent is not zero volts, and a client must not render
+    /// it as an empty battery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub battery: Option<Battery>,
+}
+
+/// Motor-bus voltage, and what fraction of a pack that is.
+///
+/// Both, deliberately. Volts is the measurement; percent is a *mapping* over a pack the
+/// robot knows and a client should not have to (`duck_control::model::battery_percent`).
+/// The prototype shipped volts only, and the mapping was duplicated into the app — which is
+/// how two screens end up disagreeing about the same battery.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Battery {
+    pub volts: f64,
+    pub percent: f64,
 }
 
 /// Answer to [`Call::RobotModelApi`].
@@ -966,6 +993,7 @@ mod tests {
             degraded: false,
             healthy: true,
             reason: None,
+            battery: None,
         };
         let line = serde_json::to_string(&healthy).unwrap();
         assert!(!line.contains("reason"), "{line}");
@@ -978,6 +1006,7 @@ mod tests {
             degraded: false,
             healthy: false,
             reason: Some("motors not responding".into()),
+            battery: None,
         };
         let line = serde_json::to_string(&sick).unwrap();
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), sick);
@@ -999,6 +1028,7 @@ mod tests {
             healthy: true,
             degraded: false,
             reason: None,
+            battery: None,
         };
         assert!(!serde_json::to_string(&plain).unwrap().contains("degraded"));
 
@@ -1006,10 +1036,44 @@ mod tests {
             healthy: false,
             degraded: true,
             reason: Some("no answer from the motor bus".into()),
+            battery: None,
         };
         let line = serde_json::to_string(&bench).unwrap();
         assert!(line.contains(r#""degraded":true"#), "{line}");
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), bench);
+    }
+
+    /// An absent battery must stay absent, not become zero volts.
+    ///
+    /// This is the answer for the first second after startup, for a bus that cannot reply,
+    /// and for an older `robotd` that has never heard of the field. A `0.0` default would
+    /// make every one of those render as a flat pack — alarming, and wrong.
+    #[test]
+    fn a_missing_battery_is_unknown_not_empty() {
+        let answer: HealthResult = serde_json::from_str(r#"{"healthy":true}"#).unwrap();
+        assert!(answer.battery.is_none());
+
+        let unread = HealthResult {
+            healthy: true,
+            degraded: false,
+            reason: None,
+            battery: None,
+        };
+        assert!(!serde_json::to_string(&unread).unwrap().contains("battery"));
+
+        let measured = HealthResult {
+            battery: Some(Battery {
+                volts: 7.62,
+                percent: 63.75,
+            }),
+            ..unread
+        };
+        let line = serde_json::to_string(&measured).unwrap();
+        assert!(line.contains(r#""volts":7.62"#), "{line}");
+        assert_eq!(
+            serde_json::from_str::<HealthResult>(&line).unwrap(),
+            measured
+        );
     }
 
     /// A local build must say so, rather than looking like a release whose revision was

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -691,6 +691,16 @@ pub struct HealthResult {
     /// never judged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub motors: Option<MotorThermal>,
+    /// Board temperature in °C — the hottest of the SoC's thermal zones.
+    ///
+    /// Distinct from [`Self::motors`], and the pair is the point: a robot that has been walking
+    /// has hot *servos*, while a board in a warm enclosure with a blocked vent has a hot *SoC*
+    /// and cool motors. They fail differently and are fixed differently, and one number cannot
+    /// stand for both.
+    ///
+    /// Absent off Linux, and on a kernel without thermal sysfs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_temp_c: Option<f64>,
     /// The control loop's own numbers — the ones `healthy` was decided from.
     ///
     /// Carried so a verdict can be *checked* rather than taken on faith. "unhealthy: control

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -652,7 +652,11 @@ pub struct SafeToRestartResult {
 /// difference decides whether an update rolls back for a known reason or for a timeout.
 // No `Eq`: the battery reading is a float. Nothing compares these for exact equality
 // outside tests, where `PartialEq` is what `assert_eq!` needs anyway.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+//
+// `Default` is "nothing known": not healthy, nothing measured. That is the honest starting
+// point — and it means the next reported field added here does not break every caller that
+// builds one.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct HealthResult {
     pub healthy: bool,
     /// Set when the reason is a property of the *board*, not of the running release.
@@ -683,6 +687,80 @@ pub struct HealthResult {
     /// it as an empty battery.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub battery: Option<Battery>,
+    /// Hottest servo, when temperatures have been read. Same rule as the battery: reported,
+    /// never judged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub motors: Option<MotorThermal>,
+    /// The control loop's own numbers — the ones `healthy` was decided from.
+    ///
+    /// Carried so a verdict can be *checked* rather than taken on faith. "unhealthy: control
+    /// loop at 43.9 Hz" is a better bug report when the reader can also see that the loop has
+    /// ticked two million times and missed none of its deadlines, which says late wakeups
+    /// rather than overrunning work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_loop: Option<LoopHealth>,
+    /// What the motor bus is doing. Present on every answer; the zero values are meaningful
+    /// ("no failures"), not missing data.
+    #[serde(default)]
+    pub bus: BusHealth,
+    /// Orientation source. Absent from an older `robotd`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imu: Option<ImuHealth>,
+}
+
+/// The control loop's rate and timing.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LoopHealth {
+    /// What the loop is configured to run at, so the achieved figure means something without
+    /// the reader having the params file open.
+    pub target_hz: f64,
+    /// Achieved rate over the last window. `None` until the first window closes — which is
+    /// *unknown*, not zero: a rate of 0 Hz describes a stopped loop, and printing that for
+    /// the first second of every robot's uptime would be a lie.
+    pub achieved_hz: Option<f64>,
+    pub ticks: u64,
+    /// Ticks whose work overran the period, cumulative. Distinct from a rate shortfall: this
+    /// is the loop doing too much, a low rate is the loop being woken late, and telling them
+    /// apart is the difference between optimising and fixing a timer.
+    pub missed: u64,
+    /// Age of the last completed tick. Large means wedged.
+    pub last_tick_age_ms: u64,
+}
+
+/// The motor bus, as the loop sees it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct BusHealth {
+    /// Consecutive failed reads; any success resets it. One is ordinary on a serial bus,
+    /// which is why the cumulative count is not what is reported.
+    pub consecutive_errors: u32,
+    /// Failed attempts to bring the bus up at all. Non-zero means the loop has never
+    /// commanded anything and is still waiting for a robot to answer — the signature of
+    /// servo power being off.
+    pub startup_failures: u32,
+}
+
+/// The IMU board, which rides the motor bus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImuHealth {
+    /// Has the orientation filter converged?
+    pub ready: bool,
+    /// Reads that returned the previous sample unchanged. Non-zero means the board is
+    /// answering without refreshing: the reads succeed, nothing reports an error, and the
+    /// orientation is frozen.
+    pub stale_blocks: u64,
+}
+
+/// Servo case temperature, reduced to the part worth acting on.
+///
+/// The hottest joint rather than a mean over fifteen: a knee holding a squat runs far hotter
+/// than the mouth, and averaging hides the one servo approaching the overheat shutdown its
+/// error mask latches on.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MotorThermal {
+    /// Name of the hottest joint, as `duck_control::model::JOINT_NAMES` spells it.
+    pub hottest: String,
+    pub max_c: f64,
+    pub mean_c: f64,
 }
 
 /// Motor-bus voltage, and what fraction of a pack that is.
@@ -990,10 +1068,8 @@ mod tests {
     #[test]
     fn robot_results_round_trip() {
         let healthy = HealthResult {
-            degraded: false,
             healthy: true,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&healthy).unwrap();
         assert!(!line.contains("reason"), "{line}");
@@ -1003,10 +1079,8 @@ mod tests {
         );
 
         let sick = HealthResult {
-            degraded: false,
-            healthy: false,
             reason: Some("motors not responding".into()),
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&sick).unwrap();
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), sick);
@@ -1026,17 +1100,14 @@ mod tests {
     fn degraded_is_omitted_when_false_and_present_when_true() {
         let plain = HealthResult {
             healthy: true,
-            degraded: false,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         assert!(!serde_json::to_string(&plain).unwrap().contains("degraded"));
 
         let bench = HealthResult {
-            healthy: false,
             degraded: true,
             reason: Some("no answer from the motor bus".into()),
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&bench).unwrap();
         assert!(line.contains(r#""degraded":true"#), "{line}");
@@ -1055,9 +1126,7 @@ mod tests {
 
         let unread = HealthResult {
             healthy: true,
-            degraded: false,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         assert!(!serde_json::to_string(&unread).unwrap().contains("battery"));
 

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -382,18 +382,16 @@ struct VersionReport {
     warnings: Vec<String>,
 }
 
-/// Ask every daemon what it is running, and compare against what is installed.
-///
-/// Deliberately does **not** use the ordinary `Client::connect(..)?` + `hello()?` path.
-/// That exits non-zero when `updaterd` is unreachable, which is precisely the situation
-/// where someone is running this command. Every failure here becomes a line in the report
-/// instead.
 /// Ask `robotd` whether it is healthy.
 ///
 /// Exits non-zero when the robot is unhealthy or unreachable, so a script can gate on it —
 /// `robotctl health && do_the_thing`. The reason is always printed, because "unhealthy" on
 /// its own sends someone hunting: it distinguishes a loop that has not started from one
 /// missing its deadline from a policy that would not load.
+///
+/// Battery prints on its own line and never affects the verdict or the exit code. It is here
+/// because this is the command someone runs when a robot is behaving oddly, and "the pack is
+/// at 8%" answers that question more often than anything else on the socket.
 fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
     let mut client = Client::connect_to("robotd", robot_socket)?;
     let response = client.call(&proto::Call::RobotHealth)?;
@@ -425,6 +423,14 @@ fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
             },
             health.reason.as_deref().unwrap_or("no reason given")
         );
+    }
+
+    // After the verdict, and only in human output — the JSON already carries it. Silent when
+    // unknown rather than printing a zero: for the first second of uptime, and on a robot
+    // whose bus cannot answer, there is genuinely no reading, and "0.00 V" would read as a
+    // dead pack.
+    if !json && let Some(battery) = health.battery {
+        println!("battery: {:.2} V ({:.0}%)", battery.volts, battery.percent);
     }
 
     if health.healthy {

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -556,6 +556,12 @@ fn render_health(report: &HealthReport) -> String {
                     "motors", m.max_c, m.hottest, m.mean_c
                 );
             }
+            // Its own line, next to the motors rather than merged with them: hot servos and a
+            // hot board are different faults with different fixes, and a reader scanning for
+            // "what is too hot here" needs to see which.
+            if let Some(cpu) = health.cpu_temp_c {
+                let _ = writeln!(out, "  {:<9} {cpu:.0} °C", "cpu");
+            }
         }
         (None, Some(why)) => {
             // First line only: a multi-line message would break the column layout, and the
@@ -582,7 +588,7 @@ fn render_health(report: &HealthReport) -> String {
                     service.name,
                     service.version.as_deref().unwrap_or("unknown"),
                     match &service.revision {
-                        Some(rev) => format!("(rev {rev})"),
+                        Some(rev) => format!("(rev {})", short_revision(rev)),
                         None => "(rev unknown)".to_owned(),
                     }
                 );
@@ -757,48 +763,108 @@ fn describe_attempt(entry: &proto::LogEntry) -> String {
 /// mismatch is the one support will actually hit, and it must be explained rather than
 /// merely flagged — it is *expected* right after an update and alarming only if it
 /// survives a reboot.
+/// Is a running process from a different build than the installed release?
+///
+/// **Revisions decide it when both are known**, and versions only stand in when one is not.
+/// That is not a refinement, it is the difference between right and wrong on a dev build: a
+/// binary reports `CARGO_PKG_VERSION`, while the release it was packaged into is versioned
+/// `0.1.4-dev.91.7f685a0` — the prerelease suffix is minted by `xtask package` at package
+/// time, from a run number and a SHA the compiler never saw. So a dev-channel `robotd` reports
+/// `0.1.4` against an installed `0.1.4-dev.91.7f685a0` *while being exactly that build*, and
+/// comparing versions accused every single dev install of having failed its restart — the
+/// louder of the two warnings, and always false.
+///
+/// A prefix match counts as equal so a short SHA and a full one agree; `dev.yml` passes
+/// `GITHUB_SHA` in full and `DUCK_REVISION` is likewise full, but a hand-built release with a
+/// `--short` revision must not read as a mismatch. Seven characters minimum, because a prefix
+/// rule with no floor would make an empty string match everything.
+fn is_behind(
+    running_version: &semver::Version,
+    running_revision: Option<&str>,
+    installed_version: &semver::Version,
+    installed_revision: Option<&str>,
+) -> bool {
+    match (running_revision, installed_revision) {
+        (Some(running), Some(installed)) => !same_revision(running, installed),
+        _ => running_version != installed_version,
+    }
+}
+
+/// A revision as a human wants to read it: seven characters, the abbreviation git itself uses
+/// and the one `xtask` embeds in a dev version. `DUCK_REVISION` carries the full 40, which in a
+/// column of output is noise around the seven characters anyone actually compares.
+///
+/// `get` rather than slicing: it returns `None` on a non-boundary rather than panicking, and a
+/// revision from a config file is not guaranteed to be a hex string.
+fn short_revision(revision: &str) -> &str {
+    revision.get(..7).unwrap_or(revision)
+}
+
+/// Two git revisions naming the same commit, allowing one to be an abbreviation of the other.
+fn same_revision(a: &str, b: &str) -> bool {
+    const MIN_ABBREV: usize = 7;
+    let shortest = a.len().min(b.len());
+    shortest >= MIN_ABBREV && a[..shortest] == b[..shortest]
+}
+
 fn version_warnings(
     report: &VersionReport,
     updaterd_running: Option<&semver::Version>,
 ) -> Vec<String> {
     let mut warnings = Vec::new();
 
-    let daemon_installed = report
-        .components
-        .iter()
-        .find(|c| c.name == "daemon")
+    let daemon = report.components.iter().find(|c| c.name == "daemon");
+    let daemon_installed = daemon
         .and_then(|c| c.installed.as_deref())
         .and_then(|v| semver::Version::parse(v).ok());
+    let daemon_revision = daemon.and_then(|c| c.revision.as_deref());
+
+    let updaterd_revision = report
+        .services
+        .iter()
+        .find(|s| s.name == "updaterd")
+        .and_then(|s| s.revision.as_deref());
+
+    // Name the revision alongside the version wherever it is known, because on the dev channel
+    // the version alone cannot show a difference: both sides read `0.1.4` and the SHA is the
+    // whole story.
+    let identify = |version: &semver::Version, revision: Option<&str>| match revision {
+        Some(rev) => format!("{version} (rev {})", short_revision(rev)),
+        None => version.to_string(),
+    };
 
     if let (Some(running), Some(installed)) = (updaterd_running, daemon_installed.as_ref())
-        && running != installed
+        && is_behind(running, updaterd_revision, installed, daemon_revision)
     {
         warnings.push(format!(
-            "updaterd is running {running} but the installed daemon release is {installed}.\n  \
+            "updaterd is running {} but the installed daemon release is {}.\n  \
              Expected right after an update — updaterd never restarts itself, so it keeps\n  \
              running the old binary until the next reboot. If this survives a reboot, the\n  \
              new release is not being launched: check the `current` symlink and the unit's\n  \
-             ExecStart path."
+             ExecStart path.",
+            identify(running, updaterd_revision),
+            identify(installed, daemon_revision)
         ));
     }
 
     // robotd is in `on_apply`'s restart set, so unlike updaterd it *should* already be on
     // the installed release. A mismatch here means the restart did not take effect, which
     // is a different and more serious situation than updaterd's expected lag.
-    let robotd_running = report
-        .services
-        .iter()
-        .find(|s| s.name == "robotd")
+    let robotd = report.services.iter().find(|s| s.name == "robotd");
+    let robotd_running = robotd
         .and_then(|s| s.version.as_deref())
         .and_then(|v| semver::Version::parse(v).ok());
-    if let (Some(running), Some(installed)) = (robotd_running, daemon_installed.as_ref())
-        && &running != installed
+    let robotd_revision = robotd.and_then(|s| s.revision.as_deref());
+    if let (Some(running), Some(installed)) = (robotd_running.as_ref(), daemon_installed.as_ref())
+        && is_behind(running, robotd_revision, installed, daemon_revision)
     {
         warnings.push(format!(
-            "robotd is running {running} but the installed daemon release is {installed}.\n  \
+            "robotd is running {} but the installed daemon release is {}.\n  \
              robotd is in on_apply's restart set, so it should already be on the installed\n  \
              release: either the restart did not happen, or it failed and systemd restarted\n  \
-             the old binary. Check `systemctl status robotd` and the update log."
+             the old binary. Check `systemctl status robotd` and the update log.",
+            identify(running, robotd_revision),
+            identify(installed, daemon_revision)
         ));
     }
 
@@ -820,7 +886,7 @@ fn render_version(report: &VersionReport) -> String {
     let mut out = String::new();
 
     let rev = |r: &Option<String>| match r {
-        Some(rev) => format!("rev {rev}"),
+        Some(rev) => format!("rev {}", short_revision(rev)),
         None => "rev unknown".to_owned(),
     };
 
@@ -1298,6 +1364,7 @@ mod tests {
                     max_c: 48.0,
                     mean_c: 36.0,
                 }),
+                cpu_temp_c: Some(52.0),
                 control_loop: Some(proto::LoopHealth {
                     target_hz: 50.0,
                     achieved_hz: Some(49.8),
@@ -1320,6 +1387,8 @@ mod tests {
         assert!(out.contains("2490 ticks"), "{out}");
         assert!(out.contains("7.62 V (64%)"), "{out}");
         assert!(out.contains("48 °C max (left_knee)"), "{out}");
+        // Board and servos on separate lines: they fail differently.
+        assert!(out.contains("cpu       52 °C"), "{out}");
         assert!(out.contains("bus       ok"), "{out}");
         assert!(out.contains("imu       ready"), "{out}");
         // And the software half, in the same answer — the whole point of one command.
@@ -1513,6 +1582,93 @@ mod tests {
             revision: None,
             error: None,
         }
+    }
+
+    fn service_at(name: &'static str, version: &str, revision: &str) -> ServiceReport {
+        ServiceReport {
+            revision: Some(revision.into()),
+            ..service(name, version)
+        }
+    }
+
+    /// **From a real board.** A dev-channel install accused itself of a failed restart.
+    ///
+    /// `robotctl health` on the Radxa reported "robotd is running 0.1.4 but the installed
+    /// daemon release is 0.1.4-dev.91.7f685a0 … either the restart did not happen, or it
+    /// failed" — while `robotd`'s own revision was `7f685a0`, the very commit that release was
+    /// built from. It *was* the new build.
+    ///
+    /// A binary reports `CARGO_PKG_VERSION`; the prerelease suffix is minted by `xtask
+    /// package` from a run number and a SHA, long after the compiler has gone. So on the dev
+    /// channel the versions differ by construction and can never agree, and the loudest
+    /// warning this command has was firing on every single dev install — training its reader
+    /// to ignore it, which is worse than not having it.
+    #[test]
+    fn a_dev_build_matching_by_revision_is_not_reported_as_behind() {
+        let sha = "7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b";
+        let mut report = report(
+            vec![
+                service_at("updaterd", "0.1.4", sha),
+                service_at("robotd", "0.1.4", sha),
+            ],
+            Some("0.1.4-dev.91.7f685a0"),
+        );
+        // What `listInstalled` reports for the active release: the same commit, in full.
+        report.components[0].revision = Some(sha.to_owned());
+
+        let warnings = version_warnings(&report, Some(&semver::Version::parse("0.1.4").unwrap()));
+        assert!(
+            warnings.is_empty(),
+            "same commit on both sides must not warn: {warnings:?}"
+        );
+    }
+
+    /// The other half of that fix: a genuinely stale `robotd` must still be caught, and on the
+    /// dev channel the *revision* is the only thing that can catch it — both sides say `0.1.4`.
+    #[test]
+    fn a_dev_build_from_another_commit_is_still_reported_as_behind() {
+        let mut report = report(
+            vec![service_at(
+                "robotd",
+                "0.1.4",
+                "28c8f3b636fd0ada2b30cd8b7c367ef375c27f29",
+            )],
+            Some("0.1.4-dev.91.7f685a0"),
+        );
+        report.components[0].revision = Some("7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b".to_owned());
+
+        let warnings = version_warnings(&report, None);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("robotd is running"), "{warnings:?}");
+        // Named by revision, since the versions are identical and would show no difference.
+        assert!(warnings[0].contains("rev 28c8f3b"), "{warnings:?}");
+        assert!(warnings[0].contains("rev 7f685a0"), "{warnings:?}");
+        // Abbreviated, not forty characters of hex in the middle of a sentence.
+        assert!(!warnings[0].contains("28c8f3b636"), "{warnings:?}");
+    }
+
+    /// A short revision and a full one name the same commit. `dev.yml` passes `GITHUB_SHA` in
+    /// full, but nothing guarantees a hand-cut release does.
+    #[test]
+    fn an_abbreviated_revision_matches_its_full_form() {
+        assert!(same_revision(
+            "7f685a0",
+            "7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b"
+        ));
+        assert!(!same_revision(
+            "28c8f3b",
+            "7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b"
+        ));
+        // Too short to mean anything: a prefix rule with no floor would match everything,
+        // including an empty string, and silently stop reporting stale daemons.
+        assert!(!same_revision(
+            "",
+            "7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b"
+        ));
+        assert!(!same_revision(
+            "7f68",
+            "7f685a0c0a51ba928a3bba5b575b2b78ca8dd59b"
+        ));
     }
 
     /// The whole point of the command: after an update, `updaterd` is still running the old

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -71,8 +71,8 @@ struct Cli {
     #[arg(long, global = true, default_value = proto::DEFAULT_SOCKET)]
     socket: PathBuf,
 
-    /// Path to the robotd socket. Only used by `version`, which asks each daemon what it
-    /// is running.
+    /// Path to the robotd socket. Used by `health` and `version`, the two commands that ask
+    /// the robot about itself rather than telling the update engine to do something.
     #[arg(long, global = true, default_value = "/run/robotd.sock")]
     robot_socket: PathBuf,
 
@@ -91,11 +91,21 @@ enum Namespace {
         command: UpdateCommand,
     },
 
-    /// Is the robot healthy, and if not, why not.
+    /// The full state of this robot: hardware and software.
     ///
-    /// The same question the update system's health gate asks, and the reason auto-rollback
-    /// means anything. It was previously only answerable by hand-writing JSON at the socket,
-    /// which is a poor way to ask the one thing that decides whether a release is kept.
+    /// Hardware from `robotd` — the verdict the update system's health gate turns on, the loop
+    /// and bus numbers behind it, the IMU, the battery and the motor temperatures. Software
+    /// from `updaterd` — what is running, what is installed, what is pinned, and how the last
+    /// update went.
+    ///
+    /// One command because that is how the question arrives. "What is wrong with this robot"
+    /// does not divide into hardware and software until after it is answered, and a robot that
+    /// reverted a release an hour ago looks exactly like a robot with unpowered servos until
+    /// both halves are on screen together.
+    ///
+    /// Exits non-zero when the robot is unhealthy or unreachable, so it can gate a script.
+    /// Nothing else here affects the exit code: a flat pack, a hot motor and a pinned
+    /// component are reported, not judged.
     Health {
         /// Machine-readable output, for scripts and support bundles.
         #[arg(long)]
@@ -370,6 +380,14 @@ struct ComponentReport {
     name: String,
     installed: Option<String>,
     revision: Option<String>,
+    /// Set when this component refuses anything but one version. Worth surfacing without
+    /// being asked: a pinned component silently ignores every release published after it,
+    /// and the symptom — "updates stopped arriving" — points nowhere near the cause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pinned: Option<String>,
+    /// The last update attempt, as one line. `None` on a robot that has never updated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_attempt: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -382,67 +400,240 @@ struct VersionReport {
     warnings: Vec<String>,
 }
 
-/// Ask `robotd` whether it is healthy.
+// ── health reporting ─────────────────────────────────────────────────────────
+
+/// The whole state of one robot: what the hardware is doing, and what software is on it.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+struct HealthReport {
+    /// `robotd`'s answer. `None` when it could not be asked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    robot: Option<proto::HealthResult>,
+    /// Why `robotd` could not be asked. Reported rather than fatal: a stopped `robotd` is
+    /// itself the most useful sentence this command can print, and the software half is still
+    /// worth having — that is often what explains the stopped daemon.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    robot_error: Option<String>,
+    software: VersionReport,
+}
+
+impl HealthReport {
+    /// Is the robot working? `None` when `robotd` could not be asked.
+    fn healthy(&self) -> Option<bool> {
+        self.robot.as_ref().map(|r| r.healthy)
+    }
+}
+
+/// Report the full state of the robot: control loop, bus, IMU, battery, motor temperature,
+/// and the software running and installed.
+///
+/// Both halves, in one command, because the question "what is wrong with this robot" does not
+/// divide along that line — a robot that reverted a release an hour ago and a robot whose
+/// servos are unpowered look identical until you can see both at once. `robotctl version`
+/// remains the software half on its own, for when that is all that is wanted.
 ///
 /// Exits non-zero when the robot is unhealthy or unreachable, so a script can gate on it —
-/// `robotctl health && do_the_thing`. The reason is always printed, because "unhealthy" on
-/// its own sends someone hunting: it distinguishes a loop that has not started from one
-/// missing its deadline from a policy that would not load.
-///
-/// Battery prints on its own line and never affects the verdict or the exit code. It is here
-/// because this is the command someone runs when a robot is behaving oddly, and "the pack is
-/// at 8%" answers that question more often than anything else on the socket.
-fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
-    let mut client = Client::connect_to("robotd", robot_socket)?;
-    let response = client.call(&proto::Call::RobotHealth)?;
+/// `robotctl health && do_the_thing`, which `install.sh` relies on. Nothing else here affects
+/// the exit code: a flat pack, a hot motor and a pinned component are all *reported*, and a
+/// command that failed because of a low battery would be a command nobody could script.
+fn run_health(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Failure> {
+    let mut report = HealthReport {
+        robot: None,
+        robot_error: None,
+        software: collect_version_report(socket, robot_socket),
+    };
 
-    let health: proto::HealthResult = response.result_as().map_err(|e| {
-        Failure::new(
-            exit::FAILED,
-            format!("robotd answered robot.health with something unexpected: {e}"),
-        )
-    })?;
+    match Client::connect_to("robotd", robot_socket) {
+        Err(failure) => report.robot_error = Some(failure.message),
+        Ok(mut client) => match client.call(&proto::Call::RobotHealth) {
+            Err(failure) => report.robot_error = Some(failure.message),
+            Ok(response) => match response.result_as::<proto::HealthResult>() {
+                Ok(health) => report.robot = Some(health),
+                Err(e) => {
+                    report.robot_error =
+                        Some(format!("robotd answered robot.health unreadably: {e}"));
+                }
+            },
+        },
+    }
 
     if json {
         println!(
             "{}",
-            serde_json::to_string(&health).unwrap_or_else(|_| "{}".to_owned())
+            serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_owned())
         );
-    } else if health.healthy {
-        println!("healthy");
     } else {
-        // "degraded" reads as what it is: this release is fine, this board cannot move.
-        // Still a non-zero exit — `install.sh` and anyone else scripting this should hear
-        // about an unpowered robot rather than see a silent success.
-        println!(
-            "{}: {}",
-            if health.degraded {
-                "degraded"
-            } else {
-                "unhealthy"
-            },
-            health.reason.as_deref().unwrap_or("no reason given")
-        );
+        print!("{}", render_health(&report));
     }
 
-    // After the verdict, and only in human output — the JSON already carries it. Silent when
-    // unknown rather than printing a zero: for the first second of uptime, and on a robot
-    // whose bus cannot answer, there is genuinely no reading, and "0.00 V" would read as a
-    // dead pack.
-    if !json && let Some(battery) = health.battery {
-        println!("battery: {:.2} V ({:.0}%)", battery.volts, battery.percent);
-    }
-
-    if health.healthy {
-        Ok(())
-    } else {
-        // REFUSED, not FAILED: the robot answered correctly and the answer was "no". That is
-        // a verdict, not a malfunction, and a script should be able to tell them apart.
-        Err(Failure::silent(exit::REFUSED))
+    match report.healthy() {
+        Some(true) => Ok(()),
+        // REFUSED, not FAILED: the robot answered correctly and the answer was "no". That is a
+        // verdict, not a malfunction, and a script should be able to tell them apart.
+        Some(false) => Err(Failure::silent(exit::REFUSED)),
+        // Nothing answered. Distinct again: there is no verdict to act on.
+        None => Err(Failure::silent(exit::UNREACHABLE)),
     }
 }
 
+/// The report as a human reads it: the verdict first, then the evidence, then the software.
+///
+/// Pure, so the cases that matter are testable without a robot — and the cases that matter are
+/// the missing ones, which a live test on a working robot never produces.
+fn render_health(report: &HealthReport) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    match (&report.robot, &report.robot_error) {
+        (Some(health), _) => {
+            let verdict = match (health.healthy, health.degraded) {
+                (true, _) => "healthy".to_owned(),
+                // "degraded" reads as what it is: this release is fine, this board cannot move.
+                (false, true) => format!(
+                    "degraded: {}",
+                    health.reason.as_deref().unwrap_or("no reason given")
+                ),
+                (false, false) => format!(
+                    "unhealthy: {}",
+                    health.reason.as_deref().unwrap_or("no reason given")
+                ),
+            };
+            let _ = writeln!(out, "robot     {verdict}");
+
+            if let Some(l) = &health.control_loop {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {} of {:.1} Hz · {} ticks · {} missed · last {} ms ago",
+                    "loop",
+                    // Unknown is not 0 Hz: for the first second there is no measurement, and
+                    // printing one would describe a healthy robot as stopped.
+                    match l.achieved_hz {
+                        Some(hz) => format!("{hz:.1}"),
+                        None => "not measured yet,".to_owned(),
+                    },
+                    l.target_hz,
+                    l.ticks,
+                    l.missed,
+                    l.last_tick_age_ms
+                );
+            }
+
+            let bus = match (health.bus.consecutive_errors, health.bus.startup_failures) {
+                (0, 0) => "ok".to_owned(),
+                (0, n) => format!("waiting for a robot to answer, {n} attempts"),
+                (n, _) => format!("{n} consecutive read failures"),
+            };
+            let _ = writeln!(out, "  {:<9} {bus}", "bus");
+
+            if let Some(imu) = &health.imu {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {}{}",
+                    "imu",
+                    if imu.ready { "ready" } else { "not ready" },
+                    match imu.stale_blocks {
+                        0 => String::new(),
+                        // Worth shouting about: the board answers, so nothing else reports a
+                        // fault, while the orientation being fed to the policy is frozen.
+                        n => format!(", {n} stale reads — orientation may be dead"),
+                    }
+                );
+            }
+
+            // Silent when unknown rather than printing a zero: for the first second of uptime,
+            // and on a robot whose bus cannot answer, there is genuinely no reading, and
+            // "0.00 V" would read as a dead pack.
+            if let Some(b) = &health.battery {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {:.2} V ({:.0}%)",
+                    "battery", b.volts, b.percent
+                );
+            }
+            if let Some(m) = &health.motors {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {:.0} °C max ({}) · {:.0} °C mean",
+                    "motors", m.max_c, m.hottest, m.mean_c
+                );
+            }
+        }
+        (None, Some(why)) => {
+            // First line only: a multi-line message would break the column layout, and the
+            // rest of it is the `systemctl status` hint the connect error already carries.
+            let brief = why.lines().next().unwrap_or("unavailable");
+            let _ = writeln!(out, "robot     unavailable — {brief}");
+        }
+        (None, None) => {
+            let _ = writeln!(out, "robot     unavailable");
+        }
+    }
+
+    let _ = writeln!(out, "\nsoftware");
+    for service in &report.software.services {
+        match &service.error {
+            Some(why) => {
+                let brief = why.lines().next().unwrap_or("unavailable");
+                let _ = writeln!(out, "  {:<9} unavailable — {brief}", service.name);
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {} {}",
+                    service.name,
+                    service.version.as_deref().unwrap_or("unknown"),
+                    match &service.revision {
+                        Some(rev) => format!("(rev {rev})"),
+                        None => "(rev unknown)".to_owned(),
+                    }
+                );
+            }
+        }
+    }
+    for component in &report.software.components {
+        let _ = writeln!(
+            out,
+            "  {:<9} {} installed{}",
+            component.name,
+            component.installed.as_deref().unwrap_or("none"),
+            match &component.pinned {
+                Some(v) => format!(", pinned to {v}"),
+                None => String::new(),
+            }
+        );
+        if let Some(attempt) = &component.last_attempt {
+            let _ = writeln!(out, "  {:<9} last update {attempt}", "");
+        }
+    }
+
+    // Same shape `robotctl version` uses, blank line and all: these are often multi-line —
+    // the `systemctl status` hint on an unreachable daemon is the useful half — and the two
+    // commands should not disagree about how a warning looks.
+    for warning in &report.software.warnings {
+        let _ = writeln!(out, "\n! {warning}");
+    }
+
+    out
+}
+
 fn run_version(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Failure> {
+    let report = collect_version_report(socket, robot_socket);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).unwrap_or_default()
+        );
+    } else {
+        print!("{}", render_version(&report));
+    }
+    Ok(())
+}
+
+/// Ask both daemons what they are running and `updaterd` what is installed.
+///
+/// Shared by `version` and `health` so the software half of a support report is gathered one
+/// way. Two commands assembling it separately is how they start disagreeing.
+fn collect_version_report(socket: &Path, robot_socket: &Path) -> VersionReport {
     let build = proto::build_info!();
     let mut report = VersionReport {
         robotctl: build.version.to_owned(),
@@ -498,16 +689,7 @@ fn run_version(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Fai
     }
 
     report.warnings = version_warnings(&report, updaterd_running.as_ref());
-
-    if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report).unwrap_or_default()
-        );
-    } else {
-        print!("{}", render_version(&report));
-    }
-    Ok(())
+    report
 }
 
 /// Installed release per component, with the revision of the active one.
@@ -543,9 +725,30 @@ fn installed_components(client: &mut Client) -> Vec<ComponentReport> {
                 name: status.component.to_string(),
                 installed: status.installed.map(|v| v.to_string()),
                 revision,
+                pinned: status.pinned.map(|v| v.to_string()),
+                last_attempt: status.last_attempt.as_ref().map(describe_attempt),
             }
         })
         .collect()
+}
+
+/// One update attempt in one line: what it tried, and how it went.
+///
+/// The outcome's *reason* is kept for the failures, not trimmed to "rolled back" — it is the
+/// only place the cause of an automatic revert appears outside the journal, and a robot that
+/// reverted a week ago is exactly the robot someone is asking about.
+fn describe_attempt(entry: &proto::LogEntry) -> String {
+    let target = match (&entry.from, &entry.to) {
+        (Some(from), Some(to)) => format!("{from} → {to}"),
+        (None, Some(to)) => to.to_string(),
+        (Some(from), None) => format!("from {from}"),
+        (None, None) => "unknown version".to_owned(),
+    };
+    match &entry.outcome {
+        proto::Outcome::Success => format!("{target}: applied"),
+        proto::Outcome::RolledBack { reason } => format!("{target}: ROLLED BACK — {reason}"),
+        proto::Outcome::Aborted { reason } => format!("{target}: refused — {reason}"),
+    }
 }
 
 /// Disagreements worth telling a human about.
@@ -792,7 +995,7 @@ fn main() -> ExitCode {
 fn run(cli: Cli) -> Result<(), Failure> {
     let command = match cli.namespace {
         Namespace::Health { json } => {
-            return run_health(&cli.robot_socket, json);
+            return run_health(&cli.socket, &cli.robot_socket, json);
         }
         Namespace::Version { json } => {
             return run_version(&cli.socket, &cli.robot_socket, json);
@@ -1067,6 +1270,224 @@ mod tests {
         assert!(result.is_err(), "--ref with --version must be rejected");
     }
 
+    // ── health reporting ─────────────────────────────────────────────────────
+
+    fn health_report(
+        robot: Option<proto::HealthResult>,
+        robot_error: Option<&str>,
+    ) -> HealthReport {
+        HealthReport {
+            robot,
+            robot_error: robot_error.map(str::to_owned),
+            software: report(vec![service("robotd", "0.2.0")], Some("0.2.0")),
+        }
+    }
+
+    /// A working robot, rendered whole: every section present, one line each.
+    #[test]
+    fn health_renders_hardware_and_software_together() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: true,
+                battery: Some(proto::Battery {
+                    volts: 7.62,
+                    percent: 63.75,
+                }),
+                motors: Some(proto::MotorThermal {
+                    hottest: "left_knee".into(),
+                    max_c: 48.0,
+                    mean_c: 36.0,
+                }),
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: Some(49.8),
+                    ticks: 2490,
+                    missed: 2,
+                    last_tick_age_ms: 12,
+                }),
+                bus: proto::BusHealth::default(),
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("robot     healthy"), "{out}");
+        assert!(out.contains("49.8 of 50.0 Hz"), "{out}");
+        assert!(out.contains("2490 ticks"), "{out}");
+        assert!(out.contains("7.62 V (64%)"), "{out}");
+        assert!(out.contains("48 °C max (left_knee)"), "{out}");
+        assert!(out.contains("bus       ok"), "{out}");
+        assert!(out.contains("imu       ready"), "{out}");
+        // And the software half, in the same answer — the whole point of one command.
+        assert!(out.contains("software"), "{out}");
+        assert!(out.contains("robotd    0.2.0"), "{out}");
+        assert!(out.contains("daemon    0.2.0 installed"), "{out}");
+    }
+
+    /// A stopped `robotd` must still produce the software half.
+    ///
+    /// This is the shape of a real support case — "the robot does nothing" is very often a
+    /// daemon that failed to start, and what is *installed* is then the interesting half. A
+    /// command that bailed out on the first unreachable socket would withhold exactly the
+    /// information that explains the unreachable socket.
+    #[test]
+    fn health_reports_software_when_robotd_is_down() {
+        let out = render_health(&health_report(
+            None,
+            Some(
+                "cannot reach robotd at /run/robotd.sock: No such file or directory\nIs the service running?",
+            ),
+        ));
+
+        assert!(
+            out.contains("robot     unavailable — cannot reach robotd"),
+            "{out}"
+        );
+        // First line only: the hint belongs in the warnings block, not wrapped through a
+        // column layout.
+        assert!(!out.contains("robot     unavailable — cannot reach robotd at /run/robotd.sock: No such file or directory\nIs"), "{out}");
+        assert!(out.contains("software"), "{out}");
+        assert!(out.contains("daemon    0.2.0 installed"), "{out}");
+    }
+
+    /// Nothing measured yet must not render as zeros.
+    ///
+    /// This is every robot for its first second, and the state a live test never catches. "0.0
+    /// Hz" and "0.00 V" describe a stopped loop on a dead battery — the opposite of a robot
+    /// that has only just started.
+    #[test]
+    fn health_renders_unknowns_as_unknown() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                reason: Some("control loop has not completed a cycle yet".into()),
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: None,
+                    ticks: 0,
+                    missed: 0,
+                    last_tick_age_ms: 0,
+                }),
+                imu: Some(proto::ImuHealth {
+                    ready: false,
+                    stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(
+            out.contains("unhealthy: control loop has not completed"),
+            "{out}"
+        );
+        assert!(out.contains("not measured yet"), "{out}");
+        assert!(out.contains("not ready"), "{out}");
+        // No battery line and no motors line at all, rather than zeroed ones.
+        assert!(!out.contains(" V ("), "{out}");
+        assert!(!out.contains("°C"), "{out}");
+    }
+
+    /// The two findings that must not hide: a bus that has stopped answering, and an IMU that
+    /// answers without refreshing.
+    ///
+    /// Stale IMU reads are the nastiest of the lot — the reads *succeed*, so nothing else
+    /// reports a fault, while the orientation feeding the policy is frozen.
+    #[test]
+    fn health_renders_a_broken_bus_and_a_stale_imu() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: false,
+                reason: Some("7 consecutive bus read failures".into()),
+                bus: proto::BusHealth {
+                    consecutive_errors: 7,
+                    startup_failures: 0,
+                },
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 41,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("7 consecutive read failures"), "{out}");
+        assert!(out.contains("41 stale reads"), "{out}");
+        assert!(out.contains("orientation may be dead"), "{out}");
+    }
+
+    /// An unpowered bench board reads as *degraded*, and the attempt count is the actionable
+    /// part: it is how you tell "still coming up" from "there is no robot on this bus".
+    #[test]
+    fn health_renders_a_degraded_board_waiting_for_its_bus() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                degraded: true,
+                reason: Some("no robot on the motor bus after 4 attempts".into()),
+                bus: proto::BusHealth {
+                    consecutive_errors: 0,
+                    startup_failures: 4,
+                },
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("degraded: no robot on the motor bus"), "{out}");
+        assert!(
+            out.contains("waiting for a robot to answer, 4 attempts"),
+            "{out}"
+        );
+    }
+
+    /// A pinned component and a rollback are both things nobody thinks to ask about, and both
+    /// explain "updates stopped working" — so they appear without being asked for.
+    #[test]
+    fn health_surfaces_a_pin_and_the_last_update() {
+        let mut report = health_report(Some(proto::HealthResult::default()), None);
+        report.software.components[0].pinned = Some("0.1.9".into());
+        report.software.components[0].last_attempt =
+            Some("0.1.9 → 0.2.0: ROLLED BACK — not healthy within 30s".into());
+
+        let out = render_health(&report);
+        assert!(out.contains("pinned to 0.1.9"), "{out}");
+        assert!(out.contains("ROLLED BACK"), "{out}");
+    }
+
+    /// The summary line for one update attempt, including the reason a revert happened —
+    /// which outside the journal exists nowhere else.
+    #[test]
+    fn an_attempt_is_summarised_with_its_reason() {
+        let entry = |outcome| proto::LogEntry {
+            at: 0,
+            component: proto::ComponentId::new("daemon"),
+            from: Some(semver::Version::new(0, 1, 9)),
+            to: Some(semver::Version::new(0, 2, 0)),
+            outcome,
+        };
+
+        assert_eq!(
+            describe_attempt(&entry(proto::Outcome::Success)),
+            "0.1.9 → 0.2.0: applied"
+        );
+        let rolled = describe_attempt(&entry(proto::Outcome::RolledBack {
+            reason: "not healthy within 30s".into(),
+        }));
+        assert!(rolled.contains("ROLLED BACK"), "{rolled}");
+        assert!(rolled.contains("not healthy within 30s"), "{rolled}");
+
+        // A first install has no `from`, and must not render as "None → 1.0.0".
+        let first = proto::LogEntry {
+            from: None,
+            ..entry(proto::Outcome::Success)
+        };
+        assert_eq!(describe_attempt(&first), "0.2.0: applied");
+    }
+
     // ── version reporting ────────────────────────────────────────────────────
 
     fn report(services: Vec<ServiceReport>, daemon_installed: Option<&str>) -> VersionReport {
@@ -1078,6 +1499,8 @@ mod tests {
                 name: "daemon".into(),
                 installed: daemon_installed.map(str::to_owned),
                 revision: None,
+                pinned: None,
+                last_attempt: None,
             }],
             warnings: Vec::new(),
         }

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -52,8 +52,16 @@ const MAX_LINE: usize = 64 * 1024;
 const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Window over which the achieved rate is measured, and therefore how quickly a degraded
-/// loop becomes visible to the health gate.
+/// loop becomes visible to the health gate. Doubles as the battery sampling interval
+/// ([`sample_battery`]).
 const RATE_WINDOW: Duration = Duration::from_secs(1);
+
+/// Smoothing on the reported battery voltage. At one sample per [`RATE_WINDOW`] this is a
+/// ~10 s time constant, which is what makes the number readable: the raw voltage sags
+/// several tenths of a volt on every step and recovers between them, so an unsmoothed
+/// reading swings while the pack is doing nothing unusual. Borrowed, with the figure, from
+/// `microduck_runtime`.
+const BATTERY_EMA_ALPHA: f64 = 0.1;
 
 #[derive(Parser, Debug)]
 #[command(name = "robotd", about = "Robot control daemon", version)]
@@ -141,6 +149,10 @@ struct RobotState {
     /// reading the startup pose. Non-zero means the loop is still waiting for a robot to
     /// answer and has never commanded anything.
     startup_bus_failures: AtomicU32,
+    /// Motor-bus voltage, EMA-smoothed, as `f64::to_bits`. Zero means *not read yet* — a
+    /// distinction that has to survive to the wire, since zero volts and unknown volts look
+    /// nothing alike to whoever is deciding whether to charge the robot.
+    battery_v: AtomicU64,
     shutdown: AtomicBool,
 
     period_us: u64,
@@ -161,6 +173,7 @@ impl RobotState {
             achieved_hz: AtomicU64::new(0),
             consecutive_errors: AtomicU32::new(0),
             startup_bus_failures: AtomicU32::new(0),
+            battery_v: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
             min_achieved_hz: params.health.min_achieved_hz,
@@ -172,16 +185,22 @@ impl RobotState {
     }
 
     fn health(&self) -> proto::HealthResult {
+        // Attached to every answer, healthy or not, and consulted by none of the checks
+        // below. A verdict must never depend on it: see `HealthResult::battery`.
+        let battery = self.battery();
+
         let unhealthy = |reason: String| proto::HealthResult {
             healthy: false,
             degraded: false,
             reason: Some(reason),
+            battery,
         };
         // Not healthy, but not the release's fault either — see `HealthResult::degraded`.
         let degraded = |reason: String| proto::HealthResult {
             healthy: false,
             degraded: true,
             reason: Some(reason),
+            battery,
         };
 
         if self.force_unhealthy {
@@ -231,7 +250,23 @@ impl RobotState {
             healthy: true,
             degraded: false,
             reason: None,
+            battery,
         }
+    }
+
+    /// The last battery reading, mapped to a percentage — or `None` if there has not been
+    /// one.
+    ///
+    /// Zero is the "never read" sentinel rather than a measurement: the atomic starts there,
+    /// and a robot whose bus cannot answer never leaves it. Reporting that as `0.00 V, 0%`
+    /// would put a flat-battery warning in front of anyone whose robot has been up for less
+    /// than a second.
+    fn battery(&self) -> Option<proto::Battery> {
+        let volts = f64::from_bits(self.battery_v.load(Ordering::Relaxed));
+        (volts > 0.0).then(|| proto::Battery {
+            volts,
+            percent: duck_control::battery_percent(volts),
+        })
     }
 
     fn safe_to_restart(&self) -> proto::SafeToRestartResult {
@@ -629,11 +664,17 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
             window_start = Instant::now();
             window_ticks = 0;
 
+            sample_battery(&mut io, &state);
+
             if last_summary.elapsed() >= LOOP_SUMMARY_INTERVAL {
                 tracing::info!(
                     total = ticks,
                     hz = format!("{hz:.1}"),
                     missed = state.missed.load(Ordering::Relaxed),
+                    battery_v = format!(
+                        "{:.2}",
+                        f64::from_bits(state.battery_v.load(Ordering::Relaxed))
+                    ),
                     "control loop"
                 );
                 last_summary = Instant::now();
@@ -641,6 +682,35 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
         }
     }
     tracing::info!("control loop stopped");
+}
+
+/// Read the battery and publish it, once per [`RATE_WINDOW`].
+///
+/// Not part of the tick. `present_input_voltage` is a second bus transaction — about a
+/// millisecond — which is nothing once a second and would be 5% of the budget at 50 Hz. A
+/// second is also faster than a battery can meaningfully change.
+///
+/// Called from the loop thread because that thread owns the IO, and nothing else may touch
+/// the bus: a transaction issued from the IPC side would interleave bytes with a tick and
+/// corrupt both.
+fn sample_battery<T: RobotIo>(io: &mut T, state: &RobotState) {
+    match io.bus_voltage() {
+        Ok(volts) => {
+            let previous = f64::from_bits(state.battery_v.load(Ordering::Relaxed));
+            // Seed from the first reading rather than blending up from zero, which would
+            // spend ten seconds reporting a battery flatter than it is.
+            let smoothed = if previous > 0.0 {
+                BATTERY_EMA_ALPHA * volts + (1.0 - BATTERY_EMA_ALPHA) * previous
+            } else {
+                volts
+            };
+            state.battery_v.store(smoothed.to_bits(), Ordering::Relaxed);
+        }
+        // Keep the last reading. A single failed transaction is ordinary on a serial bus, and
+        // dropping to "unknown" over one would make the reported battery flicker. A bus that
+        // is really gone already shows up in the health verdict itself.
+        Err(e) => tracing::debug!(error = %e, "voltage read failed; keeping the last reading"),
+    }
 }
 
 async fn serve(state: Arc<RobotState>, socket_path: PathBuf) -> std::io::Result<()> {
@@ -1077,6 +1147,57 @@ mod tests {
         assert_eq!(written.positions, resting);
     }
 
+    /// **The invariant the battery field lives or dies by.** A flat pack must be reported and
+    /// must not touch the verdict.
+    ///
+    /// If it ever did, updating a robot on a low battery would roll the release back — and the
+    /// replacement would be judged on the same low battery, so the robot could not be updated
+    /// at all until someone noticed and charged it. The whole reason `degraded` exists is to
+    /// keep board conditions out of the rollback decision; a battery that gated would walk
+    /// straight back into it.
+    #[test]
+    fn a_flat_battery_is_reported_and_changes_no_verdict() {
+        let s = state();
+        ticked(&s, 100);
+        // Below BATTERY_EMPTY_V: the pack is done and the robot is struggling.
+        s.battery_v.store(6.1f64.to_bits(), Ordering::Relaxed);
+
+        let health = s.health();
+        let battery = health.battery.expect("a flat battery is still a reading");
+        assert!(battery.volts < duck_control::BATTERY_EMPTY_V);
+        assert_eq!(battery.percent, 0.0);
+
+        assert!(health.healthy, "{:?}", health.reason);
+        assert!(!health.degraded);
+    }
+
+    /// Zero volts is what the atomic holds before the first read lands, and it must reach the
+    /// wire as absent rather than as a pack at 0 V — otherwise `robotctl health` announces a
+    /// flat battery on every robot that has been up for less than a second.
+    #[test]
+    fn an_unread_battery_is_absent_not_empty() {
+        let s = state();
+        ticked(&s, 1);
+        assert_eq!(s.battery_v.load(Ordering::Relaxed), 0);
+        assert!(s.health().battery.is_none());
+    }
+
+    /// The reading travels on every answer, not only the healthy one — a robot that is
+    /// unhealthy *because* it is out of power is exactly when someone wants to see the pack.
+    #[test]
+    fn battery_is_reported_alongside_an_unhealthy_verdict() {
+        let s = state();
+        s.startup_bus_failures.store(4, Ordering::Relaxed);
+        s.battery_v.store(7.5f64.to_bits(), Ordering::Relaxed);
+
+        let health = s.health();
+        assert!(!health.healthy);
+        assert!(
+            health.battery.is_some(),
+            "battery dropped from a bad answer"
+        );
+    }
+
     /// While waiting, health must say *why*. The update system quotes this string as the
     /// reason it rolled a release back, and "control loop has not completed a cycle yet"
     /// describes a robot that is about to start, not one that cannot see its servos.
@@ -1210,6 +1331,9 @@ mod tests {
             }
             fn write(&mut self, t: &JointTargets) -> duck_control::io::Result<()> {
                 self.0.write(t)
+            }
+            fn bus_voltage(&mut self) -> duck_control::io::Result<f64> {
+                self.0.bus_voltage()
             }
         }
         control_loop(Borrowed(io), state, period).await

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -52,8 +52,8 @@ const MAX_LINE: usize = 64 * 1024;
 const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Window over which the achieved rate is measured, and therefore how quickly a degraded
-/// loop becomes visible to the health gate. Doubles as the battery sampling interval
-/// ([`sample_battery`]).
+/// loop becomes visible to the health gate. Doubles as the slow-sensor sampling interval
+/// ([`publish_slow_sensors`]).
 const RATE_WINDOW: Duration = Duration::from_secs(1);
 
 /// Smoothing on the reported battery voltage. At one sample per [`RATE_WINDOW`] this is a
@@ -153,6 +153,16 @@ struct RobotState {
     /// distinction that has to survive to the wire, since zero volts and unknown volts look
     /// nothing alike to whoever is deciding whether to charge the robot.
     battery_v: AtomicU64,
+    /// Hottest servo of the last thermal sample: temperature as `f64::to_bits`, and which
+    /// joint it was. Zero means *not read yet*, same as the battery.
+    motor_max_c: AtomicU64,
+    motor_mean_c: AtomicU64,
+    /// Index into [`duck_control::JOINT_NAMES`] of the hottest joint.
+    motor_hottest: AtomicU32,
+    /// Mirrors of the bus's own IMU diagnostics, refreshed with the thermal sample. Held here
+    /// so the IPC side can report them without touching the loop's IO.
+    imu_stale_blocks: AtomicU64,
+    imu_ready: AtomicBool,
     shutdown: AtomicBool,
 
     period_us: u64,
@@ -174,6 +184,11 @@ impl RobotState {
             consecutive_errors: AtomicU32::new(0),
             startup_bus_failures: AtomicU32::new(0),
             battery_v: AtomicU64::new(0),
+            motor_max_c: AtomicU64::new(0),
+            motor_mean_c: AtomicU64::new(0),
+            motor_hottest: AtomicU32::new(0),
+            imu_stale_blocks: AtomicU64::new(0),
+            imu_ready: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
             min_achieved_hz: params.health.min_achieved_hz,
@@ -185,23 +200,34 @@ impl RobotState {
     }
 
     fn health(&self) -> proto::HealthResult {
-        // Attached to every answer, healthy or not, and consulted by none of the checks
-        // below. A verdict must never depend on it: see `HealthResult::battery`.
-        let battery = self.battery();
+        // Everything the robot can say about itself, attached to every answer whatever the
+        // verdict — and consulted by none of the checks below.
+        //
+        // Two separate jobs in one method, deliberately. `healthy`/`degraded` are the update
+        // system's inputs and may only reflect what a *release* can be blamed for. The rest
+        // is a description of the robot for whoever is looking at it, and it travels on the
+        // same answer because a robot behaving oddly is asked exactly one question, once.
+        let describe =
+            |healthy: bool, degraded: bool, reason: Option<String>| proto::HealthResult {
+                healthy,
+                degraded,
+                reason,
+                battery: self.battery(),
+                motors: self.motor_thermal(),
+                control_loop: Some(self.loop_health()),
+                bus: proto::BusHealth {
+                    consecutive_errors: self.consecutive_errors.load(Ordering::Relaxed),
+                    startup_failures: self.startup_bus_failures.load(Ordering::Relaxed),
+                },
+                imu: Some(proto::ImuHealth {
+                    ready: self.imu_ready.load(Ordering::Relaxed),
+                    stale_blocks: self.imu_stale_blocks.load(Ordering::Relaxed),
+                }),
+            };
 
-        let unhealthy = |reason: String| proto::HealthResult {
-            healthy: false,
-            degraded: false,
-            reason: Some(reason),
-            battery,
-        };
+        let unhealthy = |reason: String| describe(false, false, Some(reason));
         // Not healthy, but not the release's fault either — see `HealthResult::degraded`.
-        let degraded = |reason: String| proto::HealthResult {
-            healthy: false,
-            degraded: true,
-            reason: Some(reason),
-            battery,
-        };
+        let degraded = |reason: String| describe(false, true, Some(reason));
 
         if self.force_unhealthy {
             return unhealthy("forced unhealthy by --unhealthy".into());
@@ -246,12 +272,39 @@ impl RobotState {
             ));
         }
 
-        proto::HealthResult {
-            healthy: true,
-            degraded: false,
-            reason: None,
-            battery,
+        describe(true, false, None)
+    }
+
+    /// The loop's own numbers, as the readout reports them.
+    fn loop_health(&self) -> proto::LoopHealth {
+        let hz = f64::from_bits(self.achieved_hz.load(Ordering::Relaxed));
+        let now_us = self.started.elapsed().as_micros() as u64;
+        proto::LoopHealth {
+            target_hz: 1_000_000.0 / self.period_us as f64,
+            // Zero is the "no window has closed yet" sentinel, not a measured rate.
+            achieved_hz: (hz > 0.0).then_some(hz),
+            ticks: self.ticks.load(Ordering::Relaxed),
+            missed: self.missed.load(Ordering::Relaxed),
+            last_tick_age_ms: now_us.saturating_sub(self.last_tick_us.load(Ordering::Relaxed))
+                / 1000,
         }
+    }
+
+    /// The hottest servo of the last thermal sample, or `None` before the first one.
+    fn motor_thermal(&self) -> Option<proto::MotorThermal> {
+        let max_c = f64::from_bits(self.motor_max_c.load(Ordering::Relaxed));
+        if max_c <= 0.0 {
+            return None;
+        }
+        let hottest = self.motor_hottest.load(Ordering::Relaxed) as usize;
+        Some(proto::MotorThermal {
+            hottest: duck_control::JOINT_NAMES
+                .get(hottest)
+                .unwrap_or(&"unknown")
+                .to_string(),
+            max_c,
+            mean_c: f64::from_bits(self.motor_mean_c.load(Ordering::Relaxed)),
+        })
     }
 
     /// The last battery reading, mapped to a percentage — or `None` if there has not been
@@ -664,7 +717,7 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
             window_start = Instant::now();
             window_ticks = 0;
 
-            sample_battery(&mut io, &state);
+            publish_slow_sensors(&mut io, &state);
 
             if last_summary.elapsed() >= LOOP_SUMMARY_INTERVAL {
                 tracing::info!(
@@ -675,6 +728,10 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
                         "{:.2}",
                         f64::from_bits(state.battery_v.load(Ordering::Relaxed))
                     ),
+                    motor_max_c = format!(
+                        "{:.0}",
+                        f64::from_bits(state.motor_max_c.load(Ordering::Relaxed))
+                    ),
                     "control loop"
                 );
                 last_summary = Instant::now();
@@ -684,32 +741,55 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
     tracing::info!("control loop stopped");
 }
 
-/// Read the battery and publish it, once per [`RATE_WINDOW`].
+/// Sample and publish everything that does not need sampling every tick, once per
+/// [`RATE_WINDOW`].
 ///
-/// Not part of the tick. `present_input_voltage` is a second bus transaction — about a
-/// millisecond — which is nothing once a second and would be 5% of the budget at 50 Hz. A
-/// second is also faster than a battery can meaningfully change.
+/// Not part of the tick. The voltage/temperature registers are a second bus transaction —
+/// about a millisecond — which is nothing once a second and would be 5% of the budget at
+/// 50 Hz. A second is also faster than a pack can drain or a servo can heat up.
 ///
 /// Called from the loop thread because that thread owns the IO, and nothing else may touch
 /// the bus: a transaction issued from the IPC side would interleave bytes with a tick and
-/// corrupt both.
-fn sample_battery<T: RobotIo>(io: &mut T, state: &RobotState) {
-    match io.bus_voltage() {
-        Ok(volts) => {
+/// corrupt both. The IMU counters come from the same `io`, so they are mirrored here rather
+/// than reached for from the socket.
+fn publish_slow_sensors<T: RobotIo>(io: &mut T, state: &RobotState) {
+    state
+        .imu_stale_blocks
+        .store(io.imu_stale_blocks(), Ordering::Relaxed);
+    state.imu_ready.store(io.imu_ready(), Ordering::Relaxed);
+
+    match io.slow_sensors() {
+        Ok(slow) => {
             let previous = f64::from_bits(state.battery_v.load(Ordering::Relaxed));
             // Seed from the first reading rather than blending up from zero, which would
             // spend ten seconds reporting a battery flatter than it is.
             let smoothed = if previous > 0.0 {
-                BATTERY_EMA_ALPHA * volts + (1.0 - BATTERY_EMA_ALPHA) * previous
+                BATTERY_EMA_ALPHA * slow.volts + (1.0 - BATTERY_EMA_ALPHA) * previous
             } else {
-                volts
+                slow.volts
             };
             state.battery_v.store(smoothed.to_bits(), Ordering::Relaxed);
+
+            // Temperature is not smoothed: a servo's case is already a slow signal, and an
+            // EMA would only delay the one reading anybody cares about — the joint climbing
+            // towards its overheat shutdown.
+            let (hottest, max_c) = slow.temps_c.iter().enumerate().fold(
+                (0usize, f64::MIN),
+                |(best, high), (joint, &t)| {
+                    if t > high { (joint, t) } else { (best, high) }
+                },
+            );
+            let mean_c = slow.temps_c.iter().sum::<f64>() / slow.temps_c.len() as f64;
+            state.motor_max_c.store(max_c.to_bits(), Ordering::Relaxed);
+            state
+                .motor_mean_c
+                .store(mean_c.to_bits(), Ordering::Relaxed);
+            state.motor_hottest.store(hottest as u32, Ordering::Relaxed);
         }
-        // Keep the last reading. A single failed transaction is ordinary on a serial bus, and
+        // Keep the last sample. A single failed transaction is ordinary on a serial bus, and
         // dropping to "unknown" over one would make the reported battery flicker. A bus that
-        // is really gone already shows up in the health verdict itself.
-        Err(e) => tracing::debug!(error = %e, "voltage read failed; keeping the last reading"),
+        // is really gone already shows up in the verdict and in `bus.consecutive_errors`.
+        Err(e) => tracing::debug!(error = %e, "slow-sensor read failed; keeping the last sample"),
     }
 }
 
@@ -1189,6 +1269,7 @@ mod tests {
         let s = state();
         s.startup_bus_failures.store(4, Ordering::Relaxed);
         s.battery_v.store(7.5f64.to_bits(), Ordering::Relaxed);
+        s.motor_max_c.store(48.0f64.to_bits(), Ordering::Relaxed);
 
         let health = s.health();
         assert!(!health.healthy);
@@ -1196,6 +1277,70 @@ mod tests {
             health.battery.is_some(),
             "battery dropped from a bad answer"
         );
+        // The rest of the description too: an unhealthy robot is exactly when someone needs
+        // the whole picture, not a verdict on its own.
+        assert!(health.motors.is_some(), "thermals dropped");
+        assert!(health.control_loop.is_some(), "loop section dropped");
+        assert!(health.imu.is_some(), "imu section dropped");
+        // And the number *this* verdict was based on: "no robot on the motor bus" is only
+        // actionable next to the count of attempts behind it.
+        assert_eq!(health.bus.startup_failures, 4);
+    }
+
+    /// The loop section must carry the numbers the verdict was decided from, so a reader can
+    /// check it rather than take it on faith.
+    ///
+    /// That distinction has already paid once: 43.9 Hz with `missed = 0` is a loop being
+    /// *woken* late, not a loop doing too much, and the two have entirely different fixes.
+    #[test]
+    fn the_loop_section_reports_what_the_verdict_used() {
+        let s = state();
+        ticked(&s, 2490);
+        s.achieved_hz.store(49.8f64.to_bits(), Ordering::Relaxed);
+        s.missed.store(3, Ordering::Relaxed);
+
+        let l = s.health().control_loop.expect("loop section");
+        assert_eq!(l.achieved_hz, Some(49.8));
+        assert_eq!(l.target_hz, 50.0);
+        assert_eq!(l.ticks, 2490);
+        assert_eq!(l.missed, 3);
+
+        // Unmeasured stays unmeasured rather than becoming 0 Hz — that would describe a
+        // stopped loop, which is the opposite of "started less than a second ago".
+        s.achieved_hz.store(0, Ordering::Relaxed);
+        assert_eq!(s.health().control_loop.unwrap().achieved_hz, None);
+    }
+
+    /// The hottest joint is named, not merely measured. "48 °C" prompts "which one?", and the
+    /// answer decides whether it is the knee holding the robot up or something wrong.
+    #[test]
+    fn thermals_name_the_hottest_joint() {
+        let s = state();
+        ticked(&s, 100);
+        let knee = duck_control::JOINT_NAMES
+            .iter()
+            .position(|n| *n == "left_knee")
+            .unwrap();
+        s.motor_max_c.store(48.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_mean_c.store(36.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_hottest.store(knee as u32, Ordering::Relaxed);
+
+        let motors = s.health().motors.expect("thermals");
+        assert_eq!(motors.hottest, "left_knee");
+        assert_eq!(motors.max_c, 48.0);
+        assert_eq!(motors.mean_c, 36.0);
+
+        // A servo cooking must not change the verdict, for the same reason a flat pack must
+        // not: it is a fact about the robot, not evidence about the release.
+        assert!(s.health().healthy);
+    }
+
+    /// Unread thermals are absent, not 0 °C — which would read as a robot in a freezer.
+    #[test]
+    fn unread_thermals_are_absent() {
+        let s = state();
+        ticked(&s, 1);
+        assert!(s.health().motors.is_none());
     }
 
     /// While waiting, health must say *why*. The update system quotes this string as the
@@ -1332,8 +1477,8 @@ mod tests {
             fn write(&mut self, t: &JointTargets) -> duck_control::io::Result<()> {
                 self.0.write(t)
             }
-            fn bus_voltage(&mut self) -> duck_control::io::Result<f64> {
-                self.0.bus_voltage()
+            fn slow_sensors(&mut self) -> duck_control::io::Result<duck_control::SlowSensors> {
+                self.0.slow_sensors()
             }
         }
         control_loop(Borrowed(io), state, period).await

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -191,9 +191,9 @@ impl RobotState {
             imu_ready: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
-            min_achieved_hz: params.health.min_achieved_hz,
-            stall_periods: params.health.stall_periods,
-            max_consecutive_errors: params.health.max_consecutive_errors,
+            min_achieved_hz: params.update_gate.min_achieved_hz,
+            stall_periods: params.update_gate.stall_periods,
+            max_consecutive_errors: params.update_gate.max_consecutive_errors,
             force_unhealthy,
             force_busy,
         }
@@ -981,7 +981,7 @@ mod tests {
         // A short window so the test does not sleep for the real 500 ms default. Two
         // periods at 50 Hz is 40 ms.
         let mut params = Params::default();
-        params.health.stall_periods = 2;
+        params.update_gate.stall_periods = 2;
         let s = RobotState::new(&params, false, false);
 
         s.ticks.store(1, Ordering::Relaxed);

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -20,6 +20,7 @@
 //! than hanging the caller.
 
 mod params;
+mod soc;
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -159,6 +160,9 @@ struct RobotState {
     motor_mean_c: AtomicU64,
     /// Index into [`duck_control::JOINT_NAMES`] of the hottest joint.
     motor_hottest: AtomicU32,
+    /// Hottest board thermal zone, as `f64::to_bits`. Zero means no reading — off Linux, or a
+    /// kernel with no thermal sysfs ([`soc`]).
+    cpu_temp_c: AtomicU64,
     /// Mirrors of the bus's own IMU diagnostics, refreshed with the thermal sample. Held here
     /// so the IPC side can report them without touching the loop's IO.
     imu_stale_blocks: AtomicU64,
@@ -187,6 +191,7 @@ impl RobotState {
             motor_max_c: AtomicU64::new(0),
             motor_mean_c: AtomicU64::new(0),
             motor_hottest: AtomicU32::new(0),
+            cpu_temp_c: AtomicU64::new(0),
             imu_stale_blocks: AtomicU64::new(0),
             imu_ready: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
@@ -214,6 +219,12 @@ impl RobotState {
                 reason,
                 battery: self.battery(),
                 motors: self.motor_thermal(),
+                cpu_temp_c: {
+                    // Zero is "never read", the same sentinel the battery uses: a board at
+                    // 0 °C is a sensor that is not there, not a cold robot.
+                    let c = f64::from_bits(self.cpu_temp_c.load(Ordering::Relaxed));
+                    (c > 0.0).then_some(c)
+                },
                 control_loop: Some(self.loop_health()),
                 bus: proto::BusHealth {
                     consecutive_errors: self.consecutive_errors.load(Ordering::Relaxed),
@@ -732,6 +743,10 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
                         "{:.0}",
                         f64::from_bits(state.motor_max_c.load(Ordering::Relaxed))
                     ),
+                    cpu_c = format!(
+                        "{:.0}",
+                        f64::from_bits(state.cpu_temp_c.load(Ordering::Relaxed))
+                    ),
                     "control loop"
                 );
                 last_summary = Instant::now();
@@ -757,6 +772,13 @@ fn publish_slow_sensors<T: RobotIo>(io: &mut T, state: &RobotState) {
         .imu_stale_blocks
         .store(io.imu_stale_blocks(), Ordering::Relaxed);
     state.imu_ready.store(io.imu_ready(), Ordering::Relaxed);
+
+    // Before the bus read, and unconditionally: this is a `sysfs` read that owes the motor bus
+    // nothing, and a board cooking behind a blocked vent is *more* likely to be worth seeing on
+    // a robot whose servos have stopped answering, not less.
+    if let Some(celsius) = soc::hottest_zone_c() {
+        state.cpu_temp_c.store(celsius.to_bits(), Ordering::Relaxed);
+    }
 
     match io.slow_sensors() {
         Ok(slow) => {
@@ -1341,6 +1363,25 @@ mod tests {
         let s = state();
         ticked(&s, 1);
         assert!(s.health().motors.is_none());
+        assert!(s.health().cpu_temp_c.is_none());
+    }
+
+    /// Board and servo temperatures are separate readings, and the case that justifies both is
+    /// them disagreeing: a board cooking behind a blocked vent while the motors sit idle and
+    /// cool. One number could not express it.
+    #[test]
+    fn a_hot_board_and_cool_motors_are_both_reported() {
+        let s = state();
+        ticked(&s, 100);
+        s.cpu_temp_c.store(84.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_max_c.store(31.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_mean_c.store(30.0f64.to_bits(), Ordering::Relaxed);
+
+        let health = s.health();
+        assert_eq!(health.cpu_temp_c, Some(84.0));
+        assert_eq!(health.motors.expect("thermals").max_c, 31.0);
+        // And neither touches the verdict — a warm afternoon is not a bad release.
+        assert!(health.healthy);
     }
 
     /// While waiting, health must say *why*. The update system quotes this string as the

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -19,7 +19,7 @@ pub const DEFAULT_PATH: &str = "/etc/robot/robotd.toml";
 pub struct Params {
     pub bus: Bus,
     pub control: Control,
-    pub health: Health,
+    pub update_gate: UpdateGate,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -38,9 +38,24 @@ pub struct Control {
     pub hz: u32,
 }
 
+/// Thresholds that decide `healthy` — and therefore whether an update is kept.
+///
+/// **Not** the thresholds for everything `robot.health` reports. That answer also describes the
+/// battery, the motor temperatures and the loop counters, and none of those may reach a verdict
+/// (`docs/robotd-design.md` §4.5) — so none of them has a setting here. Naming this section
+/// `[health]` invited exactly that mistake: it reads like "how the robot is doing", when what it
+/// configures is the one question auto-rollback turns on.
+///
+/// Everything here is a property of the *software*. A future `[thermal]` section for a motor
+/// temperature that should throttle the robot would be a different thing, and belongs under a
+/// different name.
+///
+/// The section was called `[health]`. Renamed outright rather than aliased: a board carrying
+/// the old name gets a parse error naming the section, which is a better outcome than a robot
+/// quietly running on default thresholds nobody chose.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields, default)]
-pub struct Health {
+pub struct UpdateGate {
     /// Below this achieved rate the robot reports unhealthy, which is what makes the
     /// updater's auto-rollback mean something. A loop running at 60% of target is alive,
     /// answers every request, and is badly broken.
@@ -72,7 +87,7 @@ impl Default for Control {
     }
 }
 
-impl Default for Health {
+impl Default for UpdateGate {
     fn default() -> Self {
         Self {
             // 90% of the default rate. Generous enough not to trip on a slow tick, tight
@@ -186,7 +201,7 @@ mod tests {
         let p = Params::load(&path, true).unwrap();
         assert_eq!(p.bus.port, "/dev/ttyUSB0");
         assert_eq!(p.control.hz, 50);
-        assert_eq!(p.health.stall_periods, 25);
+        assert_eq!(p.update_gate.stall_periods, 25);
     }
 
     /// The shipped example must agree with the built-in defaults, or the file documents a
@@ -201,25 +216,39 @@ mod tests {
         assert_eq!(from_file.bus.port, built_in.bus.port);
         assert_eq!(from_file.control.hz, built_in.control.hz);
         assert_eq!(
-            from_file.health.min_achieved_hz,
-            built_in.health.min_achieved_hz
+            from_file.update_gate.min_achieved_hz,
+            built_in.update_gate.min_achieved_hz
         );
         assert_eq!(
-            from_file.health.stall_periods,
-            built_in.health.stall_periods
+            from_file.update_gate.stall_periods,
+            built_in.update_gate.stall_periods
         );
         assert_eq!(
-            from_file.health.max_consecutive_errors,
-            built_in.health.max_consecutive_errors
+            from_file.update_gate.max_consecutive_errors,
+            built_in.update_gate.max_consecutive_errors
         );
     }
 
     /// A typo in a key must fail loudly. Silently ignoring `min_acheived_hz` would leave
-    /// the health gate at a threshold the operator believes they changed.
+    /// the update gate at a threshold the operator believes they changed.
     #[test]
     fn an_unknown_key_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
-        let path = write(dir.path(), "[health]\nmin_acheived_hz = 10.0\n");
+        let path = write(dir.path(), "[update_gate]\nmin_acheived_hz = 10.0\n");
+        assert!(Params::load(&path, true).is_err());
+    }
+
+    /// The old section name must be *rejected*, not silently ignored.
+    ///
+    /// A board still carrying `[health]` gets a `robotd` that refuses to start and says why,
+    /// which is the honest outcome: `deny_unknown_fields` means the operator hears about the
+    /// file rather than running on defaults they did not choose while believing otherwise.
+    /// `install.sh` never overwrites `robotd.toml`, so the fix is to edit the section name —
+    /// and the parse error names it.
+    #[test]
+    fn the_old_health_section_name_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "[health]\nmin_achieved_hz = 40.0\n");
         assert!(Params::load(&path, true).is_err());
     }
 

--- a/robotd/src/soc.rs
+++ b/robotd/src/soc.rs
@@ -1,0 +1,84 @@
+//! What the *board* says about itself, as opposed to what the robot says.
+//!
+//! Deliberately not in `duck-control` and not behind [`crate::RobotIo`]: nothing here touches
+//! the Dynamixel bus. It is a `sysfs` read, so it belongs to the daemon that runs on a Linux
+//! board rather than to the crate that models a robot — and it keeps working when the motor
+//! bus does not, which is exactly when a thermal reading is interesting.
+//!
+//! Absent everywhere but Linux, and absent on a Linux box with no thermal zones. Both answer
+//! `None` by simply finding no files, which is why there is no `cfg` here: a laptop dev build
+//! reports no board temperature and says so, rather than failing to compile.
+
+/// Where the kernel exposes every thermal sensor it knows about.
+const THERMAL_ROOT: &str = "/sys/class/thermal";
+
+/// Millidegrees Celsius, per the kernel's thermal sysfs ABI.
+const MILLI_PER_DEGREE: f64 = 1000.0;
+
+/// The hottest thermal zone on the board, in °C.
+///
+/// **The maximum across zones, not the CPU's alone.** A Radxa Zero 3 exposes `soc-thermal` and
+/// `gpu-thermal`; other boards add NPU and DDR zones. Reporting the hottest of them is the
+/// conservative answer to "is this board too hot", and it cannot silently omit the zone that
+/// was actually climbing — which picking one zone by name would, the first time a board wired
+/// its sensors differently.
+///
+/// `None` when there are no readable zones: not Linux, or a kernel without thermal sysfs.
+/// Never `Some(0.0)` — a zone that reads as nonsense is skipped rather than averaged in, since
+/// 0 °C on a running board is a sensor fault, not a temperature.
+pub fn hottest_zone_c() -> Option<f64> {
+    let mut hottest: Option<f64> = None;
+
+    // `read_dir` once per sample rather than a cached list of paths: it is a few microseconds
+    // at 1 Hz, and a cache would go stale against a zone that appears when a driver loads.
+    for entry in std::fs::read_dir(THERMAL_ROOT).ok()?.flatten() {
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with("thermal_zone") {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(entry.path().join("temp")) else {
+            continue;
+        };
+        let Ok(milli) = raw.trim().parse::<f64>() else {
+            continue;
+        };
+        let celsius = milli / MILLI_PER_DEGREE;
+        // A negative or zero reading is a sensor that is not working. Below-freezing is
+        // physically possible for a board and pointless to chase; a fault is far likelier.
+        if celsius <= 0.0 {
+            continue;
+        }
+        if hottest.is_none_or(|high| celsius > high) {
+            hottest = Some(celsius);
+        }
+    }
+
+    hottest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On Linux CI this must find the host's own zones; on macOS it must answer `None` rather
+    /// than panic. Either way the *shape* is what is asserted, because a test cannot know what
+    /// temperature the machine running it is at.
+    #[test]
+    fn a_reading_is_plausible_or_absent() {
+        match hottest_zone_c() {
+            None => {} // No thermal sysfs. Correct on macOS, and on a container without it.
+            Some(c) => assert!(
+                (1.0..=150.0).contains(&c),
+                "{c} °C is not a temperature a board reports; check the millidegree scale"
+            ),
+        }
+    }
+
+    /// The scale is the whole risk here: the kernel reports millidegrees, and forgetting the
+    /// divisor turns 47 °C into 47000, which would sail through any "is it hot" threshold
+    /// anyone later writes against this.
+    #[test]
+    fn millidegrees_convert_to_degrees() {
+        assert_eq!(47123.0 / MILLI_PER_DEGREE, 47.123);
+    }
+}

--- a/robotd/tests/updater_gate.rs
+++ b/robotd/tests/updater_gate.rs
@@ -103,6 +103,36 @@ impl Robotd {
         }
         panic!("robotd never became healthy; last answer was {last:?}");
     }
+
+    /// One `robot.health` answer, as raw JSON over the socket.
+    ///
+    /// Raw rather than through `SocketRobotClient`, whose `health()` collapses the answer to
+    /// the three-way verdict the engine needs and drops everything else — including the
+    /// battery this exists to look at. These are the bytes `robotctl health` sends.
+    async fn health(&self) -> updater::proto::HealthResult {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let mut stream = tokio::net::UnixStream::connect(&self.socket).await.unwrap();
+        let request = format!(
+            "{}\n",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": updater::proto::method::ROBOT_HEALTH,
+                "params": {},
+            })
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut line = String::new();
+        tokio::io::BufReader::new(stream)
+            .read_line(&mut line)
+            .await
+            .unwrap();
+
+        let response: updater::proto::Response = serde_json::from_str(line.trim()).unwrap();
+        assert!(response.error.is_none(), "{:?}", response.error);
+        serde_json::from_value(response.result.expect("result")).expect("HealthResult shape")
+    }
 }
 
 impl Drop for Robotd {
@@ -245,6 +275,41 @@ async fn real_robotd_answers_every_method_the_engine_calls() {
     assert!(
         !client.remote_session_active(t).await,
         "no session should be active on a fresh robotd"
+    );
+}
+
+/// The battery reaches the wire, mapped, from a real process.
+///
+/// The only test that covers the whole chain: the loop calling `RobotIo::bus_voltage`, the
+/// EMA, the published atomic, the volts→percent mapping, and the JSON. Unit tests write the
+/// atomic directly and would all still pass if the sampler were never called at all — which
+/// is precisely the bug worth catching, because on a board it looks like a flat battery.
+#[tokio::test]
+async fn real_robotd_reports_a_mapped_battery() {
+    let fx = Fixture::new();
+    let robotd = Robotd::spawn(fx.socket(), &[]).await;
+    robotd.wait_until_healthy().await;
+
+    // Sampled once per rate window, so the first reading lands about a second after the loop
+    // starts. Absent before that is correct, not a failure.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut health = robotd.health().await;
+    while health.battery.is_none() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        health = robotd.health().await;
+    }
+
+    let battery = health
+        .battery
+        .expect("battery must be sampled within a few seconds of the loop starting");
+    // `FakeIo` reports 7.4 V, which is the middle of the 6.6–8.2 V span.
+    assert!(
+        (battery.volts - 7.4).abs() < 0.01,
+        "expected the fake bus voltage, got {battery:?}"
+    );
+    assert!(
+        (battery.percent - 50.0).abs() < 1.0,
+        "percent must be mapped from volts, got {battery:?}"
     );
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -577,6 +577,7 @@ report() {
     cat <<'EOF'
 
   robotctl version                    what is running, and what is installed
+  robotctl health                     is the robot working, and how is its battery
   robotctl update status              update state per component
   robotctl update check               is a newer release available
   sudo robotctl update apply daemon   update now (mutations are root-only by design)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -576,8 +576,8 @@ report() {
     say "installed daemon ${version}"
     cat <<'EOF'
 
+  robotctl health                     the whole robot: hardware and software
   robotctl version                    what is running, and what is installed
-  robotctl health                     is the robot working, and how is its battery
   robotctl update status              update state per component
   robotctl update check               is a newer release available
   sudo robotctl update apply daemon   update now (mutations are root-only by design)


### PR DESCRIPTION
`robotctl health` printed a verdict and nothing else. The verdict was both the useful part and the frustrating one: `unhealthy: control loop at 43.9 Hz` says what is wrong and nothing about why, and answering that meant a second command, the journal, or hand-written JSON at the socket. It also could not tell you the single thing most likely to explain a robot behaving oddly — how much charge is left.

```
$ robotctl health
robot     healthy
  loop      50.1 of 50.0 Hz · 2834 ticks · 0 missed · last 13 ms ago
  bus       ok
  imu       ready
  battery   7.62 V (64%)
  motors    41 °C max (left_knee) · 36 °C mean

software
  updaterd  0.1.4 (rev abc1234)
  robotd    0.1.5 (rev def5678)
  daemon    0.1.5 installed
            last update 0.1.4 → 0.1.5: applied
```

Three commits, reviewable in order:

1. **`Report the battery, and never gate on it`** — the measurement, the mapping, and the rule.
2. **`robotctl health reports the whole robot`** — the rest of the sections, and the software half.
3. **`robotd.toml: [health] is really [update_gate]`** — the config section renamed to what it configures.

## Battery, where there is no fuel gauge

The only measurement available is what the servos report as their own supply — the pack seen through the bus, so it sags under load and recovers at rest. Read once a second and smoothed with an EMA (α=0.1, ~10 s); approach and figures borrowed from `microduck_runtime`, where they were arrived at against real hardware.

Volts **and** percent go on the wire. The 6.6/8.2 V mapping lives in `duck_control::model::battery_percent` so there is one of it — the prototype sent volts only and the app re-derived the percentage from its own constants, which is how the same pack shows two different numbers on two screens.

## Motor temperature came free

`present_temperature` (146) is one register past `present_input_voltage` (144), so a 3-byte read gets both and thermals cost no extra transaction. Reported as the **hottest** joint, named: a knee holding a squat runs far above the mouth, and a mean over fifteen servos hides the one servo approaching the overheat shutdown its error mask latches on.

Neither rides the tick: those registers sit eight bytes past the end of the block `read()` fetches, with twelve bytes of trajectory registers nobody wants in between. One extra transaction per second (~1 ms) beats widening every tick's read to 22 bytes per servo at 50 Hz.

## One command, both halves

"What is wrong with this robot" does not divide into hardware and software until after it is answered — a robot that reverted a release an hour ago looks exactly like a robot with unpowered servos until both are on screen together. `robotctl version` stays the software half alone, and the gathering is shared so the two commands cannot disagree.

The loop section carries the numbers the verdict was *computed from*: 43.9 Hz next to `missed = 0` says the loop is being woken late, not doing too much. That distinction is what made the `Delay`→`Skip` fix in c5c1187 a one-liner instead of a hardware investigation.

Two more things nobody thinks to ask about, both of which explain "updates stopped working": a **pinned** component, and the **last update attempt** with the reason behind an automatic revert — which outside the journal exists nowhere else.

## Reported, never judged

`healthy`/`degraded` still come only from what a release can be blamed for. Battery, thermals and counters are descriptions, and tests hold the line: a verdict that gated on the battery would roll a release back on a low pack, then judge its replacement on the same low pack, and the robot could not be updated at all until someone worked out why. That is the trap `degraded` was added to close for an unpowered bench board; temperature would reopen it on a warm afternoon.

That is also why `[health]` in `robotd.toml` becomes `[update_gate]`: the three thresholds there decide the verdict and nothing else, and the old name read like it configured everything the answer now contains. Renamed with no alias — a board carrying `[health]` gets a parse error naming the section, which beats a robot silently running on defaults its operator did not choose.

## Exit codes

Contract unchanged, since `install.sh` gates on it: `0` healthy, `REFUSED` unhealthy, `UNREACHABLE` when nothing answered. What changed is that an unreachable `robotd` no longer aborts the command — it prints the software half anyway, because "the robot does nothing" is very often a daemon that failed to start, and what is installed is then the half that explains it.

## Testing

`cargo test --workspace` green (17 suites, 311 tests), `clippy --all-targets` and `fmt` clean. Verified by hand against a real `robotd` and a real `updaterd` on the playground: healthy, `robotd` stopped (software half survives, exit 3), and `--json`.

New tests cover what a live robot never produces: nothing-measured-yet rendering as unknown rather than `0.0 Hz`/`0.00 V`, absent-is-not-zero at the proto/`robotd`/CLI layers, a flat pack changing no verdict, a stale IMU, a bench board waiting on its bus, a pin, a rollback summary, and the renamed section rejecting its old name. One live-socket test drives the whole battery chain against a real process — the unit tests write the atomic directly and would all still pass if the sampler were never called, which is exactly the failure that looks like a dead battery on a board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)