### PR TITLE
configd, and a BLE client to drive it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +313,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -364,6 +497,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "configd"
+version = "0.1.4"
+dependencies = [
+ "async-trait",
+ "clap",
+ "duck-ipc-proto",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zbus",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +561,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -587,6 +752,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +805,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -715,6 +927,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1295,6 +1520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1656,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,10 +1720,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2004,6 +2279,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2580,6 +2866,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unescaper"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2960,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2976,6 +3274,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,4 +3426,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,10 +196,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluer"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af68112f5c60196495c8b0eea68349817855f565df5b04b2477916d09fb1a901"
+dependencies = [
+ "custom_debug",
+ "dbus",
+ "dbus-crossroads",
+ "dbus-tokio",
+ "displaydoc",
+ "futures",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "macaddr",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+]
+
+[[package]]
 name = "btd"
 version = "0.1.4"
 dependencies = [
+ "bluer",
+ "clap",
+ "dbus",
  "duck-ipc-proto",
+ "futures",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -384,6 +429,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
 
 [[package]]
+name = "custom_debug"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da7d1ad9567b3e11e877f1d7a0fa0360f04162f94965fc4448fbed41a65298e"
+dependencies = [
+ "custom_debug_derive",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,12 +669,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -547,6 +698,17 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -583,6 +745,7 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -666,6 +829,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -889,6 +1058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1257,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "mach2"
@@ -1150,12 +1341,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1219,6 +1442,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1796,7 +2039,7 @@ dependencies = [
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",
- "nix",
+ "nix 0.26.4",
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
@@ -1908,6 +2151,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -2091,6 +2356,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2378,6 +2654,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "btd"
+version = "0.1.4"
+dependencies = [
+ "duck-ipc-proto",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,10 +367,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluez-async"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
+dependencies = [
+ "bitflags 2.13.1",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures",
+ "itertools",
+ "log",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 2.0.19",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "bluez-generated"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
 name = "btd"
 version = "0.1.4"
 dependencies = [
  "bluer",
+ "btleplug",
  "clap",
  "dbus",
  "duck-ipc-proto",
@@ -372,6 +411,34 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a11621cb2c8c024e444734292482b1ad86fb50ded066cf46252e46643c8748"
+dependencies = [
+ "async-trait",
+ "bitflags 2.13.1",
+ "bluez-async",
+ "dashmap 6.2.1",
+ "dbus",
+ "futures",
+ "jni 0.19.0",
+ "jni-utils",
+ "log",
+ "objc2",
+ "objc2-core-bluetooth",
+ "objc2-foundation",
+ "once_cell",
+ "static_assertions",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -397,6 +464,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -651,6 +724,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +823,7 @@ dependencies = [
  "rustypot",
  "serde",
  "serialport",
- "thiserror",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -741,6 +841,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding_rs"
@@ -1039,6 +1145,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1316,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1362,10 +1474,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
 
 [[package]]
 name = "jni"
@@ -1376,12 +1511,12 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.19",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1395,6 +1530,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1414,6 +1558,21 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "jni 0.19.0",
+ "log",
+ "once_cell",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -1470,6 +1629,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1638,6 +1806,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-bluetooth"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1883,19 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "paste"
@@ -1791,7 +2017,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -1814,7 +2040,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1873,6 +2099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1989,7 +2224,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-support",
- "thiserror",
+ "thiserror 2.0.19",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -2091,7 +2326,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -2235,6 +2470,18 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 2.0.19",
+ "xml",
 ]
 
 [[package]]
@@ -2433,6 +2680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,11 +2809,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2654,6 +2927,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2882,7 +3156,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2919,7 +3193,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-support",
- "thiserror",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "toml 1.1.3+spec-1.1.0",
@@ -3108,10 +3382,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3137,7 +3513,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3154,6 +3530,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3234,6 +3619,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xml"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # docs/architecture.md §1. `robotd`, `btd` and `mediad` join as siblings.
 [workspace]
 resolver = "3"
-members = ["btd", "duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
+members = ["btd", "configd", "duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
 
 # ONNX Runtime, which robotd dlopens to run a policy. One source of truth: `xtask package`
 # bakes these into the release's preinstall hook, and a test asserts scripts/setup-board.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # docs/architecture.md §1. `robotd`, `btd` and `mediad` join as siblings.
 [workspace]
 resolver = "3"
-members = ["duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
+members = ["btd", "duck-control", "duck-ipc-proto", "updater", "robotctl", "robotd", "test-support", "xtask"]
 
 # ONNX Runtime, which robotd dlopens to run a policy. One source of truth: `xtask package`
 # bakes these into the release's preinstall hook, and a test asserts scripts/setup-board.sh

--- a/btd/Cargo.toml
+++ b/btd/Cargo.toml
@@ -14,17 +14,34 @@ description = "BLE transport adapter — a GATT front door onto the robot's JSON
 # stays unprivileged while `configd` is the one running as root.
 [dependencies]
 duck-ipc-proto = { path = "../duck-ipc-proto" }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal"] }
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
-# `bluer` (BlueZ) and tokio are deliberately NOT here yet, and adding them needs a decision
-# rather than a line:
+# BlueZ, reached over bluetoothd's D-Bus API. Only on Linux, and this only ever *runs* on the
+# Radxa — but the crate must still *build* on a macOS laptop, because `cargo test` there is the
+# whole onboarding path for a teammate (roadmap, "Organisation"). Those are different claims and
+# only the first is true, so the radio sits behind `cfg(target_os = "linux")` while the session
+# logic is driven by channels and needs no radio to test.
 #
-#  - BlueZ is Linux-only, so the real backend must sit behind a trait with a fake, as
-#    `duck-control` does for the Dynamixel bus — the suite runs on a macOS laptop with no
-#    hardware, no network and no Docker, and that must stay true.
-#  - `bluer` links libdbus, which the release pipeline **cross-compiles** for aarch64. A C
-#    dependency needs a sysroot that CI does not have today, so this is a build-system change
-#    and not a dependency addition. Measure it against a pure-Rust D-Bus client (`zbus`,
-#    already the likely choice for `configd`) before committing to either.
+# Pinned rather than floated: bluer is 0.x and breaks across minor versions, and its GATT-server
+# API is the part most likely to move.
 #
-# Until that is settled this crate is the transport-independent half — framing and routing —
-# which is where all the logic worth testing lives anyway.
+# `dbus/vendored` builds libdbus from source with `cc` instead of linking the target's copy.
+# That is what makes this cross-compile: `cargo board` uses cargo-zigbuild, and `zig cc`
+# supplies a cross C compiler — the same mechanism that already builds `zstd-sys` — but the
+# sysroot has libc, not libdbus. Verified: a full aarch64 release build links clean.
+#
+# The cost of vendoring is that this libdbus is ours to keep current rather than the distro's.
+# Acceptable for a library reached only over a local socket by a daemon we wrote, but it is a
+# thing to remember exists.
+[target.'cfg(target_os = "linux")'.dependencies]
+bluer = { version = "=0.17.4", features = ["bluetoothd"] }
+dbus = { version = "0.9", features = ["vendored"] }
+uuid = "1"
+futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/btd/Cargo.toml
+++ b/btd/Cargo.toml
@@ -19,6 +19,8 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+# The GATT UUIDs are a wire contract every client needs, not a Linux detail — see src/gatt.rs.
+uuid = "1"
 
 # BlueZ, reached over bluetoothd's D-Bus API. Only on Linux, and this only ever *runs* on the
 # Radxa — but the crate must still *build* on a macOS laptop, because `cargo test` there is the
@@ -40,8 +42,17 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 bluer = { version = "=0.17.4", features = ["bluetoothd"] }
 dbus = { version = "0.9", features = ["vendored"] }
-uuid = "1"
 futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+
+# `btctl`, the laptop-side client in examples/. A dev-dependency on purpose: an example's deps
+# never reach the shipped artifact, so btleplug is not on the robot.
+#
+# btleplug rather than bluer because this half runs on a developer's machine — CoreBluetooth on
+# macOS, BlueZ on Linux, WinRT on Windows. bluer would make the client Linux-only, which defeats
+# the point of having one.
+btleplug = "0.11"
+futures = "0.3"
+serde_json = "1"

--- a/btd/Cargo.toml
+++ b/btd/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "btd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "BLE transport adapter — a GATT front door onto the robot's JSON-RPC API"
+
+# A transport adapter and nothing else (architecture.md §4.1): `btd` owns no state. Every
+# request it accepts is forwarded verbatim to the service that owns the answer, over that
+# service's unix socket. So it depends on the method table and on nothing that implements
+# behaviour — no update engine, no control loop, no NetworkManager client.
+#
+# It is also the process that parses bytes arriving from anyone in radio range, which is why it
+# stays unprivileged while `configd` is the one running as root.
+[dependencies]
+duck-ipc-proto = { path = "../duck-ipc-proto" }
+
+# `bluer` (BlueZ) and tokio are deliberately NOT here yet, and adding them needs a decision
+# rather than a line:
+#
+#  - BlueZ is Linux-only, so the real backend must sit behind a trait with a fake, as
+#    `duck-control` does for the Dynamixel bus — the suite runs on a macOS laptop with no
+#    hardware, no network and no Docker, and that must stay true.
+#  - `bluer` links libdbus, which the release pipeline **cross-compiles** for aarch64. A C
+#    dependency needs a sysroot that CI does not have today, so this is a build-system change
+#    and not a dependency addition. Measure it against a pure-Rust D-Bus client (`zbus`,
+#    already the likely choice for `configd`) before committing to either.
+#
+# Until that is settled this crate is the transport-independent half — framing and routing —
+# which is where all the logic worth testing lives anyway.

--- a/btd/examples/btctl.rs
+++ b/btd/examples/btctl.rs
@@ -1,0 +1,299 @@
+//! `btctl` — talk to a robot over BLE from a laptop.
+//!
+//! The phone app's stand-in, and the only way to test `btd` against a real radio.
+//!
+//! An **example, not a binary**, so `btleplug` never reaches the robot: examples' dependencies
+//! are dev-dependencies, and nothing here is in the shipped artifact. `robotctl` is the tool
+//! that ships, and it speaks unix sockets on the robot itself.
+//!
+//! `btleplug` rather than `bluer`, because this runs on a developer's machine: CoreBluetooth on
+//! macOS, BlueZ on Linux, WinRT on Windows. `bluer` would restrict the client to Linux, which
+//! defeats the point.
+//!
+//! It reuses `btd::framing` deliberately. The chunking here is the *client* half of the same
+//! module the robot uses, so if the framing were asymmetric this would not work — which makes
+//! it a real test of the protocol rather than a reimplementation that could agree with itself.
+//!
+//! ```text
+//! cargo run -p btd --example btctl -- scan
+//! cargo run -p btd --example btctl -- status
+//! cargo run -p btd --example btctl -- wifi scan
+//! cargo run -p btd --example btctl -- wifi connect "Pollen" --psk secret
+//! cargo run -p btd --example btctl -- name "Ducky"
+//! cargo run -p btd --example btctl -- call robot.health
+//! ```
+
+use std::time::Duration;
+
+use btd::gatt::{REQUEST_UUID, RESPONSE_UUID, SERVICE_UUID};
+use btd::framing::{self, Reassembler};
+use btleplug::api::{
+    Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, ScanFilter, WriteType,
+};
+use btleplug::platform::{Manager, Peripheral};
+use clap::{Parser, Subcommand};
+use futures::StreamExt;
+
+/// How long to look for a robot before giving up.
+///
+/// Generous, because BLE discovery is genuinely slow and a robot advertises at whatever interval
+/// BlueZ chose. Shorter than this and a laptop that was simply unlucky reports "no robot".
+const SCAN_TIME: Duration = Duration::from_secs(8);
+
+/// How long to wait for a reply once the request is written.
+///
+/// Longer than any single call except `net.connect`, which polls NetworkManager for up to 45s
+/// and so gets its own budget below.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(15);
+const SLOW_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Parser)]
+#[command(
+    version,
+    about = "Talk to a robot over BLE — the phone app's stand-in",
+    long_about = "Finds a robot advertising the duck GATT service and speaks the same JSON-RPC \
+                  lines every other transport uses. This is a development tool: it is an example \
+                  rather than a binary, so it never ships to a robot."
+)]
+struct Cli {
+    /// Connect to this robot by advertised name. Without it, the first one found wins.
+    #[arg(long, global = true)]
+    name: Option<String>,
+
+    /// Print every line sent and received.
+    #[arg(long, global = true)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// List robots in range, and stop.
+    Scan,
+    /// Version handshake plus update status.
+    Status,
+    /// Name, serial and uptime.
+    Info,
+    /// Is the control loop healthy?
+    Health,
+    /// Wifi.
+    #[command(subcommand)]
+    Wifi(Wifi),
+    /// Rename the robot.
+    Name { name: String },
+    /// Reboot it.
+    Reboot,
+    /// Send any method, for whatever is not wrapped above.
+    Call {
+        method: String,
+        /// Parameters as JSON. Defaults to `{}`.
+        params: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum Wifi {
+    /// What the wifi is doing — SSID, signal, addresses.
+    Status,
+    /// Networks the robot can see.
+    Scan,
+    /// Join a network.
+    Connect {
+        ssid: String,
+        /// Omit for an open network.
+        #[arg(long)]
+        psk: Option<String>,
+    },
+    /// Forget a stored network.
+    Forget { ssid: String },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let manager = Manager::new().await?;
+    let adapter = manager
+        .adapters()
+        .await?
+        .into_iter()
+        .next()
+        .ok_or("no Bluetooth adapter on this machine")?;
+
+    eprintln!("scanning for {SCAN_TIME:?}…");
+    // Filter by our service UUID so a busy office does not drown the robot in headphones. Note
+    // some platforms ignore the filter and return everything, which is why the name check below
+    // still happens.
+    adapter
+        .start_scan(ScanFilter { services: vec![SERVICE_UUID] })
+        .await?;
+    tokio::time::sleep(SCAN_TIME).await;
+
+    let mut found: Vec<(Peripheral, String)> = Vec::new();
+    for peripheral in adapter.peripherals().await? {
+        let Some(properties) = peripheral.properties().await? else { continue };
+        if !properties.services.contains(&SERVICE_UUID) {
+            continue;
+        }
+        let name = properties.local_name.unwrap_or_else(|| properties.address.to_string());
+        found.push((peripheral, name));
+    }
+    let _ = adapter.stop_scan().await;
+
+    if found.is_empty() {
+        return Err("no robot found advertising the duck service. \
+                    Is btd running, and is the robot in range?"
+            .into());
+    }
+
+    if matches!(cli.command, Command::Scan) {
+        for (peripheral, name) in &found {
+            let address = peripheral.properties().await?.map(|p| p.address.to_string());
+            println!("{name}  {}", address.unwrap_or_default());
+        }
+        return Ok(());
+    }
+
+    let (peripheral, name) = match &cli.name {
+        Some(wanted) => found
+            .into_iter()
+            .find(|(_, name)| name == wanted)
+            .ok_or_else(|| format!("no robot named {wanted:?} in range"))?,
+        None => found.into_iter().next().expect("non-empty"),
+    };
+    eprintln!("connecting to {name}…");
+
+    peripheral.connect().await?;
+    peripheral.discover_services().await?;
+
+    let (request, response) = characteristics(&peripheral)?;
+
+    // Subscribe *before* writing, or a reply can arrive before there is anywhere to put it.
+    // btd's session begins on the first write, so the order here is not merely defensive: the
+    // notify half has to exist for the session to have somewhere to answer.
+    peripheral.subscribe(&response).await?;
+    let mut notifications = peripheral.notifications().await?;
+
+    let (line, timeout) = request_line(&cli.command)?;
+    if cli.verbose {
+        eprintln!("→ {line}");
+    }
+
+    // Chunked by the same code the robot uses. btleplug does not expose the negotiated MTU, so
+    // 20 bytes — the floor every BLE link guarantees — is the safe assumption. Slower than
+    // necessary on a good link, and correct on every link.
+    for chunk in framing::chunks(&line, 20) {
+        peripheral.write(&request, &chunk, WriteType::WithoutResponse).await?;
+    }
+
+    let mut reassembler = Reassembler::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("no reply within {timeout:?}").into());
+        }
+
+        let Ok(Some(notification)) = tokio::time::timeout(remaining, notifications.next()).await
+        else {
+            return Err(format!("no reply within {timeout:?}").into());
+        };
+
+        for line in reassembler.push(&notification.value)? {
+            if cli.verbose {
+                eprintln!("← {line}");
+            }
+            // Notifications with no `id` are a progress stream, not an answer; print them and
+            // keep waiting for the response that closes the call.
+            let value: serde_json::Value = serde_json::from_str(&line)?;
+            let is_answer = value.get("id").is_some_and(|id| !id.is_null());
+
+            println!("{}", serde_json::to_string_pretty(&value)?);
+            if is_answer {
+                let _ = peripheral.disconnect().await;
+                // A JSON-RPC error is the robot answering, not this tool failing — so it is
+                // printed above and reported through the exit status rather than as a panic.
+                return if value.get("error").is_some() {
+                    Err("the robot returned an error".into())
+                } else {
+                    Ok(())
+                };
+            }
+        }
+    }
+}
+
+/// Find the two characteristics, and check they can do what we need.
+///
+/// Checking the properties rather than assuming them turns a confusing silence — a write that
+/// lands nowhere — into a clear message naming which half is wrong.
+fn characteristics(
+    peripheral: &Peripheral,
+) -> Result<(Characteristic, Characteristic), Box<dyn std::error::Error>> {
+    let all = peripheral.characteristics();
+    let find = |uuid| all.iter().find(|c| c.uuid == uuid).cloned();
+
+    let request = find(REQUEST_UUID)
+        .ok_or("the robot has no request characteristic; is this the right service?")?;
+    let response = find(RESPONSE_UUID).ok_or("the robot has no response characteristic")?;
+
+    if !request.properties.intersects(CharPropFlags::WRITE | CharPropFlags::WRITE_WITHOUT_RESPONSE) {
+        return Err("the request characteristic is not writable".into());
+    }
+    if !response.properties.contains(CharPropFlags::NOTIFY) {
+        return Err("the response characteristic cannot notify".into());
+    }
+    Ok((request, response))
+}
+
+/// One command becomes one JSON-RPC line, plus how long to wait for it.
+fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::error::Error>> {
+    let (method, params, timeout) = match command {
+        Command::Scan => unreachable!("handled before connecting"),
+        Command::Status => ("update.status", serde_json::json!({}), REPLY_TIMEOUT),
+        Command::Info => ("system.info", serde_json::json!({}), REPLY_TIMEOUT),
+        Command::Health => ("robot.health", serde_json::json!({}), REPLY_TIMEOUT),
+        Command::Name { name } => (
+            "system.setName",
+            serde_json::json!({ "name": name }),
+            REPLY_TIMEOUT,
+        ),
+        Command::Reboot => ("system.reboot", serde_json::json!({}), REPLY_TIMEOUT),
+        Command::Wifi(Wifi::Status) => ("net.status", serde_json::json!({}), REPLY_TIMEOUT),
+        // A scan asks NetworkManager to re-scan, which takes seconds on a quiet radio.
+        Command::Wifi(Wifi::Scan) => ("net.scan", serde_json::json!({}), SLOW_REPLY_TIMEOUT),
+        Command::Wifi(Wifi::Connect { ssid, psk }) => {
+            let mut params = serde_json::json!({ "ssid": ssid });
+            if let Some(psk) = psk {
+                params["psk"] = serde_json::Value::String(psk.clone());
+            }
+            // configd polls NM for up to 45s before calling a join timed out, so this must wait
+            // longer than that or the tool gives up before the robot has decided.
+            ("net.connect", params, SLOW_REPLY_TIMEOUT)
+        }
+        Command::Wifi(Wifi::Forget { ssid }) => (
+            "net.forget",
+            serde_json::json!({ "ssid": ssid }),
+            REPLY_TIMEOUT,
+        ),
+        Command::Call { method, params } => {
+            let params = match params {
+                Some(text) => serde_json::from_str(text)
+                    .map_err(|e| format!("params must be JSON: {e}"))?,
+                None => serde_json::json!({}),
+            };
+            (method.as_str(), params, SLOW_REPLY_TIMEOUT)
+        }
+    };
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    Ok((serde_json::to_string(&request)?, timeout))
+}

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -28,20 +28,10 @@ use bluer::gatt::{CharacteristicReader, CharacteristicWriter};
 use futures::StreamExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use crate::gatt::{REQUEST_UUID, RESPONSE_UUID, SERVICE_UUID};
 use crate::link::{Link, QUEUE};
 use crate::session;
 use crate::upstream::Sockets;
-
-/// The robot's GATT service, and its two characteristics.
-///
-/// Random v4 UUIDs rather than anything derived: these are ours, they are a contract with the
-/// phone app, and they must not change once an app ships against them. Written out in full so
-/// that grepping for a value finds this comment.
-pub const SERVICE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a10-3b47-4c8e-9a1f-2d7e8c4b6019");
-/// Central → robot. NDJSON request bytes, chunked.
-pub const REQUEST_UUID: uuid::Uuid = uuid::uuid!("6f5d2a11-3b47-4c8e-9a1f-2d7e8c4b6019");
-/// Robot → central. NDJSON response and notification bytes, chunked.
-pub const RESPONSE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a12-3b47-4c8e-9a1f-2d7e8c4b6019");
 
 /// How long to wait between attempts to find a usable adapter.
 ///
@@ -223,20 +213,3 @@ fn spawn_session(
     });
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The three UUIDs are a contract with the phone app: distinct, and stable forever once an
-    /// app ships against them. A copy-paste making two of them equal would present one
-    /// characteristic and hang a client waiting for the other.
-    #[test]
-    fn the_uuids_are_distinct() {
-        let all = [SERVICE_UUID, REQUEST_UUID, RESPONSE_UUID];
-        for (i, a) in all.iter().enumerate() {
-            for b in &all[i + 1..] {
-                assert_ne!(a, b);
-            }
-        }
-    }
-}

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -1,0 +1,242 @@
+//! The radio. BlueZ via `bluetoothd`'s D-Bus API, Linux only.
+//!
+//! Everything here is plumbing between BlueZ and [`crate::session`]'s two channels. No decision
+//! about the robot is taken in this file, which is the point: the logic that could be wrong is
+//! the logic that is tested, and this is the part that needs a radio.
+//!
+//! It uses `bluer`'s **IO model** rather than its callback model. The callback model hands you a
+//! notifier with no way to tell which central subscribed, so pairing a subscription to the
+//! session that should feed it means guessing — one global slot, and a second phone breaks it.
+//! The IO model reports `device_address()` on both halves, so a connection is a real duplex
+//! stream and several centrals cost nothing extra.
+//!
+//! **Untested against hardware.** It type-checks for aarch64 and has never met a real central.
+//! Treat what follows as intent until someone connects a phone.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use bluer::adv::Advertisement;
+// The reader and writer live on `gatt` rather than `gatt::local`: they are the same socket
+// halves the client side uses, so bluer shares them between both roles.
+use bluer::gatt::local::{
+    Application, Characteristic, CharacteristicControlEvent, CharacteristicNotify,
+    CharacteristicNotifyMethod, CharacteristicWrite, CharacteristicWriteMethod, Service,
+    characteristic_control,
+};
+use bluer::gatt::{CharacteristicReader, CharacteristicWriter};
+use futures::StreamExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::link::{Link, QUEUE};
+use crate::session;
+use crate::upstream::Sockets;
+
+/// The robot's GATT service, and its two characteristics.
+///
+/// Random v4 UUIDs rather than anything derived: these are ours, they are a contract with the
+/// phone app, and they must not change once an app ships against them. Written out in full so
+/// that grepping for a value finds this comment.
+pub const SERVICE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a10-3b47-4c8e-9a1f-2d7e8c4b6019");
+/// Central → robot. NDJSON request bytes, chunked.
+pub const REQUEST_UUID: uuid::Uuid = uuid::uuid!("6f5d2a11-3b47-4c8e-9a1f-2d7e8c4b6019");
+/// Robot → central. NDJSON response and notification bytes, chunked.
+pub const RESPONSE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a12-3b47-4c8e-9a1f-2d7e8c4b6019");
+
+/// How long to wait between attempts to find a usable adapter.
+///
+/// Measured on the board: `hci0` does not exist until roughly 73 seconds after power-on —
+/// `aic-bluetooth.service` attaches the AIC8800's UART late, and `bluetooth.service` itself
+/// spends 26s blocked behind `dbus`. A daemon that exited on "no adapter" would be restarted by
+/// systemd into the same emptiness for over a minute, so it waits. Same lesson as `robotd`
+/// waiting for the motor bus rather than giving up on it.
+const ADAPTER_RETRY: Duration = Duration::from_secs(5);
+
+/// Halves of a connection seen so far. BlueZ delivers the write and notify sides as separate
+/// events, in either order, so a session starts when the second one arrives.
+#[derive(Default)]
+struct Half {
+    reader: Option<CharacteristicReader>,
+    writer: Option<CharacteristicWriter>,
+}
+
+/// Wait for an adapter, then advertise and serve until cancelled.
+pub async fn serve(sockets: Sockets, name: String) -> bluer::Result<()> {
+    let bt = bluer::Session::new().await?;
+
+    let adapter = loop {
+        match bt.default_adapter().await {
+            Ok(adapter) => break adapter,
+            Err(e) => {
+                tracing::warn!(error = %e, retry_in = ?ADAPTER_RETRY, "no Bluetooth adapter yet");
+                tokio::time::sleep(ADAPTER_RETRY).await;
+            }
+        }
+    };
+    adapter.set_powered(true).await?;
+
+    tracing::warn!(
+        adapter = adapter.name(),
+        address = %adapter.address().await?,
+        service = %SERVICE_UUID,
+        "serving BLE"
+    );
+
+    // The advertised name is what someone sees in a phone's Bluetooth list, so it is the robot's
+    // name rather than the service's. `system.setName` will rewrite it once `configd` exists;
+    // until then it is the hostname, which is at least unique per board.
+    let advertisement = Advertisement {
+        service_uuids: [SERVICE_UUID].into_iter().collect(),
+        discoverable: Some(true),
+        local_name: Some(name),
+        ..Default::default()
+    };
+    let _adv = adapter.advertise(advertisement).await?;
+
+    let (control, control_handle) = characteristic_control();
+    let app = Application {
+        services: vec![Service {
+            uuid: SERVICE_UUID,
+            primary: true,
+            characteristics: vec![Characteristic {
+                uuid: REQUEST_UUID,
+                write: Some(CharacteristicWrite {
+                    write: true,
+                    // Write-without-response too: a chunked request does not need an ATT
+                    // acknowledgement per chunk, and requiring one roughly halves throughput on
+                    // the slowest link in the system.
+                    write_without_response: true,
+                    // Encryption is NOT required yet, and that is a gap rather than a decision.
+                    // §7 says the characteristic carrying wifi credentials must be paired and
+                    // encrypted, and `encrypt_authenticated_write` is the flag — but setting it
+                    // without a pairing story (a button-held window, or a secret printed under
+                    // the robot) yields a robot nobody can provision. It goes on in the same
+                    // change that decides how a phone may bond, and before `net.connect` is
+                    // routed.
+                    method: CharacteristicWriteMethod::Io,
+                    ..Default::default()
+                }),
+                notify: Some(CharacteristicNotify {
+                    notify: true,
+                    method: CharacteristicNotifyMethod::Io,
+                    ..Default::default()
+                }),
+                control_handle,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let _app = adapter.serve_gatt_application(app).await?;
+
+    // Half-open connections, keyed by central. Entries are short-lived: BlueZ sends both events
+    // for a connecting client in quick succession, and an entry that never completes is one
+    // half of a client that gave up.
+    let mut halves: HashMap<bluer::Address, Half> = HashMap::new();
+
+    futures::pin_mut!(control);
+    while let Some(event) = control.next().await {
+        let address = match &event {
+            CharacteristicControlEvent::Write(req) => req.device_address(),
+            CharacteristicControlEvent::Notify(notifier) => notifier.device_address(),
+        };
+
+        let half = halves.entry(address).or_default();
+        let mtu = match event {
+            CharacteristicControlEvent::Write(req) => {
+                let mtu = req.mtu();
+                match req.accept() {
+                    Ok(reader) => half.reader = Some(reader),
+                    Err(e) => {
+                        tracing::warn!(peer = %address, error = %e, "could not accept a write");
+                        halves.remove(&address);
+                        continue;
+                    }
+                }
+                mtu
+            }
+            CharacteristicControlEvent::Notify(notifier) => {
+                let mtu = notifier.mtu();
+                half.writer = Some(notifier);
+                mtu
+            }
+        };
+
+        // Both halves present: this is a whole connection, so it becomes a session.
+        if half.reader.is_some() && half.writer.is_some() {
+            let Half { reader, writer } = halves.remove(&address).expect("entry present");
+            let (reader, writer) = (reader.expect("reader"), writer.expect("writer"));
+            tracing::info!(peer = %address, mtu, "central connected");
+            spawn_session(address, mtu, reader, writer, sockets.clone());
+        }
+    }
+
+    tracing::warn!("BlueZ closed the characteristic control stream");
+    Ok(())
+}
+
+/// Bridge one connection's reader and writer onto a [`Link`], and run a session over it.
+fn spawn_session(
+    address: bluer::Address,
+    mtu: usize,
+    mut reader: CharacteristicReader,
+    mut writer: CharacteristicWriter,
+    sockets: Sockets,
+) {
+    let (link, to_session, mut from_session) = Link::pair(mtu, address.to_string());
+    tokio::spawn(session::run(link, sockets));
+
+    // Radio → session.
+    tokio::spawn(async move {
+        // One MTU per read: BlueZ delivers a characteristic write as a datagram, so a larger
+        // buffer would not coalesce chunks and a smaller one would truncate them.
+        let mut buf = vec![0u8; mtu.max(QUEUE)];
+        loop {
+            match reader.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if to_session.send(buf[..n].to_vec()).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(peer = %address, error = %e, "read failed");
+                    break;
+                }
+            }
+        }
+        tracing::debug!(peer = %address, "radio reader closed");
+    });
+
+    // Session → radio. Chunks arrive already sized for this MTU, so each one is a single
+    // notification.
+    tokio::spawn(async move {
+        while let Some(chunk) = from_session.recv().await {
+            if let Err(e) = writer.write_all(&chunk).await {
+                tracing::debug!(peer = %address, error = %e, "notify failed; central gone");
+                break;
+            }
+        }
+        let _ = writer.shutdown().await;
+        tracing::debug!(peer = %address, "radio writer closed");
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three UUIDs are a contract with the phone app: distinct, and stable forever once an
+    /// app ships against them. A copy-paste making two of them equal would present one
+    /// characteristic and hang a client waiting for the other.
+    #[test]
+    fn the_uuids_are_distinct() {
+        let all = [SERVICE_UUID, REQUEST_UUID, RESPONSE_UUID];
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}

--- a/btd/src/framing.rs
+++ b/btd/src/framing.rs
@@ -1,0 +1,199 @@
+//! Turning a GATT characteristic into a line-oriented byte pipe.
+//!
+//! The control plane is NDJSON — one JSON object per line — over every transport
+//! (`architecture.md` §2.2). BLE is the only one where a message does not fit in a single
+//! write: usable payload is `ATT_MTU - 3`, which on a phone that never renegotiates is 20
+//! bytes, and on a good link is a few hundred. So a line arrives in pieces and leaves in
+//! pieces.
+//!
+//! **There is no framing header.** The newline that already separates messages is the frame
+//! delimiter, in both directions. That is safe rather than lucky: `serde_json` escapes a
+//! newline inside a string as `\n`, so a raw `0x0A` never appears inside a serialised JSON
+//! object — which is the same property that makes NDJSON work on the unix socket.
+//!
+//! Adding a length prefix would mean a second framing dialect that only BLE speaks, and
+//! every client would have to implement it. A phone app can instead do exactly what
+//! `robotctl` does: write bytes, read until newline.
+
+/// Longest line we will reassemble before giving up on a peer.
+///
+/// A BLE client that never sends a newline would otherwise grow this buffer without bound,
+/// and it is reachable by anyone in radio range. Generous next to any real request — the
+/// largest is an `update.apply` with a long ref — and far below `updaterd`'s own 1 MiB line
+/// limit, because nothing that big has any business arriving over BLE.
+pub const MAX_LINE: usize = 8 * 1024;
+
+/// Reassembles inbound chunks into whole lines.
+#[derive(Debug, Default)]
+pub struct Reassembler {
+    buf: Vec<u8>,
+}
+
+/// Why a peer's bytes were rejected. Both cases mean "drop the connection", but they are
+/// logged differently: one is a client that cannot frame, the other may be an attack.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FramingError {
+    /// No newline within [`MAX_LINE`].
+    LineTooLong,
+    /// Not valid UTF-8, so it cannot be JSON either.
+    NotUtf8,
+}
+
+impl Reassembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one chunk; get back every complete line it completed.
+    ///
+    /// Returns a `Vec` because one write can legitimately carry several short lines — a
+    /// client that batches `hello` and `update.status` into one 40-byte write is being
+    /// efficient, not wrong.
+    pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<String>, FramingError> {
+        if self.buf.len() + chunk.len() > MAX_LINE {
+            // Clear rather than keep the partial line: whatever follows is unparseable
+            // anyway, and holding it would let a peer pin the memory.
+            self.buf.clear();
+            return Err(FramingError::LineTooLong);
+        }
+        self.buf.extend_from_slice(chunk);
+
+        let mut lines = Vec::new();
+        while let Some(at) = self.buf.iter().position(|&b| b == b'\n') {
+            let line = self.buf.drain(..=at).collect::<Vec<u8>>();
+            // Drop the newline, and tolerate CRLF from a client that helpfully added one.
+            let line = &line[..line.len() - 1];
+            let line = line.strip_suffix(b"\r").unwrap_or(line);
+
+            if line.is_empty() {
+                continue;
+            }
+            match std::str::from_utf8(line) {
+                Ok(text) => lines.push(text.to_owned()),
+                Err(_) => {
+                    self.buf.clear();
+                    return Err(FramingError::NotUtf8);
+                }
+            }
+        }
+        Ok(lines)
+    }
+
+    /// Bytes held pending a newline. For logging a peer that has gone quiet mid-line.
+    pub fn pending(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+/// Split one outbound line into notification-sized chunks, newline included.
+///
+/// The newline is part of the payload rather than a separate final chunk: a client that
+/// reassembles until newline then needs no notion of "end of message" beyond the one it
+/// already has.
+pub fn chunks(line: &str, mtu: usize) -> Vec<Vec<u8>> {
+    // A zero or absurd MTU would divide by zero or emit one chunk per byte. 20 is the
+    // floor BLE guarantees before any negotiation.
+    let mtu = mtu.max(20);
+
+    let mut bytes = line.as_bytes().to_vec();
+    if !bytes.ends_with(b"\n") {
+        bytes.push(b'\n');
+    }
+    bytes.chunks(mtu).map(<[u8]>::to_vec).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_line_split_across_chunks_reassembles() {
+        let mut r = Reassembler::new();
+        assert!(r.push(b"{\"jsonrpc\":\"2.0\"").unwrap().is_empty());
+        assert!(r.push(b",\"id\":1,\"method\":").unwrap().is_empty());
+        let lines = r.push(b"\"hello\"}\n").unwrap();
+        assert_eq!(lines, vec![r#"{"jsonrpc":"2.0","id":1,"method":"hello"}"#]);
+        assert_eq!(r.pending(), 0);
+    }
+
+    /// One write may carry several lines, and all of them must come back.
+    #[test]
+    fn several_lines_in_one_chunk_all_come_back() {
+        let mut r = Reassembler::new();
+        assert_eq!(r.push(b"{\"a\":1}\n{\"b\":2}\n").unwrap().len(), 2);
+    }
+
+    /// A trailing partial line must be kept, not discarded: it is the next message's start.
+    #[test]
+    fn a_partial_trailing_line_is_retained() {
+        let mut r = Reassembler::new();
+        let lines = r.push(b"{\"a\":1}\n{\"b\":").unwrap();
+        assert_eq!(lines, vec![r#"{"a":1}"#]);
+        assert_eq!(r.push(b"2}\n").unwrap(), vec![r#"{"b":2}"#]);
+    }
+
+    /// Blank lines are ignored rather than forwarded as an empty request, matching what
+    /// `robotd` and `updaterd` already do on their sockets.
+    #[test]
+    fn blank_lines_are_skipped() {
+        let mut r = Reassembler::new();
+        assert!(r.push(b"\n\n\r\n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlf_is_tolerated() {
+        let mut r = Reassembler::new();
+        assert_eq!(r.push(b"{\"a\":1}\r\n").unwrap(), vec![r#"{"a":1}"#]);
+    }
+
+    /// An unbounded peer must be cut off rather than allowed to grow the buffer. This is the
+    /// one framing failure reachable by anybody in radio range.
+    #[test]
+    fn a_line_without_a_newline_is_refused_at_the_cap() {
+        let mut r = Reassembler::new();
+        let big = vec![b'x'; MAX_LINE + 1];
+        assert_eq!(r.push(&big), Err(FramingError::LineTooLong));
+        // And the buffer was released, so the peer cannot pin memory by retrying.
+        assert_eq!(r.pending(), 0);
+    }
+
+    #[test]
+    fn invalid_utf8_is_refused() {
+        let mut r = Reassembler::new();
+        assert_eq!(r.push(&[0xff, 0xfe, b'\n']), Err(FramingError::NotUtf8));
+    }
+
+    /// Chunking and reassembly are each other's inverse — the property the whole transport
+    /// rests on. Checked across MTUs from the BLE floor to bigger than the message.
+    #[test]
+    fn chunking_round_trips_at_every_mtu() {
+        let line = format!(r#"{{"jsonrpc":"2.0","id":7,"result":{{"pad":"{}"}}}}"#, "y".repeat(300));
+
+        for mtu in [20, 23, 100, 185, 512, 4096] {
+            let mut r = Reassembler::new();
+            let mut got = Vec::new();
+            for chunk in chunks(&line, mtu) {
+                assert!(chunk.len() <= mtu.max(20), "chunk exceeded mtu {mtu}");
+                got.extend(r.push(&chunk).unwrap());
+            }
+            assert_eq!(got, vec![line.clone()], "mtu {mtu}");
+        }
+    }
+
+    /// A newline is appended if absent and never doubled if present — otherwise a client
+    /// sees an empty line between every message.
+    #[test]
+    fn chunks_terminate_with_exactly_one_newline() {
+        for line in ["{\"a\":1}", "{\"a\":1}\n"] {
+            let flat: Vec<u8> = chunks(line, 512).concat();
+            assert_eq!(flat.iter().filter(|&&b| b == b'\n').count(), 1, "{line:?}");
+            assert_eq!(flat.last(), Some(&b'\n'), "{line:?}");
+        }
+    }
+
+    /// A degenerate MTU must not panic or emit one chunk per byte.
+    #[test]
+    fn an_absurd_mtu_falls_back_to_the_ble_floor() {
+        assert_eq!(chunks(&"z".repeat(40), 0).len(), 3); // 41 bytes over 20-byte chunks
+    }
+}

--- a/btd/src/framing.rs
+++ b/btd/src/framing.rs
@@ -39,6 +39,19 @@ pub enum FramingError {
     NotUtf8,
 }
 
+impl std::fmt::Display for FramingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LineTooLong => write!(f, "no newline within {MAX_LINE} bytes"),
+            Self::NotUtf8 => write!(f, "not valid UTF-8"),
+        }
+    }
+}
+
+// A real error, not just a Debug-able enum: this crate is a library, and a client using it — the
+// `btctl` example is the first — wants `?` to work.
+impl std::error::Error for FramingError {}
+
 impl Reassembler {
     pub fn new() -> Self {
         Self::default()

--- a/btd/src/gatt.rs
+++ b/btd/src/gatt.rs
@@ -1,0 +1,36 @@
+//! The GATT contract: the UUIDs a client must know.
+//!
+//! Platform-independent on purpose. These live here rather than in [`crate::bluez`] because they
+//! are part of the wire contract, exactly like the method names in `duck-ipc-proto` — the robot
+//! serves them and every client must look for them, so a client that cannot compile for Linux
+//! still needs them. `examples/btctl.rs`, which runs on a laptop, is the case that proves it.
+//!
+//! Random v4 UUIDs rather than anything derived: they are ours, and they must not change once an
+//! app has shipped against them. Written out in full so that grepping for a value finds this
+//! comment.
+
+/// The robot's service. What a client scans for.
+pub const SERVICE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a10-3b47-4c8e-9a1f-2d7e8c4b6019");
+
+/// Central → robot. NDJSON request bytes, chunked, written here.
+pub const REQUEST_UUID: uuid::Uuid = uuid::uuid!("6f5d2a11-3b47-4c8e-9a1f-2d7e8c4b6019");
+
+/// Robot → central. NDJSON response and notification bytes, chunked, notified here.
+pub const RESPONSE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a12-3b47-4c8e-9a1f-2d7e8c4b6019");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Distinct, and stable forever once an app ships against them. A copy-paste making two of
+    /// them equal would present one characteristic and hang a client waiting for the other.
+    #[test]
+    fn the_uuids_are_distinct() {
+        let all = [SERVICE_UUID, REQUEST_UUID, RESPONSE_UUID];
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}

--- a/btd/src/lib.rs
+++ b/btd/src/lib.rs
@@ -1,0 +1,30 @@
+//! `btd` — the BLE front door onto the robot's API.
+//!
+//! **A transport adapter and nothing else** (`architecture.md` §4.1). `btd` owns no state, and
+//! that is load-bearing rather than tidy: if provisioning or config lived here, every other
+//! service would depend on `btd`, and an SDK would absurdly have to go through Bluetooth to
+//! set a robot's name.
+//!
+//! So the design is a pipe. A GATT service with two characteristics — write `request`, notify
+//! `response` — carries **the same NDJSON JSON-RPC lines as every other transport**, and `btd`
+//! reassembles them, checks the method against [`route`]'s table, forwards them verbatim to
+//! the owning service's unix socket, and chunks the replies back. Adding a method to the
+//! protocol needs no change here beyond one line in that table.
+//!
+//! It is also the process that parses bytes from anyone in radio range, which is why it runs
+//! unprivileged while `configd` — which only ever sees typed JSON from a peer-credentialled
+//! local socket — is the one running as root. Putting the parser on the safe side of that
+//! boundary matters more than hardening the dispatcher.
+//!
+//! ## What exists today
+//!
+//! The transport-independent half: [`framing`] and [`route`], both tested without a radio.
+//! The GATT backend and the daemon binary follow — and BLE on this board is not usable until
+//! roughly 73s after power-on (`aic-bluetooth.service` brings `hci0` up late), so whatever
+//! drives the adapter must wait and retry for one rather than assume it exists at startup.
+//!
+//! `net.*` and `system.*` — wifi, name, reboot — are not in [`route`] yet because `configd`
+//! does not exist yet. When it does they are one arm each, and nothing else here changes.
+
+pub mod framing;
+pub mod route;

--- a/btd/src/lib.rs
+++ b/btd/src/lib.rs
@@ -29,6 +29,7 @@
 #[cfg(target_os = "linux")]
 pub mod bluez;
 pub mod framing;
+pub mod gatt;
 pub mod link;
 pub mod route;
 pub mod session;

--- a/btd/src/lib.rs
+++ b/btd/src/lib.rs
@@ -16,15 +16,20 @@
 //! local socket — is the one running as root. Putting the parser on the safe side of that
 //! boundary matters more than hardening the dispatcher.
 //!
-//! ## What exists today
+//! ## Layout
 //!
-//! The transport-independent half: [`framing`] and [`route`], both tested without a radio.
-//! The GATT backend and the daemon binary follow — and BLE on this board is not usable until
-//! roughly 73s after power-on (`aic-bluetooth.service` brings `hci0` up late), so whatever
-//! drives the adapter must wait and retry for one rather than assume it exists at startup.
+//! [`framing`] and [`route`] are pure logic. [`session`] is the whole of the behaviour, and it
+//! reaches the radio only through [`link::Link`] — two channels, not a trait — so the tests
+//! drive a complete session over real unix sockets with no Bluetooth involved. [`upstream`]
+//! holds the connections to the services that own the answers.
 //!
 //! `net.*` and `system.*` — wifi, name, reboot — are not in [`route`] yet because `configd`
 //! does not exist yet. When it does they are one arm each, and nothing else here changes.
 
+#[cfg(target_os = "linux")]
+pub mod bluez;
 pub mod framing;
+pub mod link;
 pub mod route;
+pub mod session;
+pub mod upstream;

--- a/btd/src/link.rs
+++ b/btd/src/link.rs
@@ -1,0 +1,51 @@
+//! The seam between the radio and everything worth testing.
+//!
+//! Deliberately **not a trait**. A `GattLink` trait would need an async `recv` and an async
+//! `send`, and the session loop has to wait on both at once — which means either splitting the
+//! link into halves with associated types, or fighting the borrow checker inside a `select!`.
+//! Two channels and a plain struct express the same thing with none of that, and the test
+//! constructs one by hand rather than implementing anything.
+//!
+//! So a backend's whole job is: accept a connection, feed inbound chunks into `inbound`, write
+//! whatever appears on `outbound` back to the central, and drop the channels when the central
+//! goes away. What happens between those two channels is [`crate::session`], and it never
+//! learns whether a radio is involved.
+
+use tokio::sync::mpsc;
+
+/// How many chunks may queue in either direction before a backend has to slow down.
+///
+/// Small on purpose. BLE is slow, so a deep buffer would mostly serve to hide a stalled peer
+/// and delay noticing it; the update progress stream is advisory anyway — `updaterd` already
+/// drops a subscriber that cannot keep up rather than applying backpressure to an update.
+pub const QUEUE: usize = 32;
+
+/// One connected central.
+pub struct Link {
+    /// Chunks written by the central to the `request` characteristic, in arrival order.
+    /// Closed when it disconnects.
+    pub inbound: mpsc::Receiver<Vec<u8>>,
+    /// Chunks to notify on the `response` characteristic.
+    pub outbound: mpsc::Sender<Vec<u8>>,
+    /// Usable notification payload — `ATT_MTU - 3` — as negotiated for this connection.
+    ///
+    /// Read once per session rather than per message: a central may renegotiate, but not
+    /// mid-line, and re-reading it would let a line be chunked two different ways.
+    pub mtu: usize,
+    /// The central's address, for the log line. Never used for authorization — a BLE address
+    /// is trivially spoofed, and pairing is what authorizes (`architecture.md` §4.2).
+    pub peer: String,
+}
+
+impl Link {
+    /// A link wired to channels the caller drives. Used by tests and by `--fake`.
+    pub fn pair(mtu: usize, peer: impl Into<String>) -> (Self, mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
+        let (to_robot, inbound) = mpsc::channel(QUEUE);
+        let (outbound, from_robot) = mpsc::channel(QUEUE);
+        (
+            Self { inbound, outbound, mtu, peer: peer.into() },
+            to_robot,
+            from_robot,
+        )
+    }
+}

--- a/btd/src/main.rs
+++ b/btd/src/main.rs
@@ -1,0 +1,146 @@
+//! `btd` — the BLE front door onto the robot's API.
+//!
+//! Runs only on the robot. See the crate docs in `lib.rs` for what it is and why it owns
+//! nothing; this file is argument parsing, logging and startup.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use btd::upstream::Sockets;
+use clap::Parser;
+
+/// `robotd`'s socket. Not in `duck-ipc-proto` because that crate's `DEFAULT_SOCKET` is
+/// `updaterd`'s, and inventing a second constant there would imply a contract that does not
+/// exist — `robotd.service` names this path on its command line.
+const ROBOT_SOCKET: &str = "/run/robotd.sock";
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about = "BLE transport adapter for the robot API",
+    long_about = "Serves a GATT service that carries the same JSON-RPC lines as every other \
+                  transport, forwarding each request to the service that owns it. Exposes a \
+                  subset: status, update trigger and progress. Never motor control."
+)]
+struct Args {
+    /// `updaterd`'s socket.
+    #[arg(long, default_value = duck_ipc_proto::DEFAULT_SOCKET)]
+    update_socket: PathBuf,
+
+    /// `robotd`'s socket.
+    #[arg(long, default_value = ROBOT_SOCKET)]
+    robot_socket: PathBuf,
+
+    /// Name to advertise. Defaults to the hostname.
+    ///
+    /// This is what someone sees in a phone's Bluetooth list. It becomes `system.setName`'s
+    /// business once `configd` exists; until then the hostname is at least unique per board.
+    #[arg(long)]
+    name: Option<String>,
+}
+
+/// The first line this daemon writes is its own identity, at `warn` so it survives
+/// `RUST_LOG=warn` on a long-running board (`architecture.md` §8.1).
+///
+/// `exe` earns its place: it says which release directory the process was actually launched
+/// from, which is the difference between "the update worked" and "the symlink moved but systemd
+/// is still running the old path".
+fn log_startup_identity(service: &str) {
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "unknown".to_owned());
+
+    tracing::warn!(
+        service,
+        build = %duck_ipc_proto::build_info!(),
+        exe,
+        pid = std::process::id(),
+        "starting"
+    );
+}
+
+fn hostname() -> String {
+    // /etc/hostname rather than the `hostname` crate or a libc call: one file read, no
+    // dependency, and it is what the board is actually configured with.
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_owned())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "robot".to_owned())
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+    log_startup_identity("btd");
+
+    let sockets = Sockets {
+        updater: args.update_socket,
+        robot: args.robot_socket,
+    };
+    let name = args.name.unwrap_or_else(hostname);
+
+    run(sockets, name).await
+}
+
+#[cfg(target_os = "linux")]
+async fn run(sockets: Sockets, name: String) -> ExitCode {
+    tokio::select! {
+        result = btd::bluez::serve(sockets, name) => match result {
+            // `serve` only returns when BlueZ closes the control stream, which means the
+            // adapter went away. Exiting non-zero lets systemd restart us into the retry loop
+            // rather than leaving a daemon that is advertising nothing.
+            Ok(()) => {
+                tracing::error!("BLE service ended unexpectedly");
+                ExitCode::FAILURE
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "BLE service failed");
+                ExitCode::FAILURE
+            }
+        },
+        () = shutdown() => {
+            tracing::info!("shutting down");
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+/// Off-Linux this daemon has nothing to serve, and says so rather than pretending.
+///
+/// The crate still builds and tests here, which is the point: `cargo test` on a laptop is the
+/// onboarding path, and only the radio is Linux-only.
+#[cfg(not(target_os = "linux"))]
+async fn run(_sockets: Sockets, _name: String) -> ExitCode {
+    tracing::error!(
+        "btd needs BlueZ, which is Linux-only. This binary exists here so the crate builds \
+         and its tests run; it cannot serve BLE on this platform."
+    );
+    ExitCode::FAILURE
+}
+
+/// Resolve on SIGTERM (systemd stop) or SIGINT (Ctrl-C).
+#[cfg(target_os = "linux")]
+async fn shutdown() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut term = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "cannot listen for SIGTERM");
+            return std::future::pending().await;
+        }
+    };
+    tokio::select! {
+        _ = term.recv() => {}
+        _ = tokio::signal::ctrl_c() => {}
+    }
+}

--- a/btd/src/main.rs
+++ b/btd/src/main.rs
@@ -9,11 +9,6 @@ use std::process::ExitCode;
 use btd::upstream::Sockets;
 use clap::Parser;
 
-/// `robotd`'s socket. Not in `duck-ipc-proto` because that crate's `DEFAULT_SOCKET` is
-/// `updaterd`'s, and inventing a second constant there would imply a contract that does not
-/// exist — `robotd.service` names this path on its command line.
-const ROBOT_SOCKET: &str = "/run/robotd.sock";
-
 #[derive(Parser, Debug)]
 #[command(
     version,
@@ -24,12 +19,16 @@ const ROBOT_SOCKET: &str = "/run/robotd.sock";
 )]
 struct Args {
     /// `updaterd`'s socket.
-    #[arg(long, default_value = duck_ipc_proto::DEFAULT_SOCKET)]
+    #[arg(long, default_value = duck_ipc_proto::socket::UPDATER)]
     update_socket: PathBuf,
 
     /// `robotd`'s socket.
-    #[arg(long, default_value = ROBOT_SOCKET)]
+    #[arg(long, default_value = duck_ipc_proto::socket::ROBOT)]
     robot_socket: PathBuf,
+
+    /// `configd`'s socket — wifi and the robot's identity.
+    #[arg(long, default_value = duck_ipc_proto::socket::CONFIG)]
+    config_socket: PathBuf,
 
     /// Name to advertise. Defaults to the hostname.
     ///
@@ -85,6 +84,7 @@ async fn main() -> ExitCode {
     let sockets = Sockets {
         updater: args.update_socket,
         robot: args.robot_socket,
+        config: args.config_socket,
     };
     let name = args.name.unwrap_or_else(hostname);
 

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -25,6 +25,8 @@ pub enum Upstream {
     Updater,
     /// `robotd`.
     Robot,
+    /// `configd` — wifi and the robot's identity.
+    Config,
 }
 
 /// Where this call goes, or `None` if BLE may not make it.
@@ -55,6 +57,28 @@ pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
 
         // Is the robot alright? The one `robot.*` call an app has any use for.
         RobotHealth => Some(Upstream::Robot),
+
+        // ── provisioning, which is what §4.1 puts BLE here for ──────────────
+        //
+        // This is the case the whole transport exists to serve: a robot that has never seen a
+        // network cannot be configured over that network, so BLE is the only way in. All four
+        // are permitted, including the two that change things.
+        NetStatus => Some(Upstream::Config),
+        NetScan => Some(Upstream::Config),
+        // Carries a wifi passphrase. §7 requires the characteristic to be paired and
+        // encrypted, and it is not yet — see the comment on `write` in `bluez.rs`. Routing it
+        // before that lands is the one ordering mistake to avoid here.
+        NetConnect(_) => Some(Upstream::Config),
+        NetForget(_) => Some(Upstream::Config),
+
+        // Name and identity. Renaming from the app is the reason `system.setName` exists.
+        SystemInfo => Some(Upstream::Config),
+        SystemSetName(_) => Some(Upstream::Config),
+
+        // Rebooting is drastic but recoverable, and it is what an app offers when a robot is
+        // confused — the alternative being "unplug it", which for a walking robot is worse.
+        // Unlike `resetToGolden` it discards nothing.
+        SystemReboot => Some(Upstream::Config),
 
         // ── refused ─────────────────────────────────────────────────────────
 
@@ -105,17 +129,47 @@ mod tests {
         ComponentId::new("daemon")
     }
 
-    /// Nothing that replaces or discards software may be reached from the radio, except the
-    /// one call §4.1 puts there on purpose.
+    /// Exactly which mutating calls BLE may make, named one by one.
+    ///
+    /// The list is the security boundary, so it is spelled out rather than counted: adding a
+    /// mutating method and routing it should have to change this line and say why in the
+    /// commit. `update.apply` is the update trigger §4.1 names; the rest are provisioning,
+    /// which is what BLE is *for* — a robot that has never seen a network cannot be configured
+    /// over that network.
     #[test]
-    fn apply_is_the_only_mutating_call_ble_may_make() {
+    fn only_these_mutating_calls_are_reachable_over_ble() {
         let mutating_and_allowed: Vec<&str> = every_call()
             .iter()
             .filter(|c| c.is_mutating() && upstream_for(c).is_some())
             .map(proto::Call::method)
             .collect();
 
-        assert_eq!(mutating_and_allowed, vec![proto::method::APPLY]);
+        assert_eq!(
+            mutating_and_allowed,
+            vec![
+                proto::method::APPLY,
+                proto::method::NET_CONNECT,
+                proto::method::NET_FORGET,
+                proto::method::SYSTEM_SET_NAME,
+                proto::method::SYSTEM_REBOOT,
+            ]
+        );
+    }
+
+    /// Provisioning must be reachable, and reach `configd` — the case BLE exists for.
+    #[test]
+    fn provisioning_reaches_configd() {
+        for call in [
+            proto::Call::NetStatus,
+            proto::Call::NetScan,
+            proto::Call::NetConnect(proto::NetConnectParams { ssid: "Home".into(), psk: None }),
+            proto::Call::NetForget(proto::NetForgetParams { ssid: "Home".into() }),
+            proto::Call::SystemInfo,
+            proto::Call::SystemSetName(proto::SetNameParams { name: "duck".into() }),
+            proto::Call::SystemReboot,
+        ] {
+            assert_eq!(upstream_for(&call), Some(Upstream::Config), "{}", call.method());
+        }
     }
 
     /// The refusals, named individually. If a future change makes one of these reachable it
@@ -189,6 +243,16 @@ mod tests {
             proto::Call::RobotHealth,
             proto::Call::RobotModelApi,
             proto::Call::RobotRemoteSessionActive,
+            proto::Call::NetStatus,
+            proto::Call::NetScan,
+            proto::Call::NetConnect(proto::NetConnectParams {
+                ssid: "Home".into(),
+                psk: Some("secret".into()),
+            }),
+            proto::Call::NetForget(proto::NetForgetParams { ssid: "Home".into() }),
+            proto::Call::SystemInfo,
+            proto::Call::SystemSetName(proto::SetNameParams { name: "duck".into() }),
+            proto::Call::SystemReboot,
         ]
     }
 }

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -1,0 +1,194 @@
+//! Which calls BLE may make, and which socket answers them.
+//!
+//! BLE exposes a **subset** of the robot API (`architecture.md` §4.1): provisioning, status,
+//! and the update trigger with its progress. It is too slow and too constrained for the full
+//! surface, and — more to the point — a radio anybody within a few metres can talk to is not
+//! the transport over which to offer "reset this robot to factory state".
+//!
+//! One table decides both questions, because they are the same question: a call is permitted
+//! exactly when this file names the service that answers it.
+//!
+//! **The match is deliberately exhaustive.** Adding a variant to [`proto::Call`] makes this
+//! file fail to compile, so a new method cannot reach the radio because someone forgot this
+//! file existed. A `_ => None` wildcard would be the safe default in the moment and the wrong
+//! one over time: it would silently deny new methods, and the first symptom would be a phone
+//! app that cannot see a feature nobody remembered to route.
+
+use duck_ipc_proto as proto;
+
+/// The service that owns the answer to a call.
+///
+/// One socket per service, connected directly — there is no broker (`architecture.md` §2.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Upstream {
+    /// `updaterd`, at `proto::DEFAULT_SOCKET`.
+    Updater,
+    /// `robotd`.
+    Robot,
+}
+
+/// Where this call goes, or `None` if BLE may not make it.
+///
+/// Read the `None` arms as the security boundary: each one is a deliberate decision that a
+/// phone in the room does not get to do this.
+pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
+    use proto::Call::*;
+    match call {
+        // The version handshake. Must be reachable or no client can establish anything.
+        Hello(_) => Some(Upstream::Updater),
+
+        // ── the update subset §4.1 names ────────────────────────────────────
+        //
+        // `Apply` is the only mutating call BLE may make, and it is intended: BLE implies
+        // physical presence plus pairing (§4.2), and "update the robot from the phone" is
+        // M6's headline. Note it still has to pass `updaterd`'s own peer policy — btd's uid
+        // must be in `allow_uids` for this to be more than a permission error. Leaving it
+        // out is a safe default: BLE can then read everything and change nothing.
+        Apply(_) => Some(Upstream::Updater),
+        Check(_) => Some(Upstream::Updater),
+        Status => Some(Upstream::Updater),
+        Subscribe => Some(Upstream::Updater),
+        // Read-only, and what support asks for first. `update.log` is the record that
+        // survives a wiped journal (§8.2), so a phone able to read it is worth having.
+        Log(_) => Some(Upstream::Updater),
+        ListInstalled(_) => Some(Upstream::Updater),
+
+        // Is the robot alright? The one `robot.*` call an app has any use for.
+        RobotHealth => Some(Upstream::Robot),
+
+        // ── refused ─────────────────────────────────────────────────────────
+
+        // Operator surgery. Choosing which installed release runs, or pinning one, is a
+        // considered decision made with `robotctl` and a record of who did it — not a
+        // mistap in a phone UI.
+        Select(_) | Pin(_) => None,
+
+        // Recovery, and deliberately not here *yet*. The engine reverts a bad release on its
+        // own (health gate plus boot counter), so the phone needs no button for the ordinary
+        // case. Recovery mode (§8.2) is what should reopen this, with its own thinking about
+        // what a stranger holding a broken robot is allowed to trigger.
+        Rollback(_) => None,
+
+        // Factory reset in all but name: back to the golden image, discarding every release
+        // since. Never over a radio.
+        ResetToGolden(_) => None,
+
+        // `updaterd`'s private questions to `robotd` — may I restart the control loop, which
+        // model API is this, is a telepresence session live. Internal plumbing of the update
+        // decision, of no use to a client and misleading if exposed: a phone reading
+        // `safeToRestart` would learn nothing it could act on.
+        RobotSafeToRestart | RobotModelApi | RobotRemoteSessionActive => None,
+    }
+}
+
+/// The JSON-RPC error to answer a refused call with.
+///
+/// [`proto::code::PERMISSION_DENIED`] rather than `METHOD_NOT_FOUND`, because the two mean
+/// different things to whoever is holding the phone: this method exists and this transport
+/// may not use it — "try `robotctl`", not "upgrade your app".
+pub fn refusal(call: &proto::Call) -> proto::Error {
+    proto::Error::new(
+        proto::code::PERMISSION_DENIED,
+        format!(
+            "{} is not available over Bluetooth; use robotctl on the robot",
+            call.method()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use duck_ipc_proto::{ComponentId, semver};
+
+    fn component() -> ComponentId {
+        ComponentId::new("daemon")
+    }
+
+    /// Nothing that replaces or discards software may be reached from the radio, except the
+    /// one call §4.1 puts there on purpose.
+    #[test]
+    fn apply_is_the_only_mutating_call_ble_may_make() {
+        let mutating_and_allowed: Vec<&str> = every_call()
+            .iter()
+            .filter(|c| c.is_mutating() && upstream_for(c).is_some())
+            .map(proto::Call::method)
+            .collect();
+
+        assert_eq!(mutating_and_allowed, vec![proto::method::APPLY]);
+    }
+
+    /// The refusals, named individually. If a future change makes one of these reachable it
+    /// should have to delete a line here and say why in the commit.
+    #[test]
+    fn the_refused_calls_stay_refused() {
+        for call in [
+            proto::Call::Rollback(proto::ComponentParams { component: component() }),
+            proto::Call::ResetToGolden(proto::ComponentParams { component: component() }),
+            proto::Call::Select(proto::SelectParams {
+                component: component(),
+                version: semver::Version::new(1, 0, 0),
+            }),
+            proto::Call::Pin(proto::PinParams { component: component(), version: None }),
+            proto::Call::RobotSafeToRestart,
+            proto::Call::RobotModelApi,
+            proto::Call::RobotRemoteSessionActive,
+        ] {
+            assert_eq!(upstream_for(&call), None, "{}", call.method());
+        }
+    }
+
+    /// A phone must be able to establish a session, see the robot's state, start an update
+    /// and watch it. Without all four the transport is not useful for what it exists to do.
+    #[test]
+    fn the_app_path_is_reachable() {
+        let expected = [
+            (proto::Call::Hello(proto::HelloParams { api_version: proto::API_VERSION }), Upstream::Updater),
+            (proto::Call::Status, Upstream::Updater),
+            (proto::Call::Subscribe, Upstream::Updater),
+            (proto::Call::RobotHealth, Upstream::Robot),
+        ];
+        for (call, want) in expected {
+            assert_eq!(upstream_for(&call), Some(want), "{}", call.method());
+        }
+    }
+
+    /// A refusal must be distinguishable from "no such method", because the two ask the user
+    /// for different things.
+    #[test]
+    fn a_refusal_says_permission_denied_and_names_the_method() {
+        let call = proto::Call::ResetToGolden(proto::ComponentParams { component: component() });
+        let err = refusal(&call);
+
+        assert_eq!(err.code, proto::code::PERMISSION_DENIED);
+        assert!(err.message.contains(proto::method::RESET_TO_GOLDEN), "{}", err.message);
+    }
+
+    /// Every variant, so the tests above cannot silently skip one. The exhaustive match in
+    /// `upstream_for` is what forces this list to be maintained: a new variant breaks the
+    /// build there, and whoever fixes it arrives here next.
+    fn every_call() -> Vec<proto::Call> {
+        let version = semver::Version::new(1, 4, 2);
+        vec![
+            proto::Call::Hello(proto::HelloParams { api_version: proto::API_VERSION }),
+            proto::Call::Check(proto::ComponentParams { component: component() }),
+            proto::Call::Apply(proto::ApplyParams {
+                component: component(),
+                target: proto::Target::Latest,
+                options: proto::ApplyOptions::default(),
+            }),
+            proto::Call::Rollback(proto::ComponentParams { component: component() }),
+            proto::Call::ResetToGolden(proto::ComponentParams { component: component() }),
+            proto::Call::Select(proto::SelectParams { component: component(), version: version.clone() }),
+            proto::Call::Pin(proto::PinParams { component: component(), version: Some(version) }),
+            proto::Call::Status,
+            proto::Call::ListInstalled(proto::ComponentParams { component: component() }),
+            proto::Call::Log(proto::LogParams { limit: 20 }),
+            proto::Call::Subscribe,
+            proto::Call::RobotSafeToRestart,
+            proto::Call::RobotHealth,
+            proto::Call::RobotModelApi,
+            proto::Call::RobotRemoteSessionActive,
+        ]
+    }
+}

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -19,7 +19,7 @@ use duck_ipc_proto as proto;
 /// The service that owns the answer to a call.
 ///
 /// One socket per service, connected directly — there is no broker (`architecture.md` §2.2).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Upstream {
     /// `updaterd`, at `proto::DEFAULT_SOCKET`.
     Updater,

--- a/btd/src/session.rs
+++ b/btd/src/session.rs
@@ -1,0 +1,365 @@
+//! One connected central, from `hello` to disconnect.
+//!
+//! This is the whole of `btd`'s behaviour, and it holds no state about the robot — only about
+//! the conversation: a reassembly buffer and whichever upstream sockets this session has had
+//! reason to open.
+//!
+//! A request is forwarded **verbatim**. `btd` parses each line only far enough to answer two
+//! questions — is this method allowed here, and which socket owns it — and then passes the
+//! original bytes on. It never rewrites `id`, never re-serialises params, and never invents a
+//! result. That is what keeps it a transport rather than a second implementation of the API,
+//! and it is why adding a protocol method costs one line in [`crate::route`] and nothing here.
+
+use duck_ipc_proto as proto;
+use tokio::sync::mpsc;
+
+use crate::framing::{self, Reassembler};
+use crate::link::{Link, QUEUE};
+use crate::route;
+use crate::upstream::{Pool, Sockets};
+
+/// Serve one central until it disconnects or breaks framing.
+pub async fn run(mut link: Link, sockets: Sockets) {
+    let peer = link.peer.clone();
+    tracing::info!(peer = %peer, mtu = link.mtu, "session opened");
+
+    let (replies_tx, mut replies) = mpsc::channel::<String>(QUEUE);
+    let mut pool = Pool::new(sockets, replies_tx);
+    let mut inbound = Reassembler::new();
+
+    loop {
+        tokio::select! {
+            // Bytes from the radio.
+            chunk = link.inbound.recv() => {
+                let Some(chunk) = chunk else { break };
+
+                let lines = match inbound.push(&chunk) {
+                    Ok(lines) => lines,
+                    Err(e) => {
+                        // Framing failures end the session rather than being answered. There
+                        // is no id to answer *to* — we never saw a complete request — and a
+                        // peer that cannot frame will not be helped by a JSON error it also
+                        // cannot parse.
+                        tracing::warn!(peer = %peer, error = ?e, "framing failed; closing session");
+                        break;
+                    }
+                };
+
+                for line in lines {
+                    if let Some(response) = dispatch(&mut pool, &line).await
+                        && send_line(&link, &response).await.is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+
+            // A reply or a notification from a service.
+            line = replies.recv() => {
+                // The channel is held by `pool`, which lives as long as this loop, so `None`
+                // is unreachable — but treat it as end-of-session rather than panicking.
+                let Some(line) = line else { break };
+                if send_line(&link, &line).await.is_err() {
+                    return;
+                }
+            }
+        }
+    }
+
+    if inbound.pending() > 0 {
+        // Worth a line: it distinguishes "client finished and left" from "client vanished
+        // mid-message", which is the difference between a normal disconnect and a bug.
+        tracing::debug!(peer = %peer, pending = inbound.pending(), "session ended mid-line");
+    }
+    tracing::info!(peer = %peer, "session closed");
+}
+
+/// Handle one complete line. Returns a response `btd` must answer itself, if any.
+///
+/// `None` means the line was forwarded and the upstream will answer — the ordinary path.
+async fn dispatch(pool: &mut Pool, line: &str) -> Option<String> {
+    let request: proto::Request = match serde_json::from_str(line) {
+        Ok(request) => request,
+        Err(e) => {
+            // No id is recoverable from an unparseable line, so the response carries `null` —
+            // which the spec requires and every client already handles.
+            return Some(encode(&proto::Response::err(
+                None,
+                proto::Error::new(proto::code::PARSE_ERROR, e.to_string()),
+            )));
+        }
+    };
+
+    // A notification — no id — expects no reply, so a refused one is dropped silently. It is
+    // still not forwarded: the allowlist is not advisory.
+    let id = request.id.clone();
+
+    let call = match request.as_call() {
+        Ok(call) => call,
+        Err(e) => return id.map(|id| encode(&proto::Response::err(Some(id), e))),
+    };
+
+    let Some(upstream) = route::upstream_for(&call) else {
+        tracing::info!(method = call.method(), "refused over BLE");
+        return id.map(|id| encode(&proto::Response::err(Some(id), route::refusal(&call))));
+    };
+
+    if let Err(e) = pool.send(upstream, line).await {
+        tracing::warn!(method = call.method(), upstream = ?upstream, error = %e, "upstream unreachable");
+        // Naming the service is what makes this diagnosable from a phone screenshot: "robotd
+        // is not answering" is a different problem from "the robot refused".
+        return id.map(|id| {
+            encode(&proto::Response::err(
+                Some(id),
+                proto::Error::new(
+                    proto::code::INTERNAL_ERROR,
+                    format!("{upstream:?} is not answering: {e}"),
+                ),
+            ))
+        });
+    }
+    None
+}
+
+/// Chunk one line out to the central.
+async fn send_line(link: &Link, line: &str) -> Result<(), ()> {
+    for chunk in framing::chunks(line, link.mtu) {
+        if link.outbound.send(chunk).await.is_err() {
+            // The backend dropped its half: the central is gone.
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+fn encode(response: &proto::Response) -> String {
+    // A Response is plain strings, ints and enums; this cannot fail. If it somehow did,
+    // sending nothing would hang the client, so send something it can parse as an error.
+    serde_json::to_string(response).unwrap_or_else(|_| {
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal error"}}"#.to_owned()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixListener;
+    use tokio::sync::mpsc::{Receiver, Sender};
+
+    /// A stand-in for one daemon: accepts a connection, records the lines it receives, and
+    /// replies with whatever the test queued.
+    ///
+    /// A real unix socket rather than a mock, because the framing between `btd` and a daemon is
+    /// part of what is under test — the same reason `robotd`'s own tests speak over a socket.
+    struct FakeDaemon {
+        path: PathBuf,
+        seen: Sender<String>,
+        replies: Vec<String>,
+    }
+
+    impl FakeDaemon {
+        fn spawn(dir: &std::path::Path, name: &str, replies: Vec<String>) -> (PathBuf, Receiver<String>) {
+            let path = dir.join(name);
+            let (seen, seen_rx) = mpsc::channel(16);
+            let daemon = FakeDaemon { path: path.clone(), seen, replies };
+
+            let listener = UnixListener::bind(&daemon.path).expect("bind");
+            tokio::spawn(async move {
+                while let Ok((stream, _)) = listener.accept().await {
+                    let seen = daemon.seen.clone();
+                    let replies = daemon.replies.clone();
+                    tokio::spawn(async move {
+                        let (read, mut write) = stream.into_split();
+                        let mut lines = BufReader::new(read).lines();
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            let _ = seen.send(line).await;
+                            for reply in &replies {
+                                let _ = write.write_all(format!("{reply}\n").as_bytes()).await;
+                            }
+                            let _ = write.flush().await;
+                        }
+                    });
+                }
+            });
+            (path, seen_rx)
+        }
+    }
+
+    /// Collect notified chunks and reassemble them the way a client would.
+    async fn read_reply(from_robot: &mut Receiver<Vec<u8>>) -> String {
+        let mut r = Reassembler::new();
+        loop {
+            let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), from_robot.recv())
+                .await
+                .expect("client saw no reply")
+                .expect("link closed");
+            if let Some(line) = r.push(&chunk).expect("framing").into_iter().next() {
+                return line;
+            }
+        }
+    }
+
+    fn sockets(dir: &std::path::Path, updater: &str, robot: &str) -> Sockets {
+        Sockets { updater: dir.join(updater), robot: dir.join(robot) }
+    }
+
+    /// The ordinary path: an allowed call reaches the right daemon **byte for byte**, and its
+    /// reply comes back. Verbatim forwarding is the property that keeps btd a transport.
+    #[tokio::test]
+    async fn an_allowed_call_is_forwarded_verbatim_and_answered() {
+        let dir = tempdir();
+        let (_, mut seen) = FakeDaemon::spawn(dir.path(), "updaterd.sock",
+            vec![r#"{"jsonrpc":"2.0","id":1,"result":{"api_version":2,"daemon_version":"0.1.4","revision":null}}"#.into()]);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(23, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"hello","params":{"api_version":2}}"#;
+        to_robot.send(request.as_bytes().to_vec()).await.unwrap();
+        to_robot.send(b"\n".to_vec()).await.unwrap();
+
+        assert_eq!(seen.recv().await.unwrap(), request, "not forwarded byte for byte");
+        assert!(read_reply(&mut from_robot).await.contains(r#""api_version":2"#));
+    }
+
+    /// A refused call must never touch the upstream. Answering correctly is not enough — the
+    /// point of the allowlist is that the daemon never sees it.
+    #[tokio::test]
+    async fn a_refused_call_never_reaches_the_daemon() {
+        let dir = tempdir();
+        let (_, mut seen) = FakeDaemon::spawn(dir.path(), "updaterd.sock", vec![]);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(23, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        to_robot.send(
+            format!("{}\n", r#"{"jsonrpc":"2.0","id":9,"method":"update.resetToGolden","params":{"component":"daemon"}}"#)
+                .into_bytes(),
+        ).await.unwrap();
+
+        let reply = read_reply(&mut from_robot).await;
+        assert!(reply.contains(&proto::code::PERMISSION_DENIED.to_string()), "{reply}");
+
+        // Nothing arrived at the daemon, and "nothing" needs a moment to be provable.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert!(seen.try_recv().is_err(), "a refused call was forwarded");
+    }
+
+    /// `robot.*` goes to `robotd` and not to `updaterd`. One table drives routing and
+    /// permission, so a mistake here would send an update trigger to the control daemon.
+    #[tokio::test]
+    async fn robot_calls_go_to_robotd() {
+        let dir = tempdir();
+        let (_, mut updater_seen) = FakeDaemon::spawn(dir.path(), "updaterd.sock", vec![]);
+        let (_, mut robot_seen) = FakeDaemon::spawn(dir.path(), "robotd.sock",
+            vec![r#"{"jsonrpc":"2.0","id":2,"result":{"healthy":true}}"#.into()]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(185, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        to_robot.send(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"robot.health\"}\n".to_vec()).await.unwrap();
+
+        assert!(robot_seen.recv().await.unwrap().contains("robot.health"));
+        assert!(read_reply(&mut from_robot).await.contains(r#""healthy":true"#));
+        assert!(updater_seen.try_recv().is_err(), "robotd's call went to updaterd");
+    }
+
+    /// A subscription is a stream of notifications on an open connection, and every one has to
+    /// reach the central. This is the case that would break if replies were correlated to
+    /// requests rather than forwarded as they arrive.
+    #[tokio::test]
+    async fn every_notification_in_a_stream_reaches_the_client() {
+        let dir = tempdir();
+        let progress: Vec<String> = (0..3)
+            .map(|i| format!(
+                r#"{{"jsonrpc":"2.0","method":"update.progress","params":{{"component":"daemon","phase":"downloading","percent":{},"detail":null}}}}"#,
+                i * 50
+            ))
+            .collect();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "updaterd.sock", progress);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(23, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        to_robot.send(b"{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"update.subscribe\"}\n".to_vec()).await.unwrap();
+
+        // A 23-byte MTU means each of these arrives in several chunks, so this also proves
+        // reassembly survives back-to-back messages.
+        for expected in [0, 50, 100] {
+            let line = read_reply(&mut from_robot).await;
+            assert!(line.contains(&format!(r#""percent":{expected}"#)), "{line}");
+        }
+    }
+
+    /// Garbage gets an error with a null id, not a dropped session: a client that sent one bad
+    /// line should be able to carry on.
+    #[tokio::test]
+    async fn an_unparseable_line_is_answered_and_the_session_survives() {
+        let dir = tempdir();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "updaterd.sock",
+            vec![r#"{"jsonrpc":"2.0","id":1,"result":{"api_version":2,"daemon_version":null,"revision":null}}"#.into()]);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(185, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        to_robot.send(b"not json at all\n".to_vec()).await.unwrap();
+        let reply = read_reply(&mut from_robot).await;
+        assert!(reply.contains(&proto::code::PARSE_ERROR.to_string()), "{reply}");
+        assert!(reply.contains(r#""id":null"#), "{reply}");
+
+        // Still usable.
+        to_robot.send(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"hello\",\"params\":{\"api_version\":2}}\n".to_vec()).await.unwrap();
+        assert!(read_reply(&mut from_robot).await.contains(r#""api_version":2"#));
+    }
+
+    /// A daemon that is not running must produce a diagnosable error naming it, rather than a
+    /// hang. `robotd` is missing precisely when an update has just restarted it, which is when
+    /// someone is most likely to be looking at a phone.
+    #[tokio::test]
+    async fn a_dead_daemon_is_reported_rather_than_hanging() {
+        let dir = tempdir();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "updaterd.sock", vec![]);
+        // No robotd socket at all.
+
+        let (link, to_robot, mut from_robot) = Link::pair(185, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "absent.sock")));
+
+        to_robot.send(b"{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"robot.health\"}\n".to_vec()).await.unwrap();
+
+        let reply = read_reply(&mut from_robot).await;
+        assert!(reply.contains("Robot is not answering"), "{reply}");
+    }
+
+    /// A notification (no id) gets no reply even when refused — the spec says so, and a client
+    /// waiting for one would wait forever.
+    #[tokio::test]
+    async fn a_refused_notification_is_answered_with_silence() {
+        let dir = tempdir();
+        let (_, mut seen) = FakeDaemon::spawn(dir.path(), "updaterd.sock", vec![]);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(185, "AA:BB");
+        tokio::spawn(run(link, sockets(dir.path(), "updaterd.sock", "robotd.sock")));
+
+        to_robot.send(
+            format!("{}\n", r#"{"jsonrpc":"2.0","method":"update.resetToGolden","params":{"component":"daemon"}}"#)
+                .into_bytes(),
+        ).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert!(from_robot.try_recv().is_err(), "a notification was answered");
+        assert!(seen.try_recv().is_err(), "a refused notification was forwarded");
+    }
+
+    /// Sockets live in a temp directory, and unix socket paths are short by necessity — a
+    /// long temp path would exceed `sun_path` and fail to bind for reasons unrelated to btd.
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new().prefix("btd").tempdir().expect("tempdir")
+    }
+}

--- a/btd/src/session.rs
+++ b/btd/src/session.rs
@@ -202,7 +202,12 @@ mod tests {
     }
 
     fn sockets(dir: &std::path::Path, updater: &str, robot: &str) -> Sockets {
-        Sockets { updater: dir.join(updater), robot: dir.join(robot) }
+        Sockets {
+            updater: dir.join(updater),
+            robot: dir.join(robot),
+            // Not exercised by these tests; `configd` gets its own once it has a fake.
+            config: dir.join("configd.sock"),
+        }
     }
 
     /// The ordinary path: an allowed call reaches the right daemon **byte for byte**, and its

--- a/btd/src/upstream.rs
+++ b/btd/src/upstream.rs
@@ -1,0 +1,141 @@
+//! Connections to the services that actually own the answers.
+//!
+//! One socket per service, connected directly — with four services there is no case for a
+//! broker, and a bus would be another component that can fail (`architecture.md` §2.2).
+//!
+//! Every operation here is timeout-bounded, without exception. Any peer may be dead, and a
+//! closed or silent socket is a normal answer rather than an error worth retrying forever —
+//! `robotd` in particular is the service most likely to be missing, since it is the one an
+//! update restarts.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+
+use crate::route::Upstream;
+
+/// Long enough for a loaded board, short enough that a phone gets an answer rather than a
+/// spinner. A unix socket connect either succeeds immediately or the daemon is not there.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Cap on a single write. A blocked write means the daemon has stopped reading, which is a
+/// dead peer rather than a slow one.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Where each service listens.
+#[derive(Debug, Clone)]
+pub struct Sockets {
+    pub updater: PathBuf,
+    pub robot: PathBuf,
+}
+
+impl Sockets {
+    pub fn path(&self, upstream: Upstream) -> &Path {
+        match upstream {
+            Upstream::Updater => &self.updater,
+            Upstream::Robot => &self.robot,
+        }
+    }
+}
+
+/// The write half of a live connection. The read half lives in a spawned task.
+struct Conn {
+    write: tokio::net::unix::OwnedWriteHalf,
+}
+
+/// Connections opened so far in one BLE session, made on demand.
+///
+/// Lazy rather than eager because most sessions touch one service: a phone asking for the
+/// version has no reason to make `robotd` accept a connection it will never use. And because
+/// connecting eagerly would mean a dead `robotd` delayed or failed a session that did not need
+/// it.
+pub struct Pool {
+    sockets: Sockets,
+    conns: HashMap<Upstream, Conn>,
+    /// Every reply and notification from every upstream, merged. Merging is safe because
+    /// JSON-RPC correlates by `id`, which is the client's business — `btd` forwards lines
+    /// without reading them.
+    replies: mpsc::Sender<String>,
+}
+
+impl Pool {
+    pub fn new(sockets: Sockets, replies: mpsc::Sender<String>) -> Self {
+        Self { sockets, conns: HashMap::new(), replies }
+    }
+
+    /// Send one line to `upstream`, connecting first if needed.
+    pub async fn send(&mut self, upstream: Upstream, line: &str) -> io::Result<()> {
+        if !self.conns.contains_key(&upstream) {
+            let conn = self.open(upstream).await?;
+            self.conns.insert(upstream, conn);
+        }
+
+        // Unwrap is sound: just inserted, or the contains_key above held.
+        let conn = self.conns.get_mut(&upstream).expect("connection present");
+
+        let mut bytes = line.as_bytes().to_vec();
+        bytes.push(b'\n');
+
+        let write = async {
+            conn.write.write_all(&bytes).await?;
+            conn.write.flush().await
+        };
+        match tokio::time::timeout(WRITE_TIMEOUT, write).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                // A broken pipe here is ordinary — the daemon restarted. Drop the connection
+                // so the next call reconnects rather than writing into a dead socket forever.
+                self.conns.remove(&upstream);
+                Err(e)
+            }
+            Err(_) => {
+                self.conns.remove(&upstream);
+                Err(io::Error::new(io::ErrorKind::TimedOut, "upstream write timed out"))
+            }
+        }
+    }
+
+    async fn open(&self, upstream: Upstream) -> io::Result<Conn> {
+        let path = self.sockets.path(upstream);
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, UnixStream::connect(path))
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "connect timed out"))??;
+
+        let (read, write) = stream.into_split();
+        let replies = self.replies.clone();
+        let label = format!("{upstream:?}");
+
+        // The read half is pumped for the session's lifetime. Responses and notifications are
+        // the same thing to us: a line to forward. That is what makes `update.subscribe`'s
+        // progress stream work without any special case.
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(read).lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        // A full queue means the central cannot keep up. Give up on the line
+                        // rather than the session: progress is advisory, and blocking here
+                        // would stall every other upstream too.
+                        if replies.try_send(line).is_err() {
+                            tracing::debug!(upstream = %label, "dropped a line; client is behind");
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::debug!(upstream = %label, error = %e, "upstream read failed");
+                        break;
+                    }
+                }
+            }
+            tracing::debug!(upstream = %label, "upstream closed");
+        });
+
+        tracing::debug!(upstream = ?upstream, path = %path.display(), "connected");
+        Ok(Conn { write })
+    }
+}

--- a/btd/src/upstream.rs
+++ b/btd/src/upstream.rs
@@ -32,6 +32,7 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct Sockets {
     pub updater: PathBuf,
     pub robot: PathBuf,
+    pub config: PathBuf,
 }
 
 impl Sockets {
@@ -39,6 +40,7 @@ impl Sockets {
         match upstream {
             Upstream::Updater => &self.updater,
             Upstream::Robot => &self.robot,
+            Upstream::Config => &self.config,
         }
     }
 }

--- a/btd/systemd/btd.service
+++ b/btd/systemd/btd.service
@@ -1,0 +1,84 @@
+# btd — the BLE front door onto the robot API.
+#
+# Install to /etc/systemd/system/btd.service.
+#
+# Two properties follow from btd being part of the recovery path (docs/architecture.md §1.1)
+# and must be preserved:
+#
+#   1. NO dependency on robotd or updaterd, in either direction. btd must answer when the
+#      robot does not — that is most of why it exists. It reaches both over their sockets,
+#      and a missing socket is a normal answer it reports rather than a reason not to start.
+#   2. It stays UNPRIVILEGED. btd is the process that parses bytes from anyone in radio
+#      range; configd is the one that runs as root. Putting the parser on the safe side of
+#      that boundary matters more than hardening the dispatcher.
+
+[Unit]
+Description=Robot BLE transport adapter
+Documentation=file:///opt/robot/daemon/current/docs/architecture.md
+
+# bluetoothd is a hard requirement — btd speaks to BlueZ over D-Bus and has nothing to do
+# without it. `Wants` rather than `Requires`: if bluetoothd is slow or restarts, btd waits
+# and retries for an adapter rather than failing (see ADAPTER_RETRY in src/bluez.rs).
+#
+# On the Radxa, hci0 does not exist until ~73s after power-on: aic-bluetooth.service attaches
+# the AIC8800's UART late, and bluetooth.service itself spends ~26s blocked behind dbus. So
+# ordering after bluetooth.service is necessary but nowhere near sufficient, and the retry
+# loop is what actually makes startup work.
+After=dbus.service bluetooth.service
+Wants=bluetooth.service
+
+# No network dependency: BLE is the transport that has to work when the network does not.
+After=local-fs.target
+
+[Service]
+Type=exec
+ExecStart=/opt/robot/daemon/current/bin/btd
+
+# Unprivileged, unlike robotd — btd touches no hardware directly, only D-Bus and two unix
+# sockets, so there is no excuse for root here.
+#
+# `robot` is what gets it through the 0660 sockets updaterd and robotd listen on.
+#
+# `bluetooth` is what should get it through BlueZ's D-Bus policy — but VERIFY THAT ON THE
+# BOARD before trusting it: Debian's /usr/share/dbus-1/system.d/bluetooth.conf grants
+# send_destination="org.bluez" to root and to at_console, and whether a group covers a
+# session-less daemon differs between images. If btd logs a D-Bus permission error on
+# startup, a drop-in policy granting this user access to org.bluez is the fix — not running
+# it as root.
+#
+# The users and groups must exist or the unit fails to start; see sysusers.d/btd.conf,
+# installed alongside.
+User=btd
+Group=btd
+SupplementaryGroups=robot bluetooth
+
+Restart=always
+RestartSec=5s
+
+# Tighter than robotd can be, because this process has no hardware to reach. It needs D-Bus
+# (a unix socket) and two unix sockets, and nothing else.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+CapabilityBoundingSet=
+
+# stderr → journal; level via RUST_LOG. The startup identity line (version, revision, exe
+# path) is at `warn`, so it survives RUST_LOG=warn on a long-running board.
+Environment=RUST_LOG=info
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/btd/systemd/sysusers.d/btd.conf
+++ b/btd/systemd/sysusers.d/btd.conf
@@ -1,0 +1,19 @@
+# Creates the `btd` system user and group.
+#
+# Install to /usr/lib/sysusers.d/btd.conf; systemd-sysusers creates them at boot, or run
+# `systemd-sysusers` once by hand.
+#
+# btd runs as its own unprivileged user rather than root, because it is the process that
+# parses bytes arriving from anyone in radio range (docs/architecture.md §1.1). Its access
+# comes entirely from group membership, granted in btd.service:
+#
+#   robot      — reaches updaterd's and robotd's 0660 sockets
+#   bluetooth  — should reach org.bluez over D-Bus; verify on the image
+#
+# Note what this deliberately does NOT confer: being in `robot` lets btd *talk* to updaterd,
+# not change the robot's software. Mutating calls additionally require allow_uids/allow_gids
+# in updater.toml, so leaving btd out of those is a safe default — BLE can then read
+# everything and change nothing (§2.2, and btd/src/route.rs).
+#
+# btd.service will fail to start if this user does not exist.
+u btd - "Robot BLE transport adapter" - -

--- a/configd/Cargo.toml
+++ b/configd/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "configd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Wifi and robot identity — the config service"
+
+# Its own service rather than part of robotd, because config must be reachable when robotd is
+# dead: provisioning wifi is exactly what a client needs when things are broken
+# (architecture.md §3.1). And not part of btd, because btd owns nothing (§4.1) — an SDK should
+# not have to go through Bluetooth to set a robot's name.
+#
+# It stores no credentials. NetworkManager owns those.
+[dependencies]
+duck-ipc-proto = { path = "../duck-ipc-proto" }
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal"] }
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+async-trait.workspace = true
+libc = "0.2"
+
+# NetworkManager and logind, both Linux-only. As with btd, the crate must still build and test on
+# a macOS laptop — `cargo test` there is the onboarding path — so the backend sits behind a trait
+# with an in-memory fake and the D-Bus client is not in the graph off-Linux.
+#
+# `zbus` rather than the `dbus` crate: pure Rust, so no vendored C to cross-compile, and NM's
+# settings are a nested a{sa{sv}} that zvariant expresses without ceremony. The cost is that the
+# shipped artifact carries two D-Bus stacks, since btd links libdbus through bluer. Worth
+# revisiting if bluer ever grows a zbus backend.
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = "5"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/configd/src/lib.rs
+++ b/configd/src/lib.rs
@@ -1,0 +1,27 @@
+//! `configd` — wifi and the robot's identity.
+//!
+//! It exists because **config must be reachable when `robotd` is dead** (`architecture.md`
+//! §3.1): provisioning wifi is exactly what a client needs when things are broken, so it cannot
+//! live in the control daemon. And because `btd` **owns nothing** (§4.1) — if this lived in the
+//! BLE service, an SDK would absurdly have to go through Bluetooth to set a robot's name.
+//!
+//! So it is a fifth service, deliberately: one socket, four `net.*` methods and three
+//! `system.*` ones, and every transport — BLE, `robotctl`, later `mediad`'s remote gateway —
+//! is a client of it rather than a reimplementation.
+//!
+//! **It stores no credentials.** NetworkManager owns those, persists them root-only and
+//! reconnects on its own; `configd` hands a passphrase over and forgets it. What it does own is
+//! a small [`store`] file: the robot's name, and whatever identity follows.
+//!
+//! It runs as root, which is not the default this repo prefers. The reason is narrow: logind's
+//! `Reboot` is polkit-gated, there is no polkit on the board, and a session-less non-root caller
+//! is therefore denied. The trust boundary is still in the right place — `btd` is the process
+//! parsing bytes from anyone in radio range, and it is unprivileged; `configd` only ever sees
+//! typed JSON from a peer-credentialled local socket. See `systemd/configd.service` for the
+//! sandbox that goes with it.
+
+pub mod net;
+#[cfg(target_os = "linux")]
+pub mod nm;
+pub mod power;
+pub mod store;

--- a/configd/src/main.rs
+++ b/configd/src/main.rs
@@ -1,0 +1,414 @@
+//! `configd` — see the crate docs in `lib.rs` for why this is its own service.
+//!
+//! This file is the socket, the peer policy and the dispatch.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use clap::Parser;
+use configd::net::{FakeNet, Net};
+use configd::power;
+use configd::store::Store;
+use duck_ipc_proto as proto;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+/// Owner and group read/write, nothing for others — the same as every other socket here. This
+/// is the first layer of access control: reaching the socket at all requires the group.
+const SOCKET_MODE: u32 = 0o660;
+
+/// Refuse absurdly long lines rather than buffering them.
+const MAX_LINE: usize = 64 * 1024;
+
+const DEFAULT_STATE_DIR: &str = "/var/lib/robot/config";
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about = "Wifi and robot identity",
+    long_about = "Serves net.* and system.* over a unix socket. Drives NetworkManager for wifi \
+                  and never stores a credential. Lives apart from robotd because config must be \
+                  reachable when the robot is not."
+)]
+struct Args {
+    #[arg(long, default_value = proto::socket::CONFIG)]
+    socket: PathBuf,
+
+    /// Where the config file lives. Outside any release directory, so it survives an update
+    /// *and* a rollback.
+    #[arg(long, default_value = DEFAULT_STATE_DIR)]
+    state_dir: PathBuf,
+
+    /// uids permitted to make changes. Read-only calls are never gated.
+    #[arg(long, value_delimiter = ',')]
+    allow_uid: Vec<u32>,
+
+    /// gids permitted to make changes.
+    #[arg(long, value_delimiter = ',')]
+    allow_gid: Vec<u32>,
+
+    /// Serve an in-memory wifi stack instead of NetworkManager.
+    ///
+    /// The whole `net.*` surface, including the failures that are awkward to provoke against a
+    /// real access point — a wrong passphrase especially — without a board or a radio.
+    #[arg(long)]
+    fake_net: bool,
+}
+
+/// Who may change this robot's configuration.
+///
+/// Two tiers, matching `updaterd` (`architecture.md` §2.2): the socket's group decides who may
+/// *talk*, and this decides who may *change*. Read-only calls are deliberately ungated so
+/// support can inspect a robot it is not authorised to reconfigure — and so `btd` can report
+/// wifi status without being trusted to join a network.
+///
+/// An unknown peer is denied. `SO_PEERCRED` failing is not something to shrug at when the
+/// decision is "may this reboot the robot".
+struct PeerPolicy {
+    owner_uid: u32,
+    allow_uids: Vec<u32>,
+    allow_gids: Vec<u32>,
+}
+
+impl PeerPolicy {
+    fn may_mutate(&self, peer: Option<&tokio::net::unix::UCred>) -> Result<(), String> {
+        let Some(peer) = peer else {
+            return Err("peer credentials unavailable; refusing a mutating request".into());
+        };
+        if peer.uid() == self.owner_uid
+            || self.allow_uids.contains(&peer.uid())
+            || self.allow_gids.contains(&peer.gid())
+        {
+            return Ok(());
+        }
+        Err(format!(
+            "uid {} / gid {} may not change this robot's configuration; add it to --allow-uid \
+             or --allow-gid, or run as uid {}",
+            peer.uid(),
+            peer.gid(),
+            self.owner_uid
+        ))
+    }
+}
+
+struct Service {
+    net: Arc<dyn Net>,
+    store: Store,
+    policy: PeerPolicy,
+}
+
+fn log_startup_identity(service: &str) {
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "unknown".to_owned());
+    tracing::warn!(
+        service,
+        build = %proto::build_info!(),
+        exe,
+        pid = std::process::id(),
+        "starting"
+    );
+}
+
+fn hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_owned())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "robot".to_owned())
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+    log_startup_identity("configd");
+
+    let net: Arc<dyn Net> = match backend(args.fake_net).await {
+        Ok(net) => net,
+        Err(e) => {
+            tracing::error!(error = %e, "no wifi backend");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let service = Arc::new(Service {
+        net,
+        store: Store::new(args.state_dir.join("config.json"), hostname()),
+        policy: PeerPolicy {
+            owner_uid: unsafe { libc::getuid() },
+            allow_uids: args.allow_uid,
+            allow_gids: args.allow_gid,
+        },
+    });
+
+    tokio::select! {
+        result = serve(service, args.socket) => match result {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                tracing::error!(error = %e, "IPC server failed");
+                ExitCode::FAILURE
+            }
+        },
+        () = shutdown() => {
+            tracing::info!("shutting down");
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn backend(fake: bool) -> Result<Arc<dyn Net>, String> {
+    if fake {
+        tracing::warn!("serving a FAKE wifi stack; nothing here touches a real network");
+        return Ok(Arc::new(FakeNet::new()));
+    }
+    // A failure here means NetworkManager is not on the bus at all, which on this board means
+    // the wifi migration was never run. Say that, rather than reporting a D-Bus error nobody
+    // can act on.
+    configd::nm::NetworkManager::new()
+        .await
+        .map(|nm| Arc::new(nm) as Arc<dyn Net>)
+        .map_err(|e| {
+            format!(
+                "cannot reach NetworkManager on the system bus ({e}). If this board still runs \
+                 netplan, run scripts/migrate-network.sh first."
+            )
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn backend(_fake: bool) -> Result<Arc<dyn Net>, String> {
+    // NetworkManager is Linux-only, so off-board there is only the fake — and saying so is more
+    // useful than refusing to start, because `--fake-net` is how the surface is exercised from a
+    // laptop anyway.
+    tracing::warn!("not Linux: serving a FAKE wifi stack");
+    Ok(Arc::new(FakeNet::new()))
+}
+
+async fn serve(service: Arc<Service>, socket_path: PathBuf) -> std::io::Result<()> {
+    // A leftover socket from a killed process must not stop us coming up.
+    if socket_path.exists() {
+        tracing::warn!(path = %socket_path.display(), "removing stale socket");
+        let _ = std::fs::remove_file(&socket_path);
+    }
+    if let Some(parent) = socket_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let listener = UnixListener::bind(&socket_path)?;
+
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(SOCKET_MODE))?;
+
+    tracing::info!(
+        path = %socket_path.display(),
+        mode = format!("{SOCKET_MODE:o}"),
+        "serving config IPC"
+    );
+
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::warn!(error = %e, "accept failed");
+                continue;
+            }
+        };
+        let service = Arc::clone(&service);
+        tokio::spawn(async move {
+            if let Err(e) = handle(service, stream).await {
+                tracing::debug!(error = %e, "connection ended");
+            }
+        });
+    }
+}
+
+async fn handle(service: Arc<Service>, stream: UnixStream) -> std::io::Result<()> {
+    // Read once, per connection: credentials cannot change under a live socket, and asking per
+    // request would be a syscall for an answer that is already known.
+    let peer = stream.peer_cred().ok();
+    let (read_half, mut write_half) = stream.into_split();
+    let mut lines = BufReader::new(read_half).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.len() > MAX_LINE {
+            let response = proto::Response::err(
+                None,
+                proto::Error::new(proto::code::INVALID_REQUEST, "request too large"),
+            );
+            write_line(&mut write_half, &response).await?;
+            continue;
+        }
+
+        let request: proto::Request = match serde_json::from_str(&line) {
+            Ok(request) => request,
+            Err(e) => {
+                let response = proto::Response::err(
+                    None,
+                    proto::Error::new(proto::code::PARSE_ERROR, e.to_string()),
+                );
+                write_line(&mut write_half, &response).await?;
+                continue;
+            }
+        };
+
+        // Notifications get no reply, per the spec.
+        let Some(id) = request.id.clone() else { continue };
+
+        let response = match request.as_call() {
+            Ok(call) => dispatch(&service, peer.as_ref(), id, &call).await,
+            Err(e) => proto::Response::err(Some(id), e),
+        };
+        write_line(&mut write_half, &response).await?;
+    }
+    Ok(())
+}
+
+async fn dispatch(
+    service: &Service,
+    peer: Option<&tokio::net::unix::UCred>,
+    id: proto::Id,
+    call: &proto::Call,
+) -> proto::Response {
+    // Authorise before doing anything, and log the caller alongside the method: "who told this
+    // robot to reboot" is the first thing support asks.
+    if call.is_mutating() {
+        if let Err(reason) = service.policy.may_mutate(peer) {
+            tracing::warn!(method = call.method(), %reason, "refused");
+            return proto::Response::err(
+                Some(id),
+                proto::Error::new(proto::code::PERMISSION_DENIED, reason),
+            );
+        }
+        tracing::info!(
+            method = call.method(),
+            uid = peer.map(|p| p.uid()),
+            gid = peer.map(|p| p.gid()),
+            "authorised"
+        );
+    }
+
+    match call {
+        proto::Call::Hello(_) => proto::Response::ok(
+            Some(id),
+            &proto::HelloResult {
+                api_version: proto::API_VERSION,
+                daemon_version: proto::semver::Version::parse(env!("CARGO_PKG_VERSION")).ok(),
+                revision: proto::build_info!().revision.map(str::to_owned),
+            },
+        ),
+
+        proto::Call::NetStatus => reply(id, service.net.status().await),
+        proto::Call::NetScan => reply(id, service.net.scan().await),
+        proto::Call::NetConnect(params) => {
+            // `params` redacts the key in its own Debug, which is what makes logging the request
+            // safe. See `NetConnectParams` in duck-ipc-proto.
+            tracing::info!(?params, "joining a network");
+            reply(id, service.net.connect(&params.ssid, params.psk.as_deref()).await)
+        }
+        proto::Call::NetForget(params) => reply(id, service.net.forget(&params.ssid).await),
+
+        proto::Call::SystemInfo => proto::Response::ok(
+            Some(id),
+            &proto::SystemInfoResult {
+                name: service.store.name(),
+                // No per-device identity exists yet; provisioning has to define one
+                // (`updater-design.md` §5.7). `None` rather than something invented.
+                serial: None,
+                uptime_seconds: uptime_seconds(),
+            },
+        ),
+        proto::Call::SystemSetName(params) => match service.store.set_name(&params.name) {
+            Ok(name) => {
+                // The advertised BLE name does not change until btd restarts, and saying so is
+                // better than a client wondering why the phone still shows the old one.
+                tracing::info!(%name, "renamed; btd advertises the new name after a restart");
+                proto::Response::ok(Some(id), &proto::SetNameResult { name })
+            }
+            Err(e) => proto::Response::err(
+                Some(id),
+                proto::Error::new(proto::code::INVALID_PARAMS, e.to_string()),
+            ),
+        },
+        proto::Call::SystemReboot => {
+            power::schedule();
+            proto::Response::ok(
+                Some(id),
+                &proto::RebootResult { in_seconds: power::REBOOT_DELAY.as_secs() },
+            )
+        }
+
+        // `update.*` is `updaterd`'s and `robot.*` is `robotd`'s. A client reaching here aimed at
+        // the wrong socket, so say that rather than report a generic failure.
+        other => proto::Response::err(
+            Some(id),
+            proto::Error::new(
+                proto::code::METHOD_NOT_FOUND,
+                format!("{} is not served by configd", other.method()),
+            ),
+        ),
+    }
+}
+
+/// A backend result becomes a response. Backend failures are `INTERNAL_ERROR` because they mean
+/// the machinery broke — a *refusal* is a successful call with a `Failed` outcome, which is a
+/// distinction a client acts on.
+fn reply<T: serde::Serialize>(id: proto::Id, result: Result<T, String>) -> proto::Response {
+    match result {
+        Ok(value) => proto::Response::ok(Some(id), &value),
+        Err(e) => {
+            tracing::warn!(error = %e, "backend failed");
+            proto::Response::err(Some(id), proto::Error::new(proto::code::INTERNAL_ERROR, e))
+        }
+    }
+}
+
+/// Seconds since boot, from `/proc/uptime`. Zero where there is no procfs, which is only ever a
+/// developer's laptop.
+fn uptime_seconds() -> u64 {
+    std::fs::read_to_string("/proc/uptime")
+        .ok()
+        .and_then(|s| s.split_whitespace().next()?.parse::<f64>().ok())
+        .map(|secs| secs as u64)
+        .unwrap_or(0)
+}
+
+async fn write_line<T: serde::Serialize>(
+    out: &mut tokio::net::unix::OwnedWriteHalf,
+    message: &T,
+) -> std::io::Result<()> {
+    let mut line = serde_json::to_vec(message)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push(b'\n');
+    out.write_all(&line).await?;
+    out.flush().await
+}
+
+/// Resolve on SIGTERM (systemd stop) or SIGINT (Ctrl-C).
+async fn shutdown() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut term = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "cannot listen for SIGTERM");
+            return std::future::pending().await;
+        }
+    };
+    tokio::select! {
+        _ = term.recv() => {}
+        _ = tokio::signal::ctrl_c() => {}
+    }
+}

--- a/configd/src/net.rs
+++ b/configd/src/net.rs
@@ -1,0 +1,250 @@
+//! Wifi, as a trait plus a fake.
+//!
+//! **NetworkManager owns the credentials** (`architecture.md` §3). `configd` never stores a
+//! PSK: it hands one to NM, which persists the profile root-only and reconnects on its own.
+//! That is less code, better security, and one less thing to migrate — and it survives
+//! `configd` being restarted, updated or rolled back.
+//!
+//! The trait exists for the same reason `duck-control` has `RobotIo`: the suite runs on a
+//! laptop with no hardware, no network and no D-Bus, and the logic worth testing is the
+//! dispatch and authorisation around this, not NM itself.
+
+use async_trait::async_trait;
+use duck_ipc_proto as proto;
+
+/// What went wrong, in terms a caller can act on.
+pub type NetResult<T> = Result<T, String>;
+
+#[async_trait]
+pub trait Net: Send + Sync {
+    async fn status(&self) -> NetResult<proto::NetStatusResult>;
+    async fn scan(&self) -> NetResult<proto::NetScanResult>;
+    /// Join `ssid`, storing it so NM reconnects by itself next time.
+    async fn connect(&self, ssid: &str, psk: Option<&str>) -> NetResult<proto::ConnectResult>;
+    async fn forget(&self, ssid: &str) -> NetResult<proto::ForgetResult>;
+}
+
+/// A wifi stack that exists only in memory.
+///
+/// Used by every test and by `--fake`, which is how the whole `net.*` surface can be exercised
+/// end to end from a laptop — including the failures that are awkward to provoke against a real
+/// access point, like a wrong passphrase.
+pub struct FakeNet {
+    inner: tokio::sync::Mutex<FakeState>,
+}
+
+struct FakeState {
+    /// What the radio can see, and the key each one actually wants.
+    visible: Vec<(proto::Network, Option<String>)>,
+    saved: Vec<String>,
+    connected: Option<String>,
+}
+
+impl FakeNet {
+    /// Two networks in range: one WPA2 with a known key, one open.
+    pub fn new() -> Self {
+        Self::with_visible(vec![
+            (
+                proto::Network {
+                    ssid: "Pollen".into(),
+                    signal: 82,
+                    security: proto::Security::WpaPsk,
+                    saved: false,
+                },
+                Some("correct-key".to_owned()),
+            ),
+            (
+                proto::Network {
+                    ssid: "Cafe".into(),
+                    signal: 41,
+                    security: proto::Security::Open,
+                    saved: false,
+                },
+                None,
+            ),
+        ])
+    }
+
+    pub fn with_visible(visible: Vec<(proto::Network, Option<String>)>) -> Self {
+        Self {
+            inner: tokio::sync::Mutex::new(FakeState { visible, saved: Vec::new(), connected: None }),
+        }
+    }
+}
+
+impl Default for FakeNet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Net for FakeNet {
+    async fn status(&self) -> NetResult<proto::NetStatusResult> {
+        let state = self.inner.lock().await;
+        Ok(match &state.connected {
+            Some(ssid) => proto::NetStatusResult {
+                state: proto::NetState::Connected,
+                ssid: Some(ssid.clone()),
+                signal: state
+                    .visible
+                    .iter()
+                    .find(|(n, _)| &n.ssid == ssid)
+                    .map(|(n, _)| n.signal),
+                ip4: Some("192.168.50.63".into()),
+                ip6: None,
+                mac: Some("50:37:cd:16:1b:92".into()),
+                iface: Some("wlan0".into()),
+            },
+            None => proto::NetStatusResult {
+                state: proto::NetState::Disconnected,
+                ssid: None,
+                signal: None,
+                ip4: None,
+                ip6: None,
+                mac: Some("50:37:cd:16:1b:92".into()),
+                iface: Some("wlan0".into()),
+            },
+        })
+    }
+
+    async fn scan(&self) -> NetResult<proto::NetScanResult> {
+        let state = self.inner.lock().await;
+        let mut networks: Vec<proto::Network> = state
+            .visible
+            .iter()
+            .map(|(n, _)| proto::Network { saved: state.saved.contains(&n.ssid), ..n.clone() })
+            .collect();
+        networks.sort_by_key(|n| std::cmp::Reverse(n.signal));
+        Ok(proto::NetScanResult { networks })
+    }
+
+    async fn connect(&self, ssid: &str, psk: Option<&str>) -> NetResult<proto::ConnectResult> {
+        let mut state = self.inner.lock().await;
+
+        let Some((network, wanted)) = state.visible.iter().find(|(n, _)| n.ssid == ssid).cloned()
+        else {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::NotFound,
+                detail: None,
+            });
+        };
+
+        if network.security == proto::Security::Enterprise {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::Unsupported,
+                detail: Some("802.1X needs a certificate flow this API does not have".into()),
+            });
+        }
+        if wanted.is_some() && psk.is_none() {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::Unsupported,
+                detail: Some("this network needs a passphrase".into()),
+            });
+        }
+        if wanted.is_some() && wanted.as_deref() != psk {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::BadKey,
+                detail: None,
+            });
+        }
+
+        state.connected = Some(ssid.to_owned());
+        if !state.saved.iter().any(|s| s == ssid) {
+            state.saved.push(ssid.to_owned());
+        }
+        Ok(proto::ConnectResult::Connected {
+            ssid: ssid.to_owned(),
+            ip4: Some("192.168.50.63".into()),
+        })
+    }
+
+    async fn forget(&self, ssid: &str) -> NetResult<proto::ForgetResult> {
+        let mut state = self.inner.lock().await;
+        let before = state.saved.len();
+        state.saved.retain(|s| s != ssid);
+        if state.connected.as_deref() == Some(ssid) {
+            state.connected = None;
+        }
+        Ok(proto::ForgetResult { removed: state.saved.len() != before })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_wrong_key_is_reported_as_a_wrong_key() {
+        let net = FakeNet::new();
+        let result = net.connect("Pollen", Some("wrong")).await.unwrap();
+        assert!(matches!(
+            result,
+            proto::ConnectResult::Failed { reason: proto::ConnectFailure::BadKey, .. }
+        ));
+    }
+
+    /// A secured network with no passphrase is refused before trying, and distinguishably from a
+    /// wrong one — a client should ask for a password rather than say "that was wrong".
+    #[tokio::test]
+    async fn a_missing_key_is_not_a_wrong_key() {
+        let net = FakeNet::new();
+        let result = net.connect("Pollen", None).await.unwrap();
+        assert!(matches!(
+            result,
+            proto::ConnectResult::Failed { reason: proto::ConnectFailure::Unsupported, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_ssid_is_not_found() {
+        let net = FakeNet::new();
+        assert!(matches!(
+            net.connect("Nowhere", Some("k")).await.unwrap(),
+            proto::ConnectResult::Failed { reason: proto::ConnectFailure::NotFound, .. }
+        ));
+    }
+
+    /// The whole provisioning arc: scan, join, see it stored and connected, forget it.
+    #[tokio::test]
+    async fn connecting_stores_the_network_and_forgetting_removes_it() {
+        let net = FakeNet::new();
+        assert!(net.scan().await.unwrap().networks.iter().all(|n| !n.saved));
+
+        assert!(matches!(
+            net.connect("Pollen", Some("correct-key")).await.unwrap(),
+            proto::ConnectResult::Connected { .. }
+        ));
+
+        let status = net.status().await.unwrap();
+        assert_eq!(status.state, proto::NetState::Connected);
+        assert_eq!(status.ssid.as_deref(), Some("Pollen"));
+        assert!(status.ip4.is_some(), "connected with no address");
+
+        let saved = net.scan().await.unwrap();
+        assert!(saved.networks.iter().find(|n| n.ssid == "Pollen").unwrap().saved);
+
+        assert!(net.forget("Pollen").await.unwrap().removed);
+        assert_eq!(net.status().await.unwrap().state, proto::NetState::Disconnected);
+        // Forgetting again is not an error — a client must not present it as one.
+        assert!(!net.forget("Pollen").await.unwrap().removed);
+    }
+
+    /// An open network needs no key, and asking with one is not an error either.
+    #[tokio::test]
+    async fn an_open_network_joins_without_a_key() {
+        let net = FakeNet::new();
+        assert!(matches!(
+            net.connect("Cafe", None).await.unwrap(),
+            proto::ConnectResult::Connected { .. }
+        ));
+    }
+
+    /// Strongest first, because that is the order a phone shows them in.
+    #[tokio::test]
+    async fn scan_results_are_sorted_by_signal() {
+        let net = FakeNet::new();
+        let networks = net.scan().await.unwrap().networks;
+        assert!(networks.windows(2).all(|w| w[0].signal >= w[1].signal), "{networks:?}");
+    }
+}

--- a/configd/src/nm.rs
+++ b/configd/src/nm.rs
@@ -1,0 +1,544 @@
+//! NetworkManager over D-Bus. Linux only.
+//!
+//! `zbus` rather than the `dbus` crate: pure Rust, so no vendored C, and NM's settings are a
+//! nested `a{sa{sv}}` that `zvariant` expresses without ceremony. The cost is that the shipped
+//! artifact now carries two D-Bus stacks — `btd` links libdbus through `bluer` — which is real
+//! and worth revisiting if `bluer` ever grows a `zbus` backend, or if the BlueZ calls turn out
+//! small enough to hand-roll.
+//!
+//! **Untested against a real NetworkManager.** It type-checks for aarch64; every claim here is
+//! intent until it runs on the board.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use duck_ipc_proto as proto;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+
+use crate::net::{Net, NetResult};
+
+/// Values from NetworkManager's own `nm-dbus-interface.h`, read from upstream rather than
+/// remembered. These are the numbers that make "you typed the password wrong" reportable, which
+/// is the entire reason NM was chosen over netplan — so they are named, not inlined.
+mod nm {
+    pub const DEVICE_TYPE_WIFI: u32 = 2;
+
+    pub const STATE_UNAVAILABLE: u32 = 20;
+    pub const STATE_DISCONNECTED: u32 = 30;
+    pub const STATE_ACTIVATED: u32 = 100;
+    pub const STATE_FAILED: u32 = 120;
+
+    pub const REASON_NO_SECRETS: u32 = 7;
+    pub const REASON_SUPPLICANT_DISCONNECT: u32 = 8;
+    pub const REASON_SUPPLICANT_TIMEOUT: u32 = 11;
+    pub const REASON_SSID_NOT_FOUND: u32 = 53;
+    pub const REASON_IP_CONFIG_UNAVAILABLE: u32 = 5;
+
+    /// `NM_802_11_AP_SEC_KEY_MGMT_PSK`
+    pub const SEC_KEY_MGMT_PSK: u32 = 0x100;
+    /// `NM_802_11_AP_SEC_KEY_MGMT_802_1X`
+    pub const SEC_KEY_MGMT_802_1X: u32 = 0x200;
+    /// `NM_802_11_AP_SEC_KEY_MGMT_SAE`
+    pub const SEC_KEY_MGMT_SAE: u32 = 0x400;
+    /// `NM_802_11_AP_FLAGS_PRIVACY`
+    pub const AP_FLAGS_PRIVACY: u32 = 0x1;
+}
+
+/// How long to wait for a join to resolve one way or the other.
+///
+/// Association is quick; DHCP is what takes time on a busy network. Long enough to succeed on a
+/// slow one, short enough that a phone gets an answer instead of a spinner — and a `Timeout` is
+/// a reportable outcome rather than a hang, which is the point.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(45);
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager"
+)]
+trait Manager {
+    fn get_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+
+    #[zbus(name = "AddAndActivateConnection")]
+    fn add_and_activate_connection(
+        &self,
+        connection: HashMap<&str, HashMap<&str, Value<'_>>>,
+        device: &zbus::zvariant::ObjectPath<'_>,
+        specific_object: &zbus::zvariant::ObjectPath<'_>,
+    ) -> zbus::Result<(OwnedObjectPath, OwnedObjectPath)>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.Device",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Device {
+    #[zbus(property)]
+    fn device_type(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn interface(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn state(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn state_reason(&self) -> zbus::Result<(u32, u32)>;
+    #[zbus(property, name = "Ip4Config")]
+    fn ip4_config(&self) -> zbus::Result<OwnedObjectPath>;
+    #[zbus(property, name = "Ip6Config")]
+    fn ip6_config(&self) -> zbus::Result<OwnedObjectPath>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.Device.Wireless",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Wireless {
+    fn request_scan(&self, options: HashMap<&str, Value<'_>>) -> zbus::Result<()>;
+    fn get_all_access_points(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+    #[zbus(property)]
+    fn hw_address(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn active_access_point(&self) -> zbus::Result<OwnedObjectPath>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.AccessPoint",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait AccessPoint {
+    #[zbus(property)]
+    fn ssid(&self) -> zbus::Result<Vec<u8>>;
+    #[zbus(property)]
+    fn strength(&self) -> zbus::Result<u8>;
+    #[zbus(property)]
+    fn flags(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn rsn_flags(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn wpa_flags(&self) -> zbus::Result<u32>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.IP4Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Ip4Config {
+    #[zbus(property)]
+    fn address_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.IP6Config",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Ip6Config {
+    #[zbus(property)]
+    fn address_data(&self) -> zbus::Result<Vec<HashMap<String, OwnedValue>>>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.Settings",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/Settings"
+)]
+trait Settings {
+    fn list_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.NetworkManager.Settings.Connection",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Connection {
+    fn get_settings(&self) -> zbus::Result<HashMap<String, HashMap<String, OwnedValue>>>;
+    fn delete(&self) -> zbus::Result<()>;
+}
+
+pub struct NetworkManager {
+    bus: zbus::Connection,
+}
+
+impl NetworkManager {
+    pub async fn new() -> zbus::Result<Self> {
+        Ok(Self { bus: zbus::Connection::system().await? })
+    }
+
+    /// The first wifi device NM knows about.
+    ///
+    /// `None` is a real answer, not an error: on a board still running netplan, NM manages no
+    /// wifi device at all, and that reports as `Unavailable` rather than a failure — which is a
+    /// provisioning problem the caller can be told about (`scripts/migrate-network.sh`).
+    async fn wifi_device(&self) -> NetResult<Option<OwnedObjectPath>> {
+        let manager = ManagerProxy::new(&self.bus).await.map_err(bus_err)?;
+        for path in manager.get_devices().await.map_err(bus_err)? {
+            let device = DeviceProxy::builder(&self.bus)
+                .path(&path)
+                .map_err(bus_err)?
+                .build()
+                .await
+                .map_err(bus_err)?;
+            if device.device_type().await.unwrap_or(0) == nm::DEVICE_TYPE_WIFI {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn first_address(&self, addresses: Vec<HashMap<String, OwnedValue>>) -> Option<String> {
+        addresses
+            .first()
+            .and_then(|entry| entry.get("address").cloned())
+            .and_then(|value| String::try_from(value).ok())
+    }
+
+    /// Which stored profile, if any, is for this SSID.
+    async fn saved_connection(&self, ssid: &str) -> NetResult<Option<OwnedObjectPath>> {
+        let settings = SettingsProxy::new(&self.bus).await.map_err(bus_err)?;
+        for path in settings.list_connections().await.map_err(bus_err)? {
+            let connection = ConnectionProxy::builder(&self.bus)
+                .path(&path)
+                .map_err(bus_err)?
+                .build()
+                .await
+                .map_err(bus_err)?;
+            let Ok(config) = connection.get_settings().await else { continue };
+
+            // The SSID lives as raw bytes under the wifi section, because an SSID is not
+            // required to be UTF-8. Ours are compared as text, which is what a user typed.
+            let stored = config
+                .get("802-11-wireless")
+                .and_then(|section| section.get("ssid"))
+                .and_then(|value| Vec::<u8>::try_from(value.clone()).ok())
+                .and_then(|bytes| String::from_utf8(bytes).ok());
+
+            if stored.as_deref() == Some(ssid) {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn bus_err(e: impl std::fmt::Display) -> String {
+    format!("NetworkManager D-Bus call failed: {e}")
+}
+
+/// AP security flags → what a client needs to know to ask for the right thing.
+fn security_of(flags: u32, rsn: u32, wpa: u32) -> proto::Security {
+    let key_mgmt = rsn | wpa;
+    if key_mgmt & nm::SEC_KEY_MGMT_802_1X != 0 {
+        proto::Security::Enterprise
+    } else if key_mgmt & nm::SEC_KEY_MGMT_SAE != 0 {
+        proto::Security::Wpa3Sae
+    } else if key_mgmt & nm::SEC_KEY_MGMT_PSK != 0 {
+        proto::Security::WpaPsk
+    } else if flags & nm::AP_FLAGS_PRIVACY != 0 {
+        // Privacy bit set but no WPA/RSN key management: WEP, which nothing should still be
+        // using. Reported so a client can say "too old to join" rather than failing obscurely.
+        proto::Security::Wep
+    } else {
+        proto::Security::Open
+    }
+}
+
+/// A device state and reason → why the join failed.
+///
+/// This mapping is the payoff for choosing NetworkManager: `BadKey` is a distinct, actionable
+/// answer, and no other stack on the board reports it.
+fn failure_of(state: u32, reason: u32) -> (proto::ConnectFailure, Option<String>) {
+    let detail = Some(format!("NetworkManager state {state}, reason {reason}"));
+    let failure = match reason {
+        nm::REASON_NO_SECRETS => proto::ConnectFailure::BadKey,
+        nm::REASON_SSID_NOT_FOUND => proto::ConnectFailure::NotFound,
+        nm::REASON_SUPPLICANT_TIMEOUT
+        | nm::REASON_SUPPLICANT_DISCONNECT
+        | nm::REASON_IP_CONFIG_UNAVAILABLE => proto::ConnectFailure::Timeout,
+        _ => proto::ConnectFailure::Other,
+    };
+    (failure, detail)
+}
+
+#[async_trait]
+impl Net for NetworkManager {
+    async fn status(&self) -> NetResult<proto::NetStatusResult> {
+        let Some(path) = self.wifi_device().await? else {
+            return Ok(proto::NetStatusResult {
+                state: proto::NetState::Unavailable,
+                ssid: None,
+                signal: None,
+                ip4: None,
+                ip6: None,
+                mac: None,
+                iface: None,
+            });
+        };
+
+        let device = DeviceProxy::builder(&self.bus).path(&path).map_err(bus_err)?.build().await.map_err(bus_err)?;
+        let wireless = WirelessProxy::builder(&self.bus).path(&path).map_err(bus_err)?.build().await.map_err(bus_err)?;
+
+        let raw_state = device.state().await.unwrap_or(nm::STATE_UNAVAILABLE);
+        let state = match raw_state {
+            nm::STATE_ACTIVATED => proto::NetState::Connected,
+            nm::STATE_UNAVAILABLE => proto::NetState::Unavailable,
+            nm::STATE_DISCONNECTED | nm::STATE_FAILED => proto::NetState::Disconnected,
+            // Everything between disconnected and activated is "still trying", and a client
+            // should poll rather than conclude anything.
+            _ => proto::NetState::Connecting,
+        };
+
+        let (mut ssid, mut signal) = (None, None);
+        if let Ok(ap_path) = wireless.active_access_point().await
+            && ap_path.as_str() != "/"
+        {
+            if let Ok(ap) = AccessPointProxy::builder(&self.bus).path(&ap_path).map_err(bus_err)?.build().await {
+                ssid = ap.ssid().await.ok().and_then(|bytes| String::from_utf8(bytes).ok());
+                signal = ap.strength().await.ok();
+            }
+        }
+
+        let mut ip4 = None;
+        if let Ok(config_path) = device.ip4_config().await
+            && config_path.as_str() != "/"
+            && let Ok(config) = Ip4ConfigProxy::builder(&self.bus).path(&config_path).map_err(bus_err)?.build().await
+            && let Ok(addresses) = config.address_data().await
+        {
+            ip4 = self.first_address(addresses).await;
+        }
+
+        let mut ip6 = None;
+        if let Ok(config_path) = device.ip6_config().await
+            && config_path.as_str() != "/"
+            && let Ok(config) = Ip6ConfigProxy::builder(&self.bus).path(&config_path).map_err(bus_err)?.build().await
+            && let Ok(addresses) = config.address_data().await
+        {
+            ip6 = self.first_address(addresses).await;
+        }
+
+        Ok(proto::NetStatusResult {
+            state,
+            ssid,
+            signal,
+            ip4,
+            ip6,
+            mac: wireless.hw_address().await.ok(),
+            iface: device.interface().await.ok(),
+        })
+    }
+
+    async fn scan(&self) -> NetResult<proto::NetScanResult> {
+        let Some(path) = self.wifi_device().await? else {
+            return Ok(proto::NetScanResult { networks: Vec::new() });
+        };
+        let wireless = WirelessProxy::builder(&self.bus).path(&path).map_err(bus_err)?.build().await.map_err(bus_err)?;
+
+        // A scan request is a hint, not a command: NM rate-limits it and refuses while one is in
+        // flight. Either way the cached access-point list below is what we return, which is why
+        // the error is dropped rather than reported — a client asking twice in a second should
+        // get the previous results, not a failure.
+        let _ = wireless.request_scan(HashMap::new()).await;
+
+        let mut networks: Vec<proto::Network> = Vec::new();
+        for ap_path in wireless.get_all_access_points().await.map_err(bus_err)? {
+            let Ok(ap) = AccessPointProxy::builder(&self.bus).path(&ap_path).map_err(bus_err)?.build().await else {
+                continue;
+            };
+            let Some(ssid) = ap.ssid().await.ok().and_then(|b| String::from_utf8(b).ok()) else {
+                // A hidden network advertises an empty SSID, and one that is not UTF-8 cannot be
+                // named in JSON. Skipped rather than shown as a blank row.
+                continue;
+            };
+            if ssid.is_empty() {
+                continue;
+            }
+
+            let security = security_of(
+                ap.flags().await.unwrap_or(0),
+                ap.rsn_flags().await.unwrap_or(0),
+                ap.wpa_flags().await.unwrap_or(0),
+            );
+            let signal = ap.strength().await.unwrap_or(0);
+            let saved = self.saved_connection(&ssid).await?.is_some();
+
+            // One entry per SSID, strongest wins. A mesh or a dual-band router presents several
+            // access points for one network, and a list with "Pollen" five times is a worse
+            // answer than the truth.
+            match networks.iter_mut().find(|n| n.ssid == ssid) {
+                Some(existing) if existing.signal < signal => existing.signal = signal,
+                Some(_) => {}
+                None => networks.push(proto::Network { ssid, signal, security, saved }),
+            }
+        }
+
+        networks.sort_by_key(|n| std::cmp::Reverse(n.signal));
+        Ok(proto::NetScanResult { networks })
+    }
+
+    async fn connect(&self, ssid: &str, psk: Option<&str>) -> NetResult<proto::ConnectResult> {
+        let Some(device_path) = self.wifi_device().await? else {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::Unsupported,
+                detail: Some(
+                    "NetworkManager manages no wifi device; this board may still be on netplan"
+                        .into(),
+                ),
+            });
+        };
+
+        // Refuse what we cannot do, before changing anything. An enterprise network needs a
+        // username and certificate flow this API has no shape for, and half-attempting it would
+        // leave a broken profile behind.
+        if let Some(found) = self.scan().await?.networks.iter().find(|n| n.ssid == ssid).cloned() {
+            if found.security == proto::Security::Enterprise {
+                return Ok(proto::ConnectResult::Failed {
+                    reason: proto::ConnectFailure::Unsupported,
+                    detail: Some("802.1X networks need a certificate flow this API lacks".into()),
+                });
+            }
+            if found.security != proto::Security::Open && psk.is_none() {
+                return Ok(proto::ConnectResult::Failed {
+                    reason: proto::ConnectFailure::Unsupported,
+                    detail: Some("this network needs a passphrase".into()),
+                });
+            }
+        }
+
+        let manager = ManagerProxy::new(&self.bus).await.map_err(bus_err)?;
+
+        // The settings dictionary NM wants. Only `802-11-wireless.ssid` and the key are ours to
+        // state; `autoconnect` defaults on, which is what makes the robot rejoin by itself after
+        // a reboot — the property that keeps `configd` out of the reconnect business entirely.
+        let mut wireless: HashMap<&str, Value<'_>> = HashMap::new();
+        wireless.insert("ssid", Value::from(ssid.as_bytes().to_vec()));
+        wireless.insert("mode", Value::from("infrastructure"));
+
+        let mut connection: HashMap<&str, Value<'_>> = HashMap::new();
+        connection.insert("id", Value::from(ssid));
+        connection.insert("type", Value::from("802-11-wireless"));
+
+        let mut settings: HashMap<&str, HashMap<&str, Value<'_>>> = HashMap::new();
+        settings.insert("connection", connection);
+        settings.insert("802-11-wireless", wireless);
+
+        if let Some(psk) = psk {
+            let mut security: HashMap<&str, Value<'_>> = HashMap::new();
+            // `wpa-psk` covers WPA2 and WPA2/WPA3-transition. A WPA3-only network wants `sae`,
+            // and NM is lenient enough to negotiate in practice — if a board proves otherwise,
+            // this is where the scan's `Security` should choose.
+            security.insert("key-mgmt", Value::from("wpa-psk"));
+            security.insert("psk", Value::from(psk));
+            settings.insert("802-11-wireless-security", security);
+        }
+
+        let root = zbus::zvariant::ObjectPath::try_from("/").map_err(bus_err)?;
+        let device = zbus::zvariant::ObjectPath::try_from(device_path.as_str()).map_err(bus_err)?;
+
+        if let Err(e) = manager.add_and_activate_connection(settings, &device, &root).await {
+            return Ok(proto::ConnectResult::Failed {
+                reason: proto::ConnectFailure::Other,
+                detail: Some(format!("{e}")),
+            });
+        }
+
+        // NM returns as soon as activation *starts*, so the outcome has to be waited for. This
+        // poll is what turns "config applied" into "associated, addressed, and here is the IP" —
+        // the difference that made netplan unusable for provisioning.
+        let deadline = tokio::time::Instant::now() + CONNECT_TIMEOUT;
+        let device_proxy = DeviceProxy::builder(&self.bus).path(&device_path).map_err(bus_err)?.build().await.map_err(bus_err)?;
+
+        loop {
+            match device_proxy.state().await.unwrap_or(nm::STATE_UNAVAILABLE) {
+                nm::STATE_ACTIVATED => {
+                    let status = self.status().await?;
+                    return Ok(proto::ConnectResult::Connected {
+                        ssid: status.ssid.unwrap_or_else(|| ssid.to_owned()),
+                        ip4: status.ip4,
+                    });
+                }
+                nm::STATE_FAILED => {
+                    let (_, reason) = device_proxy.state_reason().await.unwrap_or((0, 0));
+                    let (failure, detail) = failure_of(nm::STATE_FAILED, reason);
+                    return Ok(proto::ConnectResult::Failed { reason: failure, detail });
+                }
+                _ => {}
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                let (_, reason) = device_proxy.state_reason().await.unwrap_or((0, 0));
+                // A timeout still carries NM's reason: "still authenticating after 45s" and
+                // "waiting for DHCP" are different problems.
+                let (_, detail) = failure_of(nm::STATE_FAILED, reason);
+                return Ok(proto::ConnectResult::Failed {
+                    reason: proto::ConnectFailure::Timeout,
+                    detail,
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    async fn forget(&self, ssid: &str) -> NetResult<proto::ForgetResult> {
+        let Some(path) = self.saved_connection(ssid).await? else {
+            return Ok(proto::ForgetResult { removed: false });
+        };
+        let connection = ConnectionProxy::builder(&self.bus).path(&path).map_err(bus_err)?.build().await.map_err(bus_err)?;
+        connection.delete().await.map_err(bus_err)?;
+        Ok(proto::ForgetResult { removed: true })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The security mapping decides whether a client asks for a password, and which kind. Pure
+    /// arithmetic on NM's flags, so it is testable without a bus — and worth testing, because
+    /// getting `Open` wrong for a secured network means silently attempting an unauthenticated
+    /// join.
+    #[test]
+    fn security_flags_map_to_what_a_client_must_ask_for() {
+        assert_eq!(security_of(0, 0, 0), proto::Security::Open);
+        assert_eq!(security_of(nm::AP_FLAGS_PRIVACY, 0, 0), proto::Security::Wep);
+        assert_eq!(security_of(nm::AP_FLAGS_PRIVACY, nm::SEC_KEY_MGMT_PSK, 0), proto::Security::WpaPsk);
+        assert_eq!(security_of(nm::AP_FLAGS_PRIVACY, 0, nm::SEC_KEY_MGMT_PSK), proto::Security::WpaPsk);
+        assert_eq!(security_of(nm::AP_FLAGS_PRIVACY, nm::SEC_KEY_MGMT_SAE, 0), proto::Security::Wpa3Sae);
+        assert_eq!(
+            security_of(nm::AP_FLAGS_PRIVACY, nm::SEC_KEY_MGMT_802_1X, 0),
+            proto::Security::Enterprise
+        );
+
+        // A WPA2/WPA3 transition AP advertises both; SAE wins, because a client offering SAE
+        // gets the better of the two and PSK still works underneath.
+        assert_eq!(
+            security_of(nm::AP_FLAGS_PRIVACY, nm::SEC_KEY_MGMT_PSK | nm::SEC_KEY_MGMT_SAE, 0),
+            proto::Security::Wpa3Sae
+        );
+        // Enterprise outranks everything: attempting a PSK join there cannot work.
+        assert_eq!(
+            security_of(nm::AP_FLAGS_PRIVACY, nm::SEC_KEY_MGMT_PSK | nm::SEC_KEY_MGMT_802_1X, 0),
+            proto::Security::Enterprise
+        );
+    }
+
+    /// The reason mapping is why NetworkManager was chosen over netplan, so the one that matters
+    /// most is pinned: a rejected key must be `BadKey` and nothing else.
+    #[test]
+    fn a_rejected_key_is_reported_as_bad_key() {
+        let (failure, detail) = failure_of(nm::STATE_FAILED, nm::REASON_NO_SECRETS);
+        assert_eq!(failure, proto::ConnectFailure::BadKey);
+        // The detail carries NM's raw numbers for a support ticket, but is never the primary
+        // message a user sees.
+        assert!(detail.unwrap().contains("reason 7"));
+
+        assert_eq!(
+            failure_of(nm::STATE_FAILED, nm::REASON_SSID_NOT_FOUND).0,
+            proto::ConnectFailure::NotFound
+        );
+        assert_eq!(
+            failure_of(nm::STATE_FAILED, nm::REASON_SUPPLICANT_TIMEOUT).0,
+            proto::ConnectFailure::Timeout
+        );
+        // An unmapped reason must not masquerade as a wrong password — that would send a user
+        // round a loop retyping a key that was already correct.
+        assert_eq!(failure_of(nm::STATE_FAILED, 999).0, proto::ConnectFailure::Other);
+    }
+}

--- a/configd/src/power.rs
+++ b/configd/src/power.rs
@@ -1,0 +1,57 @@
+//! Rebooting, through systemd rather than around it.
+//!
+//! `reboot(2)` would be one syscall and is wrong here: it cuts power without stopping services,
+//! so `robotd` never releases servo torque and the update journal never flushes. A robot that
+//! reboots by falling over is not an acceptable implementation of `system.reboot`.
+//!
+//! logind's `Reboot` is polkit-gated, and there is **no polkit on this board** — so a
+//! session-less non-root caller is simply denied. That is the whole reason `configd` runs as
+//! root. It is a narrow, sandboxed root (see `systemd/configd.service`), and the alternative was
+//! installing a JS policy engine to authorise a single call.
+
+use std::time::Duration;
+
+/// Gap between answering and rebooting.
+///
+/// Load-bearing rather than polite: a daemon that rebooted inside the call would drop the
+/// connection before responding, and every client — a phone especially — would have to treat a
+/// broken pipe as success. Long enough for the response to be chunked out over BLE at 20 bytes a
+/// notification, short enough that nobody wonders whether it worked.
+pub const REBOOT_DELAY: Duration = Duration::from_secs(3);
+
+/// Answer now, reboot shortly.
+pub fn schedule() {
+    tokio::spawn(async {
+        tokio::time::sleep(REBOOT_DELAY).await;
+        tracing::warn!("rebooting now, as requested over IPC");
+        if let Err(e) = reboot().await {
+            // Nothing else to try: a failed reboot leaves the robot running, which is the safe
+            // direction, but the reason must reach the journal or this looks like a call that was
+            // silently ignored.
+            tracing::error!(error = %e, "reboot failed; the robot is still running");
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+async fn reboot() -> Result<(), String> {
+    // `Reboot(false)` — false meaning "not interactive", so logind does not try to ask anyone.
+    let bus = zbus::Connection::system().await.map_err(|e| e.to_string())?;
+    bus.call_method(
+        Some("org.freedesktop.login1"),
+        "/org/freedesktop/login1",
+        Some("org.freedesktop.login1.Manager"),
+        "Reboot",
+        &(false),
+    )
+    .await
+    .map_err(|e| format!("logind refused: {e}"))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn reboot() -> Result<(), String> {
+    // Rebooting a developer's laptop because a test called `system.reboot` would be a memorable
+    // way to learn about `cfg`.
+    Err("not rebooting: this is not the robot".to_owned())
+}

--- a/configd/src/store.rs
+++ b/configd/src/store.rs
@@ -1,0 +1,214 @@
+//! The config store: a file, not a service (`architecture.md` §3.1).
+//!
+//! Deliberately not a daemon of its own. A plain file plus `flock` for write serialisation and
+//! write-to-temp-plus-`rename(2)` for atomicity gives no single point of failure, stays readable
+//! when any service is down, and the updater never touches it — so it survives an update *and*
+//! a rollback (`updater-design.md` §5.7).
+//!
+//! `inotify` is not here yet. It belongs when a *second* process reads this file; today
+//! `configd` is the only one, and watching a file you are the sole writer of is ceremony.
+//!
+//! This holds identity and preferences. It holds no credentials — NetworkManager owns those.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Longest name accepted.
+///
+/// Bounded by BLE, not by taste: a legacy advertisement has 31 bytes of payload total, and the
+/// local name shares it with flags and a 16-byte service UUID. A name longer than this is
+/// silently truncated by the adapter or pushed into a scan response the phone may not request —
+/// either way the robot appears under a name nobody chose. Truncating here, visibly, and
+/// returning what was stored is the honest version.
+pub const MAX_NAME: usize = 24;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Config {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+pub struct Store {
+    path: PathBuf,
+    /// Used when the file has no name yet, so an unprovisioned robot still has an identity
+    /// rather than an empty string in a phone's Bluetooth list.
+    fallback: String,
+}
+
+impl Store {
+    pub fn new(path: impl Into<PathBuf>, fallback: impl Into<String>) -> Self {
+        Self { path: path.into(), fallback: fallback.into() }
+    }
+
+    /// The robot's name, or the fallback.
+    ///
+    /// A missing or unparseable file yields the fallback rather than an error: an unprovisioned
+    /// board must come up with a working name, and a daemon that refuses to start because its
+    /// optional config is malformed is far harder to diagnose remotely than one that logs and
+    /// carries on — the same reasoning as `robotd.toml` being optional.
+    pub fn name(&self) -> String {
+        match self.read() {
+            Ok(config) => config.name.unwrap_or_else(|| self.fallback.clone()),
+            Err(e) => {
+                tracing::warn!(path = %self.path.display(), error = %e, "unreadable config; using the default name");
+                self.fallback.clone()
+            }
+        }
+    }
+
+    /// Store a name, returning what was actually stored.
+    ///
+    /// The caller must display the returned value, not what it sent: trimming and truncation
+    /// mean they can differ, and a client showing its own input would disagree with the robot.
+    pub fn set_name(&self, requested: &str) -> std::io::Result<String> {
+        let name = sanitise(requested);
+        if name.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "a name must have at least one printable character",
+            ));
+        }
+
+        let mut config = self.read().unwrap_or_default();
+        config.name = Some(name.clone());
+        self.write(&config)?;
+        Ok(name)
+    }
+
+    fn read(&self) -> std::io::Result<Config> {
+        match fs::read_to_string(&self.path) {
+            Ok(text) => serde_json::from_str(&text)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Write-to-temp, fsync, rename, fsync the directory.
+    ///
+    /// The directory fsync is the step usually forgotten: without it the rename may not survive
+    /// a power cut, and a robot switched off at the wall is the normal case rather than the
+    /// exceptional one. Same discipline as the update journal (`architecture.md` §8.2).
+    fn write(&self, config: &Config) -> std::io::Result<()> {
+        let dir = self.path.parent().unwrap_or(Path::new("."));
+        fs::create_dir_all(dir)?;
+
+        // `flock` serialises writers. Held on the lock file rather than the config itself, so
+        // the lock outlives the rename that replaces the config.
+        let lock_path = self.path.with_extension("lock");
+        let lock = fs::OpenOptions::new().create(true).write(true).truncate(false).open(&lock_path)?;
+        lock.lock()?;
+
+        let text = serde_json::to_string_pretty(config)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let temp_path = self.path.with_extension("tmp");
+        {
+            let mut temp = fs::File::create(&temp_path)?;
+            temp.write_all(text.as_bytes())?;
+            temp.write_all(b"\n")?;
+            temp.sync_all()?;
+        }
+        fs::rename(&temp_path, &self.path)?;
+        fs::File::open(dir)?.sync_all()?;
+        Ok(())
+    }
+}
+
+/// Trim, drop anything unprintable, and truncate to [`MAX_NAME`] on a character boundary.
+///
+/// Control characters are the ones that matter: this string reaches a BLE advertisement, a log
+/// line and eventually an app's UI, and a newline in it would let a name split a journal record
+/// in two.
+fn sanitise(requested: &str) -> String {
+    let cleaned: String = requested
+        .trim()
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect();
+
+    // `chars().take()` rather than slicing by byte: a name is UTF-8 and truncating mid-codepoint
+    // would panic.
+    cleaned.chars().take(MAX_NAME).collect::<String>().trim_end().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(dir: &Path) -> Store {
+        Store::new(dir.join("config.json"), "radxa-zero3")
+    }
+
+    /// An unprovisioned robot still has a name.
+    #[test]
+    fn a_missing_file_yields_the_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(store(dir.path()).name(), "radxa-zero3");
+    }
+
+    #[test]
+    fn a_name_survives_a_write_and_a_reread() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+
+        assert_eq!(store.set_name("Ducky").unwrap(), "Ducky");
+        assert_eq!(store.name(), "Ducky");
+        // A second store over the same file reads it too — this is a file, not process state.
+        assert_eq!(super::Store::new(dir.path().join("config.json"), "other").name(), "Ducky");
+    }
+
+    /// A malformed file must not stop the daemon starting: it logs and falls back.
+    #[test]
+    fn a_corrupt_file_yields_the_fallback_rather_than_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("config.json"), "{not json").unwrap();
+        assert_eq!(store(dir.path()).name(), "radxa-zero3");
+    }
+
+    /// Control characters would split a log line or corrupt an advertisement.
+    #[test]
+    fn control_characters_are_stripped() {
+        let dir = tempfile::tempdir().unwrap();
+        let stored = store(dir.path()).set_name("Duck\ny\u{0}").unwrap();
+        assert_eq!(stored, "Ducky");
+    }
+
+    /// Truncation must happen on a character boundary, or a multi-byte name panics.
+    #[test]
+    fn a_long_multibyte_name_is_truncated_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let stored = store(dir.path()).set_name(&"é".repeat(80)).unwrap();
+        assert_eq!(stored.chars().count(), MAX_NAME);
+    }
+
+    /// The stored name is what the caller must display, so the difference is returned rather
+    /// than hidden.
+    #[test]
+    fn whitespace_is_trimmed_and_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(store(dir.path()).set_name("  Ducky  ").unwrap(), "Ducky");
+    }
+
+    /// A name of only whitespace is refused rather than stored as empty — an empty name in a
+    /// phone's Bluetooth list is indistinguishable from a broken robot.
+    #[test]
+    fn an_empty_name_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = store(dir.path()).set_name("   \n ").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        // And nothing was written, so the previous name stands.
+        assert_eq!(store(dir.path()).name(), "radxa-zero3");
+    }
+
+    /// No temp or lock file left behind that a later read could mistake for the config.
+    #[test]
+    fn writing_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        store(dir.path()).set_name("Ducky").unwrap();
+        assert!(!dir.path().join("config.tmp").exists());
+    }
+}

--- a/configd/systemd/configd.service
+++ b/configd/systemd/configd.service
@@ -1,0 +1,90 @@
+# configd — wifi and the robot's identity.
+#
+# Install to /etc/systemd/system/configd.service.
+#
+# Three properties follow from why this service exists (docs/architecture.md §3.1) and must be
+# preserved:
+#
+#   1. NO dependency on robotd, in either direction. Config must be reachable when the robot is
+#      dead — provisioning wifi is exactly what a client needs when things are broken. That is
+#      the whole reason this is not part of robotd.
+#   2. NO dependency on btd either. BLE is one front door among several; btd is a client of
+#      this socket, and an SDK or robotctl must not have to go through Bluetooth.
+#   3. The socket must be group-readable by `robot`, because that is how btd, robotctl and
+#      later mediad reach it.
+
+[Unit]
+Description=Robot config service (wifi, identity)
+Documentation=file:///opt/robot/daemon/current/docs/architecture.md
+
+# NetworkManager is what actually owns wifi, so there is nothing to serve without it. `Wants`
+# rather than `Requires`: if NM is missing, configd starts and reports net.state=unavailable,
+# which is a diagnosable answer and tells you the board is still on netplan.
+After=dbus.service NetworkManager.service
+Wants=NetworkManager.service
+
+# No network-online dependency on purpose. This service is how you *get* a network.
+After=local-fs.target
+
+[Service]
+Type=exec
+ExecStart=/opt/robot/daemon/current/bin/configd
+
+# Root, and this is the one thing here that deserves justification rather than assumption.
+#
+# configd needs exactly two privileges: NetworkManager's D-Bus API (which needs polkit or root
+# to modify connections) and logind's Reboot (likewise). There is NO polkit on this image, and
+# without it systemd denies both to any session-less non-root caller. So the choice was root, or
+# installing a JS policy engine to authorise two calls.
+#
+# The trust boundary is still in the right place: btd — the process parsing bytes from anyone in
+# radio range — is unprivileged, and configd only ever sees typed JSON arriving over a
+# peer-credentialled local socket. Making the parser unprivileged matters more than making the
+# dispatcher unprivileged.
+#
+# If polkit ever arrives for another reason, this should drop to a dedicated user plus two
+# polkit rules. Until then the sandbox below is what limits it, and unlike robotd — which needs
+# raw device access — configd can be locked down properly because it touches no hardware.
+User=root
+Group=robot
+
+Restart=always
+RestartSec=2s
+
+# A narrow root. Everything here is deliberate:
+#   - ProtectSystem=strict makes the whole filesystem read-only except ReadWritePaths.
+#   - The state dir is the ONLY writable path: it holds the robot's name and must survive an
+#     update and a rollback, which is why it is under /var/lib and not in a release directory.
+#   - AF_NETLINK is absent: configd asks NetworkManager over D-Bus (a unix socket) and never
+#     touches an interface itself.
+#   - CAP_SYS_BOOT is NOT granted, because logind performs the reboot; configd only asks. A
+#     capability here would let it call reboot(2) directly, which is precisely the unclean
+#     shutdown this service exists to avoid.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/robot/config /run
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+StateDirectory=robot/config
+
+# stderr → journal; level via RUST_LOG. The startup identity line is at `warn` so it survives
+# RUST_LOG=warn on a long-running board.
+#
+# net.connect is logged, and its passphrase is NOT: NetConnectParams has a hand-written Debug
+# that redacts the key (duck-ipc-proto), with a test to keep it that way.
+Environment=RUST_LOG=info
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/configd/systemd/sysusers.d/README
+++ b/configd/systemd/sysusers.d/README
@@ -1,0 +1,6 @@
+configd runs as root, so it needs no user of its own — see the justification in
+configd.service. It does need the `robot` group to exist, which
+updater/systemd/sysusers.d/robot.conf already creates.
+
+This file is a placeholder marking that absence deliberately: if configd ever drops to an
+unprivileged user (which needs polkit on the image), its sysusers entry belongs here.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -39,12 +39,25 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// Bumped on any incompatible change. A peer speaking a different version is refused
 /// rather than misparsed — a stale `robotctl` in someone's shell is normal.
 ///
-/// v2 added `HelloResult::revision`. During prototyping the wire shape simply changes and
-/// this bumps; no accommodation is made for peers that predate a field, because there are
-/// none in the field yet.
-pub const API_VERSION: u32 = 2;
+/// v2 added `HelloResult::revision`. v3 added the `net.*` and `system.*` namespaces. During
+/// prototyping the wire shape simply changes and this bumps; no accommodation is made for
+/// peers that predate a field, because there are none in the field yet.
+pub const API_VERSION: u32 = 3;
 
 pub const DEFAULT_SOCKET: &str = "/run/updaterd.sock";
+
+/// Where each service listens by default.
+///
+/// These are defaults matching the shipped units, not a contract the daemons are bound by —
+/// every one takes a `--socket` override, and `updaterd` reads `robot_socket` from its config.
+/// They live here because more than one client needs them: `robotctl` and `btd` both connect
+/// to all three, and a path duplicated per client is a path that drifts per client.
+pub mod socket {
+    /// `updaterd`. Same value as [`super::DEFAULT_SOCKET`], which predates this module.
+    pub const UPDATER: &str = super::DEFAULT_SOCKET;
+    pub const ROBOT: &str = "/run/robotd.sock";
+    pub const CONFIG: &str = "/run/configd.sock";
+}
 
 /// Method names, as they go on the wire. Namespaced so a new namespace cannot collide
 /// with `update.*`. [`Call`] is the typed form.
@@ -78,6 +91,30 @@ pub mod method {
     pub const ROBOT_MODEL_API: &str = "robot.modelApi";
     /// Is a telepresence session live?
     pub const ROBOT_SESSION_ACTIVE: &str = "robot.remoteSessionActive";
+
+    // ── configd's side ───────────────────────────────────────────────────────
+    //
+    // Wifi and the robot's identity. Served by `configd` rather than `robotd` because config
+    // must be reachable when the robot is dead — provisioning wifi is exactly what a client
+    // needs when things are broken (`architecture.md` §3.1).
+    //
+    // NetworkManager owns the credentials; these methods drive it. We never store a PSK.
+
+    /// What is the wifi doing — SSID, signal, addresses.
+    pub const NET_STATUS: &str = "net.status";
+    /// Which networks can this robot see?
+    pub const NET_SCAN: &str = "net.scan";
+    /// Join a network, storing it for next time.
+    pub const NET_CONNECT: &str = "net.connect";
+    /// Forget a stored network.
+    pub const NET_FORGET: &str = "net.forget";
+
+    /// Name, serial, uptime.
+    pub const SYSTEM_INFO: &str = "system.info";
+    /// Rename the robot. This is the name a phone sees.
+    pub const SYSTEM_SET_NAME: &str = "system.setName";
+    /// Reboot, cleanly, through systemd.
+    pub const SYSTEM_REBOOT: &str = "system.reboot";
 }
 
 /// JSON-RPC error codes.
@@ -155,6 +192,17 @@ pub enum Call {
     RobotHealth,
     RobotModelApi,
     RobotRemoteSessionActive,
+
+    // ── net.* ────────────────────────────────────────────────────────────────
+    NetStatus,
+    NetScan,
+    NetConnect(NetConnectParams),
+    NetForget(NetForgetParams),
+
+    // ── system.* ─────────────────────────────────────────────────────────────
+    SystemInfo,
+    SystemSetName(SetNameParams),
+    SystemReboot,
 }
 
 impl Call {
@@ -176,6 +224,13 @@ impl Call {
             Call::RobotHealth => method::ROBOT_HEALTH,
             Call::RobotModelApi => method::ROBOT_MODEL_API,
             Call::RobotRemoteSessionActive => method::ROBOT_SESSION_ACTIVE,
+            Call::NetStatus => method::NET_STATUS,
+            Call::NetScan => method::NET_SCAN,
+            Call::NetConnect(_) => method::NET_CONNECT,
+            Call::NetForget(_) => method::NET_FORGET,
+            Call::SystemInfo => method::SYSTEM_INFO,
+            Call::SystemSetName(_) => method::SYSTEM_SET_NAME,
+            Call::SystemReboot => method::SYSTEM_REBOOT,
         }
     }
 
@@ -191,6 +246,12 @@ impl Call {
                 | Call::ResetToGolden(_)
                 | Call::Select(_)
                 | Call::Pin(_)
+                // Changing the robot's *configuration* is mutating too. Joining a network is
+                // not a read, and a reboot is the most disruptive thing a client can ask for.
+                | Call::NetConnect(_)
+                | Call::NetForget(_)
+                | Call::SystemSetName(_)
+                | Call::SystemReboot
         )
     }
 
@@ -225,12 +286,19 @@ impl Call {
             Call::Select(p) => encode(p),
             Call::Pin(p) => encode(p),
             Call::Log(p) => encode(p),
+            Call::NetConnect(p) => encode(p),
+            Call::NetForget(p) => encode(p),
+            Call::SystemSetName(p) => encode(p),
             Call::Status
             | Call::Subscribe
             | Call::RobotSafeToRestart
             | Call::RobotHealth
             | Call::RobotModelApi
-            | Call::RobotRemoteSessionActive => Value::Object(serde_json::Map::new()),
+            | Call::RobotRemoteSessionActive
+            | Call::NetStatus
+            | Call::NetScan
+            | Call::SystemInfo
+            | Call::SystemReboot => Value::Object(serde_json::Map::new()),
         }
     }
 
@@ -261,6 +329,13 @@ impl Call {
             method::ROBOT_HEALTH => Call::RobotHealth,
             method::ROBOT_MODEL_API => Call::RobotModelApi,
             method::ROBOT_SESSION_ACTIVE => Call::RobotRemoteSessionActive,
+            method::NET_STATUS => Call::NetStatus,
+            method::NET_SCAN => Call::NetScan,
+            method::NET_CONNECT => Call::NetConnect(decode(params)?),
+            method::NET_FORGET => Call::NetForget(decode(params)?),
+            method::SYSTEM_INFO => Call::SystemInfo,
+            method::SYSTEM_SET_NAME => Call::SystemSetName(decode(params)?),
+            method::SYSTEM_REBOOT => Call::SystemReboot,
             other => {
                 return Err(Error::new(
                     code::METHOD_NOT_FOUND,
@@ -502,6 +577,44 @@ pub struct LogParams {
     pub limit: usize,
 }
 
+/// Join a wifi network.
+///
+/// [`Debug`] is hand-written to redact `psk`, and that is the point of the type. Every other
+/// params struct derives it, and a derived one here would put a customer's wifi password into
+/// the journal the first time any service logged a request it could not handle — `configd`,
+/// `btd` and `robotctl` all log calls, and the credential-carrying one must not be readable
+/// afterwards by anyone who can run `journalctl`.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetConnectParams {
+    pub ssid: String,
+    /// `None` for an open network. Either a passphrase or a 64-hex pre-shared key;
+    /// NetworkManager accepts both and we pass it through unexamined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub psk: Option<String>,
+}
+
+impl std::fmt::Debug for NetConnectParams {
+    /// Whether a key was supplied is diagnostically useful — "wrong password" and "no password
+    /// sent for a secured network" are different bugs — so the *presence* is shown and the
+    /// value never is.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetConnectParams")
+            .field("ssid", &self.ssid)
+            .field("psk", if self.psk.is_some() { &"<redacted>" } else { &"<none>" })
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetForgetParams {
+    pub ssid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetNameParams {
+    pub name: String,
+}
+
 // ── results ──────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -684,6 +797,150 @@ pub struct SessionActiveResult {
     pub active: bool,
 }
 
+// ── net.* results ────────────────────────────────────────────────────────────
+
+/// What the wifi link is doing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetState {
+    /// Associated and addressed.
+    Connected,
+    /// Trying. A client should poll rather than conclude anything.
+    Connecting,
+    /// A wifi device exists and is idle.
+    Disconnected,
+    /// No wifi device, or nothing managing it. Distinct from `Disconnected` because it is a
+    /// provisioning problem rather than a network one — on this robot it means the board is
+    /// still on netplan (`scripts/migrate-network.sh`).
+    Unavailable,
+}
+
+/// Answer to [`Call::NetStatus`]. Every field beyond `state` is absent when not connected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetStatusResult {
+    pub state: NetState,
+    pub ssid: Option<String>,
+    /// 0-100. NetworkManager's own scale, not dBm — a percentage is what a phone shows.
+    pub signal: Option<u8>,
+    pub ip4: Option<String>,
+    pub ip6: Option<String>,
+    /// The wifi interface's hardware address. Useful as a stable robot identifier until
+    /// provisioning gives us a real serial (`updater-design.md` §5.7).
+    pub mac: Option<String>,
+    pub iface: Option<String>,
+}
+
+/// How a network is secured. What a client needs in order to know whether to ask for a
+/// password, and which kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Security {
+    Open,
+    /// WEP. Reported so a client can say "too old to join" rather than failing obscurely.
+    Wep,
+    WpaPsk,
+    Wpa3Sae,
+    /// 802.1X. Needs a username and certificate flow this API does not have, so it is
+    /// reported and refused rather than half-attempted.
+    Enterprise,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Network {
+    pub ssid: String,
+    /// 0-100.
+    pub signal: u8,
+    pub security: Security,
+    /// True when a stored profile already exists, so a client can offer "connect" rather than
+    /// asking for a password it does not need.
+    pub saved: bool,
+}
+
+/// Answer to [`Call::NetScan`], strongest first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetScanResult {
+    pub networks: Vec<Network>,
+}
+
+/// Why a join failed.
+///
+/// The distinction exists because it is the whole reason NetworkManager was chosen over
+/// netplan: "you typed the password wrong" is the single most common provisioning failure, and
+/// a client that cannot say so leaves the user with nothing to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectFailure {
+    /// Authentication rejected. Ask for the password again.
+    BadKey,
+    /// The SSID was not there. Ask them to move closer or check the name.
+    NotFound,
+    /// Associated but never finished — usually DHCP. Retrying may work.
+    Timeout,
+    /// Refused before trying: enterprise security, or a PSK missing for a secured network.
+    Unsupported,
+    Other,
+}
+
+/// Answer to [`Call::NetConnect`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ConnectResult {
+    Connected {
+        ssid: String,
+        /// Present once DHCP has finished, which is what makes the robot actually reachable.
+        ip4: Option<String>,
+    },
+    Failed {
+        reason: ConnectFailure,
+        /// NetworkManager's own words, for a support ticket. Never shown as the primary
+        /// message: `reason` is what a client should act on.
+        detail: Option<String>,
+    },
+}
+
+/// Answer to [`Call::NetForget`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgetResult {
+    /// False when there was no such stored network — not an error, and a client should not
+    /// present it as one.
+    pub removed: bool,
+}
+
+// ── system.* results ─────────────────────────────────────────────────────────
+
+/// Answer to [`Call::SystemInfo`].
+///
+/// Version deliberately absent: `hello` carries the running build and `update.status` the
+/// installed release, and those are different questions (`architecture.md` §8.3). Repeating
+/// one of them here would be the third place to get it wrong.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemInfoResult {
+    /// The robot's name, as advertised over BLE and shown in an app.
+    pub name: String,
+    /// Per-device identity, once provisioning defines one. `None` until then rather than a
+    /// fabricated value.
+    pub serial: Option<String>,
+    pub uptime_seconds: u64,
+}
+
+/// Answer to [`Call::SystemSetName`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetNameResult {
+    /// The name as stored, which may be a trimmed version of what was asked for. A client
+    /// should display this rather than what it sent.
+    pub name: String,
+}
+
+/// Answer to [`Call::SystemReboot`].
+///
+/// The reboot is *scheduled*, not immediate, and the delay is what makes this answerable at
+/// all: a daemon that rebooted inside the call would drop the connection before responding,
+/// and every client would have to treat a broken pipe as success.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RebootResult {
+    pub in_seconds: u64,
+}
+
 /// Re-exported so consumers spell version types with the *same* `semver` this crate
 /// compiled against. Without it, a crate depending on `semver` separately can end up with
 /// two incompatible copies of `Version` and a type error that reads as nonsense.
@@ -786,6 +1043,16 @@ mod tests {
             Call::RobotHealth,
             Call::RobotModelApi,
             Call::RobotRemoteSessionActive,
+            Call::NetStatus,
+            Call::NetScan,
+            Call::NetConnect(NetConnectParams {
+                ssid: "Pollen Guest".into(),
+                psk: Some("hunter2 with spaces".into()),
+            }),
+            Call::NetForget(NetForgetParams { ssid: "Old Network".into() }),
+            Call::SystemInfo,
+            Call::SystemSetName(SetNameParams { name: "duck-01".into() }),
+            Call::SystemReboot,
         ]
     }
 
@@ -884,6 +1151,10 @@ mod tests {
                 method::RESET_TO_GOLDEN,
                 method::SELECT,
                 method::PIN,
+                method::NET_CONNECT,
+                method::NET_FORGET,
+                method::SYSTEM_SET_NAME,
+                method::SYSTEM_REBOOT,
             ]
         );
     }
@@ -1037,6 +1308,44 @@ mod tests {
     #[test]
     fn build_info_macro_reports_the_calling_crate() {
         assert_eq!(build_info!().version, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// A wifi passphrase must never reach a log, and this is the only params struct where that
+    /// is true — so the redaction is hand-written and therefore able to rot. `{:?}` is what
+    /// every `tracing` call site uses, so that is what is checked.
+    #[test]
+    fn a_wifi_key_is_redacted_from_debug_output() {
+        let secret = "correct horse battery staple";
+        let params = NetConnectParams {
+            ssid: "Home".into(),
+            psk: Some(secret.into()),
+        };
+
+        let debug = format!("{params:?}");
+        assert!(!debug.contains(secret), "the key reached Debug output: {debug}");
+        assert!(debug.contains("Home"), "{debug}");
+        // Presence still visible: "wrong password" and "no password sent" are different bugs.
+        assert!(debug.contains("redacted"), "{debug}");
+
+        let open = NetConnectParams { ssid: "Cafe".into(), psk: None };
+        assert!(format!("{open:?}").contains("none"), "{open:?}");
+    }
+
+    /// Redaction must not extend to the wire, or `configd` would receive no key at all.
+    #[test]
+    fn a_wifi_key_still_serialises() {
+        let params = NetConnectParams {
+            ssid: "Home".into(),
+            psk: Some("s3cret".into()),
+        };
+        let line = serde_json::to_string(&params).unwrap();
+        assert!(line.contains("s3cret"), "{line}");
+        assert_eq!(serde_json::from_str::<NetConnectParams>(&line).unwrap(), params);
+
+        // An open network omits the field rather than sending null, so a backend can tell
+        // "no key" from "empty key".
+        let open = NetConnectParams { ssid: "Cafe".into(), psk: None };
+        assert!(!serde_json::to_string(&open).unwrap().contains("psk"));
     }
 
     /// `Target` must survive the wire in all three forms, and the two that carry data must

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -608,6 +608,23 @@ impl Server {
                     "robot.* is served by robotd, not updaterd",
                 ),
             ),
+
+            // `net.*` and `system.*` belong to `configd`, for the reason that service exists:
+            // config must be reachable when the robot is dead, and wiring it into the update
+            // engine would put provisioning behind the engine's lock.
+            Call::NetStatus
+            | Call::NetScan
+            | Call::NetConnect(_)
+            | Call::NetForget(_)
+            | Call::SystemInfo
+            | Call::SystemSetName(_)
+            | Call::SystemReboot => Response::err(
+                Some(id),
+                proto::Error::new(
+                    proto::code::METHOD_NOT_FOUND,
+                    "net.* and system.* are served by configd, not updaterd",
+                ),
+            ),
         }
     }
 


### PR DESCRIPTION
Stacks on #21 (`btd`). Adds the service `btd` was missing, and the laptop-side client that makes the whole path testable.

## `configd` — wifi and the robot's identity

`net.status`, `net.scan`, `net.connect`, `net.forget`, `system.info`, `system.setName`, `system.reboot`, over a fifth unix socket.

A separate service rather than part of `robotd`, because **config must be reachable when the robot is dead** — provisioning wifi is exactly what a client needs when things are broken (§3.1). And not part of `btd`, because `btd` owns nothing (§4.1): an SDK should not have to go through Bluetooth to set a name.

**It stores no credentials.** NetworkManager owns those, persists them root-only and reconnects by itself. A passphrase passes through `configd` and is forgotten.

### The distinction that justified choosing NM

`ConnectFailure::BadKey`. "You typed the password wrong" is the most common provisioning failure there is, and netplan cannot report it — `netplan apply` says "config applied" whether or not association succeeded. NM reports it as device state reason 7, and the mapping is tested. That's the payoff from the earlier netplan-vs-NM comparison, now in the protocol.

### The passphrase never reaches a log

`NetConnectParams` has a hand-written `Debug` that redacts `psk`, with one test asserting the key never appears in `{:?}` and another asserting it still reaches the wire. Every other params struct derives `Debug`; a derived one here would put a customer's wifi password in the journal the first time any service logged a request it couldn't handle.

### Why it runs as root

Narrowly: NM's connection-modify and logind's `Reboot` are both polkit-gated, there is **no polkit on this image**, and systemd denies both to a session-less non-root caller. The alternative was installing a JS policy engine to authorise two calls.

The trust boundary stays right: `btd` — which parses bytes from anyone in radio range — is unprivileged, and `configd` only ever sees typed JSON over a peer-credentialled socket. Unlike `robotd` it touches no hardware, so the unit sandboxes it properly: `ProtectSystem=strict`, one writable path, `AF_UNIX` only, empty `CapabilityBoundingSet`. `CAP_SYS_BOOT` is deliberately absent — logind performs the reboot, `configd` only asks, and a capability there would permit the unclean `reboot(2)` this exists to avoid.

`system.reboot` answers **before** rebooting, after 3s. A daemon that rebooted inside the call would drop the connection before responding, and every client would have to treat a broken pipe as success.

### The store

A file plus `flock` and `rename(2)`, not a service (§3.1) — readable when anything is down, and the updater never touches it so it survives an update *and* a rollback. Names are trimmed, stripped of control characters, truncated to 24 chars on a character boundary; the stored name is returned so a client displays what the robot has rather than what it sent. A missing or corrupt file yields the hostname rather than refusing to start.

## `btd` routed all seven, and the exhaustive match earned itself

Adding the methods to the protocol **broke `btd`'s build** until someone decided about each one — which is exactly what that match is for. Provisioning is the case BLE exists for (a robot that has never seen a network cannot be configured over that network), so all seven are permitted, and the test naming which mutating calls BLE may make grew from one entry to five.

`updaterd` had the same protection and the same break; it now names `configd` for `net.*`/`system.*` as it already named `robotd` for `robot.*`.

## `btctl` — the client

```
cargo run -p btd --example btctl -- scan
cargo run -p btd --example btctl -- wifi scan
cargo run -p btd --example btctl -- wifi connect "Pollen" --psk secret
cargo run -p btd --example btctl -- name "Ducky"
cargo run -p btd --example btctl -- call robot.health
```

An **example, not a binary**, so `btleplug` never reaches the robot. `btleplug` rather than `bluer` because this half runs on a laptop — CoreBluetooth on macOS — and `bluer` would make the client Linux-only.

It reuses `btd::framing`, which is the point: the chunking here is the *client* half of the same module the robot uses, so asymmetric framing simply wouldn't work. That makes it a test of the protocol rather than a reimplementation free to agree with itself.

Writing it surfaced two real flaws:

- **The GATT UUIDs were in `bluez.rs`**, which is `cfg(target_os = "linux")` — so a client couldn't reach them off-Linux. They're a wire contract like the method names, so they move to `gatt.rs` ungated.
- **`FramingError` implemented neither `Display` nor `Error`**, so `?` didn't work on it. Fine in a binary, wrong for a library.

## Testing

Whole workspace passes, and **every binary cross-compiles for aarch64** (`cargo board --bins`), so the zbus proxies and the bluer backend both type-check for the target.

- proto: 19, including the two redaction tests
- `configd`: 14 against an in-memory wifi stack that produces a wrong-key failure on demand
- `btd`: 23
- `updater`/`robotctl`/`robotd`: unchanged and passing

**Never run against a real NetworkManager or a real radio.** `configd --fake-net` serves the whole `net.*` surface from memory, which is how to exercise it without a board.

## Not in here, and worth deciding

- **`robotctl net` / `robotctl system`.** The on-robot client for these methods. `btctl` covers the BLE path, but someone on the board still has no CLI for wifi.
- **BLE encryption and pairing.** Still the gap from #21, and now it matters more: `net.connect` carries a passphrase over an unencrypted characteristic. §7 requires pairing plus encryption, and the flag is one line — but it needs a decision about how a phone may bond (a button-held window, or a secret under the robot). **I would not put this on a customer robot until that lands.**
- **Docs.** `architecture.md` §1 should list `configd`, and `roadmap.md` should say M6's BLE work started early.
- **`on_apply`'s restart set** in `updater.toml` is still `["robotd"]`. Two new daemons need to join it or an update leaves the old ones running.