### PR TITLE
update: --staging, the one way to reach a release candidate

### DIFF
--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -102,6 +102,13 @@ manifest_asset = "manifest.json"
 # if it somehow resolved the tag.
 # ref_tag_prefix = "daemon-dev-"
 
+# Where `--staging` looks: the tags `release.yml` pushes for release candidates. Shown for
+# completeness — this is the default, and a robot needs no configuration to reach a candidate.
+#
+# Reaching one still takes a person with root typing `--staging`. A candidate is flagged as a
+# prerelease, which `latest` skips, so nothing here makes this robot *track* candidates.
+# staging_tag_prefix = "daemon-staging-v"
+
 # `updaterd` restarts neither itself nor `btd`, both of which ship in this same artifact:
 # restarting itself would kill the executor mid-update, and restarting `btd` would drop
 # the connection reporting progress to the app. Both pick up the new binary at the next

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -134,6 +134,22 @@ sudo robotctl update apply --ref <branch> daemon
 `--ref` installs what that branch last built on CI, which is the whole dev workflow. `--version` pins
 an exact release. Give one of them unless you genuinely mean "go to stable".
 
+To install a **release candidate** — what `release.yml` published to staging and nobody has promoted
+yet, which is what a canary robot should run before a promotion:
+
+```
+sudo robotctl update apply --staging daemon
+```
+
+```
+sudo robotctl update apply --staging --version 0.3.0 daemon
+```
+
+A candidate is signed with the release key like any release and carries the version it will be
+promoted under. What makes it unreachable without the flag is that it is flagged as a prerelease, and
+a plain `apply` skips those so no robot drifts onto a build nobody has validated. `--staging` is that
+filter's only opt-in, it applies to the one command, and it leaves nothing switched on afterwards.
+
 A merge does not publish instantly: CI has to build `main` before `--ref main` resolves to it.
 `gh run list --branch main` says whether it is done.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ sudo robotctl update apply daemon --ref my-branch
 Two properties make this safe on every push, both enforced away from the workflow:
 
 - A dev build **cannot become `latest`** — the version is a semver prerelease, and
-  `version_from_tag` refuses to read a dev tag as a release version.
+  `version_under` refuses to read a dev tag as a release version.
 - A dev build **cannot install on a customer robot** — `allow_dev_keys` is false there, and a
   trusted key only counts as a dev key if its filename ends `.dev.pub`.
 

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -1042,18 +1042,24 @@ doesn't match `Cargo.toml` (tagging without bumping), and `promote` refuses a ve
 that doesn't match the staging manifest.
 
 - Channels: `staging` → `stable`. CI publishes candidates to `staging`.
-- A canary robot takes a candidate **by explicit version**, not by tracking the channel:
+- A canary robot takes a candidate with **one flag, per command**:
 
   ```
-  sudo robotctl update apply daemon --version 0.2.0
+  sudo robotctl update apply daemon --staging
   ```
 
-  with `tag_prefix = "daemon-staging-v"` in its config, which resolves the tag directly. An
-  earlier draft said canaries "auto-pull staging", and that is not implementable as written:
+  An earlier draft said canaries "auto-pull staging", and that was not implementable as written:
   `newest_version` skips anything GitHub flags as a prerelease *and* anything carrying a semver
-  prerelease component, with no opt-out — which is exactly what keeps a customer robot off
-  candidate builds, so the filter stays and the sentence goes. Discovered by a board reporting
-  `no releases in … with tag prefix "daemon-staging-v"` against a staging release that existed.
+  prerelease component. That filter is exactly what keeps a customer robot off candidate builds,
+  so it stays, and `--staging` is its only opt-in — a second scan under `staging_tag_prefix`
+  which allows the *GitHub* flag while still excluding semver prereleases, so a branch build can
+  never be mistaken for a candidate. `latest_manifest` is untouched, so `auto_apply` and the
+  periodic check keep resolving stable: nothing drifts onto a candidate without a person and
+  root.
+
+  The first attempt at this was a board pointed at staging by editing `tag_prefix`, which
+  reported `no releases in … with tag prefix "daemon-staging-v"` against a candidate sitting
+  right there — the prefix said where to look, and the prerelease filter refused to look.
 - On green, **promote**: repoint `stable` at the *same bytes* already validated —
   re-sign the `stable` manifest to reference the identical tarball + hash. No
   rebuild, no re-flash, no hand-copying files. Promotion is one command / one

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -777,6 +777,22 @@ pub enum Target {
     /// install of one looks like a downgrade. Refusing them would make the flow useless,
     /// and an operator naming a ref is stating intent as explicitly as naming a version.
     Ref(String),
+    /// The newest **release candidate** — what `release.yml` published to `staging` and
+    /// nobody has promoted yet.
+    ///
+    /// A candidate is unreachable any other way. It is flagged as a prerelease on GitHub, so
+    /// [`Target::Latest`] skips it by design — that filter is what keeps a robot from drifting
+    /// onto a build no one has validated, and it has no opt-out. This variant is the opt-*in*:
+    /// an operator with root saying "the one being tested", once.
+    ///
+    /// The candidate carries the same version the promoted release will (`0.3.0`, not
+    /// `0.3.0-rc1`) and is signed with the same release key. What separates the two streams is
+    /// the tag it lives under, which is why resolving this needs its own prefix rather than a
+    /// flag on the existing one.
+    Staging,
+    /// A named candidate, when the newest is not the one wanted — reinstalling the candidate a
+    /// board already ran after a rollback, or comparing two of them.
+    StagingExact(semver::Version),
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -2033,7 +2049,7 @@ mod tests {
         assert!(!serde_json::to_string(&open).unwrap().contains("psk"));
     }
 
-    /// `Target` must survive the wire in all three forms, and the two that carry data must
+    /// `Target` must survive the wire in all five forms, and the three that carry data must
     /// not be confusable. `latest` is a bare string while the others are single-key objects,
     /// which is what an externally-tagged enum with `rename_all = "snake_case"` produces —
     /// pinned here because this JSON is a contract with `btd` and the app, not an
@@ -2047,6 +2063,11 @@ mod tests {
                 r#"{"exact":"1.2.3"}"#,
             ),
             (Target::Ref("my-branch".into()), r#"{"ref":"my-branch"}"#),
+            (Target::Staging, r#""staging""#),
+            (
+                Target::StagingExact(semver::Version::new(0, 3, 0)),
+                r#"{"staging_exact":"0.3.0"}"#,
+            ),
         ];
         for (target, expected) in cases {
             let line = serde_json::to_string(&target).unwrap();

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -281,6 +281,20 @@ enum UpdateCommand {
         #[arg(long = "ref", value_name = "REF", conflicts_with = "version")]
         git_ref: Option<String>,
 
+        /// Install the release candidate from the staging channel.
+        ///
+        /// A candidate is what `release.yml` published and nobody has promoted yet. It is
+        /// signed with the release key like any release, and carries the version it will be
+        /// promoted under — what makes it unreachable otherwise is that it is flagged as a
+        /// prerelease, which a plain `apply` skips so that no robot drifts onto a build no
+        /// one has validated.
+        ///
+        /// This is that filter's only opt-in, and it is per-command on purpose: nothing on
+        /// the board is left switched on afterwards, so the next `apply` is back on stable.
+        /// Pair it with `--version` to name one candidate rather than the newest.
+        #[arg(long, conflicts_with = "git_ref")]
+        staging: bool,
+
         /// Verify everything, then stop before the symlink swap.
         #[arg(long)]
         dry_run: bool,
@@ -1586,6 +1600,25 @@ fn main() -> ExitCode {
     }
 }
 
+/// Which build `apply` should move to, from the three flags that can name one.
+///
+/// Its own function so the tests exercise this decision rather than a copy of it. clap already
+/// refuses `--ref` beside either of the others, so the only pair reaching here together is
+/// `--staging --version`, which names one candidate rather than the newest.
+fn apply_target(
+    staging: bool,
+    version: Option<&semver::Version>,
+    git_ref: Option<&str>,
+) -> proto::Target {
+    match (staging, version, git_ref) {
+        (true, Some(version), _) => proto::Target::StagingExact(version.clone()),
+        (true, None, _) => proto::Target::Staging,
+        (false, Some(version), _) => proto::Target::Exact(version.clone()),
+        (false, None, Some(git_ref)) => proto::Target::Ref(git_ref.to_owned()),
+        (false, None, None) => proto::Target::Latest,
+    }
+}
+
 fn run(cli: Cli) -> Result<(), Failure> {
     let command = match cli.namespace {
         Namespace::Health { json } => {
@@ -1632,17 +1665,12 @@ fn run(cli: Cli) -> Result<(), Failure> {
             component: name,
             version,
             git_ref,
+            staging,
             dry_run,
             interrupt_sessions,
         } => proto::Call::Apply(proto::ApplyParams {
             component: proto::ComponentId::new(name),
-            // clap enforces that version and git_ref are mutually exclusive, so the order
-            // here cannot silently prefer one over the other.
-            target: match (version, git_ref) {
-                (Some(version), _) => proto::Target::Exact(version.clone()),
-                (None, Some(git_ref)) => proto::Target::Ref(git_ref.clone()),
-                (None, None) => proto::Target::Latest,
-            },
+            target: apply_target(*staging, version.as_ref(), git_ref.as_deref()),
             options: proto::ApplyOptions {
                 dry_run: *dry_run,
                 interrupt_sessions: *interrupt_sessions,
@@ -1965,6 +1993,64 @@ mod tests {
         };
         assert_eq!(git_ref.as_deref(), Some("my-branch"));
         assert!(version.is_none());
+    }
+
+    /// `--staging` alone means the newest candidate; with `--version`, that one candidate.
+    ///
+    /// The pair is the only combination clap allows through, so the match that turns these
+    /// into a `Target` has one case that cannot be reached by argument parsing — asserted
+    /// here rather than trusted, because getting it backwards would install a *stable*
+    /// release while reporting that it installed a candidate.
+    #[test]
+    fn staging_selects_the_candidate_channel() {
+        let target = |args: &[&str]| {
+            let mut argv = vec!["robotctl", "update", "apply", "daemon"];
+            argv.extend_from_slice(args);
+            let cli = Cli::try_parse_from(argv).expect("must parse");
+            let Namespace::Update {
+                command:
+                    UpdateCommand::Apply {
+                        version,
+                        git_ref,
+                        staging,
+                        ..
+                    },
+            } = cli.namespace
+            else {
+                panic!("expected update apply");
+            };
+            apply_target(staging, version.as_ref(), git_ref.as_deref())
+        };
+
+        assert_eq!(target(&["--staging"]), proto::Target::Staging);
+        assert_eq!(
+            target(&["--staging", "--version", "0.3.0"]),
+            proto::Target::StagingExact(semver::Version::new(0, 3, 0))
+        );
+        assert_eq!(target(&[]), proto::Target::Latest);
+        assert_eq!(
+            target(&["--version", "0.3.0"]),
+            proto::Target::Exact(semver::Version::new(0, 3, 0))
+        );
+    }
+
+    /// A candidate and a branch build are different streams under different keys, so asking
+    /// for both is a mistake to report rather than one to resolve by precedence.
+    #[test]
+    fn staging_and_ref_are_refused_together() {
+        assert!(
+            Cli::try_parse_from([
+                "robotctl",
+                "update",
+                "apply",
+                "daemon",
+                "--staging",
+                "--ref",
+                "my-branch",
+            ])
+            .is_err(),
+            "--staging with --ref must be refused"
+        );
     }
 
     /// A branch name with a slash must survive argument parsing untouched.

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -220,6 +220,15 @@ pub enum SourceConfig {
         /// resolving `latest` for the fleet.
         #[serde(default = "default_ref_tag_prefix")]
         ref_tag_prefix: String,
+        /// Tag prefix for release candidates, so `--staging` resolves to
+        /// `daemon-staging-v<version>`.
+        ///
+        /// A third prefix rather than a flag on `tag_prefix`, for the reason the second one
+        /// exists: the streams must not be confusable. A candidate is flagged as a prerelease
+        /// on GitHub precisely so `newest_version` cannot reach it, and giving that scan an
+        /// "unless…" would put the fleet one config typo away from tracking candidates.
+        #[serde(default = "default_staging_tag_prefix")]
+        staging_tag_prefix: String,
     },
     HfHub {
         /// `ORG/MODEL`.
@@ -241,6 +250,11 @@ pub enum SourceConfig {
 /// with a differently-named channel sets it explicitly, the same as `tag_prefix`.
 fn default_ref_tag_prefix() -> String {
     "daemon-dev-".to_owned()
+}
+
+/// Default prefix for release-candidate tags, matching what `release.yml` pushes.
+fn default_staging_tag_prefix() -> String {
+    "daemon-staging-v".to_owned()
 }
 
 fn default_manifest_asset() -> String {
@@ -609,7 +623,12 @@ mod tests {
 
         // The stable channel, not staging. A robot on `daemon-staging-v` would install
         // every candidate build.
-        let SourceConfig::GithubReleases { tag_prefix, .. } = &daemon.source else {
+        let SourceConfig::GithubReleases {
+            tag_prefix,
+            staging_tag_prefix,
+            ..
+        } = &daemon.source
+        else {
             panic!(
                 "the shipped daemon source must be github_releases, got {:?}",
                 daemon.source
@@ -618,6 +637,14 @@ mod tests {
         assert_eq!(
             tag_prefix, "daemon-v",
             "the shipped config must track the stable channel"
+        );
+        // The shipped config names no staging prefix, so `--staging` on a customer robot
+        // depends on this default matching what `release.yml` actually pushes. A wrong
+        // default would fail with "no releases with tag prefix", which reads as "there is no
+        // candidate" rather than "this board is looking in the wrong place".
+        assert_eq!(
+            staging_tag_prefix, "daemon-staging-v",
+            "the default candidate prefix must match the tag release.yml pushes"
         );
 
         // Only components that have somewhere real to fetch from. A component whose

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -347,6 +347,8 @@ impl Engine {
             crate::proto::Target::Latest => source.latest_manifest().await?,
             crate::proto::Target::Exact(v) => source.manifest_for(v).await?,
             crate::proto::Target::Ref(git_ref) => source.manifest_at_ref(git_ref).await?,
+            crate::proto::Target::Staging => source.staging_manifest().await?,
+            crate::proto::Target::StagingExact(v) => source.staging_manifest_for(v).await?,
         };
         self.verify_manifest(&signed)?;
         let manifest = signed.parsed.clone();
@@ -379,6 +381,12 @@ impl Engine {
         // a semver prerelease, so it sorts below the release it precedes — so guarding it
         // would reject every branch install. Rollback and reset-to-golden move backwards on
         // purpose without passing through here.
+        //
+        // The two `Staging` targets are unguarded for the `Exact` reason and not the `Ref`
+        // one: a candidate carries a plain version that normally sorts *above* the installed
+        // release, so the guard would rarely fire — but when it did, it would be refusing a
+        // reinstall of the candidate a board had just rolled back from, which is exactly the
+        // move someone reaches for while investigating that rollback.
         if matches!(target, crate::proto::Target::Latest)
             && let Some(installed) = &installed
             && manifest.version < *installed

--- a/updater/src/source/github.rs
+++ b/updater/src/source/github.rs
@@ -35,6 +35,7 @@ pub struct GithubReleases {
     tag_prefix: String,
     manifest_asset: String,
     ref_tag_prefix: String,
+    staging_tag_prefix: String,
     client: reqwest::Client,
 }
 
@@ -69,11 +70,13 @@ impl GithubReleases {
         tag_prefix: String,
         manifest_asset: String,
         ref_tag_prefix: String,
+        staging_tag_prefix: String,
     ) -> Self {
         Self {
             repo,
             tag_prefix,
             ref_tag_prefix,
+            staging_tag_prefix,
             manifest_asset,
             // A failure here means a broken TLS setup, which is fatal for every
             // request anyway; fall back to a default client so construction stays
@@ -95,9 +98,9 @@ impl GithubReleases {
         format!("{}{}", self.ref_tag_prefix, git_ref)
     }
 
-    /// Parse a version out of a tag, or `None` if the tag isn't ours.
-    fn version_from_tag(&self, tag: &str) -> Option<semver::Version> {
-        semver::Version::parse(tag.strip_prefix(&self.tag_prefix)?).ok()
+    /// The tag a release candidate lives under: `daemon-staging-v` + the version.
+    fn staging_tag_for(&self, version: &semver::Version) -> String {
+        format!("{}{}", self.staging_tag_prefix, version)
     }
 
     async fn release_for_tag(&self, tag: &str) -> Result<Release, Error> {
@@ -122,6 +125,29 @@ impl GithubReleases {
     /// never become `latest` for the fleet, and relying on someone remembering a
     /// checkbox is not a safeguard.
     async fn newest_version(&self) -> Result<semver::Version, Error> {
+        self.newest_under(&self.tag_prefix, false).await
+    }
+
+    /// The newest release candidate, which is the same scan with the prerelease flag allowed.
+    ///
+    /// Only the *GitHub* flag is allowed, never a semver prerelease: candidates carry the plain
+    /// version they will be promoted under (`0.3.0`), while dev builds carry `0.3.0-dev.17.abc`
+    /// and live under a third prefix. So the two exclusions in [`Self::newest_under`] are not
+    /// redundant here — dropping one still excludes branch builds, which is the point.
+    async fn newest_staging_version(&self) -> Result<semver::Version, Error> {
+        self.newest_under(&self.staging_tag_prefix, true).await
+    }
+
+    /// Highest version among tags carrying `prefix`.
+    ///
+    /// `allow_flagged_prerelease` is the whole difference between the stable channel and the
+    /// staging one, and it is a parameter rather than a field so that the call site — one of
+    /// exactly two — states which channel it means.
+    async fn newest_under(
+        &self,
+        prefix: &str,
+        allow_flagged_prerelease: bool,
+    ) -> Result<semver::Version, Error> {
         let mut best: Option<semver::Version> = None;
 
         for page in 1..=MAX_PAGES {
@@ -136,12 +162,11 @@ impl GithubReleases {
 
             let count = releases.len();
             for release in releases {
-                if release.draft || release.prerelease {
+                if release.draft || (release.prerelease && !allow_flagged_prerelease) {
                     continue;
                 }
-                if let Some(version) = self.version_from_tag(&release.tag_name)
-                    // A semver prerelease is a dev or candidate build, whatever the
-                    // release was flagged as.
+                if let Some(version) = version_under(prefix, &release.tag_name)
+                    // A semver prerelease is a dev build, whatever the release was flagged as.
                     && version.pre.is_empty()
                     && best.as_ref().is_none_or(|b| version > *b)
                 {
@@ -157,8 +182,8 @@ impl GithubReleases {
 
         best.ok_or_else(|| {
             Error::Network(format!(
-                "no releases in {} with tag prefix {:?}",
-                self.repo, self.tag_prefix
+                "no releases in {} with tag prefix {prefix:?}",
+                self.repo
             ))
         })
     }
@@ -253,6 +278,20 @@ impl Source for GithubReleases {
         self.signed_manifest(&tag).await
     }
 
+    async fn staging_manifest(&self) -> Result<SignedBytes<Manifest>, Error> {
+        let version = self.newest_staging_version().await?;
+        let tag = self.staging_tag_for(&version);
+        tracing::debug!(repo = %self.repo, %tag, "resolved newest candidate");
+        self.signed_manifest(&tag).await
+    }
+
+    async fn staging_manifest_for(
+        &self,
+        version: &semver::Version,
+    ) -> Result<SignedBytes<Manifest>, Error> {
+        self.signed_manifest(&self.staging_tag_for(version)).await
+    }
+
     async fn fetch_artifact(
         &self,
         manifest: &Manifest,
@@ -294,6 +333,14 @@ impl Source for GithubReleases {
     }
 }
 
+/// Parse a version out of a tag carrying `prefix`, or `None` if the tag is not one of ours.
+///
+/// Free-standing because two prefixes now feed it — stable and staging — and a method reading
+/// `self.tag_prefix` invited exactly the bug where a staging scan silently measured stable tags.
+fn version_under(prefix: &str, tag: &str) -> Option<semver::Version> {
+    semver::Version::parse(tag.strip_prefix(prefix)?).ok()
+}
+
 /// Extract a filename from a URL, refusing anything that could escape `dest_dir`.
 ///
 /// A manifest is signed, but this runs *before* verification, and a compromised
@@ -328,6 +375,7 @@ mod tests {
             "daemon-v".into(),
             "manifest.json".into(),
             "daemon-dev-".into(),
+            "daemon-staging-v".into(),
         )
     }
 
@@ -336,7 +384,37 @@ mod tests {
         let s = source();
         let v = semver::Version::new(1, 4, 2);
         assert_eq!(s.tag_for(&v), "daemon-v1.4.2");
-        assert_eq!(s.version_from_tag("daemon-v1.4.2"), Some(v));
+        assert_eq!(version_under(&s.tag_prefix, "daemon-v1.4.2"), Some(v));
+    }
+
+    #[test]
+    fn staging_tags_round_trip() {
+        let s = source();
+        let v = semver::Version::new(0, 3, 0);
+        assert_eq!(s.staging_tag_for(&v), "daemon-staging-v0.3.0");
+        assert_eq!(
+            version_under("daemon-staging-v", "daemon-staging-v0.3.0"),
+            Some(v)
+        );
+    }
+
+    /// The two channels must not read each other's tags.
+    ///
+    /// This is the failure that would matter and would not look like one: a staging scan that
+    /// silently matched `daemon-v*` would report the newest *stable* release as the candidate,
+    /// and `--staging` would install what a plain `apply` already installs while claiming to
+    /// test something. It holds because `daemon-staging-v0.3.0` does not start with `daemon-v`
+    /// — an accident of naming, so it is pinned here rather than left to be re-derived.
+    #[test]
+    fn the_two_channels_cannot_read_each_others_tags() {
+        assert_eq!(version_under("daemon-v", "daemon-staging-v0.3.0"), None);
+        assert_eq!(version_under("daemon-staging-v", "daemon-v0.3.0"), None);
+        // And neither reads a dev build, which is what keeps `--staging` from resolving to a
+        // branch someone pushed.
+        assert_eq!(
+            version_under("daemon-staging-v", "daemon-dev-my-branch"),
+            None
+        );
     }
 
     /// A ref becomes a dev tag, and the ref is appended verbatim.
@@ -351,27 +429,27 @@ mod tests {
         assert_eq!(s.ref_tag_for("feature/foo"), "daemon-dev-feature/foo");
     }
 
-    /// **A dev tag must never be mistaken for a release.** `version_from_tag` drives
+    /// **A dev tag must never be mistaken for a release.** `version_under` drives
     /// `newest_version`, which is what the fleet installs — so if a dev tag parsed as a
     /// version here, a branch build could become `latest` for every robot. That is the
     /// failure the two independent guards exist to prevent, and this is the first of them.
     #[test]
     fn a_dev_tag_is_not_a_release_version() {
         let s = source();
-        assert_eq!(s.version_from_tag("daemon-dev-my-branch"), None);
+        assert_eq!(version_under(&s.tag_prefix, "daemon-dev-my-branch"), None);
         // Even when the dev tag ends in something version-shaped.
-        assert_eq!(s.version_from_tag("daemon-dev-0.2.0"), None);
+        assert_eq!(version_under(&s.tag_prefix, "daemon-dev-0.2.0"), None);
         // And the staging stream stays separate too.
-        assert_eq!(s.version_from_tag("daemon-staging-v0.2.0"), None);
+        assert_eq!(version_under(&s.tag_prefix, "daemon-staging-v0.2.0"), None);
     }
 
     /// Another channel's tags in the same repo must be ignored, not misparsed.
     #[test]
     fn foreign_tags_are_ignored() {
         let s = source();
-        assert_eq!(s.version_from_tag("model-v3.0.0"), None);
-        assert_eq!(s.version_from_tag("v1.0.0"), None);
-        assert_eq!(s.version_from_tag("daemon-vnot-a-version"), None);
+        assert_eq!(version_under(&s.tag_prefix, "model-v3.0.0"), None);
+        assert_eq!(version_under(&s.tag_prefix, "v1.0.0"), None);
+        assert_eq!(version_under(&s.tag_prefix, "daemon-vnot-a-version"), None);
     }
 
     #[test]
@@ -450,13 +528,13 @@ mod tests {
     #[test]
     fn dev_versions_are_recognised_as_prereleases() {
         let s = source();
-        let dev = s.version_from_tag("daemon-v0.2.0-dev.5.abc1234").unwrap();
+        let dev = version_under(&s.tag_prefix, "daemon-v0.2.0-dev.5.abc1234").unwrap();
         assert!(
             !dev.pre.is_empty(),
             "dev builds must carry a semver prerelease"
         );
 
-        let stable = s.version_from_tag("daemon-v0.2.0").unwrap();
+        let stable = version_under(&s.tag_prefix, "daemon-v0.2.0").unwrap();
         assert!(stable.pre.is_empty());
         // And a dev build sorts *below* the release it precedes, so it can never look
         // like an upgrade from it.

--- a/updater/src/source/local.rs
+++ b/updater/src/source/local.rs
@@ -317,4 +317,20 @@ mod tests {
         assert_eq!(fetched.bytes, 13);
         assert_eq!(rx.recv().await, Some((13, Some(13))));
     }
+
+    /// A directory has no channels, so `--staging` against a sideload source must say that
+    /// rather than quietly install whatever is newest there — which is the one answer that
+    /// would look like it worked.
+    #[tokio::test]
+    async fn a_directory_has_no_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "1.0.0", "payload.tar.zst");
+        let source = LocalDir::new(dir.path().to_path_buf());
+
+        let err = source.staging_manifest().await.unwrap_err();
+        assert!(
+            format!("{err}").contains("staging"),
+            "the refusal must name the channel: {err}"
+        );
+    }
 }

--- a/updater/src/source/mod.rs
+++ b/updater/src/source/mod.rs
@@ -53,6 +53,28 @@ pub trait Source: Send + Sync {
         )))
     }
 
+    /// Fetch the newest release candidate. Backs `robotctl update apply --staging`.
+    ///
+    /// Defaulted for the same reason as [`Source::manifest_at_ref`]: a channel split is a
+    /// property of how a source publishes, and a local directory has no candidates to offer.
+    async fn staging_manifest(&self) -> Result<SignedBytes<Manifest>, Error> {
+        Err(Error::Incompatible(
+            "this source has no staging channel; \
+             only a github_releases source publishes release candidates"
+                .to_owned(),
+        ))
+    }
+
+    /// Fetch one named candidate. Backs `--staging --version X`.
+    async fn staging_manifest_for(
+        &self,
+        version: &semver::Version,
+    ) -> Result<SignedBytes<Manifest>, Error> {
+        Err(Error::Incompatible(format!(
+            "this source has no staging channel, so it cannot resolve the candidate {version}"
+        )))
+    }
+
     /// Download the artifact and its detached signature into `dest_dir`.
     ///
     /// Streams to disk — must not assume the artifact fits in memory — and is
@@ -92,11 +114,13 @@ pub fn from_config(config: &SourceConfig) -> Box<dyn Source> {
             tag_prefix,
             manifest_asset,
             ref_tag_prefix,
+            staging_tag_prefix,
         } => Box::new(GithubReleases::new(
             repo.clone(),
             tag_prefix.clone(),
             manifest_asset.clone(),
             ref_tag_prefix.clone(),
+            staging_tag_prefix.clone(),
         )),
         SourceConfig::HfHub {
             repo,


### PR DESCRIPTION
Cutting 0.2.0 and 0.3.0 both hit the same wall: a candidate exists, is signed with the
release key, and no robot can install it. Pointing a board's `tag_prefix` at the staging
tags does not work either — it reported

    no releases in pollen-robotics/microduck_daemon with tag prefix "daemon-staging-v"

against a candidate sitting right there. The prefix says where to look; `newest_version`
refuses to look, because it skips anything GitHub flags as a prerelease and staging
publishes exactly that.

That filter is load-bearing — it is what stops a customer robot drifting onto a build
nobody has validated — so it stays, and this adds its only opt-in.

    sudo robotctl update apply daemon --staging
    sudo robotctl update apply daemon --staging --version 0.3.0

Per-command, not per-board. Nothing is left switched on: the next `apply` is back on
stable, which is the property a config setting would not have. `--staging` conflicts with
`--ref` — different streams under different keys, so asking for both is a mistake to
report rather than resolve by precedence — and pairs with `--version` to name one
candidate rather than the newest.

**What the scan does differently.** `newest_under(prefix, allow_flagged_prerelease)` is
the old scan with the two exclusions separated. Staging allows GitHub's *flag* and still
excludes *semver* prereleases, so a branch build can never resolve as a candidate: dev
builds carry `0.3.0-dev.17.abc1234` and live under a third prefix. `latest_manifest` is
untouched, so `auto_apply` and the periodic check still resolve stable — nothing drifts
onto a candidate without a person and root.

`version_from_tag` is gone in favour of a free `version_under(prefix, tag)`. A method
reading `self.tag_prefix` was one call site away from a staging scan silently measuring
stable tags, which would have made `--staging` install what a plain `apply` installs while
reporting that it had tested something. A test pins that the two namespaces cannot read
each other's tags.

The downgrade guard still applies only to `Latest`. A candidate normally sorts above the
installed release so the guard would rarely fire, but when it did it would be refusing a
reinstall of the candidate a board had just rolled back from — which is the move someone
reaches for while investigating that rollback.

**A widening, stated plainly.** Before this, a robot could not reach a candidate at all.
Now any robot can, given root. That is the same privilege `--version` already needs, and
the guard that matters is on automatic updates, which is untouched. If per-robot policy is
wanted later, a config flag defaulting to false is a small addition on top of this.