### PR TITLE
promote: a stable release carries the bytes it names

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,9 +1,16 @@
 # Promote a validated staging release to the STABLE channel.
 #
 # This is §16.3's promotion step, and the important property is what it does *not* do:
-# it never rebuilds. The stable manifest points at the artifact already published in
-# staging — same URL, same sha256 — so what reaches client robots is byte-identical to
-# what the canary validated. Promotion is a decision, not a build.
+# it never rebuilds. It copies the artifact already published in staging — same sha256,
+# checked here and again on the robot — so what reaches client robots is byte-identical
+# to what the canary validated. Promotion is a decision, not a build.
+#
+# The stable release is **self-contained**: manifest, signature, artifact and bootstrap
+# binary all hang off `daemon-v<version>`. That is why the last step can delete the
+# staging release outright. Previously the stable manifest pointed back at the staging
+# release to avoid a second copy of the bytes, which quietly made a tag named like
+# scaffolding load-bearing for the customer channel — and deleting the v0.1.x staging
+# releases duly left three stable releases pointing at a 404.
 #
 # Manual by design. A human decides that staging looked good; the machine does the
 # rest identically every time.
@@ -55,17 +62,42 @@ jobs:
             --pattern 'manifest.json' \
             --dir staging
           echo "staging_tag=$staging_tag" >> "$GITHUB_ENV"
+          echo "stable_tag=daemon-v${{ inputs.version }}" >> "$GITHUB_ENV"
+
+      # The artifact itself, so the stable release can carry it. This is the copy that
+      # makes staging disposable; the sha256 check below is what makes it safe.
+      - name: Carry the artifact forward
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_name="$(jq -r '.url | split("/") | last' staging/manifest.json)"
+          mkdir -p artifact
+          gh release download "$staging_tag" \
+            --repo "${{ github.repository }}" \
+            --pattern "$artifact_name" \
+            --pattern "$artifact_name.minisig" \
+            --dir artifact
+
+          # The manifest that ships names this digest, and the robot re-checks it before
+          # installing (`updater::verify::verify_sha256`). Checking it here too means a
+          # bad copy fails in CI rather than on a board.
+          expected="$(jq -r .sha256 staging/manifest.json)"
+          actual="$(sha256sum "artifact/$artifact_name" | cut -d' ' -f1)"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::artifact sha256 $actual does not match staging manifest $expected"
+            exit 1
+          fi
+          echo "artifact $artifact_name sha256 $actual (matches staging)"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_ENV"
 
       # The bootstrap binary has to exist on the *stable* release, because that is what
       # `https://github.com/<repo>/releases/latest/download/...` resolves to — and that
       # URL is the whole of `scripts/install.sh`'s bootstrap step. A fresh robot cannot
       # discover a staging tag, and should not be installing from one.
       #
-      # This is a second copy of those bytes, which promotion deliberately avoids for the
-      # *artifact* (§16.3: referencing the validated bytes cannot diverge, copying them
-      # can). The distinction is that this is a throwaway tool, not what gets installed:
-      # the release a robot ends up running still comes from the single staging artifact,
-      # verified by signature. The digest check below is what keeps this copy honest.
+      # Like the artifact above, this is copied rather than referenced, and for the same
+      # reason: a stable release that depends on assets living under another tag is only
+      # as durable as that tag. The digest below is what keeps this copy honest.
       - name: Carry the bootstrap binary forward
         env:
           GH_TOKEN: ${{ github.token }}
@@ -87,6 +119,7 @@ jobs:
           cargo run -p xtask -- promote \
             --version "${{ inputs.version }}" \
             --staging-tag "$staging_tag" \
+            --stable-tag "$stable_tag" \
             --repo "${{ github.repository }}" \
             --staging-manifest staging/manifest.json \
             --out dist \
@@ -123,20 +156,37 @@ jobs:
           cargo run -p xtask -- sign --dir dist --key "$RUNNER_TEMP/secret.key"
           shred -u "$RUNNER_TEMP/secret.key" 2>/dev/null || rm -f "$RUNNER_TEMP/secret.key"
 
-      # The manifest, its signature, and the bootstrap binary. The *artifact* deliberately
-      # stays where staging put it: copying those bytes would create a second copy that
-      # could diverge, while referencing the validated one cannot.
+      # Everything a robot needs, under one tag: manifest, signature, the artifact the
+      # manifest's `url` names, and the bootstrap binary `scripts/install.sh` fetches
+      # from `/releases/latest/download/`.
       - name: Create the stable release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "daemon-v${{ inputs.version }}" \
+          gh release create "$stable_tag" \
             --title "daemon ${{ inputs.version }}" \
             --notes "Promoted from \`$staging_tag\`.
 
-          The artifact is the one published in staging — same bytes, same sha256. This
-          release carries the stable manifest, its signature, and the bootstrap binary
-          used by \`scripts/install.sh\` to install a robot from scratch.
+          The artifact is the one validated in staging — same bytes, same sha256, checked
+          during promotion. This release is self-contained: manifest, signature, artifact,
+          and the bootstrap binary used by \`scripts/install.sh\` to install from scratch.
           " \
             dist/manifest.json dist/manifest.json.minisig \
+            "artifact/$artifact_name" "artifact/$artifact_name.minisig" \
             bootstrap/updaterd-bootstrap-aarch64
+
+      # Only now — the stable release exists and carries every byte it references, so the
+      # staging release has no readers left. Deleting it is what keeps the release list
+      # honest: a `daemon-staging-*` tag that outlives its promotion is installable via
+      # `--ref`, and is just an older name for what stable already serves.
+      #
+      # `--cleanup-tag`, for the same reason as in `prune-dev-releases.yml`: a surviving
+      # tag keeps resolving.
+      - name: Retire the staging release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "$staging_tag" \
+            --repo "${{ github.repository }}" \
+            --cleanup-tag --yes
+          echo "retired $staging_tag"

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -173,10 +173,12 @@ After a canary robot has run the on-device checks, promote:
 gh workflow run promote --field version=0.2.0
 ```
 
-`promote.yml` re-signs a stable manifest pointing at the **same artifact bytes** staging
-validated — no rebuild. Add `--field min_supported=0.2.0` only when remediating a bad
-release (§8.1); it forces robots below that version to update without waiting for a
-client.
+`promote.yml` re-signs a stable manifest carrying the **same artifact bytes** staging
+validated — no rebuild; the sha256 is checked during promotion and again on the robot.
+The stable release ends up self-contained (manifest, signature, artifact, bootstrap
+binary), so the staging release is deleted once promotion succeeds. Add
+`--field min_supported=0.2.0` only when remediating a bad release (§8.1); it forces
+robots below that version to update without waiting for a client.
 
 ## Rotating a key
 

--- a/docs/updater-design.md
+++ b/docs/updater-design.md
@@ -1016,7 +1016,7 @@ pass/fail + the update log. Repeatable because reset-to-golden and
 |---|---|
 | `ci.yml` | fmt, clippy, tests, plus `board-test.sh` — the only job that proves the binaries run on aarch64 Linux |
 | `release.yml` | on a `daemon-staging-v*` tag: cross-build, package, sign, **verify with the robot's own code path**, publish a prerelease |
-| `promote.yml` | manual: re-sign a *stable* manifest pointing at the staging artifact |
+| `promote.yml` | manual: re-sign a *stable* manifest, copy the validated artifact onto the stable release, retire staging |
 
 The publisher is a Rust `xtask` rather than a shell script for one reason: it reuses the
 exact `minisign`, `tar`, `zstd` and `sha2` crates the updater verifies with. A shell
@@ -1027,9 +1027,19 @@ links the *full* `minisign` crate (which can sign) while the daemon links only
 
 Three properties worth stating, because each is asserted rather than assumed:
 
-- **Promotion never rebuilds.** The stable manifest carries the staging `sha256` and
-  points at the staging artifact URL, so the bytes clients receive are the bytes the
-  canary validated; a test asserts the digest is unchanged.
+- **Promotion never rebuilds.** The stable manifest carries the staging `sha256`, and
+  promotion copies the staging artifact onto the stable release after checking that
+  digest, so the bytes clients receive are the bytes the canary validated; a test asserts
+  the digest is unchanged.
+
+  The manifest used to point back at the *staging* release rather than copy, on the
+  reasoning that one set of bytes cannot diverge while two can. What that overlooked is
+  that the robot verifies `sha256` before installing, so a diverged copy could never
+  install silently — while a stable channel whose artifacts live under a tag named like
+  scaffolding is one cleanup away from breaking. It broke: deleting the
+  `daemon-staging-v0.1.x` releases left `daemon-v0.1.0`, `v0.1.1` and `v0.1.4` correctly
+  signed and pointing at a 404. Stable releases are now self-contained and staging is
+  retired by `promote.yml` itself.
 - **Artifacts are reproducible.** Fixed mtimes in the tar mean the same inputs produce
   the same archive, so a rebuild can be compared against what shipped; a test asserts two
   packages of the same inputs hash identically.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,13 +14,23 @@
 //!   cargo xtask package --version 1.2.3 --channel daemon --bin-dir <dir> --out dist/
 //!   cargo xtask sign    --dir dist/ --key secret.key
 //!   cargo xtask promote --version 1.2.3 --staging-tag daemon-staging-v1.2.3 \
+//!                       --stable-tag daemon-v1.2.3 \
 //!                       --repo ORG/REPO --out dist/ --key secret.key
 //! ```
 //!
 //! `promote` is what makes §16.3's `staging → stable` real: it emits a *stable*
-//! manifest pointing at the **same artifact bytes** already validated in staging —
-//! same URL, same sha256 — rather than rebuilding. Promotion is therefore a
-//! re-signing, and what ships is provably what was tested.
+//! manifest carrying the **same artifact bytes** already validated in staging —
+//! same sha256 — rather than rebuilding. Promotion is therefore a re-signing, and
+//! what ships is provably what was tested.
+//!
+//! The stable manifest points at the artifact on the *stable* release, which
+//! `promote.yml` uploads alongside it. It used to point back at the staging release
+//! instead, to avoid a second copy of the bytes. That made every stable release
+//! depend on a tag named as if it were disposable — and it was duly disposed of:
+//! deleting the `daemon-staging-v0.1.x` releases left three stable releases pointing
+//! at nothing. The sha256 in the manifest is verified on the robot before install
+//! (`updater::verify::verify_sha256`), so a copy that diverged could never install
+//! silently, which is what the single-copy rule was protecting against.
 
 use std::path::{Path, PathBuf};
 
@@ -169,6 +179,11 @@ enum Command {
         #[arg(long)]
         staging_tag: String,
 
+        /// Tag of the stable release being created. The manifest's `url` points here,
+        /// so the release that `promote.yml` creates must carry the artifact itself.
+        #[arg(long)]
+        stable_tag: String,
+
         /// `ORG/REPO`, used to build the download URL.
         #[arg(long)]
         repo: String,
@@ -238,6 +253,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::Promote {
             version,
             staging_tag,
+            stable_tag,
             repo,
             staging_manifest,
             out,
@@ -245,6 +261,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => promote(
             &version,
             &staging_tag,
+            &stable_tag,
             &repo,
             &staging_manifest,
             &out,
@@ -675,12 +692,13 @@ fn sign_dir(
 
 /// Carry a validated staging artifact into the stable channel.
 ///
-/// The artifact is **not** rebuilt: URL and sha256 come from the staging manifest, so
-/// the stable channel serves the same bytes that passed staging. That is the whole
-/// point of §16.3 — promotion is a decision, not a build.
+/// The artifact is **not** rebuilt: the sha256 comes from the staging manifest, so the
+/// stable channel serves the same bytes that passed staging. That is the whole point of
+/// §16.3 — promotion is a decision, not a build.
 fn promote(
     version: &semver::Version,
     staging_tag: &str,
+    stable_tag: &str,
     repo: &str,
     staging_manifest: &Path,
     out: &Path,
@@ -701,10 +719,11 @@ fn promote(
         .and_then(|u| u.rsplit('/').next())
         .ok_or("staging manifest has no usable url")?;
 
-    // Point at the artifact on the *staging* release. Copying the file into a second
-    // release would create two sets of bytes that could diverge; referencing the
-    // validated one cannot.
-    let url = format!("https://github.com/{repo}/releases/download/{staging_tag}/{artifact_name}");
+    // Point at the artifact on the *stable* release — which makes that release
+    // self-contained, and staging disposable once promotion succeeds. `promote.yml`
+    // uploads these exact bytes under this tag; the two have to agree, and the test
+    // `promote_yml_uploads_the_artifact_it_points_at` is what keeps them agreeing.
+    let url = format!("https://github.com/{repo}/releases/download/{stable_tag}/{artifact_name}");
 
     let mut manifest = staging.clone();
     manifest["url"] = serde_json::json!(url);
@@ -870,6 +889,46 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The stable manifest names an artifact URL under the stable tag — so the workflow
+    /// that creates that release must actually upload the artifact to it.
+    ///
+    /// These two halves live in different languages and different files, and the failure
+    /// mode when they disagree is invisible until a robot tries to update: the release
+    /// looks complete, is correctly signed, and its `url` 404s. That is not hypothetical.
+    /// It is exactly the state `daemon-v0.1.0`, `v0.1.1` and `v0.1.4` were left in when
+    /// the manifest pointed at a staging release someone later deleted.
+    #[test]
+    fn promote_yml_uploads_the_artifact_it_points_at() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent");
+        let yml = std::fs::read_to_string(root.join(".github/workflows/promote.yml"))
+            .expect(".github/workflows/promote.yml must exist");
+
+        assert!(
+            yml.contains("--stable-tag"),
+            "promote.yml must pass --stable-tag, or the manifest url is built from the \
+             wrong release"
+        );
+        assert!(
+            yml.contains("\"artifact/$artifact_name\""),
+            "promote.yml must upload the artifact to the stable release — the manifest's \
+             url points there"
+        );
+        assert!(
+            yml.contains("\"artifact/$artifact_name.minisig\""),
+            "promote.yml must upload the artifact signature too — `sig_url` is derived \
+             from `url` and points at the same release"
+        );
+
+        // Retiring staging is only safe because of the two uploads above. If someone
+        // removes them, this assertion is the one that should look wrong.
+        assert!(
+            yml.contains("gh release delete \"$staging_tag\""),
+            "promote.yml should retire the staging release once stable is self-contained"
+        );
     }
 
     /// A hook that exists in the repository must be in the artifact.


### PR DESCRIPTION
Follow-up to a tag cleanup that turned up something worse than stale tags.

## The bug

The stable manifest never carried an artifact. It pointed at the one on the **staging** release:

```json
// daemon-v0.3.0/manifest.json
"url": ".../releases/download/daemon-staging-v0.3.0/daemon-0.3.0.tar.zst"
```

So `daemon-staging-*` was not scaffolding — it was permanent artifact storage for the customer channel, under a name that reads as disposable. It was duly disposed of. The `daemon-staging-v0.1.x` releases were deleted at some point, which left `daemon-v0.1.0`, `v0.1.1` and `v0.1.4` correctly signed, complete-looking, and pointing at a 404. (Those three are now deleted — they were husks.)

## Why the original reasoning doesn't hold

`promote.yml` justified referencing over copying as: two copies can diverge, one cannot. But the manifest carries `sha256` and the robot checks it before installing (`updater/src/engine.rs:520`). A diverged copy could never install silently — the property was already guaranteed. What referencing actually bought was 7.8 MB, against a stable channel that breaks if anyone tidies a staging tag.

## The change

Promotion downloads the validated artifact, checks its digest against the staging manifest, and uploads it to the stable release — which the manifest `url` now names. The stable release becomes self-contained: manifest, signature, artifact, bootstrap binary.

Staging then has no readers, so the last step deletes it with `--cleanup-tag`.

- `xtask promote` takes `--stable-tag` and builds the URL from it
- `promote.yml` gains **Carry the artifact forward** (with the sha256 check) and **Retire the staging release**
- docs updated where they described the old shape

Promotion still never rebuilds. The bytes are the canary's bytes, now checked twice — once in CI, once on the robot.

## Side effect worth having

`update --staging` resolves the newest `daemon-staging-v*` release. With promoted candidates left lying around it could resolve to something *older than stable*; today `daemon-staging-v0.2.0` and `v0.3.0` are both still up. Retiring at promotion means `--staging` only ever finds a genuine pending candidate, or reports none.

## Not retroactive

0.2.0 and 0.3.0 keep pointing at their staging releases, so **`daemon-staging-v0.2.0` and `daemon-staging-v0.3.0` must not be deleted** until those versions are retired. Only releases promoted after this merges are self-contained.

## Test

`promote_yml_uploads_the_artifact_it_points_at` — the xtask side and the workflow side are different languages in different files, and disagreement is invisible until a robot tries to update. Matches the existing "workflow and code must agree" tests in that module.

`cargo test -p xtask` 7 passed, clippy clean, fmt clean. Workflow YAML parses and step order verified; the promotion path itself can only really be exercised by running it.