### PR TITLE
release: 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "btd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bluer",
  "btleplug",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "configd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "duck-control"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "duck-ipc-proto",
  "libloading 0.8.9",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "duck-ipc-proto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",
@@ -2338,7 +2338,7 @@ checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "padd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "duck-ipc-proto",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "robotctl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "robotd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "clap",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "minisign",
@@ -3860,7 +3860,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4425,7 +4425,7 @@ checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xtask"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "minisign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ floor  = "1.23"
 target = "1.28.0"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 # 1.89 for `std::fs::File::try_lock`, which is how the single-flight update lock works
 # without a dependency (updater/src/journal.rs). Edition 2024 needs 1.85, so this covers


### PR DESCRIPTION
Version bump only — `Cargo.toml` and `Cargo.lock`. `xtask package` asserts the crate version matches the version being published, so this has to land before the tag.

## Checkup on `main` @ `4f285b7`

| check | result |
|---|---|
| `cargo test --workspace` | 498 passed, 0 failed |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets` | 0 warnings |
| clippy for `aarch64-unknown-linux-gnu`, `RUSTFLAGS=-D warnings` | 0 across `configd`, `btd`, `robotd`, `duck-control`, `robotctl`, `updater` |
| `sh -n` + shellcheck + executable, the five scripts CI lints | clean |
| `xtask` packaging tripwires | 12 passed |
| CI on `main` | success |

## What 0.4.0 carries over 0.3.0

- **Pairing a gamepad is one command** and `padd` runs from boot (#49). Driving takes a pairing step and nothing else.
- **Start brings the robot up** — torque on, two-second ramp to the home pose — and `robotctl robot init` / `robot relax` make powering the joints a command rather than a subcommand that fights the daemon for the motor bus.
- **`Privacy = off`** in the board's BlueZ config, which is what lets a pad bond at all. Boards carrying the old `Privacy = device` are corrected by `setup-board.sh`, and it does not take effect until a reboot.
- **`robotctl monitor` in degrees**, radians one keypress away (#55).
- Two CI fixes worth having in a release: the test binaries no longer fork while holding an update lock (#50), and the cross-compilation sources include the target's `-security` suite (#54).

Verified on a board: pairing including forget-then-re-pair and trust surviving a reboot, a second pad added while the first is bonded, `robot init`, `robot relax`, and Start/Stop of the policy with the bring-up ramp.

## The install consequence

`API_VERSION` 4 → 6 against 0.3.0 (`pad.*`, then `robot.init` / `robot.relax`). The handshake is an exact `!=`, so on every robot that installs this, `robotctl` disagrees with the still-running `updaterd` until it restarts — `docs/project/install-path-gap.md` §2, unchanged, and the known cost of an additive bump.

## One thing to know about 0.3.0 before promoting 0.4.0

Stable `daemon-v0.3.0` is **not self-contained**: its manifest points `url` at `daemon-staging-v0.3.0`, because it was promoted before #46 landed.

```
"url": ".../releases/download/daemon-staging-v0.3.0/daemon-0.3.0.tar.zst"
```

So **`daemon-staging-v0.3.0` must not be deleted** — every robot on stable 0.3.0 downloads from it. 0.4.0 will not have this shape: the current `promote.yml` uploads the artifact to the stable release and deletes its own staging release once promotion succeeds, and `xtask`'s `promote_yml_uploads_the_artifact_it_points_at` keeps it that way.

## After merging

```bash
git tag daemon-staging-v0.4.0 && git push --tags
```

Then, once a canary robot has run the on-device checks:

```bash
gh workflow run promote --field version=0.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)