### PR TITLE
robotctl health reports the whole robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the robot is aarch64 Linux.
 cargo test --workspace
 ```
 
-272 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+310 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
 
 The fastest way to actually *see* the update engine work is the playground, which drives
 the real engine — real signatures, real atomic swaps, real rollback — against a fake remote
@@ -82,9 +82,37 @@ docs/           architecture · update design · robotd design · roadmap · CI 
 
 Everything below assumes a **dev board**, never a customer robot.
 
-What is running, and what is installed — these are different questions, because `updaterd`
-never restarts itself during an update and so legitimately lags the installed release until
-the next reboot:
+The state of the robot, hardware and software, in one answer — control loop, motor bus, IMU,
+battery, motor temperature, then what is running, what is installed, what is pinned and how
+the last update went:
+
+```bash
+robotctl health
+```
+
+```
+robot     healthy
+  loop      50.1 of 50.0 Hz · 2834 ticks · 0 missed · last 13 ms ago
+  bus       ok
+  imu       ready
+  battery   7.62 V (64%)
+  motors    41 °C max (left_knee) · 36 °C mean
+
+software
+  updaterd  0.1.4 (rev abc1234)
+  robotd    0.1.5 (rev def5678)
+  daemon    0.1.5 installed
+            last update 0.1.4 → 0.1.5: applied
+```
+
+It exits non-zero when the robot is unhealthy or unreachable, so it can gate a script.
+Nothing else there affects the exit code: a flat pack, a hot motor and a pinned component are
+reported, not judged — a release must never be rolled back for the state of the board it
+landed on.
+
+`version` is the software half on its own, for when that is all you want. What is running and
+what is installed are different questions, because `updaterd` never restarts itself during an
+update and so legitimately lags the installed release until the next reboot:
 
 ```bash
 robotctl version

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ Companion to [`architecture.md`](architecture.md) (what we're building) and
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| tests | **272 passing**, including the health gate against a real `robotd` process |
+| tests | **310 passing**, including the health gate and the battery+thermal readout against a real `robotd` process |
 | missing | `mediad`, `btd`, `robot-config`, app, SDK |
 | never run on hardware | every claim above is from CI and a laptop. Slice 1's whole purpose is to change that |
 

--- a/docs/robotd-design.md
+++ b/docs/robotd-design.md
@@ -157,7 +157,7 @@ namespace (§7.4).
 
 | method | slice 1 |
 |---|---|
-| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count, plus the battery as a *reported* field the verdict never consults |
+| `robot.health` | **the loop is meeting its deadline** — from achieved rate and missed-deadline count — plus a description of the robot the verdict never consults: loop, bus, IMU, battery, motor temperature |
 | `robot.safeToRestart` | `true` (a constant pose is always safe to interrupt) |
 | `robot.modelApi` | unchanged constant |
 | `robot.remoteSessionActive` | `false` — `mediad` owns the real answer |
@@ -172,12 +172,27 @@ distinction is the whole reason slice 1 exists.
 
 **What may and may not reach the verdict.** `healthy` and `degraded` are the update system's
 inputs, so only conditions a *release* can be blamed for may set them — that is what
-`degraded` already exists to enforce for an unpowered bench board. The battery rides on the
-same answer without touching either, because it is the number a human wants when a robot is
-behaving oddly and this is the command they run. Gating on it would mean a robot updated on a
-low pack rolls the release back, then judges its replacement on the same low pack, and cannot
-be updated at all until someone works out why. The same rule will apply to motor temperature
-when it lands (address 146, one register past the voltage this reads).
+`degraded` already exists to enforce for an unpowered bench board. Everything else on the
+answer is a **description**, and no automatic decision may read it: battery, motor
+temperature, and the loop/bus/IMU counters. Gating on the battery would mean a robot updated
+on a low pack rolls the release back, then judges its replacement on the same low pack, and
+cannot be updated at all until someone works out why. Motor temperature would do the same on
+a hot afternoon.
+
+**Why they travel together anyway.** One method, because the question arrives once: a robot
+behaving oddly gets asked "what is going on", and a verdict without the numbers behind it just
+starts a second round of questions. The loop section carries the very figures the verdict was
+computed from, so `unhealthy: control loop at 43.9 Hz` can be read next to `missed = 0` —
+which distinguishes a loop being woken late from a loop doing too much, and those have
+different fixes. `robotctl health` adds the software half from `updaterd` and prints both.
+
+**Two bus transactions, not one.** The tick reads a contiguous block at 124–136 (pwm, current,
+velocity, position). Voltage and temperature sit at 144–146, eight bytes past its end, with
+twelve bytes of trajectory registers nothing wants in between — so they are sampled together
+once a second in a second transaction (~1 ms) rather than widening the tick's read to 22 bytes
+per servo at 50 Hz. Temperature is reported per joint reduced to *the hottest* one and named:
+a knee holding a squat runs far above the mouth, and a mean over fifteen servos hides the one
+approaching the overheat shutdown its error mask latches on.
 
 ### 4.6 Done when
 

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -4,9 +4,9 @@
 //! `sync_write` of goal positions. The IMU is listed first so it answers before the servo
 //! burst.
 //!
-//! Battery is the one thing that does not fit that shape: it lives at a register outside the
-//! block the tick fetches, so [`RobotIo::bus_voltage`] is a transaction of its own, meant to
-//! be called about once a second rather than every tick.
+//! Battery and thermals are the one thing that does not fit that shape: they live at registers
+//! outside the block the tick fetches, so [`RobotIo::slow_sensors`] is a transaction of its
+//! own, meant to be called about once a second rather than every tick.
 //!
 //! Written against `rustypot`, but the *numbers* — conversion factors and the EEPROM
 //! registers asserted at startup — come from `microduck_runtime`, where they were arrived
@@ -18,7 +18,7 @@ use std::time::Duration;
 use rustypot::servo::dynamixel::xl330::Xl330Controller;
 
 use crate::imu::{IMU_BLOCK_LEN, SflpDecoder};
-use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors};
+use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors, SlowSensors};
 use crate::model::{BAUD_RATE, EXPECTED_REGISTERS, IMU_DXL_ID, JOINT_IDS, NUM_JOINTS};
 
 /// Start of the contiguous block read every tick: `present_pwm`, `present_current`,
@@ -30,10 +30,18 @@ const READ_LEN: u8 = 12;
 /// 0.229 rev/min per count, in rad/s.
 const RAD_PER_SEC_PER_COUNT: f64 = 0.229 * (2.0 * PI / 60.0);
 
-/// `present_input_voltage` (address 144) counts 0.1 V each. Not in the block above: it sits
-/// eight bytes past its end, so battery costs a second transaction — see
-/// [`RobotIo::bus_voltage`]. Address 146 is `present_temperature`, one byte further, if
-/// motor temperature ever wants surfacing too.
+/// The second, slower block: `present_input_voltage` (144, `u16`) then `present_temperature`
+/// (146, `u8`). Three bytes covers both, so voltage and thermals cost *one* extra transaction
+/// between them rather than two — see [`RobotIo::slow_sensors`].
+///
+/// It starts eight bytes past the end of the tick's block, which is why it cannot simply be
+/// folded into [`READ_LEN`]: the gap is `velocity_trajectory`/`position_trajectory`, twelve
+/// bytes nothing here wants, and a servo answering a 22-byte read every tick would cost more
+/// bus time than the two transactions do.
+const SLOW_READ_ADDR: u8 = 144;
+const SLOW_READ_LEN: u8 = 3;
+
+/// `present_input_voltage` counts 0.1 V each.
 const VOLTS_PER_COUNT: f64 = 0.1;
 
 /// A healthy 16-device read completes well inside this. Capping it means a missing device
@@ -180,16 +188,6 @@ impl DynamixelIo {
         }
         Ok(())
     }
-
-    /// Blocks identical to their predecessor since startup. Non-zero means the IMU board
-    /// is answering without refreshing.
-    pub fn stale_imu_blocks(&self) -> u64 {
-        self.stale_imu_blocks
-    }
-
-    pub fn imu_ready(&self) -> bool {
-        self.imu.ready()
-    }
 }
 
 impl RobotIo for DynamixelIo {
@@ -261,34 +259,70 @@ impl RobotIo for DynamixelIo {
             .map_err(|e| IoError::Bus(format!("sync_write goal positions: {e}")))
     }
 
-    /// Mean supply voltage across the servos.
+    /// Supply voltage and case temperatures, in one `sync_read` over registers 144–146.
     ///
-    /// Averaged because all 15 sit on one pack: a single servo's reading is the same
-    /// measurement with more noise. Note that a silent servo does not produce a short
-    /// answer here — `rustypot`'s `sync_read` waits for every id and fails the whole
-    /// transaction if one does not reply — so this is all-or-nothing, and the caller is
-    /// expected to keep its previous reading rather than treat one miss as news. The zero
-    /// filter is for a device that answers with a nonsense value, which must not be
-    /// averaged in as if the pack were half flat.
-    fn bus_voltage(&mut self) -> Result<f64> {
-        let raw = self
+    /// Voltage is averaged because all 15 servos sit on one pack: a single reading is the
+    /// same measurement with more noise. Temperature is *not* averaged here — the caller gets
+    /// every joint, because one loaded joint running hot is the case worth seeing and a mean
+    /// over fifteen hides it.
+    ///
+    /// Note that a silent servo does not produce a short answer: `rustypot`'s `sync_read`
+    /// waits for every id and fails the whole transaction if one does not reply. So this is
+    /// all-or-nothing, and the caller is expected to keep its previous sample rather than
+    /// treat one miss as news. The zero filter on voltage guards a device that answers with a
+    /// nonsense value, which must not be averaged in as if the pack were half flat.
+    fn slow_sensors(&mut self) -> Result<SlowSensors> {
+        let blocks = self
             .controller
-            .sync_read_present_input_voltage(&JOINT_IDS)
-            .map_err(|e| IoError::Bus(format!("read present input voltage: {e}")))?;
+            .sync_read_raw_data(&JOINT_IDS, SLOW_READ_ADDR, SLOW_READ_LEN)
+            .map_err(|e| IoError::Bus(format!("voltage+temperature sync_read: {e}")))?;
 
-        let answered: Vec<f64> = raw
-            .iter()
-            .map(|&counts| counts as f64 * VOLTS_PER_COUNT)
-            .filter(|&v| v > 0.0)
-            .collect();
-        if answered.is_empty() {
+        if blocks.len() != NUM_JOINTS {
+            return Err(IoError::ShortRead {
+                what: "voltage+temperature blocks",
+                expected: NUM_JOINTS,
+                got: blocks.len(),
+            });
+        }
+
+        let mut temps_c = [0.0; NUM_JOINTS];
+        let mut volts = Vec::with_capacity(NUM_JOINTS);
+        for (joint, block) in blocks.iter().enumerate() {
+            if block.len() != SLOW_READ_LEN as usize {
+                return Err(IoError::ShortRead {
+                    what: "voltage+temperature block",
+                    expected: SLOW_READ_LEN as usize,
+                    got: block.len(),
+                });
+            }
+            // [0..2] present_input_voltage · [2] present_temperature, already in whole °C.
+            let counts = u16::from_le_bytes([block[0], block[1]]);
+            let v = counts as f64 * VOLTS_PER_COUNT;
+            if v > 0.0 {
+                volts.push(v);
+            }
+            temps_c[joint] = block[2] as f64;
+        }
+
+        if volts.is_empty() {
             return Err(IoError::ShortRead {
                 what: "input voltage",
                 expected: NUM_JOINTS,
                 got: 0,
             });
         }
-        Ok(answered.iter().sum::<f64>() / answered.len() as f64)
+        Ok(SlowSensors {
+            volts: volts.iter().sum::<f64>() / volts.len() as f64,
+            temps_c,
+        })
+    }
+
+    fn imu_stale_blocks(&self) -> u64 {
+        self.stale_imu_blocks
+    }
+
+    fn imu_ready(&self) -> bool {
+        self.imu.ready()
     }
 }
 

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -72,18 +72,51 @@ pub enum IoError {
 
 pub type Result<T> = std::result::Result<T, IoError>;
 
+/// What the servos report about their own supply and case, rather than their motion.
+///
+/// Sampled about once a second rather than every tick — see [`RobotIo::slow_sensors`]. A pack
+/// does not drain and a motor does not heat up in 20 ms, so the tick would be paying for a
+/// second bus transaction to learn nothing new.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SlowSensors {
+    /// Mean supply voltage across the servos, in volts — the only battery measurement the
+    /// robot has, since there is no fuel gauge anywhere on the hat.
+    pub volts: f64,
+    /// Per-joint case temperature in °C, indexed as [`crate::model::JOINT_NAMES`].
+    ///
+    /// Per-joint rather than an average because the interesting case is one joint carrying
+    /// the load — a knee holding a squat runs far hotter than the mouth, and a mean over
+    /// fifteen servos hides exactly the servo about to latch its overheat shutdown.
+    pub temps_c: [f64; NUM_JOINTS],
+}
+
 pub trait RobotIo {
     /// One transaction: joints and IMU together.
     fn read(&mut self) -> Result<Sensors>;
     fn write(&mut self, targets: &JointTargets) -> Result<()>;
 
-    /// Mean motor-bus voltage, in volts — the only battery measurement the robot has.
+    /// Supply voltage and case temperatures, in one extra transaction.
     ///
-    /// Its own transaction, and therefore not part of [`Sensors`]: `present_input_voltage`
-    /// lives at address 144, outside the contiguous block the tick fetches, so it cannot
-    /// ride along however much we would like it to. Costs about a millisecond, which is why
-    /// the caller is expected to ask roughly once a second rather than every tick.
-    fn bus_voltage(&mut self) -> Result<f64>;
+    /// Not part of [`Sensors`], and not on the tick's critical path: these registers sit at
+    /// 144–146, past the end of the contiguous block [`Self::read`] fetches, so reaching them
+    /// costs a transaction of its own — about a millisecond. Negligible once a second, 5% of
+    /// the budget at 50 Hz.
+    fn slow_sensors(&mut self) -> Result<SlowSensors>;
+
+    /// Diagnostics the bus keeps about itself. Default to "nothing to report" so a fake or a
+    /// future backend is not obliged to invent them.
+    ///
+    /// `sync_read` blocks identical to their predecessor: the board answered but did not
+    /// refresh, which means the policy would be fed dead orientation. Invisible unless
+    /// someone counts it, which is why it is counted.
+    fn imu_stale_blocks(&self) -> u64 {
+        0
+    }
+
+    /// Has the orientation filter converged? False for the first moments after startup.
+    fn imu_ready(&self) -> bool {
+        true
+    }
 }
 
 /// A robot made of nothing, for tests.
@@ -102,10 +135,10 @@ pub struct FakeIo {
     pub last_written: Option<JointTargets>,
     pub reads: usize,
     pub writes: usize,
-    /// What [`RobotIo::bus_voltage`] reports. Mid-pack by default so `--fake` shows a
-    /// plausible battery; set it to exercise a flat one. `None` fails the read, which is
-    /// what a robot with no bus does.
-    pub battery_v: Option<f64>,
+    /// What [`RobotIo::slow_sensors`] reports. Mid-pack and hand-warm by default so `--fake`
+    /// shows a plausible robot; set it to exercise a flat pack or a cooking servo. `None`
+    /// fails the read, which is what a robot with no bus does.
+    pub slow: Option<SlowSensors>,
     /// When true, `read` reports the last written targets as the present positions.
     track_targets: bool,
 }
@@ -125,7 +158,10 @@ impl FakeIo {
             last_written: None,
             reads: 0,
             writes: 0,
-            battery_v: Some(7.4),
+            slow: Some(SlowSensors {
+                volts: 7.4,
+                temps_c: [32.0; NUM_JOINTS],
+            }),
             track_targets: true,
         }
     }
@@ -183,8 +219,8 @@ impl RobotIo for FakeIo {
         Ok(())
     }
 
-    fn bus_voltage(&mut self) -> Result<f64> {
-        self.battery_v.ok_or(IoError::Simulated)
+    fn slow_sensors(&mut self) -> Result<SlowSensors> {
+        self.slow.ok_or(IoError::Simulated)
     }
 }
 

--- a/duck-control/src/lib.rs
+++ b/duck-control/src/lib.rs
@@ -13,7 +13,7 @@ pub mod io;
 pub mod model;
 
 pub use imu::ImuData;
-pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors};
+pub use io::{FakeIo, IoError, JointTargets, RobotIo, Sensors, SlowSensors};
 pub use model::{
     BATTERY_EMPTY_V, BATTERY_FULL_V, DEFAULT_POSITION, JOINT_IDS, JOINT_NAMES, NUM_JOINTS,
     battery_percent,

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -652,7 +652,11 @@ pub struct SafeToRestartResult {
 /// difference decides whether an update rolls back for a known reason or for a timeout.
 // No `Eq`: the battery reading is a float. Nothing compares these for exact equality
 // outside tests, where `PartialEq` is what `assert_eq!` needs anyway.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+//
+// `Default` is "nothing known": not healthy, nothing measured. That is the honest starting
+// point — and it means the next reported field added here does not break every caller that
+// builds one.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct HealthResult {
     pub healthy: bool,
     /// Set when the reason is a property of the *board*, not of the running release.
@@ -683,6 +687,80 @@ pub struct HealthResult {
     /// it as an empty battery.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub battery: Option<Battery>,
+    /// Hottest servo, when temperatures have been read. Same rule as the battery: reported,
+    /// never judged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub motors: Option<MotorThermal>,
+    /// The control loop's own numbers — the ones `healthy` was decided from.
+    ///
+    /// Carried so a verdict can be *checked* rather than taken on faith. "unhealthy: control
+    /// loop at 43.9 Hz" is a better bug report when the reader can also see that the loop has
+    /// ticked two million times and missed none of its deadlines, which says late wakeups
+    /// rather than overrunning work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_loop: Option<LoopHealth>,
+    /// What the motor bus is doing. Present on every answer; the zero values are meaningful
+    /// ("no failures"), not missing data.
+    #[serde(default)]
+    pub bus: BusHealth,
+    /// Orientation source. Absent from an older `robotd`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imu: Option<ImuHealth>,
+}
+
+/// The control loop's rate and timing.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LoopHealth {
+    /// What the loop is configured to run at, so the achieved figure means something without
+    /// the reader having the params file open.
+    pub target_hz: f64,
+    /// Achieved rate over the last window. `None` until the first window closes — which is
+    /// *unknown*, not zero: a rate of 0 Hz describes a stopped loop, and printing that for
+    /// the first second of every robot's uptime would be a lie.
+    pub achieved_hz: Option<f64>,
+    pub ticks: u64,
+    /// Ticks whose work overran the period, cumulative. Distinct from a rate shortfall: this
+    /// is the loop doing too much, a low rate is the loop being woken late, and telling them
+    /// apart is the difference between optimising and fixing a timer.
+    pub missed: u64,
+    /// Age of the last completed tick. Large means wedged.
+    pub last_tick_age_ms: u64,
+}
+
+/// The motor bus, as the loop sees it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct BusHealth {
+    /// Consecutive failed reads; any success resets it. One is ordinary on a serial bus,
+    /// which is why the cumulative count is not what is reported.
+    pub consecutive_errors: u32,
+    /// Failed attempts to bring the bus up at all. Non-zero means the loop has never
+    /// commanded anything and is still waiting for a robot to answer — the signature of
+    /// servo power being off.
+    pub startup_failures: u32,
+}
+
+/// The IMU board, which rides the motor bus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImuHealth {
+    /// Has the orientation filter converged?
+    pub ready: bool,
+    /// Reads that returned the previous sample unchanged. Non-zero means the board is
+    /// answering without refreshing: the reads succeed, nothing reports an error, and the
+    /// orientation is frozen.
+    pub stale_blocks: u64,
+}
+
+/// Servo case temperature, reduced to the part worth acting on.
+///
+/// The hottest joint rather than a mean over fifteen: a knee holding a squat runs far hotter
+/// than the mouth, and averaging hides the one servo approaching the overheat shutdown its
+/// error mask latches on.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MotorThermal {
+    /// Name of the hottest joint, as `duck_control::model::JOINT_NAMES` spells it.
+    pub hottest: String,
+    pub max_c: f64,
+    pub mean_c: f64,
 }
 
 /// Motor-bus voltage, and what fraction of a pack that is.
@@ -990,10 +1068,8 @@ mod tests {
     #[test]
     fn robot_results_round_trip() {
         let healthy = HealthResult {
-            degraded: false,
             healthy: true,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&healthy).unwrap();
         assert!(!line.contains("reason"), "{line}");
@@ -1003,10 +1079,8 @@ mod tests {
         );
 
         let sick = HealthResult {
-            degraded: false,
-            healthy: false,
             reason: Some("motors not responding".into()),
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&sick).unwrap();
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), sick);
@@ -1026,17 +1100,14 @@ mod tests {
     fn degraded_is_omitted_when_false_and_present_when_true() {
         let plain = HealthResult {
             healthy: true,
-            degraded: false,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         assert!(!serde_json::to_string(&plain).unwrap().contains("degraded"));
 
         let bench = HealthResult {
-            healthy: false,
             degraded: true,
             reason: Some("no answer from the motor bus".into()),
-            battery: None,
+            ..Default::default()
         };
         let line = serde_json::to_string(&bench).unwrap();
         assert!(line.contains(r#""degraded":true"#), "{line}");
@@ -1055,9 +1126,7 @@ mod tests {
 
         let unread = HealthResult {
             healthy: true,
-            degraded: false,
-            reason: None,
-            battery: None,
+            ..Default::default()
         };
         assert!(!serde_json::to_string(&unread).unwrap().contains("battery"));
 

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -71,8 +71,8 @@ struct Cli {
     #[arg(long, global = true, default_value = proto::DEFAULT_SOCKET)]
     socket: PathBuf,
 
-    /// Path to the robotd socket. Only used by `version`, which asks each daemon what it
-    /// is running.
+    /// Path to the robotd socket. Used by `health` and `version`, the two commands that ask
+    /// the robot about itself rather than telling the update engine to do something.
     #[arg(long, global = true, default_value = "/run/robotd.sock")]
     robot_socket: PathBuf,
 
@@ -91,11 +91,21 @@ enum Namespace {
         command: UpdateCommand,
     },
 
-    /// Is the robot healthy, and if not, why not.
+    /// The full state of this robot: hardware and software.
     ///
-    /// The same question the update system's health gate asks, and the reason auto-rollback
-    /// means anything. It was previously only answerable by hand-writing JSON at the socket,
-    /// which is a poor way to ask the one thing that decides whether a release is kept.
+    /// Hardware from `robotd` — the verdict the update system's health gate turns on, the loop
+    /// and bus numbers behind it, the IMU, the battery and the motor temperatures. Software
+    /// from `updaterd` — what is running, what is installed, what is pinned, and how the last
+    /// update went.
+    ///
+    /// One command because that is how the question arrives. "What is wrong with this robot"
+    /// does not divide into hardware and software until after it is answered, and a robot that
+    /// reverted a release an hour ago looks exactly like a robot with unpowered servos until
+    /// both halves are on screen together.
+    ///
+    /// Exits non-zero when the robot is unhealthy or unreachable, so it can gate a script.
+    /// Nothing else here affects the exit code: a flat pack, a hot motor and a pinned
+    /// component are reported, not judged.
     Health {
         /// Machine-readable output, for scripts and support bundles.
         #[arg(long)]
@@ -370,6 +380,14 @@ struct ComponentReport {
     name: String,
     installed: Option<String>,
     revision: Option<String>,
+    /// Set when this component refuses anything but one version. Worth surfacing without
+    /// being asked: a pinned component silently ignores every release published after it,
+    /// and the symptom — "updates stopped arriving" — points nowhere near the cause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pinned: Option<String>,
+    /// The last update attempt, as one line. `None` on a robot that has never updated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_attempt: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -382,67 +400,240 @@ struct VersionReport {
     warnings: Vec<String>,
 }
 
-/// Ask `robotd` whether it is healthy.
+// ── health reporting ─────────────────────────────────────────────────────────
+
+/// The whole state of one robot: what the hardware is doing, and what software is on it.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+struct HealthReport {
+    /// `robotd`'s answer. `None` when it could not be asked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    robot: Option<proto::HealthResult>,
+    /// Why `robotd` could not be asked. Reported rather than fatal: a stopped `robotd` is
+    /// itself the most useful sentence this command can print, and the software half is still
+    /// worth having — that is often what explains the stopped daemon.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    robot_error: Option<String>,
+    software: VersionReport,
+}
+
+impl HealthReport {
+    /// Is the robot working? `None` when `robotd` could not be asked.
+    fn healthy(&self) -> Option<bool> {
+        self.robot.as_ref().map(|r| r.healthy)
+    }
+}
+
+/// Report the full state of the robot: control loop, bus, IMU, battery, motor temperature,
+/// and the software running and installed.
+///
+/// Both halves, in one command, because the question "what is wrong with this robot" does not
+/// divide along that line — a robot that reverted a release an hour ago and a robot whose
+/// servos are unpowered look identical until you can see both at once. `robotctl version`
+/// remains the software half on its own, for when that is all that is wanted.
 ///
 /// Exits non-zero when the robot is unhealthy or unreachable, so a script can gate on it —
-/// `robotctl health && do_the_thing`. The reason is always printed, because "unhealthy" on
-/// its own sends someone hunting: it distinguishes a loop that has not started from one
-/// missing its deadline from a policy that would not load.
-///
-/// Battery prints on its own line and never affects the verdict or the exit code. It is here
-/// because this is the command someone runs when a robot is behaving oddly, and "the pack is
-/// at 8%" answers that question more often than anything else on the socket.
-fn run_health(robot_socket: &Path, json: bool) -> Result<(), Failure> {
-    let mut client = Client::connect_to("robotd", robot_socket)?;
-    let response = client.call(&proto::Call::RobotHealth)?;
+/// `robotctl health && do_the_thing`, which `install.sh` relies on. Nothing else here affects
+/// the exit code: a flat pack, a hot motor and a pinned component are all *reported*, and a
+/// command that failed because of a low battery would be a command nobody could script.
+fn run_health(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Failure> {
+    let mut report = HealthReport {
+        robot: None,
+        robot_error: None,
+        software: collect_version_report(socket, robot_socket),
+    };
 
-    let health: proto::HealthResult = response.result_as().map_err(|e| {
-        Failure::new(
-            exit::FAILED,
-            format!("robotd answered robot.health with something unexpected: {e}"),
-        )
-    })?;
+    match Client::connect_to("robotd", robot_socket) {
+        Err(failure) => report.robot_error = Some(failure.message),
+        Ok(mut client) => match client.call(&proto::Call::RobotHealth) {
+            Err(failure) => report.robot_error = Some(failure.message),
+            Ok(response) => match response.result_as::<proto::HealthResult>() {
+                Ok(health) => report.robot = Some(health),
+                Err(e) => {
+                    report.robot_error =
+                        Some(format!("robotd answered robot.health unreadably: {e}"));
+                }
+            },
+        },
+    }
 
     if json {
         println!(
             "{}",
-            serde_json::to_string(&health).unwrap_or_else(|_| "{}".to_owned())
+            serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_owned())
         );
-    } else if health.healthy {
-        println!("healthy");
     } else {
-        // "degraded" reads as what it is: this release is fine, this board cannot move.
-        // Still a non-zero exit — `install.sh` and anyone else scripting this should hear
-        // about an unpowered robot rather than see a silent success.
-        println!(
-            "{}: {}",
-            if health.degraded {
-                "degraded"
-            } else {
-                "unhealthy"
-            },
-            health.reason.as_deref().unwrap_or("no reason given")
-        );
+        print!("{}", render_health(&report));
     }
 
-    // After the verdict, and only in human output — the JSON already carries it. Silent when
-    // unknown rather than printing a zero: for the first second of uptime, and on a robot
-    // whose bus cannot answer, there is genuinely no reading, and "0.00 V" would read as a
-    // dead pack.
-    if !json && let Some(battery) = health.battery {
-        println!("battery: {:.2} V ({:.0}%)", battery.volts, battery.percent);
-    }
-
-    if health.healthy {
-        Ok(())
-    } else {
-        // REFUSED, not FAILED: the robot answered correctly and the answer was "no". That is
-        // a verdict, not a malfunction, and a script should be able to tell them apart.
-        Err(Failure::silent(exit::REFUSED))
+    match report.healthy() {
+        Some(true) => Ok(()),
+        // REFUSED, not FAILED: the robot answered correctly and the answer was "no". That is a
+        // verdict, not a malfunction, and a script should be able to tell them apart.
+        Some(false) => Err(Failure::silent(exit::REFUSED)),
+        // Nothing answered. Distinct again: there is no verdict to act on.
+        None => Err(Failure::silent(exit::UNREACHABLE)),
     }
 }
 
+/// The report as a human reads it: the verdict first, then the evidence, then the software.
+///
+/// Pure, so the cases that matter are testable without a robot — and the cases that matter are
+/// the missing ones, which a live test on a working robot never produces.
+fn render_health(report: &HealthReport) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    match (&report.robot, &report.robot_error) {
+        (Some(health), _) => {
+            let verdict = match (health.healthy, health.degraded) {
+                (true, _) => "healthy".to_owned(),
+                // "degraded" reads as what it is: this release is fine, this board cannot move.
+                (false, true) => format!(
+                    "degraded: {}",
+                    health.reason.as_deref().unwrap_or("no reason given")
+                ),
+                (false, false) => format!(
+                    "unhealthy: {}",
+                    health.reason.as_deref().unwrap_or("no reason given")
+                ),
+            };
+            let _ = writeln!(out, "robot     {verdict}");
+
+            if let Some(l) = &health.control_loop {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {} of {:.1} Hz · {} ticks · {} missed · last {} ms ago",
+                    "loop",
+                    // Unknown is not 0 Hz: for the first second there is no measurement, and
+                    // printing one would describe a healthy robot as stopped.
+                    match l.achieved_hz {
+                        Some(hz) => format!("{hz:.1}"),
+                        None => "not measured yet,".to_owned(),
+                    },
+                    l.target_hz,
+                    l.ticks,
+                    l.missed,
+                    l.last_tick_age_ms
+                );
+            }
+
+            let bus = match (health.bus.consecutive_errors, health.bus.startup_failures) {
+                (0, 0) => "ok".to_owned(),
+                (0, n) => format!("waiting for a robot to answer, {n} attempts"),
+                (n, _) => format!("{n} consecutive read failures"),
+            };
+            let _ = writeln!(out, "  {:<9} {bus}", "bus");
+
+            if let Some(imu) = &health.imu {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {}{}",
+                    "imu",
+                    if imu.ready { "ready" } else { "not ready" },
+                    match imu.stale_blocks {
+                        0 => String::new(),
+                        // Worth shouting about: the board answers, so nothing else reports a
+                        // fault, while the orientation being fed to the policy is frozen.
+                        n => format!(", {n} stale reads — orientation may be dead"),
+                    }
+                );
+            }
+
+            // Silent when unknown rather than printing a zero: for the first second of uptime,
+            // and on a robot whose bus cannot answer, there is genuinely no reading, and
+            // "0.00 V" would read as a dead pack.
+            if let Some(b) = &health.battery {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {:.2} V ({:.0}%)",
+                    "battery", b.volts, b.percent
+                );
+            }
+            if let Some(m) = &health.motors {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {:.0} °C max ({}) · {:.0} °C mean",
+                    "motors", m.max_c, m.hottest, m.mean_c
+                );
+            }
+        }
+        (None, Some(why)) => {
+            // First line only: a multi-line message would break the column layout, and the
+            // rest of it is the `systemctl status` hint the connect error already carries.
+            let brief = why.lines().next().unwrap_or("unavailable");
+            let _ = writeln!(out, "robot     unavailable — {brief}");
+        }
+        (None, None) => {
+            let _ = writeln!(out, "robot     unavailable");
+        }
+    }
+
+    let _ = writeln!(out, "\nsoftware");
+    for service in &report.software.services {
+        match &service.error {
+            Some(why) => {
+                let brief = why.lines().next().unwrap_or("unavailable");
+                let _ = writeln!(out, "  {:<9} unavailable — {brief}", service.name);
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "  {:<9} {} {}",
+                    service.name,
+                    service.version.as_deref().unwrap_or("unknown"),
+                    match &service.revision {
+                        Some(rev) => format!("(rev {rev})"),
+                        None => "(rev unknown)".to_owned(),
+                    }
+                );
+            }
+        }
+    }
+    for component in &report.software.components {
+        let _ = writeln!(
+            out,
+            "  {:<9} {} installed{}",
+            component.name,
+            component.installed.as_deref().unwrap_or("none"),
+            match &component.pinned {
+                Some(v) => format!(", pinned to {v}"),
+                None => String::new(),
+            }
+        );
+        if let Some(attempt) = &component.last_attempt {
+            let _ = writeln!(out, "  {:<9} last update {attempt}", "");
+        }
+    }
+
+    // Same shape `robotctl version` uses, blank line and all: these are often multi-line —
+    // the `systemctl status` hint on an unreachable daemon is the useful half — and the two
+    // commands should not disagree about how a warning looks.
+    for warning in &report.software.warnings {
+        let _ = writeln!(out, "\n! {warning}");
+    }
+
+    out
+}
+
 fn run_version(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Failure> {
+    let report = collect_version_report(socket, robot_socket);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).unwrap_or_default()
+        );
+    } else {
+        print!("{}", render_version(&report));
+    }
+    Ok(())
+}
+
+/// Ask both daemons what they are running and `updaterd` what is installed.
+///
+/// Shared by `version` and `health` so the software half of a support report is gathered one
+/// way. Two commands assembling it separately is how they start disagreeing.
+fn collect_version_report(socket: &Path, robot_socket: &Path) -> VersionReport {
     let build = proto::build_info!();
     let mut report = VersionReport {
         robotctl: build.version.to_owned(),
@@ -498,16 +689,7 @@ fn run_version(socket: &Path, robot_socket: &Path, json: bool) -> Result<(), Fai
     }
 
     report.warnings = version_warnings(&report, updaterd_running.as_ref());
-
-    if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report).unwrap_or_default()
-        );
-    } else {
-        print!("{}", render_version(&report));
-    }
-    Ok(())
+    report
 }
 
 /// Installed release per component, with the revision of the active one.
@@ -543,9 +725,30 @@ fn installed_components(client: &mut Client) -> Vec<ComponentReport> {
                 name: status.component.to_string(),
                 installed: status.installed.map(|v| v.to_string()),
                 revision,
+                pinned: status.pinned.map(|v| v.to_string()),
+                last_attempt: status.last_attempt.as_ref().map(describe_attempt),
             }
         })
         .collect()
+}
+
+/// One update attempt in one line: what it tried, and how it went.
+///
+/// The outcome's *reason* is kept for the failures, not trimmed to "rolled back" — it is the
+/// only place the cause of an automatic revert appears outside the journal, and a robot that
+/// reverted a week ago is exactly the robot someone is asking about.
+fn describe_attempt(entry: &proto::LogEntry) -> String {
+    let target = match (&entry.from, &entry.to) {
+        (Some(from), Some(to)) => format!("{from} → {to}"),
+        (None, Some(to)) => to.to_string(),
+        (Some(from), None) => format!("from {from}"),
+        (None, None) => "unknown version".to_owned(),
+    };
+    match &entry.outcome {
+        proto::Outcome::Success => format!("{target}: applied"),
+        proto::Outcome::RolledBack { reason } => format!("{target}: ROLLED BACK — {reason}"),
+        proto::Outcome::Aborted { reason } => format!("{target}: refused — {reason}"),
+    }
 }
 
 /// Disagreements worth telling a human about.
@@ -792,7 +995,7 @@ fn main() -> ExitCode {
 fn run(cli: Cli) -> Result<(), Failure> {
     let command = match cli.namespace {
         Namespace::Health { json } => {
-            return run_health(&cli.robot_socket, json);
+            return run_health(&cli.socket, &cli.robot_socket, json);
         }
         Namespace::Version { json } => {
             return run_version(&cli.socket, &cli.robot_socket, json);
@@ -1067,6 +1270,224 @@ mod tests {
         assert!(result.is_err(), "--ref with --version must be rejected");
     }
 
+    // ── health reporting ─────────────────────────────────────────────────────
+
+    fn health_report(
+        robot: Option<proto::HealthResult>,
+        robot_error: Option<&str>,
+    ) -> HealthReport {
+        HealthReport {
+            robot,
+            robot_error: robot_error.map(str::to_owned),
+            software: report(vec![service("robotd", "0.2.0")], Some("0.2.0")),
+        }
+    }
+
+    /// A working robot, rendered whole: every section present, one line each.
+    #[test]
+    fn health_renders_hardware_and_software_together() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: true,
+                battery: Some(proto::Battery {
+                    volts: 7.62,
+                    percent: 63.75,
+                }),
+                motors: Some(proto::MotorThermal {
+                    hottest: "left_knee".into(),
+                    max_c: 48.0,
+                    mean_c: 36.0,
+                }),
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: Some(49.8),
+                    ticks: 2490,
+                    missed: 2,
+                    last_tick_age_ms: 12,
+                }),
+                bus: proto::BusHealth::default(),
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("robot     healthy"), "{out}");
+        assert!(out.contains("49.8 of 50.0 Hz"), "{out}");
+        assert!(out.contains("2490 ticks"), "{out}");
+        assert!(out.contains("7.62 V (64%)"), "{out}");
+        assert!(out.contains("48 °C max (left_knee)"), "{out}");
+        assert!(out.contains("bus       ok"), "{out}");
+        assert!(out.contains("imu       ready"), "{out}");
+        // And the software half, in the same answer — the whole point of one command.
+        assert!(out.contains("software"), "{out}");
+        assert!(out.contains("robotd    0.2.0"), "{out}");
+        assert!(out.contains("daemon    0.2.0 installed"), "{out}");
+    }
+
+    /// A stopped `robotd` must still produce the software half.
+    ///
+    /// This is the shape of a real support case — "the robot does nothing" is very often a
+    /// daemon that failed to start, and what is *installed* is then the interesting half. A
+    /// command that bailed out on the first unreachable socket would withhold exactly the
+    /// information that explains the unreachable socket.
+    #[test]
+    fn health_reports_software_when_robotd_is_down() {
+        let out = render_health(&health_report(
+            None,
+            Some(
+                "cannot reach robotd at /run/robotd.sock: No such file or directory\nIs the service running?",
+            ),
+        ));
+
+        assert!(
+            out.contains("robot     unavailable — cannot reach robotd"),
+            "{out}"
+        );
+        // First line only: the hint belongs in the warnings block, not wrapped through a
+        // column layout.
+        assert!(!out.contains("robot     unavailable — cannot reach robotd at /run/robotd.sock: No such file or directory\nIs"), "{out}");
+        assert!(out.contains("software"), "{out}");
+        assert!(out.contains("daemon    0.2.0 installed"), "{out}");
+    }
+
+    /// Nothing measured yet must not render as zeros.
+    ///
+    /// This is every robot for its first second, and the state a live test never catches. "0.0
+    /// Hz" and "0.00 V" describe a stopped loop on a dead battery — the opposite of a robot
+    /// that has only just started.
+    #[test]
+    fn health_renders_unknowns_as_unknown() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                reason: Some("control loop has not completed a cycle yet".into()),
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: None,
+                    ticks: 0,
+                    missed: 0,
+                    last_tick_age_ms: 0,
+                }),
+                imu: Some(proto::ImuHealth {
+                    ready: false,
+                    stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(
+            out.contains("unhealthy: control loop has not completed"),
+            "{out}"
+        );
+        assert!(out.contains("not measured yet"), "{out}");
+        assert!(out.contains("not ready"), "{out}");
+        // No battery line and no motors line at all, rather than zeroed ones.
+        assert!(!out.contains(" V ("), "{out}");
+        assert!(!out.contains("°C"), "{out}");
+    }
+
+    /// The two findings that must not hide: a bus that has stopped answering, and an IMU that
+    /// answers without refreshing.
+    ///
+    /// Stale IMU reads are the nastiest of the lot — the reads *succeed*, so nothing else
+    /// reports a fault, while the orientation feeding the policy is frozen.
+    #[test]
+    fn health_renders_a_broken_bus_and_a_stale_imu() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: false,
+                reason: Some("7 consecutive bus read failures".into()),
+                bus: proto::BusHealth {
+                    consecutive_errors: 7,
+                    startup_failures: 0,
+                },
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 41,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("7 consecutive read failures"), "{out}");
+        assert!(out.contains("41 stale reads"), "{out}");
+        assert!(out.contains("orientation may be dead"), "{out}");
+    }
+
+    /// An unpowered bench board reads as *degraded*, and the attempt count is the actionable
+    /// part: it is how you tell "still coming up" from "there is no robot on this bus".
+    #[test]
+    fn health_renders_a_degraded_board_waiting_for_its_bus() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                degraded: true,
+                reason: Some("no robot on the motor bus after 4 attempts".into()),
+                bus: proto::BusHealth {
+                    consecutive_errors: 0,
+                    startup_failures: 4,
+                },
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("degraded: no robot on the motor bus"), "{out}");
+        assert!(
+            out.contains("waiting for a robot to answer, 4 attempts"),
+            "{out}"
+        );
+    }
+
+    /// A pinned component and a rollback are both things nobody thinks to ask about, and both
+    /// explain "updates stopped working" — so they appear without being asked for.
+    #[test]
+    fn health_surfaces_a_pin_and_the_last_update() {
+        let mut report = health_report(Some(proto::HealthResult::default()), None);
+        report.software.components[0].pinned = Some("0.1.9".into());
+        report.software.components[0].last_attempt =
+            Some("0.1.9 → 0.2.0: ROLLED BACK — not healthy within 30s".into());
+
+        let out = render_health(&report);
+        assert!(out.contains("pinned to 0.1.9"), "{out}");
+        assert!(out.contains("ROLLED BACK"), "{out}");
+    }
+
+    /// The summary line for one update attempt, including the reason a revert happened —
+    /// which outside the journal exists nowhere else.
+    #[test]
+    fn an_attempt_is_summarised_with_its_reason() {
+        let entry = |outcome| proto::LogEntry {
+            at: 0,
+            component: proto::ComponentId::new("daemon"),
+            from: Some(semver::Version::new(0, 1, 9)),
+            to: Some(semver::Version::new(0, 2, 0)),
+            outcome,
+        };
+
+        assert_eq!(
+            describe_attempt(&entry(proto::Outcome::Success)),
+            "0.1.9 → 0.2.0: applied"
+        );
+        let rolled = describe_attempt(&entry(proto::Outcome::RolledBack {
+            reason: "not healthy within 30s".into(),
+        }));
+        assert!(rolled.contains("ROLLED BACK"), "{rolled}");
+        assert!(rolled.contains("not healthy within 30s"), "{rolled}");
+
+        // A first install has no `from`, and must not render as "None → 1.0.0".
+        let first = proto::LogEntry {
+            from: None,
+            ..entry(proto::Outcome::Success)
+        };
+        assert_eq!(describe_attempt(&first), "0.2.0: applied");
+    }
+
     // ── version reporting ────────────────────────────────────────────────────
 
     fn report(services: Vec<ServiceReport>, daemon_installed: Option<&str>) -> VersionReport {
@@ -1078,6 +1499,8 @@ mod tests {
                 name: "daemon".into(),
                 installed: daemon_installed.map(str::to_owned),
                 revision: None,
+                pinned: None,
+                last_attempt: None,
             }],
             warnings: Vec::new(),
         }

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -52,8 +52,8 @@ const MAX_LINE: usize = 64 * 1024;
 const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Window over which the achieved rate is measured, and therefore how quickly a degraded
-/// loop becomes visible to the health gate. Doubles as the battery sampling interval
-/// ([`sample_battery`]).
+/// loop becomes visible to the health gate. Doubles as the slow-sensor sampling interval
+/// ([`publish_slow_sensors`]).
 const RATE_WINDOW: Duration = Duration::from_secs(1);
 
 /// Smoothing on the reported battery voltage. At one sample per [`RATE_WINDOW`] this is a
@@ -153,6 +153,16 @@ struct RobotState {
     /// distinction that has to survive to the wire, since zero volts and unknown volts look
     /// nothing alike to whoever is deciding whether to charge the robot.
     battery_v: AtomicU64,
+    /// Hottest servo of the last thermal sample: temperature as `f64::to_bits`, and which
+    /// joint it was. Zero means *not read yet*, same as the battery.
+    motor_max_c: AtomicU64,
+    motor_mean_c: AtomicU64,
+    /// Index into [`duck_control::JOINT_NAMES`] of the hottest joint.
+    motor_hottest: AtomicU32,
+    /// Mirrors of the bus's own IMU diagnostics, refreshed with the thermal sample. Held here
+    /// so the IPC side can report them without touching the loop's IO.
+    imu_stale_blocks: AtomicU64,
+    imu_ready: AtomicBool,
     shutdown: AtomicBool,
 
     period_us: u64,
@@ -174,6 +184,11 @@ impl RobotState {
             consecutive_errors: AtomicU32::new(0),
             startup_bus_failures: AtomicU32::new(0),
             battery_v: AtomicU64::new(0),
+            motor_max_c: AtomicU64::new(0),
+            motor_mean_c: AtomicU64::new(0),
+            motor_hottest: AtomicU32::new(0),
+            imu_stale_blocks: AtomicU64::new(0),
+            imu_ready: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
             period_us: params.period().as_micros() as u64,
             min_achieved_hz: params.health.min_achieved_hz,
@@ -185,23 +200,34 @@ impl RobotState {
     }
 
     fn health(&self) -> proto::HealthResult {
-        // Attached to every answer, healthy or not, and consulted by none of the checks
-        // below. A verdict must never depend on it: see `HealthResult::battery`.
-        let battery = self.battery();
+        // Everything the robot can say about itself, attached to every answer whatever the
+        // verdict — and consulted by none of the checks below.
+        //
+        // Two separate jobs in one method, deliberately. `healthy`/`degraded` are the update
+        // system's inputs and may only reflect what a *release* can be blamed for. The rest
+        // is a description of the robot for whoever is looking at it, and it travels on the
+        // same answer because a robot behaving oddly is asked exactly one question, once.
+        let describe =
+            |healthy: bool, degraded: bool, reason: Option<String>| proto::HealthResult {
+                healthy,
+                degraded,
+                reason,
+                battery: self.battery(),
+                motors: self.motor_thermal(),
+                control_loop: Some(self.loop_health()),
+                bus: proto::BusHealth {
+                    consecutive_errors: self.consecutive_errors.load(Ordering::Relaxed),
+                    startup_failures: self.startup_bus_failures.load(Ordering::Relaxed),
+                },
+                imu: Some(proto::ImuHealth {
+                    ready: self.imu_ready.load(Ordering::Relaxed),
+                    stale_blocks: self.imu_stale_blocks.load(Ordering::Relaxed),
+                }),
+            };
 
-        let unhealthy = |reason: String| proto::HealthResult {
-            healthy: false,
-            degraded: false,
-            reason: Some(reason),
-            battery,
-        };
+        let unhealthy = |reason: String| describe(false, false, Some(reason));
         // Not healthy, but not the release's fault either — see `HealthResult::degraded`.
-        let degraded = |reason: String| proto::HealthResult {
-            healthy: false,
-            degraded: true,
-            reason: Some(reason),
-            battery,
-        };
+        let degraded = |reason: String| describe(false, true, Some(reason));
 
         if self.force_unhealthy {
             return unhealthy("forced unhealthy by --unhealthy".into());
@@ -246,12 +272,39 @@ impl RobotState {
             ));
         }
 
-        proto::HealthResult {
-            healthy: true,
-            degraded: false,
-            reason: None,
-            battery,
+        describe(true, false, None)
+    }
+
+    /// The loop's own numbers, as the readout reports them.
+    fn loop_health(&self) -> proto::LoopHealth {
+        let hz = f64::from_bits(self.achieved_hz.load(Ordering::Relaxed));
+        let now_us = self.started.elapsed().as_micros() as u64;
+        proto::LoopHealth {
+            target_hz: 1_000_000.0 / self.period_us as f64,
+            // Zero is the "no window has closed yet" sentinel, not a measured rate.
+            achieved_hz: (hz > 0.0).then_some(hz),
+            ticks: self.ticks.load(Ordering::Relaxed),
+            missed: self.missed.load(Ordering::Relaxed),
+            last_tick_age_ms: now_us.saturating_sub(self.last_tick_us.load(Ordering::Relaxed))
+                / 1000,
         }
+    }
+
+    /// The hottest servo of the last thermal sample, or `None` before the first one.
+    fn motor_thermal(&self) -> Option<proto::MotorThermal> {
+        let max_c = f64::from_bits(self.motor_max_c.load(Ordering::Relaxed));
+        if max_c <= 0.0 {
+            return None;
+        }
+        let hottest = self.motor_hottest.load(Ordering::Relaxed) as usize;
+        Some(proto::MotorThermal {
+            hottest: duck_control::JOINT_NAMES
+                .get(hottest)
+                .unwrap_or(&"unknown")
+                .to_string(),
+            max_c,
+            mean_c: f64::from_bits(self.motor_mean_c.load(Ordering::Relaxed)),
+        })
     }
 
     /// The last battery reading, mapped to a percentage — or `None` if there has not been
@@ -664,7 +717,7 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
             window_start = Instant::now();
             window_ticks = 0;
 
-            sample_battery(&mut io, &state);
+            publish_slow_sensors(&mut io, &state);
 
             if last_summary.elapsed() >= LOOP_SUMMARY_INTERVAL {
                 tracing::info!(
@@ -675,6 +728,10 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
                         "{:.2}",
                         f64::from_bits(state.battery_v.load(Ordering::Relaxed))
                     ),
+                    motor_max_c = format!(
+                        "{:.0}",
+                        f64::from_bits(state.motor_max_c.load(Ordering::Relaxed))
+                    ),
                     "control loop"
                 );
                 last_summary = Instant::now();
@@ -684,32 +741,55 @@ async fn control_loop<T: RobotIo>(mut io: T, state: Arc<RobotState>, period: Dur
     tracing::info!("control loop stopped");
 }
 
-/// Read the battery and publish it, once per [`RATE_WINDOW`].
+/// Sample and publish everything that does not need sampling every tick, once per
+/// [`RATE_WINDOW`].
 ///
-/// Not part of the tick. `present_input_voltage` is a second bus transaction — about a
-/// millisecond — which is nothing once a second and would be 5% of the budget at 50 Hz. A
-/// second is also faster than a battery can meaningfully change.
+/// Not part of the tick. The voltage/temperature registers are a second bus transaction —
+/// about a millisecond — which is nothing once a second and would be 5% of the budget at
+/// 50 Hz. A second is also faster than a pack can drain or a servo can heat up.
 ///
 /// Called from the loop thread because that thread owns the IO, and nothing else may touch
 /// the bus: a transaction issued from the IPC side would interleave bytes with a tick and
-/// corrupt both.
-fn sample_battery<T: RobotIo>(io: &mut T, state: &RobotState) {
-    match io.bus_voltage() {
-        Ok(volts) => {
+/// corrupt both. The IMU counters come from the same `io`, so they are mirrored here rather
+/// than reached for from the socket.
+fn publish_slow_sensors<T: RobotIo>(io: &mut T, state: &RobotState) {
+    state
+        .imu_stale_blocks
+        .store(io.imu_stale_blocks(), Ordering::Relaxed);
+    state.imu_ready.store(io.imu_ready(), Ordering::Relaxed);
+
+    match io.slow_sensors() {
+        Ok(slow) => {
             let previous = f64::from_bits(state.battery_v.load(Ordering::Relaxed));
             // Seed from the first reading rather than blending up from zero, which would
             // spend ten seconds reporting a battery flatter than it is.
             let smoothed = if previous > 0.0 {
-                BATTERY_EMA_ALPHA * volts + (1.0 - BATTERY_EMA_ALPHA) * previous
+                BATTERY_EMA_ALPHA * slow.volts + (1.0 - BATTERY_EMA_ALPHA) * previous
             } else {
-                volts
+                slow.volts
             };
             state.battery_v.store(smoothed.to_bits(), Ordering::Relaxed);
+
+            // Temperature is not smoothed: a servo's case is already a slow signal, and an
+            // EMA would only delay the one reading anybody cares about — the joint climbing
+            // towards its overheat shutdown.
+            let (hottest, max_c) = slow.temps_c.iter().enumerate().fold(
+                (0usize, f64::MIN),
+                |(best, high), (joint, &t)| {
+                    if t > high { (joint, t) } else { (best, high) }
+                },
+            );
+            let mean_c = slow.temps_c.iter().sum::<f64>() / slow.temps_c.len() as f64;
+            state.motor_max_c.store(max_c.to_bits(), Ordering::Relaxed);
+            state
+                .motor_mean_c
+                .store(mean_c.to_bits(), Ordering::Relaxed);
+            state.motor_hottest.store(hottest as u32, Ordering::Relaxed);
         }
-        // Keep the last reading. A single failed transaction is ordinary on a serial bus, and
+        // Keep the last sample. A single failed transaction is ordinary on a serial bus, and
         // dropping to "unknown" over one would make the reported battery flicker. A bus that
-        // is really gone already shows up in the health verdict itself.
-        Err(e) => tracing::debug!(error = %e, "voltage read failed; keeping the last reading"),
+        // is really gone already shows up in the verdict and in `bus.consecutive_errors`.
+        Err(e) => tracing::debug!(error = %e, "slow-sensor read failed; keeping the last sample"),
     }
 }
 
@@ -1189,6 +1269,7 @@ mod tests {
         let s = state();
         s.startup_bus_failures.store(4, Ordering::Relaxed);
         s.battery_v.store(7.5f64.to_bits(), Ordering::Relaxed);
+        s.motor_max_c.store(48.0f64.to_bits(), Ordering::Relaxed);
 
         let health = s.health();
         assert!(!health.healthy);
@@ -1196,6 +1277,70 @@ mod tests {
             health.battery.is_some(),
             "battery dropped from a bad answer"
         );
+        // The rest of the description too: an unhealthy robot is exactly when someone needs
+        // the whole picture, not a verdict on its own.
+        assert!(health.motors.is_some(), "thermals dropped");
+        assert!(health.control_loop.is_some(), "loop section dropped");
+        assert!(health.imu.is_some(), "imu section dropped");
+        // And the number *this* verdict was based on: "no robot on the motor bus" is only
+        // actionable next to the count of attempts behind it.
+        assert_eq!(health.bus.startup_failures, 4);
+    }
+
+    /// The loop section must carry the numbers the verdict was decided from, so a reader can
+    /// check it rather than take it on faith.
+    ///
+    /// That distinction has already paid once: 43.9 Hz with `missed = 0` is a loop being
+    /// *woken* late, not a loop doing too much, and the two have entirely different fixes.
+    #[test]
+    fn the_loop_section_reports_what_the_verdict_used() {
+        let s = state();
+        ticked(&s, 2490);
+        s.achieved_hz.store(49.8f64.to_bits(), Ordering::Relaxed);
+        s.missed.store(3, Ordering::Relaxed);
+
+        let l = s.health().control_loop.expect("loop section");
+        assert_eq!(l.achieved_hz, Some(49.8));
+        assert_eq!(l.target_hz, 50.0);
+        assert_eq!(l.ticks, 2490);
+        assert_eq!(l.missed, 3);
+
+        // Unmeasured stays unmeasured rather than becoming 0 Hz — that would describe a
+        // stopped loop, which is the opposite of "started less than a second ago".
+        s.achieved_hz.store(0, Ordering::Relaxed);
+        assert_eq!(s.health().control_loop.unwrap().achieved_hz, None);
+    }
+
+    /// The hottest joint is named, not merely measured. "48 °C" prompts "which one?", and the
+    /// answer decides whether it is the knee holding the robot up or something wrong.
+    #[test]
+    fn thermals_name_the_hottest_joint() {
+        let s = state();
+        ticked(&s, 100);
+        let knee = duck_control::JOINT_NAMES
+            .iter()
+            .position(|n| *n == "left_knee")
+            .unwrap();
+        s.motor_max_c.store(48.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_mean_c.store(36.0f64.to_bits(), Ordering::Relaxed);
+        s.motor_hottest.store(knee as u32, Ordering::Relaxed);
+
+        let motors = s.health().motors.expect("thermals");
+        assert_eq!(motors.hottest, "left_knee");
+        assert_eq!(motors.max_c, 48.0);
+        assert_eq!(motors.mean_c, 36.0);
+
+        // A servo cooking must not change the verdict, for the same reason a flat pack must
+        // not: it is a fact about the robot, not evidence about the release.
+        assert!(s.health().healthy);
+    }
+
+    /// Unread thermals are absent, not 0 °C — which would read as a robot in a freezer.
+    #[test]
+    fn unread_thermals_are_absent() {
+        let s = state();
+        ticked(&s, 1);
+        assert!(s.health().motors.is_none());
     }
 
     /// While waiting, health must say *why*. The update system quotes this string as the
@@ -1332,8 +1477,8 @@ mod tests {
             fn write(&mut self, t: &JointTargets) -> duck_control::io::Result<()> {
                 self.0.write(t)
             }
-            fn bus_voltage(&mut self) -> duck_control::io::Result<f64> {
-                self.0.bus_voltage()
+            fn slow_sensors(&mut self) -> duck_control::io::Result<duck_control::SlowSensors> {
+                self.0.slow_sensors()
             }
         }
         control_loop(Borrowed(io), state, period).await

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -576,8 +576,8 @@ report() {
     say "installed daemon ${version}"
     cat <<'EOF'
 
+  robotctl health                     the whole robot: hardware and software
   robotctl version                    what is running, and what is installed
-  robotctl health                     is the robot working, and how is its battery
   robotctl update status              update state per component
   robotctl update check               is a newer release available
   sudo robotctl update apply daemon   update now (mutations are root-only by design)


### PR DESCRIPTION
**Stacked on #23** — base is `battery-in-health`, so this diff shows only the delta. Merge #23 first and this retargets to `main` on its own.

`robotctl health` printed a verdict and a battery line. The verdict was both the useful part and the frustrating one: `unhealthy: control loop at 43.9 Hz` says what is wrong and nothing about why, and answering that meant a second command, the journal, or hand-written JSON at the socket.

```
$ robotctl health
robot     healthy
  loop      50.1 of 50.0 Hz · 2834 ticks · 0 missed · last 13 ms ago
  bus       ok
  imu       ready
  battery   7.62 V (64%)
  motors    41 °C max (left_knee) · 36 °C mean

software
  updaterd  0.1.4 (rev abc1234)
  robotd    0.1.5 (rev def5678)
  daemon    0.1.5 installed
            last update 0.1.4 → 0.1.5: applied
```

## One command, both halves

"What is wrong with this robot" does not divide into hardware and software until after it is answered — a robot that reverted a release an hour ago looks exactly like a robot with unpowered servos until both are on screen together. `robotctl version` stays the software half on its own, and the gathering is shared (`collect_version_report`) so the two commands cannot disagree.

## What `robot.health` now carries

The sections behind the verdict: `control_loop` (achieved against target, ticks, missed, last-tick age), `bus` (consecutive errors, startup failures), `imu` (ready, stale reads), `battery`, `motors`. All optional or defaulted, so an older `robotd` still parses.

The loop section carries the numbers the verdict was *computed from*, which is the point: 43.9 Hz next to `missed = 0` says the loop is being woken late, not doing too much. That distinction is what made the `Delay`→`Skip` fix in c5c1187 a one-liner instead of a hardware investigation.

## Motor temperature comes for free

`present_temperature` (146) is one register past `present_input_voltage` (144), so a 3-byte read gets both and thermals cost no extra bus transaction — `bus_voltage` becomes `slow_sensors` accordingly. Reported as the **hottest** joint, named: a knee holding a squat runs far above the mouth, and a mean over fifteen servos hides the one servo approaching the overheat shutdown its error mask latches on.

## Still reported, never judged

`healthy`/`degraded` come only from what a release can be blamed for. Battery, thermals and counters are descriptions, and tests hold that line — a verdict gating on temperature would roll good releases back on a warm afternoon, then judge their replacements on the same warm afternoon. §4.5 of `robotd-design.md` states the rule for whatever field is added next.

## Exit codes, and a dead robotd

Contract unchanged, since `install.sh` gates on it: `0` healthy, `REFUSED` unhealthy, `UNREACHABLE` when nothing answered. What changed is that an unreachable `robotd` no longer aborts the command — it prints the software half anyway, because "the robot does nothing" is very often a daemon that failed to start, and what is installed is then the half that explains it.

Two more things nobody thinks to ask about, both of which explain "updates stopped working": a **pinned** component, and the **last update attempt** with the reason behind an automatic revert — which outside the journal exists nowhere else.

## Testing

`cargo test --workspace` green (17 suites, 310 tests), `clippy --all-targets` and `fmt` clean. Verified by hand against a real `robotd` plus a real `updaterd` on the playground: healthy, `robotd` stopped (software half survives, exit 3), and `--json`.

New tests cover the cases a live robot never produces — nothing measured yet rendering as unknown rather than `0.0 Hz`/`0.00 V`, a stopped `robotd` still yielding software, a stale IMU, a bench board waiting on its bus, a pin, and a rollback summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)