### PR TITLE
ci: the target architecture needs -security too

### DIFF
--- a/scripts/ci-cross-deps.sh
+++ b/scripts/ci-cross-deps.sh
@@ -50,6 +50,24 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
 
 sudo apt-get update
+
+# What apt believes about both architectures, before it is asked for anything.
+#
+# Here because this step failed with a refusal that explained nothing:
+#
+#   libudev-dev:arm64 : Depends: libudev1:arm64 (= 255.4-1ubuntu8.16)
+#                       but it is not going to be installed
+#
+# `libudev1` is `Multi-Arch: same`, so the ${ARCH} copy has to match the host's exactly — and every
+# guess about *why* it did not (mirrors drifting, phased updates, a runner image change) was
+# contradicted by the next piece of evidence. The resolver knows; it just does not say unless asked.
+# One screenful of `policy` and a simulated install is cheaper than another round of hypotheses.
+echo "==> what apt believes"
+apt-cache policy libudev1 "libudev1:${ARCH}" libudev-dev "libudev-dev:${ARCH}" || true
+dpkg -l | grep -i libudev || true
+echo "==> how it would resolve the install"
+sudo apt-get -s -o Debug::pkgProblemResolver=yes install "libudev-dev:${ARCH}" || true
+
 sudo apt-get install -y "libudev-dev:${ARCH}"
 
 # Prove it landed. A silent miss here surfaces much later as a confusing link error, or —

--- a/scripts/ci-cross-deps.sh
+++ b/scripts/ci-cross-deps.sh
@@ -40,10 +40,24 @@ if [ -f /etc/apt/sources.list ]; then
 fi
 
 # ...and $ARCH comes from ports, which is a different host serving a different set.
+#
+# **`-security` is load-bearing, not thoroughness.** `libudev1` is `Multi-Arch: same`, so apt must
+# hold both architectures at the identical version. The host's amd64 sources include
+# `noble-security`, so the moment a security update lands there — 255.4-1ubuntu8.17, in the case that
+# taught us this — apt intends to upgrade the amd64 copy to it, and then refuses to install any
+# ${ARCH} version that would disagree:
+#
+#   libudev-dev:arm64 : Depends: libudev1:arm64 (= 255.4-1ubuntu8.16)
+#                       but it is not going to be installed
+#
+# With only `${suite}` and `${suite}-updates` configured for ${ARCH}, 8.17 does not exist as far as
+# this side is concerned, so there is no version both architectures can agree on and the resolver
+# gives up. Nothing has drifted and no mirror is at fault: the suites were simply asymmetric, and it
+# broke the first time libudev had a security fix. It is *not* enough to omit this and hope.
 sudo tee "/etc/apt/sources.list.d/ports-${ARCH}.sources" >/dev/null <<EOF
 Types: deb
 URIs: http://ports.ubuntu.com/ubuntu-ports
-Suites: ${suite} ${suite}-updates
+Suites: ${suite} ${suite}-updates ${suite}-security
 Components: main universe
 Architectures: ${ARCH}
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -58,16 +72,12 @@ sudo apt-get update
 #   libudev-dev:arm64 : Depends: libudev1:arm64 (= 255.4-1ubuntu8.16)
 #                       but it is not going to be installed
 #
-# `libudev1` is `Multi-Arch: same`, so the ${ARCH} copy has to match the host's exactly — and every
-# guess about *why* it did not (mirrors drifting, phased updates, a runner image change) was
-# contradicted by the next piece of evidence. The resolver knows; it just does not say unless asked.
-# One screenful of `policy` and a simulated install is cheaper than another round of hypotheses.
+# Kept because it is what answered the question: the candidate versions, side by side, showed the
+# host being taken to a security version the ${ARCH} suites had never been told about. Guessing at
+# that from the refusal alone cost several rounds; a screenful of `policy` in the log costs nothing.
 echo "==> what apt believes"
 apt-cache policy libudev1 "libudev1:${ARCH}" libudev-dev "libudev-dev:${ARCH}" || true
 dpkg -l | grep -i libudev || true
-echo "==> how it would resolve the install"
-sudo apt-get -s -o Debug::pkgProblemResolver=yes install "libudev-dev:${ARCH}" || true
-
 sudo apt-get install -y "libudev-dev:${ARCH}"
 
 # Prove it landed. A silent miss here surfaces much later as a confusing link error, or —


### PR DESCRIPTION
The `board` job could not install the cross libudev, and nothing in the repo had changed:

```
libudev-dev:arm64 : Depends: libudev1:arm64 (= 255.4-1ubuntu8.16) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

## The cause

`apt-cache policy`, once asked:

```
libudev1:        Installed: 8.16   Candidate: 8.17   ← noble-security, amd64
libudev1:arm64:  Installed: none   Candidate: 8.16   ← noble-updates, ports
```

A **security** update landed for the host architecture. `libudev1` is `Multi-Arch: same`, so apt must hold both architectures at one identical version: it intends to take amd64 to 8.17, and the arm64 sources this script writes listed only `${suite}` and `${suite}-updates` — so 8.17 does not exist on that side. No version satisfies both, and the resolver gives up.

The suites were asymmetric from the day the script was written: the host keeps its security suite, the target never had one. It worked until `libudev` had a security fix, which was a matter of when rather than whether — and it would recur for any other `Multi-Arch: same` library this script came to need.

## The fix

One suite added to the ports source: `${suite}-security`.

Also kept: the `apt-cache policy` line that answered this. Three plausible explanations were tried and refuted before the diagnostics went in — archives drifting apart, a phased update decided per machine, a new runner image — each contradicted by the next fact. The candidate versions side by side settled it immediately. That line costs a screenful in a log nobody reads until the next time this happens.

The resolver trace (`Debug::pkgProblemResolver`) has been removed again now that it has done its job.

## What I did not do

Fetching the `.deb`s and unpacking them into a sysroot rather than installing them would also have worked, by sidestepping co-installability entirely. It was the wrong fix: it treats a symptom, and it costs dpkg's knowledge of those files. Worth reconsidering only if we ever need a target library whose host counterpart genuinely cannot be matched.

## Note on #49

#49 is blocked by this and carries the same failure. Once this merges I will rebase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)