### PR TITLE
ci: the releases page is the entry point, and it decides what you meant

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -1,0 +1,392 @@
+# Build, sign, verify and publish a release. Called, never triggered.
+#
+# The one place the release recipe lives, so the staging and stable paths cannot drift apart in what
+# they ship — this repository has been bitten more than once by two lists that were supposed to agree.
+# `release.yml` decides which channel is being published and calls this; nothing else should.
+#
+# `xtask`'s packaging tripwires read THIS file for the `--include` list, so a unit, hook or sysusers
+# file that is not named here fails a test rather than a robot.
+name: _build-release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to publish under, e.g. daemon-staging-v1.2.3'
+        required: true
+        type: string
+      version:
+        description: 'Semver being published, e.g. 1.2.3'
+        required: true
+        type: string
+      prerelease:
+        description: 'True for staging, false for stable. Decides the GitHub flag a robot reads.'
+        required: true
+        type: boolean
+
+permissions:
+  contents: write   # create the release and upload assets
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Signs with `release-1`, the key customer robots trust. `dev.yml` signs branch builds with
+    # `team.dev`, which a customer robot refuses — two keys so "any build" and "a release" are
+    # distinguishable by the robot, not by convention.
+    #
+    # ⚠ `environment: release` is NOT a gate. On this plan the environment cannot carry required
+    # reviewers or a branch policy — see docs/project/ci-setup.md. It scopes the secrets and is the
+    # hook that turns a real gate on with one settings change.
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The tagged commit, named explicitly rather than left to the default: for a release
+          # event the default is the release's target commitish, which is a branch head when
+          # someone drafts a release against a branch — and that is not necessarily what the tag
+          # points at by the time this runs.
+          ref: ${{ inputs.tag }}
+          # Full history so the recorded revision is meaningful.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+      # v2, and the zig version pinned. Two separate reasons:
+      #   - v1's mirror list 404s for current zig releases, which is how this first
+      #     surfaced — every mirror failed and the job never got a compiler.
+      #   - "latest" would let the glibc floor move under us between runs. The floor is
+      #     the whole point of building with zig (see .cargo/config.toml), so the
+      #     toolchain that sets it must be a fixed input.
+      - name: Cross-compilation C dependencies
+        run: ./scripts/ci-cross-deps.sh
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
+      - run: cargo install cargo-zigbuild --locked
+
+      - name: Derive version from the tag
+        id: version
+        run: |
+          # daemon-staging-v1.2.3 -> 1.2.3
+          # The caller resolved this from the tag; recorded here so the log shows it.
+          version="${{ inputs.version }}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "publishing $version from ${{ inputs.tag }} (prerelease=${{ inputs.prerelease }})"
+
+      # Same command and same glibc floor as scripts/board-test.sh, so what ships is
+      # what was tested rather than a differently-configured build.
+      #
+      # DUCK_REVISION and DUCK_BUILD_TIME are compiled into the binaries, so every daemon
+      # can state which commit it came from in its first log line and over IPC. Read at
+      # compile time because a shipped robot has no git repository. A build without them
+      # still works and reports "rev unknown" — which is exactly what a local build should
+      # say, and why they are not required.
+      - name: Build for the board
+        env:
+          DUCK_REVISION: ${{ github.sha }}
+          # libudev-sys (via gilrs, via padd) resolves the target's C library through
+          # pkg-config, which refuses to answer for another architecture unless told to.
+          PKG_CONFIG_ALLOW_CROSS: "1"
+          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+        run: |
+          export DUCK_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cargo board --bins
+
+      - name: Package
+        run: |
+          mkdir -p staged
+          # Every daemon that ships in this artifact. robotd is not optional: `on_apply`
+          # restarts it, so an artifact without it would fail its own restart step and roll
+          # itself back.
+          cp target/aarch64-unknown-linux-gnu/release/updaterd staged/
+          cp target/aarch64-unknown-linux-gnu/release/robotctl staged/
+          cp target/aarch64-unknown-linux-gnu/release/robotd staged/
+          # configd (wifi, identity) and btd (the BLE front door). Their units are packaged
+          # alongside; a unit whose ExecStart binary is missing fails with 203/EXEC, which
+          # reads as a broken daemon rather than an incomplete artifact.
+          cp target/aarch64-unknown-linux-gnu/release/configd staged/
+          cp target/aarch64-unknown-linux-gnu/release/btd staged/
+          # padd is the gamepad intent client. Shipped because a dev board is where
+          # anyone drives the robot from, and the intent API only stays honest if the
+          # thing exercising it daily is actually on the robot.
+          cp target/aarch64-unknown-linux-gnu/release/padd staged/
+
+          cargo run -p xtask -- package \
+            --version "${{ inputs.version }}" \
+            --channel daemon \
+            --bin-dir staged \
+            --out dist \
+            --base-url "https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}" \
+            --revision "${GITHUB_SHA}" \
+            --include "updater/systemd/updaterd.service=systemd/updaterd.service" \
+            --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
+            --include "robotd/systemd/robotd.service=systemd/robotd.service" \
+            --include "hooks/postinstall=hooks/postinstall" \
+            --include "configd/systemd/configd.service=systemd/configd.service" \
+            --include "btd/systemd/btd.service=systemd/btd.service" \
+            --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \
+            --include "padd/systemd/padd.service=systemd/padd.service" \
+            --include "padd/systemd/sysusers.d/padd.conf=systemd/sysusers.d/padd.conf" \
+            --include "deploy/journald.conf.d/10-robot.conf=deploy/journald.conf.d/10-robot.conf" \
+            --include "docs/design/architecture.md=docs/architecture.md" \
+            --include "docs/design/updater-design.md=docs/updater-design.md" \
+            --include "deploy/README.md=docs/deploy.md" \
+            --include "policies/alpha_walking.onnx=policies/alpha_walking.onnx" \
+            --include "policies/alpha_stand.onnx=policies/alpha_stand.onnx"
+
+          # The bootstrap binary, published bare alongside the artifact.
+          #
+          # A fresh robot has no way to open a `.tar.zst`: extraction happens *inside*
+          # updaterd (tar + zstd are linked in), and the `zstd` binary is not on a stock
+          # Armbian image. So `scripts/install.sh` downloads this one file and runs
+          # `updaterd install --from <dir>` to land the first release through the real
+          # engine.
+          #
+          # Byte-identical to `bin/updaterd` inside the artifact, because it is the same
+          # file — which is what lets the installer verify it after the fact by comparing
+          # its sha256 against the copy that came out of the signature-verified tarball.
+          cp staged/updaterd "dist/updaterd-bootstrap-aarch64"
+
+      # Written to a file rather than passed as an argument: a key on a command line is
+      # visible in the process list to anything else on the runner.
+      - name: Sign
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          # Lengths, not values: a key length is not sensitive, and "is not set" could not
+          # distinguish an absent secret from a present-but-empty one — which is exactly how
+          # the first real run failed, after `gh secret set` was fed stdin through a wrapper
+          # that did not forward it. A secret can be written but empty, and it still lists.
+          echo "key length: ${#MINISIGN_SECRET_KEY}, password length: ${#MINISIGN_PASSWORD}"
+          if [ -z "$MINISIGN_SECRET_KEY" ]; then
+            echo "::error::MINISIGN_SECRET_KEY is empty or unset — refusing to publish unsigned artifacts"
+            exit 1
+          fi
+          # A minisign secret key is two lines: a comment and the base64 payload. One line
+          # means the newline was lost in transit, which fails later inside minisign with a
+          # parse error that says nothing about the cause.
+          if [ "$(printf '%s' "$MINISIGN_SECRET_KEY" | wc -l)" -lt 1 ]; then
+            echo "::error::MINISIGN_SECRET_KEY looks like a single line — its newline was lost"
+            exit 1
+          fi
+          umask 077
+          # '%s', not '%s\n': the key file ends with a newline, so the stored secret already
+          # contains it. Adding another would leave a trailing blank line nobody has tested
+          # minisign against.
+          printf '%s' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/secret.key"
+          # MINISIGN_PASSWORD reaches xtask through clap's `env`, so an encrypted key
+          # needs no extra flag here.
+          cargo run -p xtask -- sign --dir dist --key "$RUNNER_TEMP/secret.key"
+          shred -u "$RUNNER_TEMP/secret.key" 2>/dev/null || rm -f "$RUNNER_TEMP/secret.key"
+
+      # Verify with the *robot's* own code path before publishing. If the updater
+      # cannot accept this release, nobody should be able to download it.
+      #
+      # Uses the sideload manifest `xtask package` already emitted and `xtask sign`
+      # already signed, so this step needs no access to the key. Re-signing here would
+      # mean handling the signing key twice in one job for no benefit.
+      - name: Verify the way a robot would
+        run: |
+          version="${{ inputs.version }}"
+          artifact="daemon-${version}.tar.zst"
+
+          mkdir -p verify/published verify/keys verify/opt verify/var
+          cp "dist/${version}.manifest.json"          verify/published/
+          cp "dist/${version}.manifest.json.minisig"  verify/published/
+          cp "dist/${artifact}"                       verify/published/
+          cp "dist/${artifact}.minisig"               verify/published/
+
+          # The public key is not a secret, but keeping it in CI config means the
+          # verification uses the same trust anchor a robot would.
+          printf '%s\n' "${{ vars.MINISIGN_PUBLIC_KEY }}" > verify/keys/release-1.pub
+
+          # The production `on_apply` and `health`, not inert placeholders. `updaterd
+          # install` overrides both for the duration of a bootstrap — see its doc comment
+          # — so this config also checks that those overrides are still in place. Writing
+          # `action = "none"` here would have tested nothing but the engine.
+          cat > verify/updater.toml <<EOF
+          trusted_keys_dir = "$PWD/verify/keys"
+          hw_rev = 1
+          state_dir = "$PWD/verify/var"
+
+          [component.daemon]
+          install_dir = "$PWD/verify/opt/daemon"
+          source = { type = "github_releases", repo = "${{ github.repository }}", tag_prefix = "daemon-v" }
+          on_apply = { action = "restart", units = ["robotd"] }
+          health = { probe = "socket", timeout = "30s" }
+          EOF
+
+          # The release ships a `preinstall` hook asserting the machine can run it, and
+          # `updaterd install` runs hooks on a bootstrap install too — correctly, since a
+          # fresh board is exactly when a missing ONNX Runtime has to be installed. This
+          # runner is not a board: it is x86_64, so the aarch64 dylib the hook would fetch
+          # could never be loaded here, and fetching ~100 MB to prove that would only make
+          # every release slower.
+          #
+          # So declare the precondition satisfied and let the hook take its "already fine"
+          # branch, touching nothing. Faking the *file* rather than skipping the hook keeps
+          # this step's claim honest: hooks still run, and a hook that started failing for
+          # any other reason would still fail the release. The hook's own logic — accepting
+          # a runtime at the floor, refusing one it cannot replace — is covered on emulated
+          # aarch64, as root, in scripts/board-test.sh.
+          #
+          # The version comes from [workspace.metadata.onnxruntime], never a literal: that
+          # table is the single source of truth the hook itself is generated from, and a
+          # second copy here would be free to drift below the floor and turn this step red
+          # for a reason that has nothing to do with the release.
+          onnx_target="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.metadata.onnxruntime.target')"
+          sudo touch "/usr/local/lib/libonnxruntime.so.${onnx_target}"
+          sudo ln -sfn "libonnxruntime.so.${onnx_target}" /usr/local/lib/libonnxruntime.so
+
+          # The same command `scripts/install.sh` runs on a fresh robot, against the same
+          # files it would download. A host-native build, because the packaged binaries are
+          # aarch64 and this runner is x86_64 — what is under test is the bootstrap logic,
+          # not the cross-compile, which `scripts/board-test.sh` covers.
+          #
+          # Note this reaches `--from`, never the `github_releases` source above: an
+          # install that silently fell back to the network would be publishing a release
+          # by fetching some *other* release, and would pass while proving nothing.
+          #
+          # As root, because that is what a robot's `updaterd` is. The release now carries a
+          # `postinstall` hook that installs unit files into /etc/systemd/system and sysusers
+          # files into /usr/lib/sysusers.d, and it fails the update when it cannot — correctly,
+          # since a release whose units never arrive is a release that does not work. Running
+          # the engine unprivileged made this step reject a perfectly good release, which is
+          # the same mismatch the preinstall hook exposed one release earlier: a step claiming
+          # to verify "the way a robot would" has to have the privilege a robot has.
+          #
+          # Built first and then run under sudo, rather than `sudo cargo run`: cargo as root
+          # would write root-owned files into the cached target directory and poison it for
+          # every later step and every later run.
+          #
+          # The hook then enables the units it installed, and they fail to start here — they
+          # are aarch64 and this is x86_64. Expected, and only a warning by design: a unit that
+          # cannot start must not fail an otherwise good update. Failure lines from
+          # btd/configd/robotd in this step's log are the runner being a runner.
+          cargo build -p updater --bin updaterd
+          sudo ./target/debug/updaterd install \
+            --config verify/updater.toml \
+            --from verify/published
+
+          # Everything the robot needs must be present in the installed release, checked
+          # through the symlink the units actually resolve.
+          #
+          # `bin/robotd` is on this list because it was once missing: the release shipped
+          # only updaterd and robotctl while `on_apply` restarted robotd, so the first real
+          # release would have failed its own restart step and rolled itself back. An
+          # artifact that is missing a binary is indistinguishable from a good one until it
+          # is installed, which is exactly why this is asserted rather than assumed.
+          #
+          # Not executed, only checked: these are aarch64 binaries and the runner is x86_64.
+          # `scripts/board-test.sh` is what runs them.
+          for required in \
+            bin/updaterd \
+            bin/robotd \
+            bin/robotctl \
+            systemd/updaterd.service \
+            systemd/robotd.service \
+            systemd/sysusers.d/robot.conf \
+            deploy/journald.conf.d/10-robot.conf \
+            version.toml
+          do
+            if [ ! -e "verify/opt/daemon/current/$required" ]; then
+              echo "::error::release is missing $required"
+              exit 1
+            fi
+          done
+          test -x "verify/opt/daemon/current/bin/updaterd"
+          test -x "verify/opt/daemon/current/bin/robotd"
+
+          # The bootstrap asset must be the same bytes as the copy inside the artifact.
+          #
+          # This is what makes the installer's chain of trust close. The bootstrap binary
+          # is downloaded bare and run *before* anything has verified it, so on its own it
+          # is only as trustworthy as the TLS connection that fetched it. After the install
+          # the script compares its digest against `current/bin/updaterd`, which came out
+          # of a signature-verified tarball — equal digests mean the unverified binary was
+          # genuine. That check is worthless if the two are allowed to differ here.
+          boot_sum=$(sha256sum "dist/updaterd-bootstrap-aarch64" | cut -d' ' -f1)
+          installed_sum=$(sha256sum "verify/opt/daemon/current/bin/updaterd" | cut -d' ' -f1)
+          if [ "$boot_sum" != "$installed_sum" ]; then
+            echo "::error::updaterd-bootstrap-aarch64 does not match bin/updaterd in the artifact"
+            exit 1
+          fi
+          echo "bootstrap binary matches the artifact ($boot_sum)"
+
+          # The revision must have made it in, or support cannot tell two builds of the
+          # same version apart.
+          if ! grep -q "revision" "verify/opt/daemon/current/version.toml"; then
+            echo "::error::version.toml records no revision"
+            exit 1
+          fi
+          cat "verify/opt/daemon/current/version.toml"
+          echo "the updater accepted this release"
+
+      # Create it if it is not there, then fill it in either way.
+      #
+      # Two things made the old single `gh release create ... dist/*` wrong, and they are the same
+      # thing seen from different sides: it only ever worked on a release that did not exist yet.
+      #
+      #   - **It could not be re-run.** If this step failed after creating the release — a network
+      #     blip, a partial upload — every re-run failed identically on "release already exists",
+      #     and the only way out was deleting the release and the tag by hand, mid-release.
+      #   - **It could not follow the UI.** Drafting a release in the web UI is the obvious way to
+      #     cut one, and it creates the release object first, so the pipeline arrived to find its
+      #     own destination already taken and died *after* signing.
+      #
+      # `--clobber` on the upload so a re-run replaces assets rather than refusing them.
+      #
+      # `--prerelease` is re-asserted on a release that already exists, and that is a safety
+      # property rather than cosmetics: staging releases are flagged as prereleases because a plain
+      # `update apply` skips prereleases, which is what keeps an unvalidated build away from robots
+      # on stable. A release drafted in the UI without that box ticked would otherwise be a
+      # candidate every robot could reach.
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            title="daemon ${{ inputs.version }} (staging)"
+            notes="Staging build from \`${GITHUB_SHA}\`.
+
+          Not for client robots. Promote it — create a release for tag \`daemon-v${{ inputs.version }}\`,
+          or run the \`promote\` workflow — once a canary has run the on-device acceptance checks.
+          Promotion ships these exact bytes.
+          "
+            flag=--prerelease
+          else
+            title="daemon ${{ inputs.version }}"
+            # Said in the release itself, because it is the one thing that distinguishes this from a
+            # promoted release and nothing else would record it. Built here means engine-verified —
+            # signature, manifest and a real install, all checked in this job — but not *canaried*:
+            # no robot ran these bytes before they became the stable channel.
+            notes="Built directly from \`${GITHUB_SHA}\`, with no staging release to promote.
+
+          Verified through the update engine in CI, but **not validated on a robot**. For the
+          canaried path, publish a pre-release for \`daemon-staging-v${{ inputs.version }}\` first
+          and then promote it.
+          "
+            flag=--prerelease=false
+          fi
+
+          # Create it if absent, fill it in either way — see the note in release.yml on why this is
+          # not a single `gh release create`. The flag is re-asserted on a release that already
+          # exists: staging must be flagged so a plain `update apply` skips it, and stable must not
+          # be, or it ships to nobody.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG exists; filling it in"
+            gh release edit "$TAG" "$flag" --title "$title"
+          else
+            gh release create "$TAG" "$flag" --title "$title" --notes "$notes"
+          fi
+
+          gh release upload "$TAG" dist/* --clobber

--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -1,0 +1,216 @@
+# Promote a validated staging release to the STABLE channel. Called, never triggered.
+#
+# This is §16.3's promotion step, and the important property is what it does *not* do: it never
+# rebuilds. It copies the artifact already published in staging — same sha256, checked here and again
+# on the robot — so what reaches client robots is byte-identical to what the canary validated.
+# Promotion is a decision, not a build.
+#
+# The stable release is **self-contained**: manifest, signature, artifact and bootstrap binary all
+# hang off `daemon-v<version>`. That is why the last step can delete the staging release outright.
+# Previously the stable manifest pointed back at the staging release to avoid a second copy of the
+# bytes, which quietly made a tag named like scaffolding load-bearing for the customer channel — and
+# deleting the v0.1.x staging releases duly left three stable releases pointing at a 404.
+#
+# Two callers: `release.yml`, when a stable release appears and a staging one exists to promote, and
+# `promote.yml` for the manual path.
+name: _promote-release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to promote, e.g. 1.2.3'
+        required: true
+        type: string
+      min_supported:
+        description: >
+          Optional: force robots below this version to update without waiting for a client. Use only
+          when remediating a bad release (§8.1).
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    # Signs with `release-1`. Promotion is the step that actually exposes customer robots to a build,
+    # so it is the most consequential thing in this repository.
+    #
+    # ⚠ `environment: release` is NOT a gate — see the same note in _build-release.yml.
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Fetch the staging manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          staging_tag="daemon-staging-v${{ inputs.version }}"
+          mkdir -p staging
+          # Fails loudly if that staging release does not exist — promoting something
+          # unbuilt should not be possible.
+          gh release download "$staging_tag" \
+            --repo "${{ github.repository }}" \
+            --pattern 'manifest.json' \
+            --dir staging
+          echo "staging_tag=$staging_tag" >> "$GITHUB_ENV"
+          echo "stable_tag=daemon-v${{ inputs.version }}" >> "$GITHUB_ENV"
+
+      # The artifact itself, so the stable release can carry it. This is the copy that
+      # makes staging disposable; the sha256 check below is what makes it safe.
+      - name: Carry the artifact forward
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_name="$(jq -r '.url | split("/") | last' staging/manifest.json)"
+          mkdir -p artifact
+          gh release download "$staging_tag" \
+            --repo "${{ github.repository }}" \
+            --pattern "$artifact_name" \
+            --pattern "$artifact_name.minisig" \
+            --dir artifact
+
+          # The manifest that ships names this digest, and the robot re-checks it before
+          # installing (`updater::verify::verify_sha256`). Checking it here too means a
+          # bad copy fails in CI rather than on a board.
+          expected="$(jq -r .sha256 staging/manifest.json)"
+          actual="$(sha256sum "artifact/$artifact_name" | cut -d' ' -f1)"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::artifact sha256 $actual does not match staging manifest $expected"
+            exit 1
+          fi
+          echo "artifact $artifact_name sha256 $actual (matches staging)"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_ENV"
+
+      # The bootstrap binary has to exist on the *stable* release, because that is what
+      # `https://github.com/<repo>/releases/latest/download/...` resolves to — and that
+      # URL is the whole of `scripts/install.sh`'s bootstrap step. A fresh robot cannot
+      # discover a staging tag, and should not be installing from one.
+      #
+      # Like the artifact above, this is copied rather than referenced, and for the same
+      # reason: a stable release that depends on assets living under another tag is only
+      # as durable as that tag. The digest below is what keeps this copy honest.
+      - name: Carry the bootstrap binary forward
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p bootstrap
+          gh release download "$staging_tag" \
+            --repo "${{ github.repository }}" \
+            --pattern 'updaterd-bootstrap-aarch64' \
+            --dir bootstrap
+
+          # `release.yml` already asserted this file is byte-identical to `bin/updaterd`
+          # inside the signed artifact. Recording the digest here means a promotion that
+          # somehow picked up different bytes is visible in the log rather than silently
+          # breaking the installer's post-install self-check.
+          sha256sum bootstrap/updaterd-bootstrap-aarch64
+
+      - name: Build the stable manifest
+        run: |
+          cargo run -p xtask -- promote \
+            --version "${{ inputs.version }}" \
+            --staging-tag "$staging_tag" \
+            --stable-tag "$stable_tag" \
+            --repo "${{ github.repository }}" \
+            --staging-manifest staging/manifest.json \
+            --out dist \
+            ${{ inputs.min_supported && format('--min-supported {0}', inputs.min_supported) || '' }}
+
+      - name: Sign
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          # Required: the release key is encrypted, and `xtask sign` reads this through
+          # clap's `env`. Without it, signing fails with "Key might be encrypted".
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          # Lengths, not values: a key length is not sensitive, and "is not set" could not
+          # distinguish an absent secret from a present-but-empty one — which is exactly how
+          # the first real run failed, after `gh secret set` was fed stdin through a wrapper
+          # that did not forward it. A secret can be written but empty, and it still lists.
+          echo "key length: ${#MINISIGN_SECRET_KEY}, password length: ${#MINISIGN_PASSWORD}"
+          if [ -z "$MINISIGN_SECRET_KEY" ]; then
+            echo "::error::MINISIGN_SECRET_KEY is empty or unset — refusing to publish unsigned artifacts"
+            exit 1
+          fi
+          # A minisign secret key is two lines: a comment and the base64 payload. One line
+          # means the newline was lost in transit, which fails later inside minisign with a
+          # parse error that says nothing about the cause.
+          if [ "$(printf '%s' "$MINISIGN_SECRET_KEY" | wc -l)" -lt 1 ]; then
+            echo "::error::MINISIGN_SECRET_KEY looks like a single line — its newline was lost"
+            exit 1
+          fi
+          umask 077
+          # '%s', not '%s\n': the key file ends with a newline, so the stored secret already
+          # contains it. Adding another would leave a trailing blank line nobody has tested
+          # minisign against.
+          printf '%s' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/secret.key"
+          cargo run -p xtask -- sign --dir dist --key "$RUNNER_TEMP/secret.key"
+          shred -u "$RUNNER_TEMP/secret.key" 2>/dev/null || rm -f "$RUNNER_TEMP/secret.key"
+
+      # Everything a robot needs, under one tag: manifest, signature, the artifact the
+      # manifest's `url` names, and the bootstrap binary `scripts/install.sh` fetches
+      # from `/releases/latest/download/`.
+      #
+      # Create-then-fill, like release.yml, and re-runnable for the same reason: a promotion that
+      # failed *after* creating the release could not be retried, which is the worst moment for a
+      # step to be one-shot — the stable release would exist, carrying nothing a robot can install,
+      # until someone deleted it by hand.
+      #
+      # `--prerelease=false` is re-asserted rather than assumed: a stable release that is flagged as
+      # a prerelease is invisible to a plain `update apply`, so a promotion into a release object
+      # someone had drafted would silently ship to nobody.
+      - name: Publish the stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="Promoted from \`$staging_tag\`.
+
+          The artifact is the one validated in staging — same bytes, same sha256, checked
+          during promotion. This release is self-contained: manifest, signature, artifact,
+          and the bootstrap binary used by \`scripts/install.sh\` to install from scratch.
+          "
+          title="daemon ${{ inputs.version }}"
+
+          if gh release view "$stable_tag" >/dev/null 2>&1; then
+            echo "release $stable_tag exists; filling it in"
+            gh release edit "$stable_tag" --prerelease=false --title "$title"
+          else
+            gh release create "$stable_tag" --title "$title" --notes "$notes"
+          fi
+
+          gh release upload "$stable_tag" \
+            dist/manifest.json dist/manifest.json.minisig \
+            "artifact/$artifact_name" "artifact/$artifact_name.minisig" \
+            bootstrap/updaterd-bootstrap-aarch64 \
+            --clobber
+
+      # Only now — the stable release exists and carries every byte it references, so the
+      # staging release has no readers left. Deleting it is what keeps the release list
+      # honest: a `daemon-staging-*` tag that outlives its promotion is installable via
+      # `--ref`, and is just an older name for what stable already serves.
+      #
+      # `--cleanup-tag`, for the same reason as in `prune-dev-releases.yml`: a surviving
+      # tag keeps resolving.
+      - name: Retire the staging release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Tolerant of already being gone, so a re-run of a promotion that got this far does not
+          # fail on the one step whose work is already done.
+          if gh release view "$staging_tag" >/dev/null 2>&1; then
+            gh release delete "$staging_tag" \
+              --repo "${{ github.repository }}" \
+              --cleanup-tag --yes
+            echo "retired $staging_tag"
+          else
+            echo "$staging_tag is already retired"
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -159,21 +159,39 @@ jobs:
       # Everything a robot needs, under one tag: manifest, signature, the artifact the
       # manifest's `url` names, and the bootstrap binary `scripts/install.sh` fetches
       # from `/releases/latest/download/`.
-      - name: Create the stable release
+      #
+      # Create-then-fill, like release.yml, and re-runnable for the same reason: a promotion that
+      # failed *after* creating the release could not be retried, which is the worst moment for a
+      # step to be one-shot — the stable release would exist, carrying nothing a robot can install,
+      # until someone deleted it by hand.
+      #
+      # `--prerelease=false` is re-asserted rather than assumed: a stable release that is flagged as
+      # a prerelease is invisible to a plain `update apply`, so a promotion into a release object
+      # someone had drafted would silently ship to nobody.
+      - name: Publish the stable release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$stable_tag" \
-            --title "daemon ${{ inputs.version }}" \
-            --notes "Promoted from \`$staging_tag\`.
+          notes="Promoted from \`$staging_tag\`.
 
           The artifact is the one validated in staging — same bytes, same sha256, checked
           during promotion. This release is self-contained: manifest, signature, artifact,
           and the bootstrap binary used by \`scripts/install.sh\` to install from scratch.
-          " \
+          "
+          title="daemon ${{ inputs.version }}"
+
+          if gh release view "$stable_tag" >/dev/null 2>&1; then
+            echo "release $stable_tag exists; filling it in"
+            gh release edit "$stable_tag" --prerelease=false --title "$title"
+          else
+            gh release create "$stable_tag" --title "$title" --notes "$notes"
+          fi
+
+          gh release upload "$stable_tag" \
             dist/manifest.json dist/manifest.json.minisig \
             "artifact/$artifact_name" "artifact/$artifact_name.minisig" \
-            bootstrap/updaterd-bootstrap-aarch64
+            bootstrap/updaterd-bootstrap-aarch64 \
+            --clobber
 
       # Only now — the stable release exists and carries every byte it references, so the
       # staging release has no readers left. Deleting it is what keeps the release list
@@ -186,7 +204,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release delete "$staging_tag" \
-            --repo "${{ github.repository }}" \
-            --cleanup-tag --yes
-          echo "retired $staging_tag"
+          # Tolerant of already being gone, so a re-run of a promotion that got this far does not
+          # fail on the one step whose work is already done.
+          if gh release view "$staging_tag" >/dev/null 2>&1; then
+            gh release delete "$staging_tag" \
+              --repo "${{ github.repository }}" \
+              --cleanup-tag --yes
+            echo "retired $staging_tag"
+          else
+            echo "$staging_tag is already retired"
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,19 +1,12 @@
-# Promote a validated staging release to the STABLE channel.
+# Promote a validated staging release to STABLE, by hand.
 #
-# This is §16.3's promotion step, and the important property is what it does *not* do:
-# it never rebuilds. It copies the artifact already published in staging — same sha256,
-# checked here and again on the robot — so what reaches client robots is byte-identical
-# to what the canary validated. Promotion is a decision, not a build.
+# The ordinary way is to create a release for `daemon-v<version>` — in the UI or by pushing the tag —
+# and let `release.yml` notice the staging release and promote it. This is the same thing without a
+# release object to create first, which is what a script wants, and it is where `min_supported` lives
+# because that flag belongs to a deliberate remediation rather than to a routine release.
 #
-# The stable release is **self-contained**: manifest, signature, artifact and bootstrap
-# binary all hang off `daemon-v<version>`. That is why the last step can delete the
-# staging release outright. Previously the stable manifest pointed back at the staging
-# release to avoid a second copy of the bytes, which quietly made a tag named like
-# scaffolding load-bearing for the customer channel — and deleting the v0.1.x staging
-# releases duly left three stable releases pointing at a 404.
-#
-# Manual by design. A human decides that staging looked good; the machine does the
-# rest identically every time.
+# Both entry points call `_promote-release.yml`, so there is one promotion recipe and no second copy
+# to drift.
 name: promote
 
 on:
@@ -31,186 +24,10 @@ on:
 permissions:
   contents: write
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   promote:
-    runs-on: ubuntu-latest
-    # Signs with `release-1`. Promotion is the step that actually exposes customer robots
-    # to a build, so it is the most consequential thing in this repository.
-    #
-    # ⚠ `environment: release` is NOT a gate — see the same note in release.yml and
-    # docs/project/ci-setup.md. It scopes the secrets and is the hook for a real gate later; on this
-    # plan it stops no one who can push.
-    environment: release
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Fetch the staging manifest
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          staging_tag="daemon-staging-v${{ inputs.version }}"
-          mkdir -p staging
-          # Fails loudly if that staging release does not exist — promoting something
-          # unbuilt should not be possible.
-          gh release download "$staging_tag" \
-            --repo "${{ github.repository }}" \
-            --pattern 'manifest.json' \
-            --dir staging
-          echo "staging_tag=$staging_tag" >> "$GITHUB_ENV"
-          echo "stable_tag=daemon-v${{ inputs.version }}" >> "$GITHUB_ENV"
-
-      # The artifact itself, so the stable release can carry it. This is the copy that
-      # makes staging disposable; the sha256 check below is what makes it safe.
-      - name: Carry the artifact forward
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_name="$(jq -r '.url | split("/") | last' staging/manifest.json)"
-          mkdir -p artifact
-          gh release download "$staging_tag" \
-            --repo "${{ github.repository }}" \
-            --pattern "$artifact_name" \
-            --pattern "$artifact_name.minisig" \
-            --dir artifact
-
-          # The manifest that ships names this digest, and the robot re-checks it before
-          # installing (`updater::verify::verify_sha256`). Checking it here too means a
-          # bad copy fails in CI rather than on a board.
-          expected="$(jq -r .sha256 staging/manifest.json)"
-          actual="$(sha256sum "artifact/$artifact_name" | cut -d' ' -f1)"
-          if [ "$expected" != "$actual" ]; then
-            echo "::error::artifact sha256 $actual does not match staging manifest $expected"
-            exit 1
-          fi
-          echo "artifact $artifact_name sha256 $actual (matches staging)"
-          echo "artifact_name=$artifact_name" >> "$GITHUB_ENV"
-
-      # The bootstrap binary has to exist on the *stable* release, because that is what
-      # `https://github.com/<repo>/releases/latest/download/...` resolves to — and that
-      # URL is the whole of `scripts/install.sh`'s bootstrap step. A fresh robot cannot
-      # discover a staging tag, and should not be installing from one.
-      #
-      # Like the artifact above, this is copied rather than referenced, and for the same
-      # reason: a stable release that depends on assets living under another tag is only
-      # as durable as that tag. The digest below is what keeps this copy honest.
-      - name: Carry the bootstrap binary forward
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p bootstrap
-          gh release download "$staging_tag" \
-            --repo "${{ github.repository }}" \
-            --pattern 'updaterd-bootstrap-aarch64' \
-            --dir bootstrap
-
-          # `release.yml` already asserted this file is byte-identical to `bin/updaterd`
-          # inside the signed artifact. Recording the digest here means a promotion that
-          # somehow picked up different bytes is visible in the log rather than silently
-          # breaking the installer's post-install self-check.
-          sha256sum bootstrap/updaterd-bootstrap-aarch64
-
-      - name: Build the stable manifest
-        run: |
-          cargo run -p xtask -- promote \
-            --version "${{ inputs.version }}" \
-            --staging-tag "$staging_tag" \
-            --stable-tag "$stable_tag" \
-            --repo "${{ github.repository }}" \
-            --staging-manifest staging/manifest.json \
-            --out dist \
-            ${{ inputs.min_supported && format('--min-supported {0}', inputs.min_supported) || '' }}
-
-      - name: Sign
-        env:
-          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
-          # Required: the release key is encrypted, and `xtask sign` reads this through
-          # clap's `env`. Without it, signing fails with "Key might be encrypted".
-          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
-        run: |
-          # Lengths, not values: a key length is not sensitive, and "is not set" could not
-          # distinguish an absent secret from a present-but-empty one — which is exactly how
-          # the first real run failed, after `gh secret set` was fed stdin through a wrapper
-          # that did not forward it. A secret can be written but empty, and it still lists.
-          echo "key length: ${#MINISIGN_SECRET_KEY}, password length: ${#MINISIGN_PASSWORD}"
-          if [ -z "$MINISIGN_SECRET_KEY" ]; then
-            echo "::error::MINISIGN_SECRET_KEY is empty or unset — refusing to publish unsigned artifacts"
-            exit 1
-          fi
-          # A minisign secret key is two lines: a comment and the base64 payload. One line
-          # means the newline was lost in transit, which fails later inside minisign with a
-          # parse error that says nothing about the cause.
-          if [ "$(printf '%s' "$MINISIGN_SECRET_KEY" | wc -l)" -lt 1 ]; then
-            echo "::error::MINISIGN_SECRET_KEY looks like a single line — its newline was lost"
-            exit 1
-          fi
-          umask 077
-          # '%s', not '%s\n': the key file ends with a newline, so the stored secret already
-          # contains it. Adding another would leave a trailing blank line nobody has tested
-          # minisign against.
-          printf '%s' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/secret.key"
-          cargo run -p xtask -- sign --dir dist --key "$RUNNER_TEMP/secret.key"
-          shred -u "$RUNNER_TEMP/secret.key" 2>/dev/null || rm -f "$RUNNER_TEMP/secret.key"
-
-      # Everything a robot needs, under one tag: manifest, signature, the artifact the
-      # manifest's `url` names, and the bootstrap binary `scripts/install.sh` fetches
-      # from `/releases/latest/download/`.
-      #
-      # Create-then-fill, like release.yml, and re-runnable for the same reason: a promotion that
-      # failed *after* creating the release could not be retried, which is the worst moment for a
-      # step to be one-shot — the stable release would exist, carrying nothing a robot can install,
-      # until someone deleted it by hand.
-      #
-      # `--prerelease=false` is re-asserted rather than assumed: a stable release that is flagged as
-      # a prerelease is invisible to a plain `update apply`, so a promotion into a release object
-      # someone had drafted would silently ship to nobody.
-      - name: Publish the stable release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          notes="Promoted from \`$staging_tag\`.
-
-          The artifact is the one validated in staging — same bytes, same sha256, checked
-          during promotion. This release is self-contained: manifest, signature, artifact,
-          and the bootstrap binary used by \`scripts/install.sh\` to install from scratch.
-          "
-          title="daemon ${{ inputs.version }}"
-
-          if gh release view "$stable_tag" >/dev/null 2>&1; then
-            echo "release $stable_tag exists; filling it in"
-            gh release edit "$stable_tag" --prerelease=false --title "$title"
-          else
-            gh release create "$stable_tag" --title "$title" --notes "$notes"
-          fi
-
-          gh release upload "$stable_tag" \
-            dist/manifest.json dist/manifest.json.minisig \
-            "artifact/$artifact_name" "artifact/$artifact_name.minisig" \
-            bootstrap/updaterd-bootstrap-aarch64 \
-            --clobber
-
-      # Only now — the stable release exists and carries every byte it references, so the
-      # staging release has no readers left. Deleting it is what keeps the release list
-      # honest: a `daemon-staging-*` tag that outlives its promotion is installable via
-      # `--ref`, and is just an older name for what stable already serves.
-      #
-      # `--cleanup-tag`, for the same reason as in `prune-dev-releases.yml`: a surviving
-      # tag keeps resolving.
-      - name: Retire the staging release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Tolerant of already being gone, so a re-run of a promotion that got this far does not
-          # fail on the one step whose work is already done.
-          if gh release view "$staging_tag" >/dev/null 2>&1; then
-            gh release delete "$staging_tag" \
-              --repo "${{ github.repository }}" \
-              --cleanup-tag --yes
-            echo "retired $staging_tag"
-          else
-            echo "$staging_tag is already retired"
-          fi
+    uses: ./.github/workflows/_promote-release.yml
+    with:
+      version: ${{ inputs.version }}
+      min_supported: ${{ inputs.min_supported }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,385 +1,126 @@
-# Publish a signed release to the STAGING channel.
+# Cutting a release. **The GitHub UI is the entry point.**
 #
-# Triggered by a `daemon-staging-v*` tag, however that tag comes into being: pushed from a
-# terminal, or created by drafting a release in the GitHub UI. Staging is where every build lands;
-# nothing
-# reaches client robots until it is promoted (see promote.yml and updater-design.md
-# §16.3). That split is the point: robots on `stable` are unaffected by a bad build,
-# and promotion ships the exact bytes staging validated.
+# Create a release in the web interface and this decides what that means, from the tag and from what
+# already exists:
+#
+#   pre-release, tag `daemon-staging-v1.2.3`  →  build it, sign it, verify it, publish to STAGING
+#   release,     tag `daemon-v1.2.3`          →  promote staging 1.2.3 if it exists — the same bytes,
+#                                                re-signed — otherwise build 1.2.3 directly
+#
+# Pushing either tag from a terminal does the same thing; the release object is created for you.
+#
+# The two shapes of stable release are not equivalent, and the one you get is recorded in the release
+# notes rather than left to be inferred. Promoted means a canary ran exactly these bytes. Built
+# directly means the artifact was verified through the real update engine here — signature, manifest,
+# a genuine install — but no robot has run it. Both are signed with the key customer robots trust, so
+# the difference is validation, not authenticity.
+#
+# Promotion never rebuilds, which is the property updater-design.md §16.3 exists to protect: what
+# reaches client robots is byte-identical to what was validated.
 name: release
 
 on:
   push:
-    tags: ['daemon-staging-v*']
-  # Creating a release in the web UI is a supported door, because it is the obvious one. It needs
-  # its own trigger: a release published through the UI does create the tag, but the workflow that
-  # matters is this one, and a release object that already exists is something the publish step has
-  # to fill in rather than choke on — see "Publish the staging release" below.
+    tags:
+      - 'daemon-staging-v*'
+      - 'daemon-v*'
+  # Publishing a release in the UI creates the tag, so `push` would cover that case on its own — but
+  # only that one. A release published against an *existing* tag fires only this, and that is a door
+  # people will use.
   release:
     types: [published]
 
 permissions:
-  contents: write   # create the release and upload assets
-
-env:
-  CARGO_TERM_COLOR: always
+  contents: write
 
 jobs:
-  publish:
+  # Which channel, which version, and whether there is anything to promote.
+  #
+  # Its own job because the two workflows it chooses between are `uses:` jobs, and those can only be
+  # conditioned on something computed outside themselves.
+  decide:
     runs-on: ubuntu-latest
-
-    # **The guard is load-bearing, not tidiness.** `on: release` cannot filter by tag, so without
-    # it this workflow would also fire for the *stable* release `promote.yml` creates — and would
-    # rebuild from source and upload the result over the promoted artifact. Promotion exists
-    # precisely so that the bytes a canary validated are the bytes robots get (updater-design.md
-    # §16.3); republishing a fresh build into that release would quietly destroy the guarantee.
-    # It also keeps `daemon-dev-*` releases from dev.yml out of here.
-    if: startsWith(github.event.release.tag_name || github.ref_name, 'daemon-staging-v')
-
-    # One name for the tag, whichever event carried it. `github.ref_name` is the tag for a push;
-    # for a release event the tag is on the payload.
-    env:
-      TAG: ${{ github.event.release.tag_name || github.ref_name }}
-    # Signs with `release-1`, the key customer robots trust. `dev.yml` signs branch builds
-    # with `team.dev`, which a customer robot refuses — two keys so "any build" and "a
-    # release" are distinguishable by the robot, not by convention.
-    #
-    # ⚠ `environment: release` is NOT a gate here. On this plan (free, private repo) the
-    # environment cannot carry required reviewers or a deployment branch policy — both were
-    # attempted and refused, see docs/project/ci-setup.md — so anyone with push access can reach
-    # this key, by pushing a tag or by authoring a workflow that declares this environment.
-    # That was accepted deliberately while no robot is in the field.
-    #
-    # The declaration stays for two reasons: the release secrets are scoped to it, so a
-    # workflow that does not declare it cannot see them; and it is the hook that turns a
-    # real gate on with one settings change if the org ever moves to GitHub Team.
-    #
-    # Fork pull requests never receive secrets, so the key is unreachable from
-    # contributor PRs regardless.
-    environment: release
+    # `on: release` cannot filter by tag, so the filtering happens here — and it matters more than it
+    # looks: `dev.yml` publishes a `daemon-dev-*` release on every push to every branch, and without
+    # this, every one of them would try to cut a release.
+    if: >-
+      startsWith(github.event.release.tag_name || github.ref_name, 'daemon-staging-v') ||
+      startsWith(github.event.release.tag_name || github.ref_name, 'daemon-v')
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+      version: ${{ steps.plan.outputs.version }}
+      tag: ${{ steps.plan.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # The tagged commit, named explicitly rather than left to the default: for a release
-          # event the default is the release's target commitish, which is a branch head when
-          # someone drafts a release against a branch — and that is not necessarily what the tag
-          # points at by the time this runs.
-          ref: ${{ github.event.release.tag_name || github.ref }}
-          # Full history so the recorded revision is meaningful.
-          fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
-      # v2, and the zig version pinned. Two separate reasons:
-      #   - v1's mirror list 404s for current zig releases, which is how this first
-      #     surfaced — every mirror failed and the job never got a compiler.
-      #   - "latest" would let the glibc floor move under us between runs. The floor is
-      #     the whole point of building with zig (see .cargo/config.toml), so the
-      #     toolchain that sets it must be a fixed input.
-      - name: Cross-compilation C dependencies
-        run: ./scripts/ci-cross-deps.sh
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.14.1
-      - run: cargo install cargo-zigbuild --locked
-
-      - name: Derive version from the tag
-        id: version
-        run: |
-          # daemon-staging-v1.2.3 -> 1.2.3
-          version="${TAG#daemon-staging-v}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "publishing $version from $TAG"
-
-      # Same command and same glibc floor as scripts/board-test.sh, so what ships is
-      # what was tested rather than a differently-configured build.
-      #
-      # DUCK_REVISION and DUCK_BUILD_TIME are compiled into the binaries, so every daemon
-      # can state which commit it came from in its first log line and over IPC. Read at
-      # compile time because a shipped robot has no git repository. A build without them
-      # still works and reports "rev unknown" — which is exactly what a local build should
-      # say, and why they are not required.
-      - name: Build for the board
-        env:
-          DUCK_REVISION: ${{ github.sha }}
-          # libudev-sys (via gilrs, via padd) resolves the target's C library through
-          # pkg-config, which refuses to answer for another architecture unless told to.
-          PKG_CONFIG_ALLOW_CROSS: "1"
-          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
-        run: |
-          export DUCK_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          cargo board --bins
-
-      - name: Package
-        run: |
-          mkdir -p staged
-          # Every daemon that ships in this artifact. robotd is not optional: `on_apply`
-          # restarts it, so an artifact without it would fail its own restart step and roll
-          # itself back.
-          cp target/aarch64-unknown-linux-gnu/release/updaterd staged/
-          cp target/aarch64-unknown-linux-gnu/release/robotctl staged/
-          cp target/aarch64-unknown-linux-gnu/release/robotd staged/
-          # configd (wifi, identity) and btd (the BLE front door). Their units are packaged
-          # alongside; a unit whose ExecStart binary is missing fails with 203/EXEC, which
-          # reads as a broken daemon rather than an incomplete artifact.
-          cp target/aarch64-unknown-linux-gnu/release/configd staged/
-          cp target/aarch64-unknown-linux-gnu/release/btd staged/
-          # padd is the gamepad intent client. Shipped because a dev board is where
-          # anyone drives the robot from, and the intent API only stays honest if the
-          # thing exercising it daily is actually on the robot.
-          cp target/aarch64-unknown-linux-gnu/release/padd staged/
-
-          cargo run -p xtask -- package \
-            --version "${{ steps.version.outputs.version }}" \
-            --channel daemon \
-            --bin-dir staged \
-            --out dist \
-            --base-url "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}" \
-            --revision "${GITHUB_SHA}" \
-            --include "updater/systemd/updaterd.service=systemd/updaterd.service" \
-            --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
-            --include "robotd/systemd/robotd.service=systemd/robotd.service" \
-            --include "hooks/postinstall=hooks/postinstall" \
-            --include "configd/systemd/configd.service=systemd/configd.service" \
-            --include "btd/systemd/btd.service=systemd/btd.service" \
-            --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \
-            --include "padd/systemd/padd.service=systemd/padd.service" \
-            --include "padd/systemd/sysusers.d/padd.conf=systemd/sysusers.d/padd.conf" \
-            --include "deploy/journald.conf.d/10-robot.conf=deploy/journald.conf.d/10-robot.conf" \
-            --include "docs/design/architecture.md=docs/architecture.md" \
-            --include "docs/design/updater-design.md=docs/updater-design.md" \
-            --include "deploy/README.md=docs/deploy.md" \
-            --include "policies/alpha_walking.onnx=policies/alpha_walking.onnx" \
-            --include "policies/alpha_stand.onnx=policies/alpha_stand.onnx"
-
-          # The bootstrap binary, published bare alongside the artifact.
-          #
-          # A fresh robot has no way to open a `.tar.zst`: extraction happens *inside*
-          # updaterd (tar + zstd are linked in), and the `zstd` binary is not on a stock
-          # Armbian image. So `scripts/install.sh` downloads this one file and runs
-          # `updaterd install --from <dir>` to land the first release through the real
-          # engine.
-          #
-          # Byte-identical to `bin/updaterd` inside the artifact, because it is the same
-          # file — which is what lets the installer verify it after the fact by comparing
-          # its sha256 against the copy that came out of the signature-verified tarball.
-          cp staged/updaterd "dist/updaterd-bootstrap-aarch64"
-
-      # Written to a file rather than passed as an argument: a key on a command line is
-      # visible in the process list to anything else on the runner.
-      - name: Sign
-        env:
-          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
-          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
-        run: |
-          # Lengths, not values: a key length is not sensitive, and "is not set" could not
-          # distinguish an absent secret from a present-but-empty one — which is exactly how
-          # the first real run failed, after `gh secret set` was fed stdin through a wrapper
-          # that did not forward it. A secret can be written but empty, and it still lists.
-          echo "key length: ${#MINISIGN_SECRET_KEY}, password length: ${#MINISIGN_PASSWORD}"
-          if [ -z "$MINISIGN_SECRET_KEY" ]; then
-            echo "::error::MINISIGN_SECRET_KEY is empty or unset — refusing to publish unsigned artifacts"
-            exit 1
-          fi
-          # A minisign secret key is two lines: a comment and the base64 payload. One line
-          # means the newline was lost in transit, which fails later inside minisign with a
-          # parse error that says nothing about the cause.
-          if [ "$(printf '%s' "$MINISIGN_SECRET_KEY" | wc -l)" -lt 1 ]; then
-            echo "::error::MINISIGN_SECRET_KEY looks like a single line — its newline was lost"
-            exit 1
-          fi
-          umask 077
-          # '%s', not '%s\n': the key file ends with a newline, so the stored secret already
-          # contains it. Adding another would leave a trailing blank line nobody has tested
-          # minisign against.
-          printf '%s' "$MINISIGN_SECRET_KEY" > "$RUNNER_TEMP/secret.key"
-          # MINISIGN_PASSWORD reaches xtask through clap's `env`, so an encrypted key
-          # needs no extra flag here.
-          cargo run -p xtask -- sign --dir dist --key "$RUNNER_TEMP/secret.key"
-          shred -u "$RUNNER_TEMP/secret.key" 2>/dev/null || rm -f "$RUNNER_TEMP/secret.key"
-
-      # Verify with the *robot's* own code path before publishing. If the updater
-      # cannot accept this release, nobody should be able to download it.
-      #
-      # Uses the sideload manifest `xtask package` already emitted and `xtask sign`
-      # already signed, so this step needs no access to the key. Re-signing here would
-      # mean handling the signing key twice in one job for no benefit.
-      - name: Verify the way a robot would
-        run: |
-          version="${{ steps.version.outputs.version }}"
-          artifact="daemon-${version}.tar.zst"
-
-          mkdir -p verify/published verify/keys verify/opt verify/var
-          cp "dist/${version}.manifest.json"          verify/published/
-          cp "dist/${version}.manifest.json.minisig"  verify/published/
-          cp "dist/${artifact}"                       verify/published/
-          cp "dist/${artifact}.minisig"               verify/published/
-
-          # The public key is not a secret, but keeping it in CI config means the
-          # verification uses the same trust anchor a robot would.
-          printf '%s\n' "${{ vars.MINISIGN_PUBLIC_KEY }}" > verify/keys/release-1.pub
-
-          # The production `on_apply` and `health`, not inert placeholders. `updaterd
-          # install` overrides both for the duration of a bootstrap — see its doc comment
-          # — so this config also checks that those overrides are still in place. Writing
-          # `action = "none"` here would have tested nothing but the engine.
-          cat > verify/updater.toml <<EOF
-          trusted_keys_dir = "$PWD/verify/keys"
-          hw_rev = 1
-          state_dir = "$PWD/verify/var"
-
-          [component.daemon]
-          install_dir = "$PWD/verify/opt/daemon"
-          source = { type = "github_releases", repo = "${{ github.repository }}", tag_prefix = "daemon-v" }
-          on_apply = { action = "restart", units = ["robotd"] }
-          health = { probe = "socket", timeout = "30s" }
-          EOF
-
-          # The release ships a `preinstall` hook asserting the machine can run it, and
-          # `updaterd install` runs hooks on a bootstrap install too — correctly, since a
-          # fresh board is exactly when a missing ONNX Runtime has to be installed. This
-          # runner is not a board: it is x86_64, so the aarch64 dylib the hook would fetch
-          # could never be loaded here, and fetching ~100 MB to prove that would only make
-          # every release slower.
-          #
-          # So declare the precondition satisfied and let the hook take its "already fine"
-          # branch, touching nothing. Faking the *file* rather than skipping the hook keeps
-          # this step's claim honest: hooks still run, and a hook that started failing for
-          # any other reason would still fail the release. The hook's own logic — accepting
-          # a runtime at the floor, refusing one it cannot replace — is covered on emulated
-          # aarch64, as root, in scripts/board-test.sh.
-          #
-          # The version comes from [workspace.metadata.onnxruntime], never a literal: that
-          # table is the single source of truth the hook itself is generated from, and a
-          # second copy here would be free to drift below the floor and turn this step red
-          # for a reason that has nothing to do with the release.
-          onnx_target="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.metadata.onnxruntime.target')"
-          sudo touch "/usr/local/lib/libonnxruntime.so.${onnx_target}"
-          sudo ln -sfn "libonnxruntime.so.${onnx_target}" /usr/local/lib/libonnxruntime.so
-
-          # The same command `scripts/install.sh` runs on a fresh robot, against the same
-          # files it would download. A host-native build, because the packaged binaries are
-          # aarch64 and this runner is x86_64 — what is under test is the bootstrap logic,
-          # not the cross-compile, which `scripts/board-test.sh` covers.
-          #
-          # Note this reaches `--from`, never the `github_releases` source above: an
-          # install that silently fell back to the network would be publishing a release
-          # by fetching some *other* release, and would pass while proving nothing.
-          #
-          # As root, because that is what a robot's `updaterd` is. The release now carries a
-          # `postinstall` hook that installs unit files into /etc/systemd/system and sysusers
-          # files into /usr/lib/sysusers.d, and it fails the update when it cannot — correctly,
-          # since a release whose units never arrive is a release that does not work. Running
-          # the engine unprivileged made this step reject a perfectly good release, which is
-          # the same mismatch the preinstall hook exposed one release earlier: a step claiming
-          # to verify "the way a robot would" has to have the privilege a robot has.
-          #
-          # Built first and then run under sudo, rather than `sudo cargo run`: cargo as root
-          # would write root-owned files into the cached target directory and poison it for
-          # every later step and every later run.
-          #
-          # The hook then enables the units it installed, and they fail to start here — they
-          # are aarch64 and this is x86_64. Expected, and only a warning by design: a unit that
-          # cannot start must not fail an otherwise good update. Failure lines from
-          # btd/configd/robotd in this step's log are the runner being a runner.
-          cargo build -p updater --bin updaterd
-          sudo ./target/debug/updaterd install \
-            --config verify/updater.toml \
-            --from verify/published
-
-          # Everything the robot needs must be present in the installed release, checked
-          # through the symlink the units actually resolve.
-          #
-          # `bin/robotd` is on this list because it was once missing: the release shipped
-          # only updaterd and robotctl while `on_apply` restarted robotd, so the first real
-          # release would have failed its own restart step and rolled itself back. An
-          # artifact that is missing a binary is indistinguishable from a good one until it
-          # is installed, which is exactly why this is asserted rather than assumed.
-          #
-          # Not executed, only checked: these are aarch64 binaries and the runner is x86_64.
-          # `scripts/board-test.sh` is what runs them.
-          for required in \
-            bin/updaterd \
-            bin/robotd \
-            bin/robotctl \
-            systemd/updaterd.service \
-            systemd/robotd.service \
-            systemd/sysusers.d/robot.conf \
-            deploy/journald.conf.d/10-robot.conf \
-            version.toml
-          do
-            if [ ! -e "verify/opt/daemon/current/$required" ]; then
-              echo "::error::release is missing $required"
-              exit 1
-            fi
-          done
-          test -x "verify/opt/daemon/current/bin/updaterd"
-          test -x "verify/opt/daemon/current/bin/robotd"
-
-          # The bootstrap asset must be the same bytes as the copy inside the artifact.
-          #
-          # This is what makes the installer's chain of trust close. The bootstrap binary
-          # is downloaded bare and run *before* anything has verified it, so on its own it
-          # is only as trustworthy as the TLS connection that fetched it. After the install
-          # the script compares its digest against `current/bin/updaterd`, which came out
-          # of a signature-verified tarball — equal digests mean the unverified binary was
-          # genuine. That check is worthless if the two are allowed to differ here.
-          boot_sum=$(sha256sum "dist/updaterd-bootstrap-aarch64" | cut -d' ' -f1)
-          installed_sum=$(sha256sum "verify/opt/daemon/current/bin/updaterd" | cut -d' ' -f1)
-          if [ "$boot_sum" != "$installed_sum" ]; then
-            echo "::error::updaterd-bootstrap-aarch64 does not match bin/updaterd in the artifact"
-            exit 1
-          fi
-          echo "bootstrap binary matches the artifact ($boot_sum)"
-
-          # The revision must have made it in, or support cannot tell two builds of the
-          # same version apart.
-          if ! grep -q "revision" "verify/opt/daemon/current/version.toml"; then
-            echo "::error::version.toml records no revision"
-            exit 1
-          fi
-          cat "verify/opt/daemon/current/version.toml"
-          echo "the updater accepted this release"
-
-      # Create it if it is not there, then fill it in either way.
-      #
-      # Two things made the old single `gh release create ... dist/*` wrong, and they are the same
-      # thing seen from different sides: it only ever worked on a release that did not exist yet.
-      #
-      #   - **It could not be re-run.** If this step failed after creating the release — a network
-      #     blip, a partial upload — every re-run failed identically on "release already exists",
-      #     and the only way out was deleting the release and the tag by hand, mid-release.
-      #   - **It could not follow the UI.** Drafting a release in the web UI is the obvious way to
-      #     cut one, and it creates the release object first, so the pipeline arrived to find its
-      #     own destination already taken and died *after* signing.
-      #
-      # `--clobber` on the upload so a re-run replaces assets rather than refusing them.
-      #
-      # `--prerelease` is re-asserted on a release that already exists, and that is a safety
-      # property rather than cosmetics: staging releases are flagged as prereleases because a plain
-      # `update apply` skips prereleases, which is what keeps an unvalidated build away from robots
-      # on stable. A release drafted in the UI without that box ticked would otherwise be a
-      # candidate every robot could reach.
-      - name: Publish the staging release
+      - name: Plan
+        id: plan
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
-          notes="Staging build from \`${GITHUB_SHA}\`.
+          set -eu
+          case "$TAG" in
+              daemon-staging-v*)
+                  version="${TAG#daemon-staging-v}"
+                  mode=staging
+                  ;;
+              daemon-v*)
+                  version="${TAG#daemon-v}"
+                  # Promote when there is something to promote. `gh release view`, not a tag lookup:
+                  # a tag with no release behind it carries no artifact, so there would be nothing
+                  # to copy.
+                  if gh release view "daemon-staging-v${version}" >/dev/null 2>&1; then
+                      mode=promote
+                  else
+                      mode=stable
+                  fi
+                  ;;
+              *)
+                  echo "::error::$TAG is neither a staging nor a release tag"
+                  exit 1
+                  ;;
+          esac
 
-          Not for client robots. Promote with the \`promote\` workflow once a canary
-          has run the on-device acceptance checks — promotion ships these exact bytes.
-          "
-          title="daemon ${{ steps.version.outputs.version }} (staging)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG exists; filling it in"
-            gh release edit "$TAG" --prerelease --title "$title"
-          else
-            gh release create "$TAG" --prerelease --title "$title" --notes "$notes"
-          fi
+          # Said out loud, in the run summary, because "which of the three things happened" is the
+          # first question anyone asks when a release looks wrong.
+          case "$mode" in
+              staging) what="build → STAGING (a prerelease; promote it once a canary has run it)" ;;
+              promote) what="promote daemon-staging-v${version} → STABLE (same bytes, re-signed)" ;;
+              stable)  what="build → STABLE directly (no staging release exists; NOT canaried)" ;;
+          esac
+          echo "$TAG: $what" | tee -a "$GITHUB_STEP_SUMMARY"
 
-          gh release upload "$TAG" dist/* --clobber
+  staging:
+    needs: decide
+    if: needs.decide.outputs.mode == 'staging'
+    uses: ./.github/workflows/_build-release.yml
+    with:
+      tag: ${{ needs.decide.outputs.tag }}
+      version: ${{ needs.decide.outputs.version }}
+      prerelease: true
+    secrets: inherit
+
+  promote:
+    needs: decide
+    if: needs.decide.outputs.mode == 'promote'
+    uses: ./.github/workflows/_promote-release.yml
+    with:
+      version: ${{ needs.decide.outputs.version }}
+    secrets: inherit
+
+  # The uncanaried path. Deliberately reachable — a version with no staging release is usually
+  # someone who knows exactly what they are shipping — and deliberately labelled, in the notes the
+  # release itself carries.
+  stable:
+    needs: decide
+    if: needs.decide.outputs.mode == 'stable'
+    uses: ./.github/workflows/_build-release.yml
+    with:
+      tag: ${{ needs.decide.outputs.tag }}
+      version: ${{ needs.decide.outputs.version }}
+      prerelease: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 # Publish a signed release to the STAGING channel.
 #
-# Triggered by a `daemon-staging-v*` tag. Staging is where every build lands; nothing
+# Triggered by a `daemon-staging-v*` tag, however that tag comes into being: pushed from a
+# terminal, or created by drafting a release in the GitHub UI. Staging is where every build lands;
+# nothing
 # reaches client robots until it is promoted (see promote.yml and updater-design.md
 # §16.3). That split is the point: robots on `stable` are unaffected by a bad build,
 # and promotion ships the exact bytes staging validated.
@@ -9,6 +11,12 @@ name: release
 on:
   push:
     tags: ['daemon-staging-v*']
+  # Creating a release in the web UI is a supported door, because it is the obvious one. It needs
+  # its own trigger: a release published through the UI does create the tag, but the workflow that
+  # matters is this one, and a release object that already exists is something the publish step has
+  # to fill in rather than choke on — see "Publish the staging release" below.
+  release:
+    types: [published]
 
 permissions:
   contents: write   # create the release and upload assets
@@ -19,6 +27,19 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    # **The guard is load-bearing, not tidiness.** `on: release` cannot filter by tag, so without
+    # it this workflow would also fire for the *stable* release `promote.yml` creates — and would
+    # rebuild from source and upload the result over the promoted artifact. Promotion exists
+    # precisely so that the bytes a canary validated are the bytes robots get (updater-design.md
+    # §16.3); republishing a fresh build into that release would quietly destroy the guarantee.
+    # It also keeps `daemon-dev-*` releases from dev.yml out of here.
+    if: startsWith(github.event.release.tag_name || github.ref_name, 'daemon-staging-v')
+
+    # One name for the tag, whichever event carried it. `github.ref_name` is the tag for a push;
+    # for a release event the tag is on the payload.
+    env:
+      TAG: ${{ github.event.release.tag_name || github.ref_name }}
     # Signs with `release-1`, the key customer robots trust. `dev.yml` signs branch builds
     # with `team.dev`, which a customer robot refuses — two keys so "any build" and "a
     # release" are distinguishable by the robot, not by convention.
@@ -39,6 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # The tagged commit, named explicitly rather than left to the default: for a release
+          # event the default is the release's target commitish, which is a branch head when
+          # someone drafts a release against a branch — and that is not necessarily what the tag
+          # points at by the time this runs.
+          ref: ${{ github.event.release.tag_name || github.ref }}
           # Full history so the recorded revision is meaningful.
           fetch-depth: 0
 
@@ -64,9 +90,9 @@ jobs:
         id: version
         run: |
           # daemon-staging-v1.2.3 -> 1.2.3
-          version="${GITHUB_REF_NAME#daemon-staging-v}"
+          version="${TAG#daemon-staging-v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "publishing $version from $GITHUB_REF_NAME"
+          echo "publishing $version from $TAG"
 
       # Same command and same glibc floor as scripts/board-test.sh, so what ships is
       # what was tested rather than a differently-configured build.
@@ -319,16 +345,41 @@ jobs:
           cat "verify/opt/daemon/current/version.toml"
           echo "the updater accepted this release"
 
-      - name: Create the staging release
+      # Create it if it is not there, then fill it in either way.
+      #
+      # Two things made the old single `gh release create ... dist/*` wrong, and they are the same
+      # thing seen from different sides: it only ever worked on a release that did not exist yet.
+      #
+      #   - **It could not be re-run.** If this step failed after creating the release — a network
+      #     blip, a partial upload — every re-run failed identically on "release already exists",
+      #     and the only way out was deleting the release and the tag by hand, mid-release.
+      #   - **It could not follow the UI.** Drafting a release in the web UI is the obvious way to
+      #     cut one, and it creates the release object first, so the pipeline arrived to find its
+      #     own destination already taken and died *after* signing.
+      #
+      # `--clobber` on the upload so a re-run replaces assets rather than refusing them.
+      #
+      # `--prerelease` is re-asserted on a release that already exists, and that is a safety
+      # property rather than cosmetics: staging releases are flagged as prereleases because a plain
+      # `update apply` skips prereleases, which is what keeps an unvalidated build away from robots
+      # on stable. A release drafted in the UI without that box ticked would otherwise be a
+      # candidate every robot could reach.
+      - name: Publish the staging release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --prerelease \
-            --title "daemon ${{ steps.version.outputs.version }} (staging)" \
-            --notes "Staging build from \`${GITHUB_SHA}\`.
+          notes="Staging build from \`${GITHUB_SHA}\`.
 
           Not for client robots. Promote with the \`promote\` workflow once a canary
           has run the on-device acceptance checks — promotion ships these exact bytes.
-          " \
-            dist/*
+          "
+          title="daemon ${{ steps.version.outputs.version }} (staging)"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG exists; filling it in"
+            gh release edit "$TAG" --prerelease --title "$title"
+          else
+            gh release create "$TAG" --prerelease --title "$title" --notes "$notes"
+          fi
+
+          gh release upload "$TAG" dist/* --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,19 +79,28 @@ process. [`docs/project/roadmap.md`](docs/project/roadmap.md) has what actually 
 
 ## Releasing
 
-Releases are signed **in CI**, never locally, behind an approval gate. Cutting one is a tag;
-promoting one re-signs a manifest over the *same bytes* the canary validated, with no rebuild:
+Releases are signed **in CI**, never locally. The entry point is the GitHub releases page, and the
+tag decides what happens:
+
+| you create | what CI does |
+|---|---|
+| a **pre-release** tagged `daemon-staging-v0.4.0` | builds, signs, verifies through the real update engine, publishes to **staging** |
+| a **release** tagged `daemon-v0.4.0` | **promotes** staging 0.4.0 if it exists — the same bytes, re-signed — otherwise builds 0.4.0 directly |
+
+Pushing either tag from a terminal does the same thing:
 
 ```bash
 git tag daemon-staging-v0.4.0 && git push --tags
 ```
 
-Or draft a release in the GitHub UI against a new `daemon-staging-v*` tag — same pipeline, and it
-fills in the release it finds rather than failing on it. Either way the assets, signature and
-manifest come from CI; what you create is the tag.
+The canaried path is two steps on purpose: publish the pre-release, install it on a robot, then
+create the release. Creating a release with no staging build to promote is allowed and says so in its
+own notes — verified in CI, never run on a robot.
 
-```bash
-gh workflow run promote --field version=0.4.0
-```
+Bump the workspace version first. `xtask package` refuses a tag that disagrees with `Cargo.toml`,
+which is what stops a robot reporting a version it is not running.
+
+`gh workflow run promote --field version=0.4.0` is the same promotion without a release to create
+first, and is where `min_supported` lives.
 
 [`docs/project/ci-setup.md`](docs/project/ci-setup.md) covers key custody, the secrets, and rotation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,15 @@ Releases are signed **in CI**, never locally, behind an approval gate. Cutting o
 promoting one re-signs a manifest over the *same bytes* the canary validated, with no rebuild:
 
 ```bash
-git tag daemon-staging-v0.2.0 && git push --tags
+git tag daemon-staging-v0.4.0 && git push --tags
 ```
 
+Or draft a release in the GitHub UI against a new `daemon-staging-v*` tag — same pipeline, and it
+fills in the release it finds rather than failing on it. Either way the assets, signature and
+manifest come from CI; what you create is the tag.
+
 ```bash
-gh workflow run promote --field version=0.2.0
+gh workflow run promote --field version=0.4.0
 ```
 
 [`docs/project/ci-setup.md`](docs/project/ci-setup.md) covers key custody, the secrets, and rotation.

--- a/docs/project/ci-setup.md
+++ b/docs/project/ci-setup.md
@@ -160,35 +160,63 @@ no benefit.
 
 ## Cutting a release
 
+**The GitHub releases page is the entry point.** What you create decides what happens, and
+`release.yml` reads the tag to work it out:
+
+| you create | mode | what CI does |
+|---|---|---|
+| pre-release, tag `daemon-staging-v0.4.0` | `staging` | cross-builds for aarch64, packages, signs with `release-1`, verifies through the real engine, publishes a **prerelease** |
+| release, tag `daemon-v0.4.0`, staging 0.4.0 exists | `promote` | re-signs a stable manifest over **the same artifact bytes** staging validated; no rebuild; retires the staging release |
+| release, tag `daemon-v0.4.0`, no staging 0.4.0 | `stable` | builds 0.4.0 and publishes it straight to stable, with the notes saying it was never canaried |
+
+The run summary names which of the three ran, because "which one was it" is the first question when a
+release looks wrong.
+
+Pushing the tag from a terminal does the same thing — the release object is created for you:
+
 ```
 git tag daemon-staging-v0.4.0 && git push --tags
 ```
 
-Drafting a release in the web UI against a new `daemon-staging-v*` tag does the same thing:
-`release.yml` triggers on both, and its publish step creates the release only if it is not already
-there, then uploads with `--clobber`. It also re-asserts `--prerelease` on a release it finds,
-which matters — a staging release *not* flagged as a prerelease is one a plain `update apply` would
-happily install, and staging exists precisely so unvalidated builds cannot reach robots.
+Bump the workspace version first: `xtask package` refuses a tag that disagrees with `Cargo.toml`.
 
-`release.yml` then cross-builds for aarch64, packages, signs, verifies through the real
-engine, and publishes a **prerelease**. Nothing reaches robots on `stable` yet.
+Two properties worth knowing, because they are what the split is *for*:
 
-Both publish steps are re-runnable. That was not true before: a release job that failed *after*
-creating its release could only be retried by deleting the release and the tag by hand, which is a
-poor thing to discover mid-release.
+- A prerelease is skipped by a plain `update apply`, so an unpromoted build cannot reach a robot that
+  did not ask for it with `--staging`. Both publish steps re-assert the flag on a release that already
+  exists — a staging release someone drafted without ticking the box would otherwise be installable by
+  the whole fleet, and a stable one flagged as a prerelease would ship to nobody.
+- Promotion never rebuilds. The stable release ends up self-contained (manifest, signature, artifact,
+  bootstrap binary), which is why the staging release can be deleted afterwards. Stable releases from
+  before that was true — `daemon-v0.3.0` — still point their `url` at their staging release, so
+  **those staging releases must not be deleted.**
 
-After a canary robot has run the on-device checks, promote:
+The manual promotion is the same recipe without a release to create first, and is where
+`min_supported` lives (§8.1 — it forces robots below that version to update without waiting for a
+client):
 
 ```
-gh workflow run promote --field version=0.2.0
+gh workflow run promote --field version=0.4.0
 ```
 
-`promote.yml` re-signs a stable manifest carrying the **same artifact bytes** staging
-validated — no rebuild; the sha256 is checked during promotion and again on the robot.
-The stable release ends up self-contained (manifest, signature, artifact, bootstrap
-binary), so the staging release is deleted once promotion succeeds. Add
-`--field min_supported=0.2.0` only when remediating a bad release (§8.1); it forces
-robots below that version to update without waiting for a client.
+### The workflows
+
+```
+release.yml            the entry point: decides staging / promote / stable
+_build-release.yml     build · package · sign · verify · publish        (called)
+_promote-release.yml   copy bytes · verify sha · re-sign · retire staging (called)
+promote.yml            workflow_dispatch → _promote-release.yml
+dev.yml                every push: an unsigned-for-customers dev build, `team.dev` key
+```
+
+The recipe lives in the two called workflows so the staging and stable paths cannot drift apart in
+what they ship. `xtask`'s packaging tripwires read `_build-release.yml` and `dev.yml` for the
+`--include` list, so a unit, hook or sysusers file that is not packaged fails a test rather than a
+robot.
+
+Both publish steps create the release only if it is absent and then upload with `--clobber`, so a job
+that failed halfway can be re-run. That was not true before: a release job that died after creating
+its release could only be retried by deleting the release and the tag by hand.
 
 ## Rotating a key
 

--- a/docs/project/ci-setup.md
+++ b/docs/project/ci-setup.md
@@ -161,11 +161,21 @@ no benefit.
 ## Cutting a release
 
 ```
-git tag daemon-staging-v0.2.0 && git push --tags
+git tag daemon-staging-v0.4.0 && git push --tags
 ```
+
+Drafting a release in the web UI against a new `daemon-staging-v*` tag does the same thing:
+`release.yml` triggers on both, and its publish step creates the release only if it is not already
+there, then uploads with `--clobber`. It also re-asserts `--prerelease` on a release it finds,
+which matters — a staging release *not* flagged as a prerelease is one a plain `update apply` would
+happily install, and staging exists precisely so unvalidated builds cannot reach robots.
 
 `release.yml` then cross-builds for aarch64, packages, signs, verifies through the real
 engine, and publishes a **prerelease**. Nothing reaches robots on `stable` yet.
+
+Both publish steps are re-runnable. That was not true before: a release job that failed *after*
+creating its release could only be retried by deleting the release and the tag by hand, which is a
+poor thing to discover mid-release.
 
 After a canary robot has run the on-device checks, promote:
 

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -82,9 +82,9 @@ cargo run -q -p test-support --example fake-release -- "$FIXTURE" --prefix /tmp/
 # A real artifact, for the installer checks at the end.
 #
 # `xtask package` from the binaries just cross-compiled, with the staging and `--include` lists
-# read out of release.yml — so this is the artifact production builds, not an approximation of
-# one. The fixture releases above deliberately carry no systemd units, and units are the whole
-# subject of those checks.
+# read out of the packaging workflow — so this is the artifact production builds, not an
+# approximation of one. The fixture releases above deliberately carry no systemd units, and units
+# are the whole subject of those checks.
 #
 # Unpacked here rather than in the container because the zstd *binary* is the one tool the
 # target image lacks, and an apt-get in the middle of a hermetic check buys a network
@@ -95,8 +95,25 @@ mkdir -p "$INSTALL_STAGED" "$INSTALL_RELEASE"
 
 # Both lists parsed from the workflow, for the reason xtask/tests/artifact.rs exists: a copy
 # kept here would be a third hand-maintained list to drift from the other two.
-for binary in $(grep -o -- 'release/[a-z]* staged/' .github/workflows/release.yml \
-    | sed 's|release/||; s| staged/||' | sort -u); do
+#
+# `_build-release.yml`, because that is where the recipe lives: `release.yml` decides which channel
+# is being published and calls it, and holds no `cp` or `--include` line of its own. Parsing the
+# entry point instead produced an empty list and a failure two hundred lines later —
+# "the installed release has no systemd/updaterd.service" — so the emptiness is now checked here,
+# where it can name its own cause.
+PACKAGING_WORKFLOW=.github/workflows/_build-release.yml
+
+staged_binaries="$(grep -o -- 'release/[a-z]* staged/' "$PACKAGING_WORKFLOW" \
+    | sed 's|release/||; s| staged/||' | sort -u)"
+if [ -z "$staged_binaries" ]; then
+    echo "error: no staged binaries found in ${PACKAGING_WORKFLOW}." >&2
+    echo "       The parse has stopped matching its 'cp ... staged/' lines, so the artifact" >&2
+    echo "       would carry no binaries and the installer checks would fail 200 lines later" >&2
+    echo "       with 'the installed release has no systemd/updaterd.service'." >&2
+    exit 1
+fi
+
+for binary in $staged_binaries; do
     cp "$TARGET_DIR/$binary" "$INSTALL_STAGED/"
 done
 
@@ -107,8 +124,15 @@ set --
 while IFS= read -r pair; do
     set -- "$@" --include "$pair"
 done <<INCLUDES
-$(grep -o -- '--include "[^"]*"' .github/workflows/release.yml | sed 's/--include //; s/"//g')
+$(grep -o -- '--include "[^"]*"' "$PACKAGING_WORKFLOW" | sed 's/--include //; s/"//g')
 INCLUDES
+
+if [ "$#" -eq 0 ]; then
+    echo "error: no --include pairs found in ${PACKAGING_WORKFLOW}." >&2
+    echo "       The artifact would carry no units, and the installer checks below are" >&2
+    echo "       entirely about units." >&2
+    exit 1
+fi
 
 # Level 1: this artifact is unpacked once and thrown away. The shipping default of 19 is
 # single-threaded and would cost more than every check below put together.
@@ -592,7 +616,7 @@ echo "    [ok] preinstall refuses an old runtime it cannot replace, naming the f
 # on a script that installed a unit into the wrong directory.
 #
 # The release is a real artifact, built by xtask package from the cross-compiled binaries and
-# the include list read out of release.yml. Not the fixture releases the engine checks use:
+# the include list read out of the packaging workflow. Not the fixture releases the engine uses:
 # those carry no systemd units by design, and units are the whole subject here.
 
 mkdir -p /stub

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -490,7 +490,16 @@ mod tests {
         // board in exactly the same way as a release missing it — `systemctl restart robotd`
         // with no such unit — and a teammate hitting that would have no reason to suspect the
         // packaging rather than their own branch.
-        let workflows = [".github/workflows/release.yml", ".github/workflows/dev.yml"].map(|w| {
+        //
+        // `_build-release.yml`, not `release.yml`: the packaging recipe lives in the reusable
+        // workflow that both the staging and the stable path call, and `release.yml` is now only the
+        // entry point choosing between them. The assertion below fails loudly on a file it cannot
+        // parse, which is what caught this rename rather than silently passing.
+        let workflows = [
+            ".github/workflows/_build-release.yml",
+            ".github/workflows/dev.yml",
+        ]
+        .map(|w| {
             (
                 w,
                 std::fs::read_to_string(repo.join(w)).unwrap_or_else(|_| panic!("{w} must exist")),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -846,6 +846,17 @@ fn sha256_hex(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// The workflows that *package* a release, which is where the `--include` list and the staged
+    /// binaries live.
+    ///
+    /// Named once, because the tests below all read the same files and the recipe has moved before:
+    /// it used to sit in `release.yml`, and now lives in the reusable `_build-release.yml` that both
+    /// the staging and stable paths call. A test that kept reading the old name would pass while
+    /// guarding nothing, which is worse than failing.
+    const PACKAGING_WORKFLOWS: [&str; 2] = ["dev.yml", "_build-release.yml"];
+
+    /// Where promotion happens: the stable manifest, the artifact carried forward, the retire step.
+    const PROMOTE_WORKFLOW: &str = "_promote-release.yml";
     /// Every unit `install.sh` installs must actually be in the artifact.
     ///
     /// The packaging workflows name each shipped file with an explicit `--include`, and
@@ -877,7 +888,7 @@ mod tests {
         units.dedup();
         assert!(units.len() >= 4, "expected several units, found {units:?}");
 
-        for workflow in ["dev.yml", "release.yml"] {
+        for workflow in PACKAGING_WORKFLOWS {
             let text = std::fs::read_to_string(root.join(".github/workflows").join(workflow))
                 .unwrap_or_else(|e| panic!("{workflow}: {e}"));
             for unit in &units {
@@ -904,22 +915,22 @@ mod tests {
         let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("xtask/ has a parent");
-        let yml = std::fs::read_to_string(root.join(".github/workflows/promote.yml"))
-            .expect(".github/workflows/promote.yml must exist");
+        let yml = std::fs::read_to_string(root.join(".github/workflows").join(PROMOTE_WORKFLOW))
+            .unwrap_or_else(|e| panic!("{PROMOTE_WORKFLOW}: {e}"));
 
         assert!(
             yml.contains("--stable-tag"),
-            "promote.yml must pass --stable-tag, or the manifest url is built from the \
+            "the promote workflow must pass --stable-tag, or the manifest url is built from the \
              wrong release"
         );
         assert!(
             yml.contains("\"artifact/$artifact_name\""),
-            "promote.yml must upload the artifact to the stable release — the manifest's \
+            "the promote workflow must upload the artifact to the stable release — the manifest's \
              url points there"
         );
         assert!(
             yml.contains("\"artifact/$artifact_name.minisig\""),
-            "promote.yml must upload the artifact signature too — `sig_url` is derived \
+            "the promote workflow must upload the artifact signature too — `sig_url` is derived \
              from `url` and points at the same release"
         );
 
@@ -927,7 +938,7 @@ mod tests {
         // removes them, this assertion is the one that should look wrong.
         assert!(
             yml.contains("gh release delete \"$staging_tag\""),
-            "promote.yml should retire the staging release once stable is self-contained"
+            "the promote workflow should retire the staging release once stable is self-contained"
         );
     }
 
@@ -964,7 +975,7 @@ mod tests {
                     continue;
                 }
                 found += 1;
-                for workflow in ["dev.yml", "release.yml"] {
+                for workflow in PACKAGING_WORKFLOWS {
                     let text =
                         std::fs::read_to_string(root.join(".github/workflows").join(workflow))
                             .unwrap_or_else(|e| panic!("{workflow}: {e}"));
@@ -1001,7 +1012,7 @@ mod tests {
                 continue;
             }
 
-            for workflow in ["dev.yml", "release.yml"] {
+            for workflow in PACKAGING_WORKFLOWS {
                 let text = std::fs::read_to_string(root.join(".github/workflows").join(workflow))
                     .unwrap_or_else(|e| panic!("{workflow}: {e}"));
                 let expected = format!("=hooks/{name}");
@@ -1031,7 +1042,7 @@ mod tests {
             .parent()
             .expect("xtask/ has a parent");
 
-        for workflow in ["dev.yml", "release.yml"] {
+        for workflow in PACKAGING_WORKFLOWS {
             let text = std::fs::read_to_string(root.join(".github/workflows").join(workflow))
                 .unwrap_or_else(|e| panic!("{workflow}: {e}"));
 

--- a/xtask/tests/artifact.rs
+++ b/xtask/tests/artifact.rs
@@ -36,7 +36,7 @@
 //! packaging recipe — reproducing the list here by hand would recreate exactly the drift these
 //! tests exist to catch. What is no longer taken on trust is the result.
 //!
-//! **Both workflows, not just `release.yml`.** `dev.yml` maintains its own copy of the staging and
+//! **Both workflows.** `dev.yml` maintains its own copy of the staging and
 //! `--include` lists, and says in a comment why they must match:
 //!
 //! > Same contents as a real release: a dev build that omitted the units or robotd would fail its
@@ -46,8 +46,8 @@
 //! Nothing enforced that. Two hand-maintained parallel lists is the same drift class as a list that
 //! disagrees with `install.sh`, and it matters more than it looks: every bug in
 //! `install-path-gap.md` was found while installing a **dev** build onto a board, because that is
-//! the artifact a branch actually ships. A test that covered only `release.yml` would have watched
-//! all four of them go past.
+//! the artifact a branch actually ships. A test that covered only the release path would have
+//! watched all four of them go past.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -59,7 +59,11 @@ const STAGED: &str = " staged/";
 ///
 /// `dev.yml` first, deliberately: it is the one that runs on every push and the one whose output
 /// reaches a board during development.
-const PACKAGING_WORKFLOWS: [&str; 2] = ["dev.yml", "release.yml"];
+/// `_build-release.yml` rather than `release.yml`: the recipe moved into the reusable workflow that
+/// both the staging and the stable path call, and `release.yml` is now only the entry point that
+/// decides between them. A constant that kept naming the old file would have left every assertion
+/// here vacuous — which is why the parse below fails loudly when it matches nothing.
+const PACKAGING_WORKFLOWS: [&str; 2] = ["dev.yml", "_build-release.yml"];
 
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Cutting a release was a tag push plus a `workflow_dispatch`, and doing it from the GitHub UI actively broke: the release object already existed, so the pipeline died on `gh release create` **after signing** — leaving a release that looks published and contains nothing a robot can install. A job that failed halfway could not be re-run either, for the same reason.

## Now

The releases page is the door, and the tag says which door it is:

| you create | mode | what happens |
|---|---|---|
| **pre-release**, `daemon-staging-v0.4.0` | `staging` | build · sign · verify through the real engine · publish as a prerelease |
| **release**, `daemon-v0.4.0`, staging exists | `promote` | re-sign a stable manifest over **the same bytes**; no rebuild; retire staging |
| **release**, `daemon-v0.4.0`, no staging | `stable` | build 0.4.0 and publish straight to stable |

The run summary names which of the three ran. Pushing either tag from a terminal still works and does the same thing.

**The third case is labelled where it cannot be missed** — in the notes the release itself carries. *Built directly* means verified through the update engine here (signature, manifest, a genuine install) but **not canaried**: no robot ran those bytes. *Promoted* means one did. Both are signed with the key customer robots trust, so the difference is validation, not authenticity.

## Structure

The recipe moved into two reusable workflows that both paths call, so staging and stable cannot drift apart in what they ship:

```
release.yml            decides: staging / promote / stable
_build-release.yml     build · package · sign · verify · publish        (called)
_promote-release.yml   copy bytes · verify sha · re-sign · retire staging (called)
promote.yml            workflow_dispatch → _promote-release.yml
```

## Two things that are safety, not tidiness

**The prerelease flag is re-asserted** on a release that already exists. A prerelease is skipped by a plain `update apply` — that is the entire mechanism keeping unvalidated builds away from robots. A staging release drafted without ticking the box would be installable by the whole fleet; a stable release flagged as one ships to nobody.

**The guard on `decide`.** `on: release` cannot filter by tag, and `dev.yml` publishes a `daemon-dev-*` release on every push to every branch. Without it, every push would try to cut a release — and a `daemon-v*` release firing the build path would upload a fresh build over a promoted artifact, destroying the guarantee promotion exists for.

## The tripwires did their job

Five tests read the workflow that packages, and all five failed on the move rather than passing vacuously: three in `xtask/src/main.rs`, one in `xtask/tests/artifact.rs`, one in `updater/src/config.rs`. They now name `_build-release.yml` through single constants, so the next move is one line each.

## Verification

498 tests pass, clippy and fmt clean. All four workflows parse as YAML with the expected triggers and job graph, and every rewritten `run:` block passes `bash -n`.

Beyond that, **this cannot be tested without cutting a real release** — which is the plan: 0.4.0 goes out through this, and if it misbehaves, 0.4.1 costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)