### PR TITLE
An older robotd's health reply must still be readable

### DIFF
--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -1137,7 +1137,12 @@ pub struct LoopHealth {
 }
 
 /// The motor bus, as the loop sees it.
+///
+/// `#[serde(default)]` for the reason spelled out on [`ImuHealth`], and it applies here even more
+/// plainly: these are failure counters whose zero the doc comments below already call meaningful.
+/// An older `robotd` that omits one is saying "no failures", not "unknown".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct BusHealth {
     /// Consecutive failed reads; any success resets it. One is ordinary on a serial bus,
     /// which is why the cumulative count is not what is reported.
@@ -1149,7 +1154,23 @@ pub struct BusHealth {
 }
 
 /// The IMU board, which rides the motor bus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `#[serde(default)]` on the struct, not on each field, and for the same reason the parent
+/// [`HealthResult`] carries `Default`: **a field added here must not make a newer reader reject
+/// an older `robotd` outright.** It did once. `consecutive_stale_blocks` was added below and
+/// released, and a branch predating it sent an `imu` section without the field — so a resident
+/// `updaterd` failed to parse the whole reply, `health` collapsed it to `Unreachable`, and the
+/// gate reverted a release from a robot that was serving its socket and running its loop at
+/// 50 Hz. An hour to find, because nothing in "not healthy within 30s: unreachable" points at a
+/// missing JSON field.
+///
+/// Sound here because every zero is *honest*: not converged, no stale reads, no run. Each one
+/// reads as "nothing to report", which is exactly what an older sender is saying. That argument
+/// is what makes this safe, and it is why the sibling sections carrying measurements —
+/// [`Battery`], [`MotorThermal`], [`LoopHealth`] — do **not** get the same treatment: a
+/// defaulted `percent: 0.0` would render as a flat pack on a robot with a full one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ImuHealth {
     /// Has the orientation filter converged?
     pub ready: bool,
@@ -1906,6 +1927,45 @@ mod tests {
         let line = serde_json::to_string(&bench).unwrap();
         assert!(line.contains(r#""degraded":true"#), "{line}");
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), bench);
+    }
+
+    /// An `imu` section from a `robotd` that predates a field must still parse.
+    ///
+    /// The regression this exists for reverted a good release. `consecutive_stale_blocks` was
+    /// added below and released; a branch that had merged `main` before that sent the section
+    /// without it, and the resident `updaterd` rejected the whole reply — so a robot serving its
+    /// socket with the loop at 50 Hz was reported as "not healthy within 30s: unreachable".
+    ///
+    /// Literal JSON rather than a struct with a field omitted, because a struct cannot express
+    /// "this field does not exist", which is the entire failure.
+    #[test]
+    fn an_imu_section_missing_its_newest_field_still_parses() {
+        let answer: HealthResult =
+            serde_json::from_str(r#"{"healthy":true,"imu":{"ready":true,"stale_blocks":3}}"#)
+                .unwrap();
+
+        let imu = answer
+            .imu
+            .expect("the section was sent, so it must survive");
+        assert_eq!(imu.stale_blocks, 3, "what was sent must be kept");
+        assert_eq!(
+            imu.consecutive_stale_blocks, 0,
+            "and what was not sent reads as nothing to report"
+        );
+        assert!(
+            !imu.frozen(),
+            "a default run must never look like a dead IMU"
+        );
+    }
+
+    /// Same for the bus counters, where a missing counter means "no failures" by construction.
+    #[test]
+    fn a_bus_section_missing_a_counter_still_parses() {
+        let answer: HealthResult =
+            serde_json::from_str(r#"{"healthy":true,"bus":{"consecutive_errors":2}}"#).unwrap();
+
+        assert_eq!(answer.bus.consecutive_errors, 2);
+        assert_eq!(answer.bus.startup_failures, 0);
     }
 
     /// An absent battery must stay absent, not become zero volts.

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1271,6 +1271,15 @@ impl Engine {
                             return Ok(());
                         }
                         crate::robot::Health::Unhealthy(reason) => last = reason,
+                        // Fails, like `Unreachable`, and reads nothing like it. "unreachable"
+                        // about a robot that is serving its socket sends the reader to the wrong
+                        // half of the system for an hour; see `docs/install-path-gap.md`.
+                        crate::robot::Health::Incompatible(reason) => {
+                            last = format!(
+                                "answered in a shape this updaterd cannot read ({reason}) — \
+                                 the robot may be fine and the contract is what disagrees"
+                            );
+                        }
                         crate::robot::Health::Unreachable => {
                             last = "unreachable".into();
                         }

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -786,6 +786,43 @@ mod tests {
         }
     }
 
+    /// A robot answering in a shape we cannot read is still a robot that is *running*.
+    ///
+    /// `robot_is_answering` guards `install --force`, which swaps a release with no health gate
+    /// behind it. Its own doc comment already states the rule — "anything other than
+    /// `Unreachable` means a robot is running and must not have the release swapped out from
+    /// under it" — but before `Health::Incompatible` existed the code could not keep it: an
+    /// unparseable reply became `Unreachable`, so a live robot whose health shape had drifted
+    /// read as absent and `--force` proceeded. Exactly the robot least worth guessing about.
+    #[tokio::test]
+    async fn a_robot_answering_unreadably_still_counts_as_answering() {
+        struct Unreadable;
+
+        #[async_trait::async_trait]
+        impl updater::robot::RobotClient for Unreadable {
+            async fn safe_to_restart(
+                &self,
+                _: std::time::Duration,
+            ) -> updater::robot::SafeToRestart {
+                updater::robot::SafeToRestart::Unreachable
+            }
+            async fn health(&self, _: std::time::Duration) -> updater::robot::Health {
+                updater::robot::Health::Incompatible("missing field `imu`".into())
+            }
+            async fn model_api(&self, _: std::time::Duration) -> Option<u32> {
+                None
+            }
+            async fn remote_session_active(&self, _: std::time::Duration) -> bool {
+                false
+            }
+        }
+
+        assert!(
+            robot_is_answering(&Unreadable).await,
+            "an unreadable answer is still an answer; --force must refuse"
+        );
+    }
+
     /// The engine emits progress once per network chunk, so a single 3.6 MB download wrote
     /// ~250 journal lines — 13 of them before the first whole percent had even accrued.
     /// That is not just noise: under journald's size cap it evicts the logs someone needs,

--- a/updater/src/robot.rs
+++ b/updater/src/robot.rs
@@ -42,6 +42,20 @@ pub enum Health {
     Degraded(String),
     /// Came up and reported a problem.
     Unhealthy(String),
+    /// Answered, in a shape this `updaterd` cannot read. Fails the gate — an unreadable
+    /// verdict is not a healthy one — but says so in different words, which is the point.
+    ///
+    /// Distinct from [`Self::Unreachable`] because the two ask for opposite things from
+    /// whoever reads the outcome. "Unreachable" sends you to look at a daemon that is
+    /// probably dead; this sends you to look at a *contract*, and the robot is likely fine.
+    /// Reusing `Unreachable` for it cost an hour: the gate reported "not healthy within 30s:
+    /// unreachable" about a `robotd` that was serving its socket and running its loop at
+    /// 50 Hz, and had merely omitted one JSON field a newer parser required. See
+    /// `docs/install-path-gap.md`.
+    ///
+    /// Carries serde's own message. It names the missing or unexpected field, which is the
+    /// single most useful string available at that moment.
+    Incompatible(String),
     /// Did not answer within the timeout — includes crash-looping and hung
     /// (socket open, no reply). Fails the gate: unproven is not healthy.
     Unreachable,
@@ -173,7 +187,7 @@ impl RobotClient for SocketRobotClient {
             ),
             Err(e) => {
                 tracing::warn!(error = %e, "robotd answered health in an unexpected shape");
-                Health::Unreachable
+                Health::Incompatible(e.to_string())
             }
         }
     }
@@ -244,5 +258,87 @@ mod tests {
                 .await
                 .is_healthy()
         );
+    }
+
+    /// Serve one canned `robot.health` result on a unix socket and ask about it.
+    ///
+    /// A real socket rather than a fake `RobotClient`, because the behaviour under test lives in
+    /// `SocketRobotClient::health` — the deserialization step. A double implementing the trait
+    /// would replace exactly the code that has the bug.
+    async fn health_of(reply: serde_json::Value) -> Health {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("robot.sock");
+        let listener = tokio::net::UnixListener::bind(&path).expect("bind");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (read_half, mut write_half) = stream.into_split();
+
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+            let mut request = String::new();
+            tokio::io::BufReader::new(read_half)
+                .read_line(&mut request)
+                .await
+                .expect("read request");
+
+            let response = crate::proto::Response::ok(Some(crate::proto::Id::Number(1)), &reply);
+            let mut line = serde_json::to_vec(&response).expect("encode");
+            line.push(b'\n');
+            write_half.write_all(&line).await.expect("write");
+            write_half.flush().await.expect("flush");
+        });
+
+        let health = SocketRobotClient::new(path)
+            .health(Duration::from_secs(5))
+            .await;
+        server.await.expect("server");
+        health
+    }
+
+    /// The reply an older `robotd` sends must still parse.
+    ///
+    /// This exact shape reverted a good release: `consecutive_stale_blocks` had been added to
+    /// `ImuHealth` and released, and a branch that merged `main` before that sent an `imu`
+    /// section without it. `robotd` was entirely healthy — socket served, both policies loaded,
+    /// loop at 50 Hz — and the resident `updaterd` could not read `healthy: true`.
+    ///
+    /// Written as literal JSON, not as a struct with a field left out, because a struct cannot
+    /// express "this field does not exist" — and that is the whole failure.
+    #[tokio::test]
+    async fn an_older_robotd_that_omits_a_health_field_is_still_healthy() {
+        let health = health_of(serde_json::json!({
+            "healthy": true,
+            "bus": { "consecutive_errors": 0 },
+            "imu": { "ready": true, "stale_blocks": 3 },
+        }))
+        .await;
+
+        assert_eq!(health, Health::Healthy, "got {health:?}");
+    }
+
+    /// And an answer that genuinely cannot be read must not claim the robot is absent.
+    ///
+    /// `Unreachable` sends whoever reads the outcome to look at a daemon that is probably dead.
+    /// When the daemon answered and the *contract* is what disagrees, that is an hour spent in
+    /// the wrong place — which is what happened. The reason string carries serde's own message
+    /// so the field is named.
+    #[tokio::test]
+    async fn an_unreadable_answer_is_incompatible_not_unreachable() {
+        let health = health_of(serde_json::json!({ "healthy": "yes, very" })).await;
+
+        match health {
+            Health::Incompatible(reason) => assert!(!reason.is_empty(), "must name the problem"),
+            other => panic!("expected Incompatible, got {other:?}"),
+        }
+    }
+
+    /// Failing the gate is not negotiable: an unreadable verdict is not a healthy one.
+    ///
+    /// Split from the test above deliberately. The point of `Incompatible` is that it reads
+    /// differently, not that it decides differently, and a future edit that softened it into a
+    /// pass would be the worst possible reading of "the robot was probably fine".
+    #[tokio::test]
+    async fn incompatible_still_fails_the_gate() {
+        assert!(!Health::Incompatible("missing field `imu`".into()).is_healthy());
     }
 }


### PR DESCRIPTION
A newer `updaterd` reading an older `robotd` reverted a good release, and the
outcome sent whoever read it to the wrong half of the system. Two separate
mistakes, one incident, both cheap to fix.

`install-path-gap.md` §2.1 has the account. `consecutive_stale_blocks` was added
to `ImuHealth` and released; a branch that had merged `main` before that sent an
`imu` section without it. `robotd` was entirely healthy — socket served, both
policies loaded, loop at 50 Hz — and the resident `updaterd` could not parse
`healthy: true`, so the gate reported `not healthy within 30s: unreachable` and
rolled back.

**`#[serde(default)]` on `ImuHealth` and `BusHealth`**, on the struct rather than
per-field, so the *next* field added to either is covered too — the same property
`HealthResult`'s `Default` already gives its own top level. That top level was
already safe; the nested sections were not, which is why the document's claim that
this fix had landed was half-true, and the wrong half.

Sound here only because every zero is honest: not converged, no stale reads, no
run, no failures. Each reads as "nothing to report", which is what an older sender
means. The measurement-carrying siblings deliberately do **not** get this — a
defaulted `Battery::percent` of 0.0 would render a full pack as flat, which
`a_missing_battery_is_unknown_not_empty` already exists to prevent. Noted in the
doc comment so the next person does not extend the attribute by symmetry. The open
question of what a *truncated* measurement section should do is left for its own
change; today it still fails the whole reply.

**`Health::Incompatible`** rather than reusing `Unreachable`. The two ask for
opposite things from the reader: "unreachable" says look at a daemon that is
probably dead, and this says look at a contract while the robot is likely fine.
An hour went into the first reading. It carries serde's own message, which names
the field, and the gate's reason line now says so in as many words. It still
fails the gate — an unreadable verdict is not a healthy one — and there is a test
pinning that, because "the robot was probably fine" is a tempting and wrong reason
to soften it later.

Five tests. The `imu` one was verified by deleting the attribute and watching it
fail with `missing field consecutive_stale_blocks` — the incident's own error. The
two `Health` tests use a real unix socket rather than a fake `RobotClient`, since
the behaviour under test is the deserialization step and a trait double would
replace exactly the code that had the bug.

Closes the two `install-path-gap.md` §2.1 items. Depends on nothing; `#41` documents the same ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: `install --force` was reading a live robot as absent

Found reviewing the first commit, and it is the more consequential half.

`robot_is_answering` guards `install --force`, which swaps a release with **no health gate behind it**. Its doc comment already stated the rule — "anything other than `Unreachable` means a robot is running and must not have the release swapped out from under it" — and the code could not keep it, because it had no way to say "answered, unreadably". An unparseable reply became `Unreachable`, so a live robot whose health shape had drifted read as absent and `--force` proceeded.

Same drift as above, aimed at the one command that deliberately runs without a gate, and it failed toward swapping rather than toward refusing. `Health::Incompatible` fixes it as a side effect: the guard now refuses. Pinned by a test with its own `RobotClient` double, since the property belongs to the guard — a later refactor could undo it without touching `robot.rs`.
