### PR TITLE
health: a stale IMU count is a rate, and "may be dead" needs a run

### DIFF
--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use rustypot::servo::dynamixel::xl330::Xl330Controller;
 
 use crate::imu::{IMU_BLOCK_LEN, SflpDecoder};
-use crate::io::{IoError, JointTargets, Result, RobotIo, Sensors, SlowSensors};
+use crate::io::{ImuStale, IoError, JointTargets, Result, RobotIo, Sensors, SlowSensors};
 use crate::model::{BAUD_RATE, EXPECTED_REGISTERS, IMU_DXL_ID, JOINT_IDS, NUM_JOINTS};
 
 /// Start of the contiguous block read every tick: `present_pwm`, `present_current`,
@@ -48,16 +48,53 @@ const VOLTS_PER_COUNT: f64 = 0.1;
 /// costs a bounded hiccup rather than stalling the loop on the serial driver's default.
 const READ_TIMEOUT: Duration = Duration::from_millis(30);
 
+/// Run of consecutive stale reads at which the journal says something.
+///
+/// 25 reads is half a second at 50 Hz — the same span [`SflpDecoder::ready`] waits for before
+/// it will call the chip's output a measurement, and far longer than any ordinary hiccup. Below
+/// it the tracker stays quiet on purpose: warning on the very first repeated block is what
+/// taught everyone to ignore this message. Kept in step with `ImuHealth::FROZEN_RUN`, which is
+/// where the same threshold is applied to the health report — this crate is the hardware layer
+/// and deliberately does not depend on the IPC vocabulary, so the number lives in both places.
+const STALE_RUN_WARN: u64 = 25;
+
+/// Detects an IMU board that answers without refreshing, by remembering the last block.
+///
+/// Split out from the read path so it can be tested without a serial port: the fault it
+/// describes is one nothing else on the robot reports, and it would otherwise be verifiable
+/// only against broken hardware.
+#[derive(Debug, Default)]
+struct StaleImuTracker {
+    /// `None` until the first block. A fixed initial value cannot work here: it would have to
+    /// be all zeros, and an all-zero block is exactly what a board whose SFLP table is still
+    /// empty sends — scoring a stale read against a predecessor that never existed.
+    last: Option<[u8; IMU_BLOCK_LEN]>,
+    stale: ImuStale,
+}
+
+impl StaleImuTracker {
+    /// Records one block and returns the length of the run it belongs to — 0 when the block is
+    /// fresh, which is the overwhelmingly common answer.
+    fn observe(&mut self, block: &[u8; IMU_BLOCK_LEN]) -> u64 {
+        if self.last.replace(*block) == Some(*block) {
+            self.stale.total = self.stale.total.saturating_add(1);
+            self.stale.run = self.stale.run.saturating_add(1);
+        } else {
+            self.stale.run = 0;
+        }
+        self.stale.run
+    }
+}
+
 pub struct DynamixelIo {
     controller: Xl330Controller,
     /// IMU first, then the servos in [`JOINT_IDS`] order — the order blocks come back in.
     ids: Vec<u8>,
     imu: SflpDecoder,
-    last_imu_block: [u8; IMU_BLOCK_LEN],
     /// Blocks identical to their predecessor. The read succeeded but the board handed back
     /// the same sample, which means the policy is being fed dead orientation data — a
     /// failure that is invisible unless someone counts it. Known to happen.
-    stale_imu_blocks: u64,
+    stale_imu: StaleImuTracker,
 }
 
 impl DynamixelIo {
@@ -82,8 +119,7 @@ impl DynamixelIo {
             controller,
             ids,
             imu: SflpDecoder::default(),
-            last_imu_block: [0; IMU_BLOCK_LEN],
-            stale_imu_blocks: 0,
+            stale_imu: StaleImuTracker::default(),
         })
     }
 
@@ -211,20 +247,18 @@ impl RobotIo for DynamixelIo {
         if blocks[0].len() == IMU_BLOCK_LEN {
             let mut raw = [0u8; IMU_BLOCK_LEN];
             raw.copy_from_slice(&blocks[0]);
-            if raw == self.last_imu_block {
-                let n = self.stale_imu_blocks.saturating_add(1);
-                self.stale_imu_blocks = n;
-                // Say so, or the counter is a number nobody ever reads. Rate-limited
-                // because a board that has stopped refreshing produces one of these every
-                // single tick, and 50 Hz of identical warnings would evict the journal.
-                if n == 1 || n.is_multiple_of(500) {
-                    tracing::warn!(
-                        stale_blocks = n,
-                        "imu board returned the same sample as last tick — orientation may be dead"
-                    );
-                }
+            // Say so, or the counters are numbers nobody ever reads — but only once the run
+            // is long enough to mean something. Rate-limited past that because a board which
+            // has stopped refreshing produces one of these every single tick, and 50 Hz of
+            // identical warnings would evict the journal.
+            let run = self.stale_imu.observe(&raw);
+            if run == STALE_RUN_WARN || (run > STALE_RUN_WARN && run.is_multiple_of(500)) {
+                tracing::warn!(
+                    consecutive = run,
+                    total = self.stale_imu.stale.total,
+                    "imu board has returned the same sample {run} reads running — orientation is frozen"
+                );
             }
-            self.last_imu_block = raw;
             sensors.imu = self.imu.decode(&raw);
         } else {
             return Err(IoError::ShortRead {
@@ -326,8 +360,8 @@ impl RobotIo for DynamixelIo {
         })
     }
 
-    fn imu_stale_blocks(&self) -> u64 {
-        self.stale_imu_blocks
+    fn imu_stale(&self) -> ImuStale {
+        self.stale_imu.stale
     }
 
     fn imu_ready(&self) -> bool {
@@ -369,5 +403,71 @@ mod tests {
         let one_count = RAD_PER_SEC_PER_COUNT;
         let expected_rpm = 0.229;
         assert!((one_count * 60.0 / (2.0 * PI) - expected_rpm).abs() < 1e-12);
+    }
+
+    fn block(n: u8) -> [u8; IMU_BLOCK_LEN] {
+        [n; IMU_BLOCK_LEN]
+    }
+
+    /// The first block has no predecessor, so it cannot be a repeat of one. This is not a
+    /// hypothetical: the natural initial value is all zeros, and an all-zero block is what a
+    /// board sends before SFLP has written its table — which used to score a stale read on the
+    /// very first tick of every boot, and put a permanent 1 in a counter rendered as an alarm.
+    #[test]
+    fn the_first_block_is_never_stale() {
+        let mut t = StaleImuTracker::default();
+        assert_eq!(t.observe(&block(0)), 0);
+        assert_eq!(t.stale.total, 0);
+    }
+
+    /// Fresh blocks must leave both counters alone. The whole point of the run is that it means
+    /// "right now", so anything that does not repeat has to clear it.
+    #[test]
+    fn fresh_blocks_count_for_nothing() {
+        let mut t = StaleImuTracker::default();
+        for n in 0..10 {
+            assert_eq!(t.observe(&block(n)), 0);
+        }
+        assert_eq!(t.stale, ImuStale { total: 0, run: 0 });
+    }
+
+    /// A hiccup: two identical blocks, then the board recovers. The total remembers it — that
+    /// is what makes "9 over 40 minutes" sayable — while the run goes back to zero, because
+    /// orientation is live again and nothing should be shouting.
+    #[test]
+    fn a_hiccup_is_remembered_in_the_total_but_not_the_run() {
+        let mut t = StaleImuTracker::default();
+        t.observe(&block(1));
+        assert_eq!(t.observe(&block(1)), 1, "the repeat is the first of a run");
+        assert_eq!(t.observe(&block(2)), 0, "a fresh block ends the run");
+        assert_eq!(t.stale, ImuStale { total: 1, run: 0 });
+    }
+
+    /// A board that has stopped refreshing repeats forever, and the run is what separates that
+    /// from the hiccup above. It has to reach the threshold the journal and the health report
+    /// both key off, or a genuinely dead IMU is never reported at all.
+    #[test]
+    fn a_dead_board_runs_past_the_warning_threshold() {
+        let mut t = StaleImuTracker::default();
+        t.observe(&block(7));
+        for _ in 0..STALE_RUN_WARN {
+            t.observe(&block(7));
+        }
+        assert_eq!(t.stale.run, STALE_RUN_WARN);
+        assert_eq!(t.stale.total, STALE_RUN_WARN);
+    }
+
+    /// Runs accumulate into the same total across separate episodes: the total is "how often
+    /// has this ever happened", not "how bad is it now".
+    #[test]
+    fn separate_episodes_add_up() {
+        let mut t = StaleImuTracker::default();
+        for n in 0..3u8 {
+            t.observe(&block(n));
+            t.observe(&block(n));
+            t.observe(&block(n));
+        }
+        assert_eq!(t.stale.total, 6, "two repeats in each of three episodes");
+        assert_eq!(t.stale.run, 2, "the last episode was still going");
     }
 }

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -90,6 +90,26 @@ pub struct SlowSensors {
     pub temps_c: [f64; NUM_JOINTS],
 }
 
+/// IMU reads that came back byte-for-byte identical to their predecessor.
+///
+/// Two numbers, because they answer two different questions and only one of them is worth
+/// waking someone for. The *total* says how often the board has repeated itself over the whole
+/// run: sporadic hits are ordinary, since the loop and the board keep their own clocks and a
+/// tick landing inside one board refresh legitimately sees the same bytes twice. The *run* says
+/// whether orientation is frozen right now — a board that has stopped fusing repeats on every
+/// single tick, so its run climbs without bound while a total on its own looks the same as a
+/// handful of hiccups.
+///
+/// Reported together so no backend can offer one without the other; a run with no total to
+/// scale it against is how the count came to be read as an alarm in the first place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ImuStale {
+    /// Stale reads since startup, cumulative and never reset.
+    pub total: u64,
+    /// Length of the current unbroken run of stale reads. Any fresh block resets it to zero.
+    pub run: u64,
+}
+
 pub trait RobotIo {
     /// One transaction: joints and IMU together.
     fn read(&mut self) -> Result<Sensors>;
@@ -117,8 +137,8 @@ pub trait RobotIo {
     /// `sync_read` blocks identical to their predecessor: the board answered but did not
     /// refresh, which means the policy would be fed dead orientation. Invisible unless
     /// someone counts it, which is why it is counted.
-    fn imu_stale_blocks(&self) -> u64 {
-        0
+    fn imu_stale(&self) -> ImuStale {
+        ImuStale::default()
     }
 
     /// Has the orientation filter converged? False for the first moments after startup.

--- a/duck-control/src/safety.rs
+++ b/duck-control/src/safety.rs
@@ -130,8 +130,8 @@ impl<T: RobotIo> Safety<T> {
         self.io.slow_sensors()
     }
 
-    pub fn imu_stale_blocks(&self) -> u64 {
-        self.io.imu_stale_blocks()
+    pub fn imu_stale(&self) -> crate::io::ImuStale {
+        self.io.imu_stale()
     }
 
     pub fn imu_ready(&self) -> bool {

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -905,10 +905,40 @@ pub struct BusHealth {
 pub struct ImuHealth {
     /// Has the orientation filter converged?
     pub ready: bool,
-    /// Reads that returned the previous sample unchanged. Non-zero means the board is
-    /// answering without refreshing: the reads succeed, nothing reports an error, and the
-    /// orientation is frozen.
+    /// Reads that returned the previous sample unchanged, cumulative since startup.
+    ///
+    /// Sporadic hits are ordinary and say nothing about whether orientation is live *now*: the
+    /// control loop and the board keep their own clocks, so a tick landing inside one board
+    /// refresh legitimately sees the same bytes twice. Useful for scale — a handful over an
+    /// hour is a healthy board — and misleading on its own, which is why it travels with the
+    /// run below rather than being reported alone.
     pub stale_blocks: u64,
+    /// Length of the current unbroken run of stale reads; any fresh block resets it to zero.
+    ///
+    /// This is the one worth alarming on. A board that has stopped fusing keeps answering the
+    /// `sync_read` — so the bus reports no error and `ready` stays true — and repeats itself on
+    /// every tick, which makes the run climb without bound. See [`ImuHealth::frozen`].
+    pub consecutive_stale_blocks: u64,
+}
+
+impl ImuHealth {
+    /// Run length at which orientation is called frozen rather than hiccuping.
+    ///
+    /// 25 reads is half a second at 50 Hz: long enough that no ordinary hiccup reaches it, short
+    /// enough to be prompt, and the same span `SflpDecoder::ready` waits for before it will
+    /// treat the chip's output as a measurement. `duck-control`'s journal warning uses the same
+    /// number — deliberately, so the log and the report agree about what "frozen" means — but
+    /// keeps its own copy, because the hardware layer does not depend on this IPC vocabulary.
+    pub const FROZEN_RUN: u64 = 25;
+
+    /// Is orientation frozen *now*, as opposed to having hiccuped at some point?
+    ///
+    /// The distinction is the whole reason both counters exist: reporting any non-zero total as
+    /// a possible dead IMU meant a healthy robot wore an alarm for its entire uptime, and a
+    /// warning that fires on a healthy robot is a warning nobody reads.
+    pub fn frozen(&self) -> bool {
+        self.consecutive_stale_blocks >= Self::FROZEN_RUN
+    }
 }
 
 /// Servo case temperature, reduced to the part worth acting on.

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -640,17 +640,38 @@ fn render_health(report: &HealthReport) -> String {
             let _ = writeln!(out, "  {:<9} {bus}", "bus");
 
             if let Some(imu) = &health.imu {
+                // Ticks are what make a stale count mean anything: 9 of them is a healthy board
+                // over 100k reads and a broken one over 20. Taken from the loop line above
+                // rather than carried in `ImuHealth`, since it is the same number of reads.
+                let ticks = health.control_loop.as_ref().map_or(0, |l| l.ticks);
+                let stale = if imu.frozen() {
+                    // The one case worth shouting about: the board answers, so the bus reports
+                    // no error and `ready` stays true, while the orientation being fed to the
+                    // policy has not changed in half a second.
+                    format!(
+                        ", orientation frozen — {} stale reads running",
+                        imu.consecutive_stale_blocks
+                    )
+                } else {
+                    match (imu.stale_blocks, ticks) {
+                        (0, _) => String::new(),
+                        // Reported as a rate, because the absolute count is the thing that read
+                        // as an alarm on a robot that was fine. One in five figures is a board
+                        // keeping its own clock; one in three reads is a board in trouble, and
+                        // the ratio says which without needing a threshold here.
+                        (n, ticks) if ticks > n => {
+                            format!(", {n} stale reads — 1 in {}", ticks / n)
+                        }
+                        // No tick count to scale against, or more stale reads than ticks
+                        // sampled. Say the number plainly rather than divide by it.
+                        (n, _) => format!(", {n} stale reads"),
+                    }
+                };
                 let _ = writeln!(
                     out,
-                    "  {:<9} {}{}",
+                    "  {:<9} {}{stale}",
                     "imu",
                     if imu.ready { "ready" } else { "not ready" },
-                    match imu.stale_blocks {
-                        0 => String::new(),
-                        // Worth shouting about: the board answers, so nothing else reports a
-                        // fault, while the orientation being fed to the policy is frozen.
-                        n => format!(", {n} stale reads — orientation may be dead"),
-                    }
                 );
             }
 
@@ -1558,6 +1579,7 @@ mod tests {
                 imu: Some(proto::ImuHealth {
                     ready: true,
                     stale_blocks: 0,
+                    consecutive_stale_blocks: 0,
                 }),
                 ..Default::default()
             }),
@@ -1625,6 +1647,7 @@ mod tests {
                 imu: Some(proto::ImuHealth {
                     ready: false,
                     stale_blocks: 0,
+                    consecutive_stale_blocks: 0,
                 }),
                 ..Default::default()
             }),
@@ -1646,9 +1669,11 @@ mod tests {
     /// answers without refreshing.
     ///
     /// Stale IMU reads are the nastiest of the lot — the reads *succeed*, so nothing else
-    /// reports a fault, while the orientation feeding the policy is frozen.
+    /// reports a fault, while the orientation feeding the policy is frozen. What earns the
+    /// alarm is the *run*: 41 reads without a refresh is most of a second of a robot balancing
+    /// on an orientation that is no longer being measured.
     #[test]
-    fn health_renders_a_broken_bus_and_a_stale_imu() {
+    fn health_renders_a_broken_bus_and_a_frozen_imu() {
         let out = render_health(&health_report(
             Some(proto::HealthResult {
                 healthy: false,
@@ -1660,6 +1685,7 @@ mod tests {
                 imu: Some(proto::ImuHealth {
                     ready: true,
                     stale_blocks: 41,
+                    consecutive_stale_blocks: 41,
                 }),
                 ..Default::default()
             }),
@@ -1667,8 +1693,94 @@ mod tests {
         ));
 
         assert!(out.contains("7 consecutive read failures"), "{out}");
-        assert!(out.contains("41 stale reads"), "{out}");
-        assert!(out.contains("orientation may be dead"), "{out}");
+        assert!(out.contains("orientation frozen"), "{out}");
+        assert!(out.contains("41 stale reads running"), "{out}");
+    }
+
+    /// A handful of stale reads over a long run is a healthy board, and must not wear an alarm.
+    ///
+    /// This is the case the old rendering got wrong: any non-zero count said "orientation may be
+    /// dead", so a robot that had hiccuped nine times in 40 minutes looked broken for its whole
+    /// uptime — and a warning that shows up on healthy robots stops being read at all. The rate
+    /// is what carries the meaning here, so the count has to appear scaled by the reads it is
+    /// drawn from.
+    #[test]
+    fn health_renders_sporadic_stale_reads_as_a_rate_without_alarm() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: true,
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: Some(50.1),
+                    ticks: 118_631,
+                    missed: 137,
+                    last_tick_age_ms: 12,
+                }),
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 9,
+                    // The board refreshed on the most recent read, so nothing is frozen.
+                    consecutive_stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("robot     healthy"), "{out}");
+        assert!(out.contains("9 stale reads — 1 in 13181"), "{out}");
+        assert!(!out.contains("frozen"), "{out}");
+        assert!(!out.contains("dead"), "{out}");
+    }
+
+    /// A run below the threshold is still not an alarm — one repeated block is ordinary, and the
+    /// robot must not be described as frozen for being sampled mid-hiccup.
+    #[test]
+    fn health_does_not_call_a_single_repeat_frozen() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: true,
+                control_loop: Some(proto::LoopHealth {
+                    target_hz: 50.0,
+                    achieved_hz: Some(50.0),
+                    ticks: 1000,
+                    missed: 0,
+                    last_tick_age_ms: 10,
+                }),
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 2,
+                    consecutive_stale_blocks: 1,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("2 stale reads — 1 in 500"), "{out}");
+        assert!(!out.contains("frozen"), "{out}");
+    }
+
+    /// Before the loop has reported any ticks there is nothing to divide by, and a rate would be
+    /// a division by zero. The count still has to appear — this is also the shape a fake or a
+    /// future backend produces if it counts stale reads without a loop behind them.
+    #[test]
+    fn health_renders_stale_reads_with_no_ticks_to_scale_against() {
+        let out = render_health(&health_report(
+            Some(proto::HealthResult {
+                healthy: true,
+                imu: Some(proto::ImuHealth {
+                    ready: true,
+                    stale_blocks: 3,
+                    consecutive_stale_blocks: 0,
+                }),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert!(out.contains("imu       ready, 3 stale reads"), "{out}");
+        assert!(!out.contains("1 in"), "{out}");
     }
 
     /// An unpowered bench board reads as *degraded*, and the attempt count is the actionable

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -187,6 +187,10 @@ struct RobotState {
     /// Mirrors of the bus's own IMU diagnostics, refreshed with the thermal sample. Held here
     /// so the IPC side can report them without touching the loop's IO.
     imu_stale_blocks: AtomicU64,
+    /// Stale reads in a row as of the last sample. Sampled rather than watched, which is fine
+    /// for the fault it describes: a board that has stopped refreshing keeps repeating, so its
+    /// run is still growing whenever the next sample lands.
+    imu_stale_run: AtomicU64,
     imu_ready: AtomicBool,
     shutdown: AtomicBool,
     /// Fan-out for `robot.state`. Bounded and lossy by design — see [`STATE_BUFFER`].
@@ -223,6 +227,7 @@ impl RobotState {
             motor_hottest: AtomicU32::new(0),
             cpu_temp_c: AtomicU64::new(0),
             imu_stale_blocks: AtomicU64::new(0),
+            imu_stale_run: AtomicU64::new(0),
             imu_ready: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
             state_tx: tokio::sync::broadcast::Sender::new(STATE_BUFFER),
@@ -267,6 +272,7 @@ impl RobotState {
                 imu: Some(proto::ImuHealth {
                     ready: self.imu_ready.load(Ordering::Relaxed),
                     stale_blocks: self.imu_stale_blocks.load(Ordering::Relaxed),
+                    consecutive_stale_blocks: self.imu_stale_run.load(Ordering::Relaxed),
                 }),
             };
 
@@ -1026,9 +1032,9 @@ fn limit_name(limit: duck_control::safety::Limit) -> &'static str {
 /// corrupt both. The IMU counters come from the same `io`, so they are mirrored here rather
 /// than reached for from the socket.
 fn publish_slow_sensors<T: RobotIo>(io: &mut Safety<T>, state: &RobotState) {
-    state
-        .imu_stale_blocks
-        .store(io.imu_stale_blocks(), Ordering::Relaxed);
+    let stale = io.imu_stale();
+    state.imu_stale_blocks.store(stale.total, Ordering::Relaxed);
+    state.imu_stale_run.store(stale.run, Ordering::Relaxed);
     state.imu_ready.store(io.imu_ready(), Ordering::Relaxed);
 
     // Before the bus read, and unconditionally: this is a `sysfs` read that owes the motor bus


### PR DESCRIPTION
On a robot that is fine:

```
imu       ready, 9 stale reads — orientation may be dead
```

Nine stale reads out of 118631, flat across two samples five seconds apart. The rendering called any non-zero count a possibly-dead IMU, so a healthy board wore an alarm for its whole uptime — and a warning that fires on healthy robots is one nobody reads.

The fault it was hunting is real and nasty: a board that stops fusing keeps answering the `sync_read`, so the bus reports no error, `ready` stays true, and the policy balances on an orientation that is no longer being measured. But the lifetime count cannot tell that from an ordinary hiccup — the loop and the board keep their own clocks, so a tick landing inside one board refresh legitimately sees the same twelve bytes twice.

## What changed

The *run* is what separates them, exactly as `BusHealth::consecutive_errors` already separates a serial hiccup from a dead bus. A board that has stopped refreshing repeats on every tick, so its run climbs without bound.

- `duck-control` tracks total **and** current run (`ImuStale`), replacing `imu_stale_blocks()`.
- `ImuHealth` carries both, plus `FROZEN_RUN = 25` and `frozen()` — half a second at 50 Hz, the same span `SflpDecoder::ready` waits for before it will trust the chip.
- `robotctl health` reports a rate when nothing is frozen, and shouts only when something is:

```
imu       ready, 9 stale reads — 1 in 13181
imu       ready, orientation frozen — 41 stale reads running
```

- The journal warning moves to the same threshold. It used to fire on the first repeated block of a run — once per boot on a healthy robot.

## Two things that fell out of writing it down

**An off-by-one.** The "previous block" started as all zeros, and an all-zero block is exactly what the board sends before SFLP has written its table — so the first tick of every boot could score a stale read against a predecessor that never existed. Some of that 9 is this.

**Testability.** Detection moves into a `StaleImuTracker` split out of the read path, so the one fault nothing else on the robot reports is now verifiable without a serial port rather than only against broken hardware. Five tests: first block never stale, fresh blocks count for nothing, a hiccup lands in the total but not the run, a dead board runs past the threshold, separate episodes add up.

## Install note

`ImuHealth` gains a field, so a new `robotctl` cannot read health from an old `robotd`. Install the pair together.

## Verified

`cargo test -p duck-control -p robotctl -p duck-ipc-proto -p robotd` — 149 passed, 0 failed. `cargo clippy --workspace --all-targets` clean. Not yet run against the board with a genuinely frozen IMU; the frozen path is covered by unit tests only.