### PR TITLE
docs: apply without --ref is a downgrade on a dev board

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -112,8 +112,30 @@ robotctl update log
 robotctl update watch
 ```
 
-The component is `daemon` — one component covering every binary. `--ref` installs what a branch last
-built on CI, which is the dev-channel workflow; `--version` pins an exact release instead.
+The component is `daemon` — one component covering every binary.
+
+**`apply daemon` with no `--ref` installs the latest *stable* release, which on a dev board is
+usually a downgrade.** It is not "install the newest thing"; it is "install what the stable channel
+offers". Right after a branch merges, that stable release is still older than everything you have been
+testing — and if it predates a daemon that now has a unit file on the board, its `ExecStart` points at
+a binary the older release does not contain, the restart fails, and the update rolls back. That is the
+gate working, but the command that caused it looked like the obvious one.
+
+So on a dev board, name what you want:
+
+```
+sudo robotctl update apply --ref main daemon
+```
+
+```
+sudo robotctl update apply --ref <branch> daemon
+```
+
+`--ref` installs what that branch last built on CI, which is the whole dev workflow. `--version` pins
+an exact release. Give one of them unless you genuinely mean "go to stable".
+
+A merge does not publish instantly: CI has to build `main` before `--ref main` resolves to it.
+`gh run list --branch main` says whether it is done.
 
 ## After an update — the part that bites
 

--- a/docs/install-path-gap.md
+++ b/docs/install-path-gap.md
@@ -86,6 +86,27 @@ a manual restart or a reboot, and unlike the others `robotctl version` cannot ev
 serves no socket, so there is nothing to ask. That is a real gap in a phone-driven flow and needs its
 own answer.
 
+### A consequence worth knowing: units outlive the release that installed them
+
+`hooks/postinstall` installs the units a release ships and, by design, leaves them behind on a
+rollback — the alternative is recording what was added so a revert can undo it, and the hook's own
+comment argues that is not worth it because the next successful update reinstalls whatever it ships.
+
+That reasoning holds for a rollback. It does not hold for a **downgrade to a release that predates a
+daemon**: the unit stays, its `ExecStart` names a binary the older release does not contain, and the
+daemon fails with `203/EXEC`. Once that daemon is also in `on_apply`'s restart set, the failed restart
+fails the *update*, which reverts.
+
+Observed exactly this way: `robotctl update apply daemon` on a board running a dev build resolved to
+stable `0.2.0`, which predates `configd`; `configd.service` could not start; the engine rolled back
+and said so. The outcome is right — a board should not silently downgrade below the release that
+introduced a daemon it is now running — but nothing states the rule, and the error names a systemd
+failure rather than the cause.
+
+Worth deciding rather than leaving as emergent behaviour: whether preflight should refuse a target
+that lacks a binary some installed unit execs, so the refusal arrives before the swap and names the
+real reason.
+
 ## Why the existing tests could not have caught them
 
 Not an accusation of the tests; they cover what they claim. The point is what nothing covers.


### PR DESCRIPTION
`sudo robotctl update apply daemon` right after merging #21 resolved to stable `0.2.0`, which
predates `configd`. The unit installed by a newer release stayed behind, its `ExecStart` named a
binary `0.2.0` does not contain, the restart failed, and the update rolled back.

The gate did its job. The problem is that the command which caused it is the obvious one to type, and
the error names a systemd failure rather than the cause.

Two docs:

- **`cheatsheet.md`** now says what `apply` without `--ref` actually means — install what the
  *stable* channel offers, not the newest thing — and that a merge is not installable until CI has
  built `main`.
- **`install-path-gap.md`** records the interaction behind it. `hooks/postinstall` deliberately leaves
  units behind on a rollback, which is right for a rollback and wrong for a downgrade below the
  release that introduced a daemon: the unit survives, its binary does not, and once that daemon is in
  `on_apply`'s restart set the failed restart fails the update.

Left as an open decision rather than fixed: preflight could refuse a target that lacks a binary some
installed unit execs, so the refusal arrives before the swap and names the real reason.

Docs only — no code changes.