### PR TITLE
deps: rustypot 1.6.0, so a payload of FF FF FD reads back correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,9 +2975,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustypot"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf51a0dc05b5a2023ec70791fba4909af8944f86d1eb293f4988573a105244"
+checksum = "ab36a098e48013e3dcf9b5e99a5bc802159fd021452bc56bc5e492235413fc33"
 dependencies = [
  "clap",
  "env_logger",

--- a/duck-control/Cargo.toml
+++ b/duck-control/Cargo.toml
@@ -26,7 +26,11 @@ tracing.workspace = true
 libloading = "0.8"
 ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dynamic"] }
 
-rustypot = "1.4.2"
+# 1.6.0 is a floor, not a preference: it de-stuffs protocol 2.0 status packets whose payload
+# contains `FF FF FD`. Before it, such a read came back oversized and the fixed-size sync
+# reads below — every one of `bus`'s — decoded garbage. A present current of -1 is enough to
+# trigger it, so this is a correctness bound on the bus, not a version bump for its own sake.
+rustypot = "1.6.0"
 # `default-features = false` drops serialport's `libudev` feature, which exists only for
 # enumerating ports (`available_ports`). We open one by path from the params file and never
 # enumerate — and libudev-sys needs a pkg-config sysroot that the board's cross-build does


### PR DESCRIPTION
Dynamixel protocol 2.0 escapes `FF FF FD` in a packet body, and rustypot did not un-escape it on reception. A status packet whose data contained that sequence came back one byte too long — and every read in `bus` is a fixed-size one, so the params were misaligned and decoded as garbage rather than being rejected. A present current of -1 is `FF FF` and enough to trigger it, which puts this on an ordinary read, not a corner case.

[rustypot 1.6.0](https://github.com/pollen-robotics/rustypot/pull/121) de-stuffs status packets on reception and stuffs instruction params on transmission.

The requirement is written as a floor because the fix is a correctness requirement of this crate's bus, not a preference for the newest release: a build that resolves 1.5.0 silently reintroduces the misalignment.

## Nothing else moves

1.5.0 → 1.6.0 changed the Rust API only inside rustypot's pyo3 bindings (`PyObject` → `Py<PyAny>` in `servo_macro.rs`), which this crate does not link. `Xl330Controller` and the `sync_read_*` surface `bus` uses are unchanged.

- `cargo test -p duck-control` — 48 passed, including `position_conversion_round_trips_through_rustypot`
- `cargo check --workspace --all-targets` — clean
