### PR TITLE
policy: an ort panic holds the pose instead of killing the loop

### DIFF
--- a/docs/slice-2-bringup.md
+++ b/docs/slice-2-bringup.md
@@ -1,14 +1,17 @@
 # Slice 2 bring-up on hardware
 
-Handoff notes for finishing this branch on a real robot. Everything below was observed on a
-Radxa Zero 3W, not inferred.
+Notes from running slice 2 on a real robot. Everything below was observed on a Radxa Zero 3W,
+not inferred.
 
-## The one open problem
+## Status
 
-**`ort` panics instead of returning an error, which kills the control thread and makes
-`robot.health` blame the wrong thing.**
+Slice 2 is merged, and the one problem the board found — **`ort` panicking instead of returning
+an error, which killed the control thread and made `robot.health` blame the wrong thing** — is
+fixed: `duck-control::policy::catching_ort_panics` turns it into a `PolicyError`, so it takes
+the existing "hold the pose and report why" path.
 
-That is the whole task. Slice 2's code is otherwise complete and its tests pass.
+**Still not run on hardware:** the fix itself, and slice 2's loop rate with inference in the
+tick. The recipe for both is [Verifying on the board](#verifying-on-the-board) below.
 
 ## What already works, verified on the board
 
@@ -65,55 +68,46 @@ The floor and target live in `[workspace.metadata.onnxruntime]` in the root `Car
 #18 generates the release's `hooks/preinstall` from them so a board below the floor is healed —
 or the update aborts *before the swap* — rather than installing and then panicking.
 
-**2. `ort` panics rather than erroring — still open. This is the task.**
+**2. `ort` panics rather than erroring — fixed.**
 
-`duck-control/src/policy.rs:87`, `ensure_runtime()`, probes the dylib with `libloading` before
-letting `ort` touch it. Its doc comment claims:
+`ensure_runtime()` probes the dylib with `libloading` before letting `ort` touch it. Its doc
+comment used to claim:
 
 > a probe that succeeds means its load will succeed too and the panic cannot fire
 
 **The board falsified that.** The probe only proves the library *loads*; 1.20.1 loads fine.
 `ort`'s own compatibility check then rejects the *version* and panics inside `setup_api`, which
 `ensure_runtime` cannot see. So the guard closes the "missing" case and not the "wrong version"
-case — and by construction it cannot close every future `ort` panic either.
+case — and by construction it could not have closed every future `ort` panic either.
 
-## What to build
+The fix does not try to. `catching_ort_panics` wraps the `ort` calls inside `Policy::load` and
+converts any panic into `PolicyError::RuntimePanic`, carrying the panic message — the version
+numbers above are the whole diagnosis, so losing them would leave a health reason nobody can
+act on. That puts a panic on the path `robotd` already had for a policy that will not load: log
+`policy unavailable; holding the pose`, store the reason, leave `controller` as `None`, **keep
+ticking at rate**, and report `policy unavailable: <reason>` so the updater rolls the release
+back for a stated cause.
 
-The graceful path already exists and is well designed. `robotd/src/main.rs:688` handles a
-policy that fails to load: it logs `policy unavailable; holding the pose`, stores the reason in
-`state.policy_error`, leaves `controller` as `None`, and **the loop still ticks at rate**.
-Health then reports `policy unavailable: <reason>` (`robotd/src/main.rs:246`), which is
-accurate and actionable, and the updater rolls the release back for a stated reason.
+Two things to know about it:
 
-The panic bypasses all of that. So: make any `ort` panic take the existing path.
+- The catch wraps the `ort` work only, not all of `load`, so a genuine bug of ours is not
+  relabelled "policy unavailable". `AssertUnwindSafe` is needed because `Session` is not
+  `UnwindSafe`; the sessions are moved into the `Policy` on success and dropped on failure, so
+  nothing of ours is observed after a catch.
+- **`panic = "abort"` would defeat it.** There is no `[profile.release]` in the root
+  `Cargo.toml` today; adding one would silently restore the dead control thread.
 
-Suggested shape — `std::panic::catch_unwind` around the `ort` work inside `Policy::load`
-(`duck-control/src/policy.rs:125`), converting a caught panic into a `PolicyError`. Points to
-settle while doing it:
+### What the tests cover, and what they do not
 
-- **Catch as narrowly as possible.** Wrap the `ort` calls, not the whole function, so a genuine
-  bug in our code is not silently converted into "policy unavailable".
-- `Session` and friends may not be `UnwindSafe`; `AssertUnwindSafe` is probably needed. Justify
-  it in a comment — the argument is that a failed `ort` init leaves nothing of ours partly
-  mutated.
-- **Extract the panic message** into the `PolicyError`, or the health reason loses the version
-  numbers that make it actionable. The string above is exactly what someone needs.
-- Consider whether `ensure_runtime`'s doc comment should keep its claim. It is now known false;
-  at minimum it should say what the probe does and does not cover.
-- `panic = "abort"` would defeat `catch_unwind`. Checked: there is no custom
-  `[profile.release]` in the root `Cargo.toml`, so the default unwind strategy applies and
-  `catch_unwind` will work. Anyone adding `panic = "abort"` later would silently break this,
-  which is worth a comment where the catch happens.
+Covered offline, in `duck-control` and `robotd`: a panic on the `ort` path becomes an error and
+keeps its message, success passes through untouched, an unprintable payload still yields a
+reason, and — via `an_unloadable_policy_holds_the_pose_and_reports_why` — a policy that will not
+load leaves the loop ticking with the underlying cause in the health string.
 
-### Test it deterministically
-
-There is no need to install an old ONNX Runtime to test this. The failure is "`ort` panicked",
-so a test only needs a panic on that path — the point is that a panicking policy load becomes
-`PolicyError` and the loop keeps ticking, not which panic it was.
-
-Slice 2 already has `an_unloadable_policy_holds_the_pose_and_reports_why` in
-`robotd/src/main.rs`. The new test should assert the same outcome when the load *panics* rather
-than returns `Err`, and that the health reason still carries the detail.
+Not covered offline: a *real* `ort` panic travelling through the control loop. Reproducing it
+needs a wrong-version runtime, which is a board, and faking one inside `Policy::load` would mean
+shipping a fault-injection knob in `duck-control` to test three lines. The board check below is
+what closes it.
 
 ## Verifying on the board
 

--- a/duck-control/src/policy.rs
+++ b/duck-control/src/policy.rs
@@ -55,6 +55,12 @@ pub enum PolicyError {
     /// the library or set `ORT_DYLIB_PATH` — and not a broken policy bundle.
     #[error("ONNX Runtime not loadable ({searched}): {detail}")]
     RuntimeMissing { searched: String, detail: String },
+    /// `ort` panicked instead of returning an error. See [`catching_ort_panics`].
+    ///
+    /// `detail` is the panic message, and carrying it is the point: the one panic we have
+    /// actually seen on a board names the two version numbers that explain it.
+    #[error("ort panicked loading the policy: {detail}")]
+    RuntimePanic { detail: String },
 }
 
 /// Where `ort` will look for the runtime, replicating its own logic.
@@ -81,9 +87,14 @@ fn dylib_name() -> String {
 /// thread dies, no tick ever lands, and `robot.health` reports "the loop has not completed a
 /// cycle" forever: the daemon looks wedged instead of saying ONNX Runtime is not installed.
 ///
-/// Probing first turns that into an ordinary error the caller can report. We use the same
-/// loader and the same search rule `ort` does, so a probe that succeeds means its load will
-/// succeed too and the panic cannot fire.
+/// Probing first turns the *missing library* case into an ordinary error the caller can
+/// report, with the operator's fix in it. That is all it does.
+///
+/// It does **not** mean `ort` cannot then panic, and an earlier version of this comment
+/// claimed it did. A board running ONNX Runtime 1.20.1 falsified that: the library loaded, so
+/// the probe passed, and `ort` panicked in `setup_api` on its own version check
+/// (`expected version >= '1.23.x', but got '1.20.1'`). The probe proves the file loads;
+/// nothing more. [`catching_ort_panics`] covers the rest, including panics we have not seen.
 fn ensure_runtime() -> Result<(), PolicyError> {
     static PROBE: OnceLock<Result<(), String>> = OnceLock::new();
     let outcome = PROBE.get_or_init(|| {
@@ -110,6 +121,51 @@ fn ensure_runtime() -> Result<(), PolicyError> {
         })
 }
 
+/// Run the `ort` calls, turning a panic from inside them into a [`PolicyError`].
+///
+/// `ort` treats some initialisation failures as unrecoverable and panics rather than
+/// returning `Err` — the version mismatch in [`ensure_runtime`]'s comment is the one a board
+/// hit, and it fires from inside a lazy init reachable through any API call. In the control
+/// thread a panic is worse than an error: the thread dies, no tick ever lands, and
+/// `robot.health` answers "the loop has not completed a cycle yet" — the one message that
+/// names no cause — while the daemon stays up serving its socket. The updater then rolls the
+/// release back for a reason nobody can act on.
+///
+/// `robotd` already handles a policy that fails to load: hold the pose, keep ticking at rate,
+/// report why, get rolled back. This makes a panic take that same path.
+///
+/// Deliberately wraps the `ort` work only, and not all of [`Policy::load`], so a genuine bug
+/// of ours does not get relabelled "policy unavailable". Note that a caught panic has still
+/// run the panic hook, so the backtrace is in the journal either way.
+///
+/// `AssertUnwindSafe` is needed because `Session` is not `UnwindSafe`. It is sound here
+/// because nothing of ours is observed after a catch: the sessions being built are moved into
+/// the `Policy` on success and dropped on failure, and the caller's answer is the error.
+///
+/// **`panic = "abort"` would defeat this.** The root `Cargo.toml` has no `[profile.release]`,
+/// so the default unwind strategy applies; adding one would silently turn this back into a
+/// dead control thread.
+fn catching_ort_panics<T>(work: impl FnOnce() -> Result<T, PolicyError>) -> Result<T, PolicyError> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(work)).unwrap_or_else(|payload| {
+        Err(PolicyError::RuntimePanic {
+            detail: panic_message(payload),
+        })
+    })
+}
+
+/// The panic message, or a stand-in saying there wasn't one.
+///
+/// `panic!` with a literal produces `&'static str`; with arguments, `String`. `ort` uses both.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panicked with no message; see the journal for the backtrace".to_owned()
+    }
+}
+
 /// A loaded policy pair.
 pub struct Policy {
     walk: Session,
@@ -128,27 +184,32 @@ impl Policy {
         standing_threshold: f64,
     ) -> Result<Self, PolicyError> {
         ensure_runtime()?;
-        let mut walk_session = open(walk)?;
-        let mut stand_session = match stand {
-            Some(path) => Some(open(path)?),
-            None => None,
-        };
 
-        // Warm up before the loop ever calls this. The first inference is always an
-        // outlier — lazy initialisation, cold pages, first-touch faults — and paying that
-        // on tick one would look exactly like a control loop that missed its deadline.
-        // It also proves ONNX Runtime is actually present and usable, which with
-        // `load-dynamic` is not known until something is run.
-        let zero = Observation::zeroed();
-        run(&mut walk_session, walk, &zero)?;
-        if let (Some(session), Some(path)) = (stand_session.as_mut(), stand) {
-            run(session, path, &zero)?;
-        }
+        // Everything below calls into `ort`, and `ort` panics on failures it considers
+        // unrecoverable — so the whole of it, and nothing else, goes inside the catch.
+        catching_ort_panics(move || {
+            let mut walk_session = open(walk)?;
+            let mut stand_session = match stand {
+                Some(path) => Some(open(path)?),
+                None => None,
+            };
 
-        Ok(Self {
-            walk: walk_session,
-            stand: stand_session,
-            standing_threshold,
+            // Warm up before the loop ever calls this. The first inference is always an
+            // outlier — lazy initialisation, cold pages, first-touch faults — and paying that
+            // on tick one would look exactly like a control loop that missed its deadline.
+            // It also proves ONNX Runtime is actually present and usable, which with
+            // `load-dynamic` is not known until something is run.
+            let zero = Observation::zeroed();
+            run(&mut walk_session, walk, &zero)?;
+            if let (Some(session), Some(path)) = (stand_session.as_mut(), stand) {
+                run(session, path, &zero)?;
+            }
+
+            Ok(Self {
+                walk: walk_session,
+                stand: stand_session,
+                standing_threshold,
+            })
         })
     }
 
@@ -283,5 +344,59 @@ mod tests {
         assert!(!stands(false, 0.0), "no standing policy, zero command");
         assert!(stands(true, 0.0), "standing policy, zero command");
         assert!(!stands(true, 0.5), "standing policy, walking command");
+    }
+
+    /// **The panic contract.** A panic out of `ort` must come back as a `PolicyError`, because
+    /// the caller is the control thread: an escaping panic kills it, no tick ever lands, and
+    /// health reports "the loop has not completed a cycle" — naming no cause — instead of
+    /// holding the pose and saying the policy is unusable.
+    ///
+    /// The message must survive too. This is the panic a Radxa actually produced, and the two
+    /// version numbers in it are the whole diagnosis; a health reason without them tells an
+    /// operator nothing.
+    ///
+    /// The panic hook still runs, so this test prints a panic and a backtrace hint. That is
+    /// wanted — on a board it is what puts the detail in the journal — and is not a failure.
+    #[test]
+    fn a_panic_out_of_ort_becomes_an_error_that_keeps_its_message() {
+        let err = catching_ort_panics::<()>(|| {
+            panic!(
+                "Failed to load ONNX Runtime dylib: ort 2.0.0-rc.11 is not compatible with \
+                 the ONNX Runtime binary found at `libonnxruntime.so`; expected version >= \
+                 '1.23.x', but got '1.20.1'"
+            )
+        })
+        .expect_err("a panic in the ort work must not escape to the caller");
+
+        assert!(
+            matches!(err, PolicyError::RuntimePanic { .. }),
+            "wrong variant: {err:?}"
+        );
+        let reported = err.to_string();
+        for detail in ["1.23.x", "1.20.1"] {
+            assert!(
+                reported.contains(detail),
+                "the version detail must reach the caller, got {reported:?}"
+            );
+        }
+    }
+
+    /// Success must pass straight through — a wrapper that swallowed the value would turn
+    /// every load into "policy unavailable" on a board where everything works.
+    #[test]
+    fn the_catch_is_transparent_when_nothing_panics() {
+        assert_eq!(catching_ort_panics(|| Ok(7)).unwrap(), 7);
+    }
+
+    /// A panic payload that is neither `&str` nor `String` must still produce a reason. The
+    /// alternative is an empty health string, which reads as "no reason given".
+    #[test]
+    fn an_unprintable_panic_payload_still_reports_something() {
+        let detail = panic_message(Box::new(42u32));
+        assert!(!detail.is_empty(), "a reason is mandatory");
+        assert!(
+            detail.contains("journal"),
+            "point somewhere useful: {detail:?}"
+        );
     }
 }

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -1648,6 +1648,15 @@ mod tests {
             reason.contains("policy"),
             "health must name the policy as the cause, got {reason:?}"
         );
+        // The detail, not just the category. The updater quotes this string as the reason it
+        // rolled a release back, so "policy unavailable" on its own is not actionable — that
+        // is the same failure as the useless "loop has not completed a cycle" this branch
+        // exists to avoid. Which detail arrives depends on the machine: the bogus path where
+        // ONNX Runtime is installed, the runtime's own diagnosis where it is not.
+        assert!(
+            reason.contains("definitely-not-a-policy.onnx") || reason.contains("ONNX Runtime"),
+            "health must carry the underlying cause, got {reason:?}"
+        );
         assert!(
             !s.moving.load(Ordering::Relaxed),
             "nothing should be reported as moving"


### PR DESCRIPTION
## Why

`robotctl update apply daemon --ref slice-2-walk-stand` rolled back on the board, and the reason the updater quoted was useless:

```
"reason": "health check failed: not healthy within 30s:
           control loop has not completed a cycle yet"
```

The journal had the real cause:

```
thread 'control' panicked at ort-2.0.0-rc.11/src/lib.rs:191:41:
Failed to load ONNX Runtime dylib: ort 2.0.0-rc.11 is not compatible with the ONNX
Runtime binary found at `libonnxruntime.so`; expected version >= '1.23.x', but got '1.20.1'
```

The wrong runtime version is fixed elsewhere (#17, #18). This is the other half: **a panicking control thread must not be able to hide why.** The thread dies, `robotd` stays up serving its socket, no tick ever lands, and health answers "has not completed a cycle yet" — the one message that names no cause.

`ensure_runtime`'s doc comment claimed this could not happen: probe the dylib with the same loader `ort` uses, and "a probe that succeeds means its load will succeed too and the panic cannot fire". 1.20.1 loads fine. `ort` then panics on its own *version* check inside `setup_api`, which the probe cannot see — and by construction the probe could never have closed every future `ort` panic either.

## What changed

`catching_ort_panics` wraps the `ort` calls inside `Policy::load` and converts any panic into `PolicyError::RuntimePanic`, **carrying the panic message** — those two version numbers are the whole diagnosis. That routes a panic onto the path `robotd` already had for a policy that will not load: log `policy unavailable; holding the pose`, keep ticking at rate, report `policy unavailable: <reason>`, get rolled back for a stated cause.

- Wraps the `ort` work only, not all of `load`, so a genuine bug of ours is not relabelled "policy unavailable".
- `AssertUnwindSafe` because `Session` is not `UnwindSafe`; the sessions are moved into the `Policy` on success and dropped on failure, so nothing of ours is observed after a catch.
- `panic = "abort"` would defeat this. There is no `[profile.release]` today, and the comment at the catch says why one must not appear.
- `ensure_runtime`'s doc comment now states what the probe does and does not cover, since the old claim is known false.

## Verification

`cargo test --workspace` — 355 passing, plus `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.

New: a panic on the `ort` path becomes an error keeping its message, success passes through untouched, an unprintable payload still yields a reason. Extended: `an_unloadable_policy_holds_the_pose_and_reports_why` now also asserts the underlying cause reaches the health string, which is the property that made the board's failure unreadable.

**Not covered offline:** a real `ort` panic travelling through the control loop — that needs a wrong-version runtime, i.e. a board. Faking one inside `Policy::load` would mean shipping a fault-injection knob in `duck-control` to test three lines. `docs/slice-2-bringup.md` says so, and keeps the board recipe that closes it.