### PR TITLE
updater: derive the restart set from the release, and prove the new updaterd starts

### DIFF
--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -128,6 +128,16 @@ action = "restart"
 # configd *is* restarted: it holds no long-lived session state, the progress stream a client
 # watches comes from updaterd rather than from it, and a config change that never takes effect
 # until reboot would be its own kind of surprise.
+#
+# **The list is additive, not authoritative.** Since the restart set is derived from the units a
+# release actually ships, this only needs to name units the release does *not* ship. Both entries
+# below are therefore redundant, and kept because a config that names what it expects is easier to
+# read than an empty list that quietly means "work it out".
+#
+# It used to be authoritative, and that is the bug this replaced: the file belongs to the operator
+# and `install.sh` preserves it, so a board provisioned before `configd` existed kept
+# `units = ["robotd"]` forever and every release swapped configd's binary while leaving the old
+# process running. See `docs/install-path-gap.md` §4.
 units  = ["robotd", "configd"]
 
 # The gate that makes auto-rollback real. 30s is still the placeholder M4 is meant to

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -121,9 +121,11 @@ Three things are true at once, and together they cost an afternoon if you do not
 
 - **`btd` is never restarted by an update.** Deliberate: restarting it drops the BLE connection
   carrying the update's own progress stream. So a `btd` fix needs a manual restart or a reboot.
-- **`configd` is restarted only if the board's `/etc/robot/updater.toml` lists it.** That file belongs
-  to the operator and is preserved across installs, so a board set up before `configd` existed still
-  says `units = ["robotd"]` and silently keeps running the old binary.
+- **`configd` used to be restarted only if the board's `/etc/robot/updater.toml` listed it** — that
+  file belongs to the operator and is preserved across installs, so a board set up before `configd`
+  existed kept `units = ["robotd"]` and silently ran the old binary. Fixed: the restart set now comes
+  from the units the release ships. A board running an older `updaterd` still has the old behaviour
+  until it restarts, because `updaterd` never restarts itself.
 - **`robotctl update apply` then reports `already_current` and does nothing**, so the obvious recovery
   command is a no-op.
 
@@ -150,18 +152,13 @@ sudo systemctl restart configd
 sudo systemctl restart btd
 ```
 
-To stop `configd` going stale on every future update, add it to the restart set on the board:
-
-```
-sudo sed -i 's|units  = \["robotd"\]|units = ["robotd", "configd"]|' /etc/robot/updater.toml
-```
+Editing the board's `updater.toml` is no longer needed — the restart set is derived from the release.
+The one thing that still requires a manual step is `updaterd` itself, which never restarts itself, so
+the fix above only takes effect once it has:
 
 ```
 sudo systemctl restart updaterd
 ```
-
-This is recorded as a real gap in `install-path-gap.md`, with the fix worth making: derive the restart
-set from the units the release ships rather than from a file on the board.
 
 ### Logs
 

--- a/docs/install-path-gap.md
+++ b/docs/install-path-gap.md
@@ -67,7 +67,14 @@ daemon release is Y … either the restart did not happen, or it failed". Nobody
 that exists and is not reached for is worth as much as one that does not exist, which is an argument
 for the update itself noticing rather than for more diagnostics.
 
-**The fix worth making: derive the restart set from the release, not from the board.** A release ships
+**Fixed** (`engine.rs::units_to_restart`): the restart set is derived from the release's
+`systemd/*.service` files, unioned with whatever the config names, minus `updaterd` and `btd` — which
+moved from a config convention enforced by a test into a `NEVER_RESTART` constant in code, because
+they are properties of what those daemons are rather than operator choices. A board whose
+`updater.toml` predates a daemon now restarts it anyway, and needs no edit. What follows is the
+reasoning, kept because it is the argument for where such lists belong.
+
+**Derive the restart set from the release, not from the board.** A release ships
 `systemd/*.service`, so it already states which units it provides — the same realisation that made
 `hooks/postinstall` the right answer for *installing* them. The engine can restart what the release
 ships, minus the two documented exclusions (`updaterd`, which is performing the update; `btd`, which

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -115,6 +115,39 @@ wrong. The earlier design put the list in `/etc/robot/updater.toml`, which `inst
 so a board provisioned before a daemon existed never restarted it, and the update said success
 anyway (`install-path-gap.md` §4).
 
+**What this does not cover, and the shape of the answer.** Not restarting `updaterd` protects the
+*in-flight* update. It says nothing about whether the new `updaterd` works, and it defers finding out
+to the next boot — by which time the update is committed, nobody is watching, and recovery lives in
+`Engine::recover_on_start`, i.e. **inside the process that is failing to start**. `Restart=on-failure`
+then crash-loops a few times and gives up, leaving a robot with no update daemon and no way to update
+out of it. That contradicts the promise that recovery works when the robot is already broken.
+
+Two layers close it, and they catch different things:
+
+1. **Self-test the new binary before committing**, and restart `updaterd` after the reply is sent.
+   A read-only mode — config loaded, engine constructed, exiting *before* recovery — catches a wrong
+   architecture, a missing library, an immediate panic, and the likely one: a new `updaterd` that
+   rejects the board's existing `updater.toml`, which is the operator's file and preserved across
+   installs. Failing there rolls back cheaply, with no reboot. The restart must be **detached**,
+   because the engine runs inside the `update.apply` RPC and would otherwise hand the client a broken
+   pipe instead of its outcome. The same "restart after replying" reasoning extends to `btd`.
+
+   Note what the *existing* `--check-only` is not: it runs `recover_on_start` for real before honouring
+   the flag, so it increments every armed trial's boot count and can revert an update. It is an
+   operator tool, not a probe, and using it mid-update would have a second engine mutating the store
+   the first one is working on.
+
+2. **A boot-time net outside `updaterd`**, for what slips through. `OnFailure=` on a curated set of
+   units fires exactly when one exhausts its restarts, and a tiny oneshot swaps `current` to golden and
+   reboots. Four constraints make it a net rather than a footgun: the set is curated (`btd`
+   legitimately fails on a board whose radio has not appeared, and reverting a good release over that
+   is a poor trade); it reads a `golden` **symlink** rather than parsing config, because a release that
+   breaks the config parser must not also break its own rescue; it needs a loop guard and must not fire
+   when `current` is already golden; and it cannot fix hardware — a `robotd` that fails for want of
+   servo power fails identically on golden, the same distinction the health gate draws between
+   unhealthy and degraded. Golden rather than previous, deliberately: when the recovery path itself is
+   what broke, previous may be broken too.
+
 This is also why the update logic cannot live in `btd`: as a client of the
 update, `btd` cannot be the thing performing it — it would kill itself partway
 through. `btd` stays a thin transport, and the resident `updaterd` owns the state

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -105,8 +105,15 @@ survive a daemon crash to perform rollback.
 **Corollary — `updaterd` must be resident, and must exclude itself from the
 restart set.** `updaterd` and `btd` both ship *inside* the daemon artifact, so a
 naive "restart everything" would kill the executor mid-swap or mid-health-gate.
-`on_apply` therefore restarts `robotd` and `mediad` only; `updaterd` and `btd`
-pick up the new binary at the next boot or an explicit later restart.
+`on_apply` therefore restarts everything the release ships **except** those two, which pick up the
+new binary at the next boot or an explicit later restart.
+
+The set is derived from the release's own `systemd/*.service` files rather than read from the
+board's config, and the two exclusions live in code (`NEVER_RESTART`) rather than in configuration:
+they are properties of what those daemons *are*, not choices an operator should be able to get
+wrong. The earlier design put the list in `/etc/robot/updater.toml`, which `install.sh` preserves —
+so a board provisioned before a daemon existed never restarted it, and the update said success
+anyway (`install-path-gap.md` §4).
 
 This is also why the update logic cannot live in `btd`: as a client of the
 update, `btd` cannot be the thing performing it — it would kill itself partway

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -122,7 +122,8 @@ to the next boot — by which time the update is committed, nobody is watching, 
 then crash-loops a few times and gives up, leaving a robot with no update daemon and no way to update
 out of it. That contradicts the promise that recovery works when the robot is already broken.
 
-Two layers close it, and they catch different things:
+Two layers close it, and they catch different things. **The first is implemented**; the second is
+its own PR.
 
 1. **Self-test the new binary before committing**, and restart `updaterd` after the reply is sent.
    A read-only mode — config loaded, engine constructed, exiting *before* recovery — catches a wrong
@@ -136,6 +137,19 @@ Two layers close it, and they catch different things:
    the flag, so it increments every armed trial's boot count and can revert an update. It is an
    operator tool, not a probe, and using it mid-update would have a second engine mutating the store
    the first one is working on.
+
+   As built: `self_test_updaterd` runs after the shipped units restart and before the health gate,
+   only where `on_apply` is a restart — a model component has no `updaterd`, and the bootstrap
+   install forces `on_apply=none` precisely because nothing is installed yet. `Error::SelfTest`
+   carries the binary's last line of stderr, so "config error: unknown field `foo`" reaches the
+   rollback reason rather than being flattened into "unreachable".
+
+   The restarts go through `systemd-run --on-active=5s`, and two details there are load-bearing. A
+   *child process* would sit in `updaterd`'s cgroup and be killed partway through restarting its own
+   parent; a transient unit is not. And the update lock is dropped **before** anything is spawned,
+   because a fork duplicates every open descriptor in the process — including locks held by other
+   engines in the same process, which surfaced as unrelated operations failing with `Busy` in the
+   test suite.
 
 2. **A boot-time net outside `updaterd`**, for what slips through. `OnFailure=` on a curated set of
    units fires exactly when one exhausts its restarts, and a tiny oneshot swaps `current` to golden and

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -288,7 +288,7 @@ impl Engine {
         progress: ProgressTx,
     ) -> Result<ApplyResult, Error> {
         // Single-flight. Busy is a normal answer, not a failure.
-        let _lock = UpdateLock::try_acquire(&self.config.state_dir)?.ok_or(Error::Busy)?;
+        let lock = UpdateLock::try_acquire(&self.config.state_dir)?.ok_or(Error::Busy)?;
 
         let cfg = self.config.component(component)?.clone();
         let store = self.store(component)?;
@@ -309,6 +309,14 @@ impl Engine {
 
         // Every operation logs through `record`, which owns what `to` means per outcome.
         self.record(component, installed, &outcome);
+
+        // The lock is released before anything is spawned, and that ordering is load-bearing: a
+        // fork duplicates every open descriptor in the process, so spawning while holding the
+        // update lock hands a copy of it to the child — and in a test binary running engines in
+        // parallel, copies of *other* engines' locks too. It surfaced as unrelated operations
+        // failing with `Busy`. Nothing below this point touches the store.
+        drop(lock);
+        schedule_restarts_if_applied(&outcome).await;
         outcome
     }
 
@@ -653,6 +661,13 @@ impl Engine {
         emit(Phase::Applying, None);
         self.run_apply_action(&cfg.on_apply, release_dir).await?;
 
+        // Only where daemons are actually being replaced. `ApplyAction::None` means this component
+        // has none to restart — a model, or the bootstrap install, which forces it precisely
+        // because nothing is installed yet and there is no running daemon to make stale.
+        if matches!(cfg.on_apply, ApplyAction::Restart { .. }) {
+            self_test_updaterd(release_dir).await?;
+        }
+
         emit(Phase::HealthGate, None);
         self.health_gate(cfg).await
     }
@@ -787,7 +802,7 @@ impl Engine {
         component: &str,
         version: &semver::Version,
     ) -> Result<ApplyResult, Error> {
-        let _lock = UpdateLock::try_acquire(&self.config.state_dir)?.ok_or(Error::Busy)?;
+        let lock = UpdateLock::try_acquire(&self.config.state_dir)?.ok_or(Error::Busy)?;
         let cfg = self.config.component(component)?.clone();
         let store = self.store(component)?;
 
@@ -820,8 +835,14 @@ impl Engine {
             });
         }
 
-        self.transition_to(component, &cfg, &store, version, current)
-            .await
+        // `select` can move to a release carrying newer binaries, so the deferred units are as
+        // stale afterwards as they are after an `apply`. Lock released first, as above.
+        let outcome = self
+            .transition_to(component, &cfg, &store, version, current)
+            .await;
+        drop(lock);
+        schedule_restarts_if_applied(&outcome).await;
+        outcome
     }
 
     /// Shared tail of rollback / reset-to-golden / select: swap, apply, gate, and
@@ -1408,6 +1429,138 @@ const SYSTEMCTL: &str = "systemctl";
 ///
 /// `systemctl` is a parameter rather than hardcoded so a test can hand it a stub. That is the
 /// only reason: nothing should ever pass anything else in production.
+/// How long the replacement `updaterd` gets to load its config and exit.
+///
+/// It parses a file and builds an engine; a second would do. Ten leaves room for a board under load
+/// mid-update without making a hung binary cost the health gate's whole budget.
+const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Units restarted *after* the outcome has been reported, not during the update.
+///
+/// The pair from [`NEVER_RESTART`]. Excluding them from the in-flight restart is right and
+/// insufficient: it left both running the old binary until someone rebooted, which is how a resident
+/// `updaterd` came to reject a newer `robotctl` with "client speaks API v4, daemon speaks v3", and
+/// how `btd` fixes were tested against binaries that were never running.
+///
+/// Deferred rather than skipped, because the reason each is excluded expires the moment the answer
+/// is out: `updaterd` has finished performing the update, and the reply `btd` was carrying has been
+/// delivered. A client sees its outcome and then a dropped connection, which for BLE is an ordinary
+/// reconnect.
+const RESTART_AFTER_REPLYING: [&str; 2] = ["updaterd", "btd"];
+
+/// How long to wait before those restarts, so the reply is on the wire first.
+///
+/// The engine runs *inside* the `update.apply` call, so restarting `updaterd` synchronously would
+/// hand the client a broken pipe instead of the outcome it waited minutes for. A response is a
+/// single write; five seconds is far more than it needs and still faster than any human reaction.
+const DEFERRED_RESTART_DELAY: &str = "5s";
+
+/// Prove the release's `updaterd` can start, before committing to it.
+///
+/// `updaterd` does not restart itself during an update, so without this a replacement binary that
+/// cannot start is discovered at the *next boot* — after the commit, with nobody watching, and with
+/// recovery living inside the very process failing to start. systemd retries it a few times and
+/// gives up, leaving a robot that cannot update its way out. Here, a failure is just a rollback: the
+/// old release is still on disk and nothing has rebooted.
+///
+/// `--self-test` and not `--check-only`: the latter runs boot recovery for real, which would have a
+/// second engine advancing this update's trial against the same store.
+///
+/// A release with no `updaterd` — a model component, or one predating the flag — passes. The point
+/// is to catch a broken replacement, not to require every artifact to contain one.
+async fn self_test_updaterd(release_dir: &Path) -> Result<(), Error> {
+    let binary = release_dir.join("bin").join("updaterd");
+    if !binary.is_file() {
+        return Ok(());
+    }
+
+    let mut command = tokio::process::Command::new(&binary);
+    command.arg("--self-test");
+
+    let output = match tokio::time::timeout(SELF_TEST_TIMEOUT, command.output()).await {
+        Ok(Ok(output)) => output,
+        // Could not be executed at all: the wrong architecture, a missing interpreter, a corrupt
+        // file. Exactly what this exists to catch.
+        Ok(Err(e)) => {
+            return Err(Error::SelfTest(format!(
+                "could not run {}: {e}",
+                binary.display()
+            )));
+        }
+        Err(_) => {
+            return Err(Error::SelfTest(format!(
+                "{} did not finish within {SELF_TEST_TIMEOUT:?}",
+                binary.display()
+            )));
+        }
+    };
+
+    if output.status.success() {
+        tracing::info!("the new updaterd passed its self-test");
+        return Ok(());
+    }
+
+    // stderr, trimmed, because that is where the reason is — "config error: unknown field
+    // `foo`" is the difference between a fixable release and a mystery.
+    let reason = String::from_utf8_lossy(&output.stderr);
+    let reason = reason.lines().last().unwrap_or("no output").trim();
+    Err(Error::SelfTest(format!("{}: {reason}", output.status)))
+}
+
+/// Schedule the deferred restarts when an operation actually moved to a new release.
+///
+/// Only on `Applied`. A rollback leaves the resident `updaterd` already matching `current` — it was
+/// never restarted, so it is still the binary belonging to the release being returned to — and
+/// restarting there would be churn with nothing to fix.
+async fn schedule_restarts_if_applied(outcome: &Result<ApplyResult, Error>) {
+    if matches!(outcome, Ok(ApplyResult::Applied { .. })) {
+        schedule_deferred_restarts().await;
+    }
+}
+
+/// Restart the deferred units, detached, a few seconds from now.
+///
+/// `systemd-run` rather than a child process, and this is the load-bearing detail: `systemctl
+/// restart updaterd` kills `updaterd`'s whole cgroup, and a child of `updaterd` is *in* that cgroup —
+/// so it would be killed partway through restarting its own parent. A transient unit lives outside
+/// it and survives.
+///
+/// Failures are logged, never returned. This runs after the update is committed and journalled; an
+/// update that succeeded must not be reported as failed because a restart could not be scheduled.
+/// The cost of that is the situation we already have today — a daemon running an old binary until
+/// the next boot — which `robotctl version` reports.
+async fn schedule_deferred_restarts() {
+    for unit in RESTART_AFTER_REPLYING {
+        let mut command = tokio::process::Command::new("systemd-run");
+        command
+            .arg(format!("--on-active={DEFERRED_RESTART_DELAY}"))
+            .arg("--timer-property=AccuracySec=100ms")
+            .arg("--")
+            .arg(SYSTEMCTL)
+            .arg("restart")
+            .arg(unit);
+
+        // `tokio::process`, not `std::process`: this runs inside the async engine, and a blocking
+        // `status()` here stalls the runtime — which showed up as unrelated operations later
+        // failing with `Busy`, because the update lock had not been released yet.
+        match command.status().await {
+            Ok(status) if status.success() => {
+                tracing::info!(unit, delay = DEFERRED_RESTART_DELAY, "restart scheduled");
+            }
+            Ok(status) => tracing::warn!(
+                unit,
+                %status,
+                "could not schedule the restart; it keeps the old binary until the next boot"
+            ),
+            Err(e) => tracing::warn!(
+                unit,
+                error = %e,
+                "could not run systemd-run; the unit keeps the old binary until the next boot"
+            ),
+        }
+    }
+}
+
 /// Units this update must not touch, whatever a release ships.
 ///
 /// `updaterd` is the process performing the update: restarting it kills the operation mid-flight.
@@ -1580,6 +1733,66 @@ esac
 
     fn calls(dir: &std::path::Path) -> String {
         std::fs::read_to_string(dir.join("calls")).unwrap_or_default()
+    }
+
+    /// A release directory whose `bin/updaterd` is a script behaving as given.
+    fn release_with_updaterd(script: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let path = bin.join("updaterd");
+        std::fs::write(&path, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        dir
+    }
+
+    /// The failure this exists to catch, and the reason it must be reported rather than counted:
+    /// a rollback reason of "unreachable" sent three investigations down the wrong path.
+    #[tokio::test]
+    async fn a_replacement_updaterd_that_cannot_start_fails_the_update() {
+        let release = release_with_updaterd(
+            "#!/bin/sh\necho 'config error: unknown field `nope`' >&2\nexit 1\n",
+        );
+
+        let err = self_test_updaterd(release.path()).await.unwrap_err();
+
+        assert!(
+            matches!(err, Error::SelfTest(_)),
+            "expected a self-test failure, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("unknown field"),
+            "the reason must survive into the message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replacement_updaterd_that_starts_passes() {
+        let release = release_with_updaterd("#!/bin/sh\nexit 0\n");
+        assert!(self_test_updaterd(release.path()).await.is_ok());
+    }
+
+    /// Model components ship no `updaterd`, and neither do releases predating the flag. Requiring
+    /// one would make this a compatibility break rather than a safety net.
+    #[tokio::test]
+    async fn a_release_without_an_updaterd_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(self_test_updaterd(dir.path()).await.is_ok());
+    }
+
+    /// The two lists are one decision, and splitting them is how a daemon gets excluded from the
+    /// restart and then forgotten. Everything held back during the update is restarted after it.
+    #[test]
+    fn every_unit_held_back_is_restarted_once_the_answer_is_out() {
+        let mut held: Vec<&str> = NEVER_RESTART.to_vec();
+        let mut deferred: Vec<&str> = RESTART_AFTER_REPLYING.to_vec();
+        held.sort_unstable();
+        deferred.sort_unstable();
+        assert_eq!(held, deferred);
     }
 
     /// Write a release directory that ships these units.

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -651,7 +651,7 @@ impl Engine {
         hooks::run(release_dir, hooks::HookKind::PostInstall, ctx, HOOK_TIMEOUT).await?;
 
         emit(Phase::Applying, None);
-        self.run_apply_action(&cfg.on_apply).await?;
+        self.run_apply_action(&cfg.on_apply, release_dir).await?;
 
         emit(Phase::HealthGate, None);
         self.health_gate(cfg).await
@@ -735,7 +735,7 @@ impl Engine {
         self.boot_counter
             .confirm(component)
             .map_err(|e| Error::RollbackFailed(e.to_string()))?;
-        self.run_apply_action(&cfg.on_apply)
+        self.run_apply_action(&cfg.on_apply, &store.release_dir(previous))
             .await
             .map_err(|e| Error::RollbackFailed(e.to_string()))?;
 
@@ -858,7 +858,10 @@ impl Engine {
             let _ = self.boot_counter.confirm(component);
             return Err(e);
         }
-        if let Err(e) = self.run_apply_action(&cfg.on_apply).await {
+        if let Err(e) = self
+            .run_apply_action(&cfg.on_apply, &store.release_dir(to))
+            .await
+        {
             let _ = self.boot_counter.confirm(component);
             return Err(e);
         }
@@ -1182,12 +1185,16 @@ impl Engine {
     /// distinction is the point, and it is why this asks systemd for `LoadState` rather than
     /// reading an exit code: `systemctl` does not reliably distinguish the two, and swallowing
     /// both would turn "the daemon is broken" into a silent success.
-    async fn run_apply_action(&self, action: &ApplyAction) -> Result<(), Error> {
+    async fn run_apply_action(
+        &self,
+        action: &ApplyAction,
+        release_dir: &Path,
+    ) -> Result<(), Error> {
         match action {
             ApplyAction::None => Ok(()),
             ApplyAction::Restart { units } => {
-                for unit in units {
-                    restart_one(SYSTEMCTL, unit).await?;
+                for unit in units_to_restart(release_dir, units) {
+                    restart_one(SYSTEMCTL, &unit).await?;
                 }
                 Ok(())
             }
@@ -1401,6 +1408,74 @@ const SYSTEMCTL: &str = "systemctl";
 ///
 /// `systemctl` is a parameter rather than hardcoded so a test can hand it a stub. That is the
 /// only reason: nothing should ever pass anything else in production.
+/// Units this update must not touch, whatever a release ships.
+///
+/// `updaterd` is the process performing the update: restarting it kills the operation mid-flight.
+/// `btd` may be the *transport the update was requested over* — restarting it drops the BLE
+/// connection carrying `update.subscribe`, so the phone that started the update never learns the
+/// outcome, which is the entire app-driven flow (`docs/updater-design.md` §4).
+///
+/// In code rather than in configuration, deliberately. These two are properties of what the daemons
+/// *are*, not choices an operator should be able to get wrong — and a board that got them wrong
+/// would break in a way nobody could see until an update was already running.
+const NEVER_RESTART: [&str; 2] = ["updaterd", "btd"];
+
+/// The units to restart: what the release ships, plus anything the config names.
+///
+/// **Derived from the release rather than read from the board**, which is the whole point.
+/// `on_apply`'s list lives in the operator's `/etc/robot/updater.toml`, and `install.sh` preserves
+/// that file — so a board provisioned before a daemon existed keeps a list that does not mention it,
+/// and every release swaps that daemon's binary while leaving the old process running. The update
+/// reports success, the daemon answers on stale code, and `apply` then says `already_current` and
+/// does nothing. Four correct fixes were diagnosed as broken that way in one afternoon; see
+/// `docs/install-path-gap.md` §4.
+///
+/// A release already states which units it provides — it ships them in `systemd/` — so it can say
+/// which to restart. Same realisation that made `hooks/postinstall` the right place to *install*
+/// them.
+///
+/// The configured list is kept as an addition rather than replaced, for a unit that is not shipped
+/// by the release but should still be restarted with it. It is no longer load-bearing: a board whose
+/// config is years out of date now gets the right behaviour anyway.
+///
+/// An unreadable or absent `systemd/` directory yields the configured list unchanged. Older releases
+/// predate the directory, and a rollback to one must still work.
+fn units_to_restart(release_dir: &Path, configured: &[String]) -> Vec<String> {
+    let mut units: Vec<String> = Vec::new();
+
+    match std::fs::read_dir(release_dir.join("systemd")) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("service") {
+                    continue;
+                }
+                if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
+                    units.push(name.to_owned());
+                }
+            }
+        }
+        Err(e) => {
+            // Not fatal. A release without a `systemd/` directory is simply an older one, and the
+            // configured list is what boards have always used.
+            tracing::debug!(
+                dir = %release_dir.display(),
+                error = %e,
+                "no units in the release; using the configured list"
+            );
+        }
+    }
+
+    units.extend(configured.iter().cloned());
+
+    // Sorted so the restart order is the same on every board and in every test, and deduplicated
+    // because the config and the release will usually name the same daemons.
+    units.sort();
+    units.dedup();
+    units.retain(|unit| !NEVER_RESTART.contains(&unit.as_str()));
+    units
+}
+
 async fn restart_one(systemctl: &str, unit: &str) -> Result<(), Error> {
     let mut c = tokio::process::Command::new(systemctl);
     c.arg("restart").arg(unit);
@@ -1505,6 +1580,91 @@ esac
 
     fn calls(dir: &std::path::Path) -> String {
         std::fs::read_to_string(dir.join("calls")).unwrap_or_default()
+    }
+
+    /// Write a release directory that ships these units.
+    fn release_shipping(units: &[&str]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("systemd")).unwrap();
+        for unit in units {
+            std::fs::write(
+                dir.path().join("systemd").join(format!("{unit}.service")),
+                "[Unit]\n",
+            )
+            .unwrap();
+        }
+        dir
+    }
+
+    /// The point of the change: a board whose config predates a daemon still restarts it.
+    ///
+    /// `units = ["robotd"]` is what a board provisioned before `configd` existed still says, and
+    /// `install.sh` preserves that file forever. Every release then swapped configd's binary and
+    /// left the old process serving, which is how four correct fixes were diagnosed as broken.
+    #[test]
+    fn a_daemon_the_board_never_heard_of_is_restarted_anyway() {
+        let release = release_shipping(&["robotd", "configd"]);
+        let stale_config = vec!["robotd".to_owned()];
+
+        assert_eq!(
+            units_to_restart(release.path(), &stale_config),
+            vec!["configd".to_owned(), "robotd".to_owned()]
+        );
+    }
+
+    /// `updaterd` is performing the update and `btd` may be the transport it arrived over. Neither
+    /// may be restarted however they reach the list — shipped by the release, named in the config,
+    /// or both.
+    #[test]
+    fn updaterd_and_btd_are_never_restarted() {
+        let release = release_shipping(&["robotd", "configd", "updaterd", "btd"]);
+        let reckless = vec!["updaterd".to_owned(), "btd".to_owned()];
+
+        assert_eq!(
+            units_to_restart(release.path(), &reckless),
+            vec!["configd".to_owned(), "robotd".to_owned()],
+            "the exclusions must hold against both sources"
+        );
+    }
+
+    /// A rollback to a release predating the `systemd/` directory has to keep working, and the
+    /// configured list is what boards used before any of this existed.
+    #[test]
+    fn a_release_shipping_no_units_falls_back_to_the_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let configured = vec!["robotd".to_owned(), "configd".to_owned()];
+
+        assert_eq!(
+            units_to_restart(dir.path(), &configured),
+            vec!["configd".to_owned(), "robotd".to_owned()]
+        );
+    }
+
+    /// Named in both places is one restart, not two — and the order is the same everywhere, so a
+    /// failure is reproducible rather than depending on directory iteration order.
+    #[test]
+    fn the_set_is_deduplicated_and_ordered() {
+        let release = release_shipping(&["robotd", "configd"]);
+        let overlapping = vec!["configd".to_owned(), "robotd".to_owned()];
+
+        assert_eq!(
+            units_to_restart(release.path(), &overlapping),
+            vec!["configd".to_owned(), "robotd".to_owned()]
+        );
+    }
+
+    /// Only `.service` files. A release ships `sysusers.d/` too, and `postinstall` reads it —
+    /// nothing there is a unit to restart.
+    #[test]
+    fn only_service_files_count() {
+        let release = release_shipping(&["robotd"]);
+        std::fs::write(release.path().join("systemd").join("robot.target"), "x").unwrap();
+        std::fs::write(release.path().join("systemd").join("notes.txt"), "x").unwrap();
+
+        assert_eq!(
+            units_to_restart(release.path(), &[]),
+            vec!["robotd".to_owned()]
+        );
     }
 
     /// The bug this whole change exists for: the release that first carries a new daemon has no

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -101,6 +101,14 @@ pub enum Error {
     #[error("hook {hook} failed: {detail}")]
     Hook { hook: String, detail: String },
 
+    /// The replacement `updaterd` could not start.
+    ///
+    /// Distinct from `HealthCheck` on purpose: the robot is fine, the *release* cannot run the
+    /// process that would install the next one. Naming it is the whole value — a rollback reason of
+    /// "unreachable" sent three separate investigations down the wrong path.
+    #[error("the new updaterd failed its self-test: {0}")]
+    SelfTest(String),
+
     #[error("health check failed: {0}")]
     Health(String),
 
@@ -138,6 +146,10 @@ impl Error {
             Error::Preflight(_) => code::PREFLIGHT_FAILED,
             Error::Hook { .. } => code::HOOK_FAILED,
             Error::Health(_) => code::HEALTH_CHECK_FAILED,
+            // Shares the health code rather than adding one: to a client this is the same class of
+            // answer — "the new release did not pass its checks and was reverted" — and the
+            // distinction that matters is in the message, which names the binary and the reason.
+            Error::SelfTest(_) => code::HEALTH_CHECK_FAILED,
             Error::RollbackFailed(_) => code::ROLLBACK_FAILED,
             Error::Config(_) | Error::Io { .. } | Error::Corrupt(_) | Error::Internal(_) => {
                 code::INTERNAL_ERROR

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -46,9 +46,32 @@ struct Args {
     #[arg(long, global = true)]
     robot_socket: Option<PathBuf>,
 
-    /// Run boot recovery, report what it would do, and exit without serving.
+    /// Run boot recovery, then exit without serving.
+    ///
+    /// Note this **performs** recovery rather than reporting it: `record_boot` advances every armed
+    /// trial and reverts one that is exhausted. An operator tool, not a probe — see `--self-test`
+    /// for the read-only one, and `updater-design.md` §4 for why the distinction cost an
+    /// investigation.
     #[arg(long, global = true)]
     check_only: bool,
+
+    /// Load the config, construct the engine, and exit. Touches no state.
+    ///
+    /// The probe an update runs against the release it just swapped in, before committing to it.
+    /// `updaterd` never restarts itself during an update, so a replacement binary that cannot start
+    /// is otherwise discovered at the *next boot* — after the commit, with nobody watching, and with
+    /// recovery living inside the process that is failing to start.
+    ///
+    /// Deliberately stops short of `recover_on_start`: running that mid-update would have a second
+    /// engine advancing the in-flight trial's boot count against the same store, and reverting the
+    /// update the first one is still performing.
+    ///
+    /// What it does exercise is what actually breaks: the binary loads and is the right
+    /// architecture, its libraries resolve, it does not panic on startup, and — the likely one — it
+    /// accepts the board's existing `updater.toml`, which belongs to the operator and is preserved
+    /// across installs while a release is free to change what it expects.
+    #[arg(long, global = true)]
+    self_test: bool,
 
     /// Enable a fault injection point (repeatable). Test/bench only — refused
     /// unless the config allows it, and never set on a client robot.
@@ -544,6 +567,12 @@ async fn serve(args: Args) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+
+    // Before recovery, not after: this must not touch state. See the flag's documentation.
+    if args.self_test {
+        tracing::info!("--self-test: config loaded and engine constructed; not serving");
+        return ExitCode::SUCCESS;
+    }
 
     // BEFORE serving. A robot that booted into a bad release has already begun
     // reverting by the time anything can ask it to do something else.

--- a/updater/updater.example.toml
+++ b/updater/updater.example.toml
@@ -129,6 +129,9 @@ manifest_asset = "manifest.json"
 # `mediad` is absent because it does not exist yet: naming a unit that isn't installed
 # makes `systemctl restart` fail, which fails the update, which rolls it back. Add it in
 # the same change that first ships it.
+# The restart set is derived from the units the release ships (`systemd/*.service`), minus `updaterd`
+# and `btd`, which must never be restarted by an update they are carrying. Anything named here is
+# *added* to that set — use it only for a unit the release does not ship.
 [component.daemon.on_apply]
 action = "restart"
 units  = ["robotd"]


### PR DESCRIPTION
`on_apply`'s unit list lived in `/etc/robot/updater.toml` — the operator's file, which `install.sh`
preserves on purpose. A board provisioned before a daemon existed kept a list that never mentioned
it, so every release swapped that daemon's binary and left the old process running.

The failure shape is what makes it worth fixing rather than documenting:

- the update reports **success** — the swap happened, the health gate passed, nothing failed;
- the daemon keeps answering, on old code, so it looks like the fix was wrong rather than absent;
- `robotctl update apply` then reports **`already_current`** and does nothing, so the obvious
  recovery command is a no-op.

Four correct wifi fixes were diagnosed as broken this way in one afternoon — `install-path-gap.md`
§4 has the full account.

## The change

A release already states which units it provides: it ships them in `systemd/`. So it can say which to
restart. Same realisation that made `hooks/postinstall` the right place to *install* them.

`units_to_restart(release_dir, configured)` reads the active release's `systemd/*.service`, unions
whatever the config names, sorts, dedups, and drops the exclusions. The configured list stays as an
**addition** — for a unit the release does not ship — but is no longer load-bearing: a board whose
config is years out of date now gets the right behaviour with no edit.

`updaterd` and `btd` move from a config convention enforced by a test into a `NEVER_RESTART` constant
in code. They are properties of what those daemons *are* — one is performing the update, the other may
be the transport it arrived over — not choices an operator should be able to get wrong. And getting
them wrong breaks only while an update is already running, which is the worst time to find out.

A release with no `systemd/` directory yields the configured list unchanged, so a rollback to a
release predating the directory still works.

## Tests

Five, covering: a daemon the board's config never heard of is restarted anyway; the exclusions hold
against both sources; an old release falls back to the config; the set is deduplicated and ordered;
only `.service` files count.

The exclusion test was verified by deleting the `retain` and watching it fail, not by reading it.

## Note for existing boards

`updaterd` never restarts itself, so a board keeps the old behaviour until `systemctl restart
updaterd` or a reboot. Documented in the cheat sheet.

---

## Second half: the new `updaterd` is proven, then restarted

Excluding `updaterd` and `btd` from the restart set protects the in-flight update and nothing else.
It left both running the old binary until someone rebooted — which is how a resident `updaterd` came
to reject a newer `robotctl` with `client speaks API v4, daemon speaks v3`, and how `btd` fixes were
tested against binaries that were never running. Worse: a replacement `updaterd` that cannot start was
discovered at the *next boot*, after the commit, with nobody watching, and with recovery living inside
the process failing to start.

**Before committing**, `self_test_updaterd` runs the release's own `updaterd --self-test` — a new
read-only mode that loads the config, builds the engine, and exits *before* `recover_on_start`. It
catches a wrong architecture, a missing library, a startup panic, and the likely one: a new `updaterd`
that rejects the board's existing `updater.toml`, which belongs to the operator and is preserved
across installs. Failing there is an ordinary rollback, old release still on disk, no reboot.
`Error::SelfTest` carries the binary's last stderr line, so the reason reaches the outcome instead of
being flattened into "unreachable".

Deliberately not `--check-only`: that one runs boot recovery *for real* before honouring the flag, so
using it here would have a second engine advancing this update's trial against the same store.

**After the outcome is journalled**, both units restart via `systemd-run --on-active=5s`. Deferred
rather than skipped, because the reason each was excluded expires once the answer is out.

Three details cost a debugging cycle each:

- `systemd-run` rather than a child process — `systemctl restart updaterd` kills updaterd's cgroup,
  and a child is *in* it, so it would be killed partway through restarting its own parent;
- the update lock is dropped **before** anything is spawned, because a fork duplicates every open
  descriptor in the process, including other engines' locks in a test binary running them in
  parallel. That surfaced as unrelated tests failing with `Busy`;
- `tokio::process`, not `std::process`, since this runs inside the async engine.

Gated on `on_apply` being a restart, so the bootstrap install — which forces `on_apply=none` because
nothing is installed yet — is untouched.

Four more tests, including one pinning that the units held back during an update are exactly the units
restarted after it: splitting those two lists is how a daemon gets excluded and then forgotten.

## Still open

The boot-time net (`OnFailure=` → swap to golden) is its own PR. `btd` belongs in that set after all:
it waits indefinitely for an adapter rather than exiting, so a *failed* `btd.service` really does mean
something is broken.
