### PR TITLE
release: verify as root, because that is what a robot's updaterd is

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,8 @@ jobs:
           # `updaterd install` runs hooks on a bootstrap install too — correctly, since a
           # fresh board is exactly when a missing ONNX Runtime has to be installed. This
           # runner is not a board: it is x86_64, so the aarch64 dylib the hook would fetch
-          # could never be loaded here, and /usr/local/lib is not writable by the runner
-          # user — which is how this first failed, with the hook aborting the install.
+          # could never be loaded here, and fetching ~100 MB to prove that would only make
+          # every release slower.
           #
           # So declare the precondition satisfied and let the hook take its "already fine"
           # branch, touching nothing. Faking the *file* rather than skipping the hook keeps
@@ -241,7 +241,25 @@ jobs:
           # Note this reaches `--from`, never the `github_releases` source above: an
           # install that silently fell back to the network would be publishing a release
           # by fetching some *other* release, and would pass while proving nothing.
-          cargo run -p updater --bin updaterd -- install \
+          #
+          # As root, because that is what a robot's `updaterd` is. The release now carries a
+          # `postinstall` hook that installs unit files into /etc/systemd/system and sysusers
+          # files into /usr/lib/sysusers.d, and it fails the update when it cannot — correctly,
+          # since a release whose units never arrive is a release that does not work. Running
+          # the engine unprivileged made this step reject a perfectly good release, which is
+          # the same mismatch the preinstall hook exposed one release earlier: a step claiming
+          # to verify "the way a robot would" has to have the privilege a robot has.
+          #
+          # Built first and then run under sudo, rather than `sudo cargo run`: cargo as root
+          # would write root-owned files into the cached target directory and poison it for
+          # every later step and every later run.
+          #
+          # The hook then enables the units it installed, and they fail to start here — they
+          # are aarch64 and this is x86_64. Expected, and only a warning by design: a unit that
+          # cannot start must not fail an otherwise good update. Failure lines from
+          # btd/configd/robotd in this step's log are the runner being a runner.
+          cargo build -p updater --bin updaterd
+          sudo ./target/debug/updaterd install \
             --config verify/updater.toml \
             --from verify/published
 


### PR DESCRIPTION
`daemon-staging-v0.3.0` failed to publish, and the release was fine:

    install failed with nothing to revert to; this robot needs attention
      reason="hook hooks/postinstall failed: exited with 1:
        install: cannot create regular file '/usr/lib/sysusers.d/btd.conf': Permission denied"

0.3.0 is the first release to carry `hooks/postinstall`, which installs the units and
sysusers files the release ships — the fix for a daemon arriving with no unit for systemd to
find. It fails the update when the copy fails, which is right: a release whose units never
arrive does not work.

The verify step ran the engine as the unprivileged runner user. On a robot `updaterd` is
root, and this step's whole claim is that it installs "the way a robot would" — so the step
was wrong, not the hook. This is the second time that mismatch has surfaced: #30 was the
same shape, with `preinstall` and /usr/local/lib. Fixing it at the privilege level rather
than per hook is what stops a third.

`cargo build` then `sudo ./target/debug/updaterd`, rather than `sudo cargo run`: cargo as
root writes root-owned files into the cached target directory and poisons it for every
later step and every later run.

Two consequences worth stating so they are not read as breakage. The hook enables the units
it installs, and they fail to start on the runner — they are aarch64 binaries on x86_64.
That is a warning by design, because a unit that cannot start must not fail an otherwise
good update, and the log lines from btd/configd/robotd in this step are the runner being a
runner. And the ONNX pre-seed from #30 stays, with its reason corrected: it is no longer
about permissions but about not fetching 100 MB of aarch64 dylib that could never load here.