### PR TITLE
release: give the verify step the runtime its own hook demands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,29 @@ jobs:
           health = { probe = "socket", timeout = "30s" }
           EOF
 
+          # The release ships a `preinstall` hook asserting the machine can run it, and
+          # `updaterd install` runs hooks on a bootstrap install too — correctly, since a
+          # fresh board is exactly when a missing ONNX Runtime has to be installed. This
+          # runner is not a board: it is x86_64, so the aarch64 dylib the hook would fetch
+          # could never be loaded here, and /usr/local/lib is not writable by the runner
+          # user — which is how this first failed, with the hook aborting the install.
+          #
+          # So declare the precondition satisfied and let the hook take its "already fine"
+          # branch, touching nothing. Faking the *file* rather than skipping the hook keeps
+          # this step's claim honest: hooks still run, and a hook that started failing for
+          # any other reason would still fail the release. The hook's own logic — accepting
+          # a runtime at the floor, refusing one it cannot replace — is covered on emulated
+          # aarch64, as root, in scripts/board-test.sh.
+          #
+          # The version comes from [workspace.metadata.onnxruntime], never a literal: that
+          # table is the single source of truth the hook itself is generated from, and a
+          # second copy here would be free to drift below the floor and turn this step red
+          # for a reason that has nothing to do with the release.
+          onnx_target="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.metadata.onnxruntime.target')"
+          sudo touch "/usr/local/lib/libonnxruntime.so.${onnx_target}"
+          sudo ln -sfn "libonnxruntime.so.${onnx_target}" /usr/local/lib/libonnxruntime.so
+
           # The same command `scripts/install.sh` runs on a fresh robot, against the same
           # files it would download. A host-native build, because the packaged binaries are
           # aarch64 and this runner is x86_64 — what is under test is the bootstrap logic,


### PR DESCRIPTION
No release can be cut since #18 landed. `release.yml`'s "Verify the way a robot would"
step installs the packaged artifact through the real engine, and #18 taught the release
to carry a `preinstall` hook that refuses a machine whose ONNX Runtime is below `ort`'s
floor. On a GitHub runner that hook does exactly what it was written to do — decides the
prerequisite is missing, fetches the aarch64 runtime, and tries to install it into
/usr/local/lib, which the runner user cannot write:

    hook hooks/preinstall failed: exited with 1:
      preinstall: ONNX Runtime absent is below 1.23, which this release requires
      install: cannot create regular file '/usr/local/lib/libonnxruntime.so.1.28.0':
        Permission denied

Running hooks on a bootstrap install is right — a fresh board is precisely when a missing
runtime must be installed — so the hook is not the bug. The runner is: it is x86_64, so
the aarch64 dylib could never load here even once written.

So the step now declares the precondition satisfied — a touched file and a symlink naming
a version at the floor — and the hook takes its "already fine" branch, touching nothing.
Faking the file rather than skipping the hook keeps the step's claim honest: hooks still
run, and one failing for any other reason still fails the release. The hook's own logic is
covered where it can be meaningfully exercised — as root, on emulated aarch64, in
scripts/board-test.sh, which asserts both that it accepts a runtime at the floor and that
it refuses one it cannot replace.

The version is read from [workspace.metadata.onnxruntime] rather than written literally.
That table is what the hook itself is generated from, and a second copy here would be free
to drift below the floor and turn the release red for a reason unrelated to the release —
which is the drift that table exists to prevent.

---

**Why this was invisible until now:** 0.1.4 shipped on Aug 3, #18 (the preinstall hook) merged Aug 4. `daemon-staging-v0.2.0` is the first tag pushed with a hook in the artifact, and it failed at the verify step — which is the step doing its job.

**How it gets tested:** `ci.yml` does not run `release.yml`, so the only real test is re-tagging. Plan is to delete `daemon-staging-v0.2.0` (its run published nothing) and re-push it on main once this merges.