### PR TITLE
Stop the test binaries forking, which was failing CI at random

### DIFF
--- a/robotd/tests/updater_gate.rs
+++ b/robotd/tests/updater_gate.rs
@@ -228,7 +228,10 @@ health = {{ probe = "socket", timeout = "3s" }}
         let robot: Box<dyn RobotClient> =
             Box::new(SocketRobotClient::new(config.robot_socket.clone()));
         let keys = KeyRing::load(&config.trusted_keys_dir, config.allow_dev_keys).unwrap();
-        Engine::new(config, keys, robot, Faults::none()).unwrap()
+        // As in the updater's own tests: no forks in a binary running engines in parallel.
+        Engine::new(config, keys, robot, Faults::none())
+            .unwrap()
+            .without_deferred_restarts()
     }
 }
 

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -101,6 +101,11 @@ pub struct Engine {
     boot_counter: BootCounter,
     pins: Pins,
     faults: Faults,
+    /// Whether an applied release schedules the deferred `updaterd`/`btd` restarts.
+    ///
+    /// On a robot, always. Off only in the test binaries, and for a reason that is about processes
+    /// rather than about restarts — see [`Engine::without_deferred_restarts`].
+    deferred_restarts: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -127,7 +132,33 @@ impl Engine {
             boot_counter,
             pins,
             faults,
+            deferred_restarts: true,
         })
+    }
+
+    /// Stop this engine spawning anything when a release is applied.
+    ///
+    /// **For test binaries, and what it removes is a `fork`, not a behaviour.** `flock` belongs to an
+    /// open file description, so a forked child inherits a *copy* of every lock the process holds and
+    /// keeps it alive until it execs. `apply` already drops its own update lock before spawning for
+    /// exactly this reason — but in a binary running engines in parallel, the child also inherits
+    /// copies of every *other* engine's lock, and those it cannot drop.
+    ///
+    /// So one test scheduling restarts made a concurrent test's `try_acquire` answer `Busy`, and the
+    /// test that noticed it was whichever one happened to be in a lock at that moment:
+    ///
+    /// ```text
+    /// ref "sub/dir" must be refused, got Busy
+    /// ```
+    ///
+    /// It needs a runner with systemd for the spawn to take long enough to matter, so it failed in CI
+    /// and never on a laptop — the worst shape a flake can have. Suppressing the spawn removes the
+    /// race rather than widening a window, and the restart path itself stays covered by
+    /// `restart_tests`, which drives it against a stub `systemctl` and asserts what it was asked.
+    #[doc(hidden)]
+    pub fn without_deferred_restarts(mut self) -> Self {
+        self.deferred_restarts = false;
+        self
     }
 
     // ── queries ──────────────────────────────────────────────────────────────
@@ -316,7 +347,7 @@ impl Engine {
         // parallel, copies of *other* engines' locks too. It surfaced as unrelated operations
         // failing with `Busy`. Nothing below this point touches the store.
         drop(lock);
-        schedule_restarts_if_applied(&outcome).await;
+        schedule_restarts_if_applied(self.deferred_restarts, &outcome).await;
         outcome
     }
 
@@ -849,7 +880,7 @@ impl Engine {
             .transition_to(component, &cfg, &store, version, current)
             .await;
         drop(lock);
-        schedule_restarts_if_applied(&outcome).await;
+        schedule_restarts_if_applied(self.deferred_restarts, &outcome).await;
         outcome
     }
 
@@ -1520,7 +1551,12 @@ async fn self_test_updaterd(release_dir: &Path) -> Result<(), Error> {
 /// Only on `Applied`. A rollback leaves the resident `updaterd` already matching `current` — it was
 /// never restarted, so it is still the binary belonging to the release being returned to — and
 /// restarting there would be churn with nothing to fix.
-async fn schedule_restarts_if_applied(outcome: &Result<ApplyResult, Error>) {
+async fn schedule_restarts_if_applied(enabled: bool, outcome: &Result<ApplyResult, Error>) {
+    if !enabled {
+        // A test binary. See `Engine::without_deferred_restarts` for why this is about forking.
+        tracing::debug!("deferred restarts suppressed");
+        return;
+    }
     if matches!(outcome, Ok(ApplyResult::Applied { .. })) {
         schedule_deferred_restarts().await;
     }

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -230,7 +230,13 @@ health = {{ probe = "socket", timeout = "2s" }}
     fn engine(&self, robot: Box<dyn RobotClient>, faults: Faults, extra: &str) -> Engine {
         let config = self.config(extra);
         let keys = KeyRing::load(&config.trusted_keys_dir, config.allow_dev_keys).unwrap();
-        Engine::new(config, keys, robot, faults).unwrap()
+        // No deferred restarts: this file runs dozens of engines in parallel, and a `fork` in any one
+        // of them hands copies of the *others*' update locks to a child, which surfaced as
+        // `got Busy` in whichever test held a lock at that moment. See
+        // `Engine::without_deferred_restarts`.
+        Engine::new(config, keys, robot, faults)
+            .unwrap()
+            .without_deferred_restarts()
     }
 
     fn engine_healthy(&self) -> Engine {

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -134,6 +134,8 @@ health = {{ probe = "socket", timeout = "2s" }}
         ))
         .unwrap();
         let keys = KeyRing::load(&config.trusted_keys_dir, false).unwrap();
+        // `without_deferred_restarts` for the same reason as `apply.rs`: engines run in parallel here
+        // and a fork in one holds another's update lock until it execs.
         Engine::new(
             config,
             keys,
@@ -143,6 +145,7 @@ health = {{ probe = "socket", timeout = "2s" }}
             faults,
         )
         .unwrap()
+        .without_deferred_restarts()
     }
 
     /// Serve in the background and return once the socket accepts connections.


### PR DESCRIPTION
`updater/tests/apply.rs` fails in CI at random and never on a laptop:

```
thread 'a_ref_cannot_escape_the_source_directory' panicked at updater/tests/apply.rs:1748:9:
ref "sub/dir" must be refused, got Busy
```

Seen on [run 31388996715](https://github.com/pollen-robotics/microduck_daemon/actions/runs/31388996715), which passed on re-run with no code change. The test that reports it is arbitrary — it is whichever one happened to be holding a lock at the wrong moment.

## The mechanism

`flock` belongs to an **open file description**, so a forked child inherits a copy of every lock the process holds and keeps it alive until it execs.

`Engine::apply` already drops its own update lock before spawning, and the comment above that `drop(lock)` names this hazard exactly. What it cannot drop are the copies the child *also* inherited of every **other** engine's lock — and this test binary runs dozens of engines in parallel. So one test scheduling its deferred `updaterd`/`btd` restarts holds a concurrent test's lock open across the fork, and that test's next `try_acquire` answers `Busy` where it expected a refusal.

It needs a runner with systemd for the fork→exec window to last long enough to matter, which is why it is CI-only. The `check` log shows the spawns responsible — dozens of `Failed to start transient timer unit: Interactive authentication required.`

## The fix

The test binaries stop spawning. `Engine::without_deferred_restarts` suppresses the scheduling, the three test builders (`updater/tests/apply.rs`, `updater/tests/ipc.rs`, `robotd/tests/updater_gate.rs`) use it, and `updaterd` keeps the production default of `true`.

This removes the race rather than widening a window — there is no fork left to inherit anything — and it changes no robot behaviour.

The restart path stays covered where it was already tested properly: `engine::restart_tests` drives it against a stub `systemctl` and asserts what it was asked, which is a better test than a real `systemd-run` failing with an authentication error as a side effect of something else.

## Verification

`cargo test --workspace`: 468 passed, 0 failed. Clippy and fmt clean.

The flake cannot be reproduced on macOS — no `systemd-run`, so no meaningful fork — so the evidence that this works is in CI: the `check` job's log should no longer contain any `Failed to start transient timer unit` lines, which is the direct observable for "the test binary no longer forks".

🤖 Generated with [Claude Code](https://claude.com/claude-code)