### PR TITLE
docs: install-path-gap catches up with the deferred restart

### DIFF
--- a/docs/install-path-gap.md
+++ b/docs/install-path-gap.md
@@ -1,6 +1,6 @@
 # The install path has no test
 
-Status: open · Date: 2026-08-05 · Owner: pierre
+Status: open · Date: 2026-08-05, revised 2026-08-07 · Owner: pierre
 
 Four bugs in a row reached a board, all in the install path, none caught by 418 tests or by
 `board-test.sh`. This records why, and what would actually close it. Written the same day, while
@@ -11,9 +11,18 @@ between a daemon that is already running and a release that has just been instal
 be caught by any amount of install testing, and they need their own fixes — kept here rather than in
 their own document because anyone investigating one will arrive believing it is the other.
 
+**Revision note.** All four bugs are fixed. What is still open is the *testing* gap the title names —
+no test installs a real artifact — plus four smaller decisions marked below. One change since the
+first draft moves enough of this document to call out here: `updaterd` and `btd` are now restarted a
+few seconds *after* the update replies (`RESTART_AFTER_REPLYING`), and the release's own `updaterd` is
+proved to start before the commit (`updaterd --self-test`). Two claims below were written against the
+old behaviour and are now false — both are corrected in place, and the second section's premise in
+particular no longer holds.
+
 ## What got through
 
-All three landed within a day, all while installing `btd` and `configd` onto a dev board.
+All four landed within a day, all while installing `btd` and `configd` onto a dev board. (The count
+read "three" until §4 was added below it.)
 
 **1. `on_apply` restarts several units in one command.** `systemctl restart robotd configd` fails as
 a whole if *either* unit is unknown — and fails without restarting the one that exists. A release
@@ -81,17 +90,26 @@ ships, minus the two documented exclusions (`updaterd`, which is performing the 
 may be the transport it was requested over). Then a release that adds a daemon restarts that daemon
 on every board, with no operator edit and no way for a board's config to be silently out of date.
 
-Two smaller options, worth noting because they are not alternatives to the above so much as
-companions: `apply` could gain a `--force` that re-runs the hooks and the restart on an
+Two smaller options, **both still open**, worth noting because they are not alternatives to the above
+so much as companions: `apply` could gain a `--force` that re-runs the hooks and the restart on an
 already-current release (there is precedent — `install --force` exists for the same class of
 chicken-and-egg), and `already_current` could compare *running* revisions rather than only the
 installed one, so it stops being a no-op precisely when something is wrong.
 
-Note the related case that is *deliberate* and stays: `btd` is excluded from `on_apply` because
-restarting it drops the BLE connection carrying the update's own progress stream. So a `btd` fix needs
-a manual restart or a reboot, and unlike the others `robotctl version` cannot even see it — `btd`
-serves no socket, so there is nothing to ask. That is a real gap in a phone-driven flow and needs its
-own answer.
+Neither is urgent now that the restart set is derived from the release: the situation they exist to
+dig you out of is much harder to reach. `already_current` still compares only the installed version.
+
+**Fixed, and this paragraph used to say otherwise.** `btd` is excluded from the *in-flight* restart
+because restarting it drops the BLE connection carrying the update's own progress stream — that part
+was and remains right. The conclusion drawn from it was not: this said a `btd` fix "needs a manual
+restart or a reboot … a real gap in a phone-driven flow", and it does not any more. The exclusion
+expires the moment the outcome is on the wire, so `btd` and `updaterd` both restart five seconds later
+via `systemd-run --on-active=5s` (`RESTART_AFTER_REPLYING`). A client sees its outcome and then a
+dropped connection, which for BLE is an ordinary reconnect.
+
+What survives is the *observability* half: `robotctl version` still cannot see `btd`, because `btd`
+serves no socket, so there is nothing to ask. That matters less now that nothing silently keeps `btd`
+on old code, but it is still the one daemon whose running revision cannot be checked.
 
 ### A consequence worth knowing: units outlive the release that installed them
 
@@ -110,9 +128,11 @@ and said so. The outcome is right — a board should not silently downgrade belo
 introduced a daemon it is now running — but nothing states the rule, and the error names a systemd
 failure rather than the cause.
 
-Worth deciding rather than leaving as emergent behaviour: whether preflight should refuse a target
-that lacks a binary some installed unit execs, so the refusal arrives before the swap and names the
-real reason.
+Worth deciding rather than leaving as emergent behaviour, and **still open**: whether preflight should
+refuse a target that lacks a binary some installed unit execs, so the refusal arrives before the swap
+and names the real reason. Today the only downgrade guard is `Error::WouldDowngrade`, which fires on
+`Latest` alone — `Exact` and `Ref` bypass it deliberately, and `Ref` is precisely how this was
+observed.
 
 ## Why the existing tests could not have caught them
 
@@ -139,11 +159,21 @@ every unit named by `install.sh` is present, and every unit's `ExecStart` binary
 and strictly stronger than the two current tests because it observes the artifact instead of the
 YAML that builds it. **Would have caught bugs 2 and 3.**
 
+Still open in the form described. There are now *three* source-reading tests rather than two — a
+`every_hook_in_the_repo_is_packaged` was added so `hooks/postinstall` cannot silently stop shipping —
+but all three still assert that `.github/workflows/*.yml` agrees with `scripts/install.sh`. They cover
+the drift class; none of them observes a tarball.
+
 **B. Install the artifact in a container, with `systemctl` stubbed.** Extend `board-test.sh`: unpack
 into a fake root, run `install.sh` *and* `hooks/postinstall` against it, and assert what landed
 where — `/etc/systemd/system/*.service`, `/usr/lib/sysusers.d/`, the `robotctl` symlink, the state
 directory. `setup-board.sh` is already tested this way, so the pattern and the stub exist. Catches
 bugs 2 and 3 *and* file-placement regressions in `install.sh`, which nothing tests today.
+
+Still open, and untouched. `board-test.sh` has a comment reading "the first install, which is the path
+`scripts/install.sh` takes on a bare board" — the line beneath it runs `updaterd install --from`, not
+`scripts/install.sh`. Nothing in the repository executes `scripts/install.sh` or the real
+`hooks/postinstall`; the engine's hook tests use a stub hook built by `test-support`.
 
 The postinstall hook makes this more valuable, not less: it is now a second thing that places files
 on a board, it runs unattended on every update rather than once by hand, and its failures are inside
@@ -175,11 +205,21 @@ D is a separate conversation, and probably follows M4 rather than preceding it.
 Found in the same session and easily confused with the above, but no amount of install testing
 would catch either — in both cases the artifact was complete and correct.
 
-The shape is always the same. **`updaterd` never restarts itself during an update** (§4.1), so it
-keeps running the old binary until the next reboot, while everything else on the box moves to the
-new release immediately. Any change to a shared contract therefore has a window where a *resident*
-daemon and an *installed* one disagree. On the dev channel, where branches are installed over each
-other in any order, that window is the normal case rather than a rare one.
+The shape was always the same, and **the sentence that used to open this section is no longer true.**
+It read: "`updaterd` never restarts itself during an update (§4.1), so it keeps running the old binary
+until the next reboot, while everything else on the box moves to the new release immediately." That was
+the root cause of both instances below, and it is fixed — `updaterd` now restarts itself five seconds
+after the update replies. The skew window is seconds, not "until someone reboots".
+
+Read the two cases with that in mind. Neither is a live incident any more; what remains is that both
+were *diagnosed* badly, and one of the two fixes is still worth having on its own merits:
+
+- Case 1's `serde(default)` fix is **not** made redundant by the shorter window. Version skew is only
+  the commonest way to hit it; any newer-parser-older-sender pair does, and the fields that caused it
+  still have no defaults.
+- Case 2's handshake fix is **mostly** made redundant, and drops from "the recovery command itself
+  stops working" to "a five-second window during which it does". It stays proposed on design grounds,
+  not urgency.
 
 Two instances, both real, both cost about an hour.
 
@@ -192,14 +232,24 @@ reply for a missing field. `RobotIo::health` maps an unparseable answer to `Heal
 the gate reported `not healthy within 30s: unreachable` about a robot that was entirely healthy, and
 reverted a good release.
 
-Fixes, both small:
+Fixes, both small, and **both still open**:
 
 - **`#[serde(default)]` on new `HealthResult` fields**, so a newer `updaterd` can still parse an
   older `robotd`. Every `--ref` install of a branch predating a health-field addition hits this
   otherwise, which is the entire dev workflow.
+
+  Half-true today, and the wrong half is the one that bit. Every *top-level* `HealthResult` field
+  carries `#[serde(default)]`, including `imu`. The field that actually caused this —
+  `consecutive_stale_blocks` on the nested `ImuHealth` — does not, and neither do `LoopHealth`'s or
+  `BusHealth`'s. So the incident reproduces verbatim the next time a field is added to a nested health
+  struct, which is exactly how it happened the first time.
 - **A distinct `Health::Incompatible`** rather than reusing `Unreachable`, so the reason reads
   "answered in a shape this updaterd does not understand" instead of implying the robot is down.
   Pure diagnostics, and it would have found the above in a minute.
+
+  Not done. `Health` still has four variants and `SocketRobotClient::health` still collapses an
+  unparseable reply to `Unreachable`. (`Error::Incompatible` exists and is a different thing — it is
+  about a *release* being refused, not a reply being unreadable.)
 
 ### 2. `API_VERSION` skew between `robotctl` and `updaterd`
 
@@ -215,13 +265,17 @@ or to restart `updaterd` — neither of which is discoverable from the error.
 
 The handshake at least *caught* it and named both versions, which is more than case 1 managed.
 
-Proposed fix, and the reason it is not already done is that it is a protocol-policy decision rather
-than a bug:
+Proposed fix, **still open**, and the reason it is not already done is that it is a protocol-policy
+decision rather than a bug:
 
 - **`hello` should refuse only when the client is *newer* than the daemon.** A v3 daemon can serve a
   v2 client perfectly, because v3 only *added* methods — refusing that direction costs the ability
   to recover and buys nothing. Client-newer-than-daemon must stay a hard failure: there the client
   may ask for something that genuinely is not there.
+
+  The handshake is still an exact `!=`. `API_VERSION` has since reached 4, and the failure was
+  observed again at v4-against-v3 — so this keeps recurring on every additive bump, just for seconds
+  at a time now instead of until a reboot.
 
 That change would also make `API_VERSION` mean what it should — "the newest contract I understand"
 rather than "the only contract I will speak" — and additive protocol growth would stop being a


### PR DESCRIPTION
All four bugs the document opens with are fixed. What is still open is the testing
gap the title names — no test installs a real artifact — plus four smaller
decisions, and the document did not say which was which.

Two claims had gone from stale to wrong, both because `updaterd` and `btd` now
restart a few seconds after the update replies:

- §4 said a `btd` fix "needs a manual restart or a reboot … a real gap in a
  phone-driven flow and needs its own answer". It has its answer. What survives is
  the observability half: `btd` serves no socket, so `robotctl version` still
  cannot see it.
- The second section opened on "`updaterd` never restarts itself during an update,
  so it keeps running the old binary until the next reboot" — the root cause of
  both skew instances it then describes. Anyone arriving at that section to
  diagnose a live skew started from a false premise.

Both corrected in place rather than deleted, because the argument for the fix is
worth keeping next to the fix.

Each remaining item is now marked with what is actually in the tree:

- `serde(default)` on health fields is half-done, and the wrong half. Top-level
  `HealthResult` fields have it; `ImuHealth::consecutive_stale_blocks` — the field
  that caused the incident — does not, nor do `LoopHealth`'s or `BusHealth`'s.
- `Health::Incompatible` is absent; an unparseable reply is still `Unreachable`.
  Noted that `Error::Incompatible` is a different thing, since it greps alike.
- The `hello` handshake is still an exact `!=`. `API_VERSION` has reached 4 and the
  failure was seen again at v4-against-v3.
- Option A exists only in its source-reading form, now three tests rather than two.
  Option B is untouched: `board-test.sh`'s comment names `scripts/install.sh` and
  the line beneath it runs `updaterd install`.
- The downgrade-preflight question, `apply --force` and `already_current` are open,
  with a note that the derived restart set made the last two much less urgent.

---

Not a draft: this is a correction to a document, ready as it stands. The four draft PRs alongside it are the items it marks as open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)