### PR TITLE
ci: releases carry a changelog, and one run means one check

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -356,35 +356,43 @@ jobs:
         run: |
           if [ "${{ inputs.prerelease }}" = "true" ]; then
             title="daemon ${{ inputs.version }} (staging)"
-            notes="Staging build from \`${GITHUB_SHA}\`.
+            provenance="Staging build from \`${GITHUB_SHA}\`.
 
           Not for client robots. Promote it — create a release for tag \`daemon-v${{ inputs.version }}\`,
           or run the \`promote\` workflow — once a canary has run the on-device acceptance checks.
-          Promotion ships these exact bytes.
-          "
+          Promotion ships these exact bytes."
             flag=--prerelease
           else
-            title="daemon ${{ inputs.version }}"
             # Said in the release itself, because it is the one thing that distinguishes this from a
             # promoted release and nothing else would record it. Built here means engine-verified —
             # signature, manifest and a real install, all checked in this job — but not *canaried*:
             # no robot ran these bytes before they became the stable channel.
-            notes="Built directly from \`${GITHUB_SHA}\`, with no staging release to promote.
+            title="daemon ${{ inputs.version }}"
+            provenance="Built directly from \`${GITHUB_SHA}\`, with no staging release to promote.
 
           Verified through the update engine in CI, but **not validated on a robot**. For the
           canaried path, publish a pre-release for \`daemon-staging-v${{ inputs.version }}\` first
-          and then promote it.
-          "
+          and then promote it."
             flag=--prerelease=false
           fi
+
+          notes="$(PROVENANCE="$provenance" TAG="$TAG" ./scripts/ci-release-notes.sh)"
 
           # Create it if absent, fill it in either way — see the note in release.yml on why this is
           # not a single `gh release create`. The flag is re-asserted on a release that already
           # exists: staging must be flagged so a plain `update apply` skips it, and stable must not
           # be, or it ships to nobody.
+          #
+          # Notes are only written when there are none. Anything typed into the UI is somebody's
+          # deliberate description of their own release and outranks a generated one.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG exists; filling it in"
             gh release edit "$TAG" "$flag" --title "$title"
+            if [ -z "$(gh release view "$TAG" --json body --jq .body)" ]; then
+              gh release edit "$TAG" --notes "$notes"
+            else
+              echo "keeping the notes it came with"
+            fi
           else
             gh release create "$TAG" "$flag" --title "$title" --notes "$notes"
           fi

--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -168,21 +168,43 @@ jobs:
       # `--prerelease=false` is re-asserted rather than assumed: a stable release that is flagged as
       # a prerelease is invisible to a plain `update apply`, so a promotion into a release object
       # someone had drafted would silently ship to nobody.
+      #
+      # Create-then-fill, like _build-release.yml, and re-runnable for the same reason: a promotion
+      # that failed *after* creating the release could not be retried, which is the worst moment for a
+      # step to be one-shot — the stable release would exist, carrying nothing a robot can install,
+      # until someone deleted it by hand.
+      #
+      # `--prerelease=false` is re-asserted rather than assumed: a stable release flagged as a
+      # prerelease is invisible to a plain `update apply`, so a promotion into a release object
+      # somebody had drafted would silently ship to nobody.
+      #
+      # The notes carry a changelog, which they did not use to. "Promoted from
+      # daemon-staging-v0.4.0" was all a stable release said, while the changelog lived on the
+      # staging release — which this workflow then deleted. The release everybody actually reads was
+      # the one with no account of what was in it.
       - name: Publish the stable release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          notes="Promoted from \`$staging_tag\`.
-
-          The artifact is the one validated in staging — same bytes, same sha256, checked
-          during promotion. This release is self-contained: manifest, signature, artifact,
-          and the bootstrap binary used by \`scripts/install.sh\` to install from scratch.
-          "
           title="daemon ${{ inputs.version }}"
+          provenance="Promoted from \`$staging_tag\`.
+
+          The artifact is the one validated in staging — same bytes, same sha256, checked during
+          promotion. This release is self-contained: manifest, signature, artifact, and the bootstrap
+          binary used by \`scripts/install.sh\` to install from scratch."
+
+          notes="$(PROVENANCE="$provenance" TAG="$stable_tag" ./scripts/ci-release-notes.sh)"
 
           if gh release view "$stable_tag" >/dev/null 2>&1; then
             echo "release $stable_tag exists; filling it in"
             gh release edit "$stable_tag" --prerelease=false --title "$title"
+            # Only when there are none: notes typed into the UI are somebody's deliberate
+            # description and outrank a generated one.
+            if [ -z "$(gh release view "$stable_tag" --json body --jq .body)" ]; then
+              gh release edit "$stable_tag" --notes "$notes"
+            else
+              echo "keeping the notes it came with"
+            fi
           else
             gh release create "$stable_tag" --title "$title" --notes "$notes"
           fi
@@ -193,13 +215,6 @@ jobs:
             bootstrap/updaterd-bootstrap-aarch64 \
             --clobber
 
-      # Only now — the stable release exists and carries every byte it references, so the
-      # staging release has no readers left. Deleting it is what keeps the release list
-      # honest: a `daemon-staging-*` tag that outlives its promotion is installable via
-      # `--ref`, and is just an older name for what stable already serves.
-      #
-      # `--cleanup-tag`, for the same reason as in `prune-dev-releases.yml`: a surviving
-      # tag keeps resolving.
       - name: Retire the staging release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       # and `provision-board.sh` on an operator's machine — so nothing else would catch a typo
       # in one until someone tried to provision a board. shellcheck is on the runner already.
       #
+      # `ci-release-notes.sh` is here despite running only in CI, unlike `ci-cross-deps.sh`: it runs
+      # *during a release*, which is the worst moment to find a typo in a shell script.
+      #
       # `migrate-network.sh` was missing from this list while being the riskiest of them —
       # it is the one step that can make a headless board unreachable, and the one nobody
       # re-runs once their own board is migrated. `board-test.sh` is deliberately absent:
@@ -56,7 +59,7 @@ jobs:
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,31 +19,36 @@
 # reaches client robots is byte-identical to what was validated.
 name: release
 
+# One trigger, deliberately.
+#
+# Publishing a release in the UI creates the tag, so this fires for the UI path as well as for
+# `git push --tags` — verified both ways. There *was* also a `release: published` trigger, and it made
+# every UI release start two identical runs; the concurrency group below cancelled one, and a
+# cancelled run counts as a failed check, so a perfectly good release showed a red ✗ on its tag.
+#
+# What one trigger gives up: publishing a release against a tag that *already exists* does nothing.
+# That tag's push already built it, so there is nothing to do — and if a build genuinely needs
+# repeating, re-run it from the Actions tab.
 on:
   push:
     tags:
       - 'daemon-staging-v*'
       - 'daemon-v*'
-  # Publishing a release in the UI creates the tag, so `push` would cover that case on its own — but
-  # only that one. A release published against an *existing* tag fires only this, and that is a door
-  # people will use.
-  release:
-    types: [published]
 
 permissions:
   contents: write
 
-# One run per tag. Publishing a release in the UI fires *both* triggers — the tag `push` and
-# `release: published` — and without this both build, sign and upload to the same release. They race
-# on the upload, and because each build stamps its own `DUCK_BUILD_TIME` the artifacts are not
-# byte-identical, so the release can end up with a manifest from one run and a tarball from another:
-# a sha256 mismatch that no robot could install and nothing would explain.
+# One run per tag, still — a belt to the single trigger's braces. Two runs publishing the same tag
+# would race on the upload, and because each build stamps its own `DUCK_BUILD_TIME` the artifacts are
+# not byte-identical: the release could end up with a manifest from one run and a tarball from
+# another, which is a sha256 mismatch no robot can install and nothing in the release explains.
 #
-# `cancel-in-progress`, because the two runs are the same work and the later event is as good as the
-# earlier one. Nothing is published until the final step, so a cancelled run leaves nothing behind.
+# `cancel-in-progress: false`, because a cancelled run reports as a failed check and there is nothing
+# to cancel for anyway: whoever pushed the same tag twice wants the second attempt to wait, not to
+# make the first look broken.
 concurrency:
-  group: release-${{ github.event.release.tag_name || github.ref_name }}
-  cancel-in-progress: true
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   # Which channel, which version, and whether there is anything to promote.
@@ -61,8 +66,8 @@ jobs:
     # every branch, and those are not release attempts. Anything else beginning with `daemon-` is
     # someone trying to cut a release, and deserves a red X with the answer in it.
     if: >-
-      startsWith(github.event.release.tag_name || github.ref_name, 'daemon-') &&
-      !startsWith(github.event.release.tag_name || github.ref_name, 'daemon-dev-')
+      startsWith(github.ref_name, 'daemon-') &&
+      !startsWith(github.ref_name, 'daemon-dev-')
     outputs:
       mode: ${{ steps.plan.outputs.mode }}
       version: ${{ steps.plan.outputs.version }}
@@ -73,7 +78,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -eu
           case "$TAG" in

--- a/scripts/ci-release-notes.sh
+++ b/scripts/ci-release-notes.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Compose release notes: why this release exists, then what changed in it.
+#
+# Called by `_build-release.yml` and `_promote-release.yml`, so the two cannot drift into describing
+# releases differently — and because the interesting half of the problem is the same for both.
+#
+# The problem it solves: a promoted release said only "Promoted from daemon-staging-v0.4.0", and the
+# changelog lived on the staging release, which promotion deletes. So the stable release — the one
+# anybody actually reads — ended up with no account of what was in it.
+#
+# The changelog comes from GitHub's own generator rather than from a file in the repo. That is
+# deliberate: a hand-maintained CHANGELOG.md is a second place to forget, and the generator already
+# knows the merged pull requests, which is what this project's history is made of.
+#
+# Reads:  TAG          the tag being published
+#         PROVENANCE   a sentence or two on where these bytes came from
+#         GH_TOKEN     needed by `gh`
+# Writes: the composed notes, on stdout.
+set -eu
+
+: "${TAG:?TAG is required}"
+: "${PROVENANCE:?PROVENANCE is required}"
+
+# The previous *stable* release, which is the sensible left edge of a changelog for either channel: a
+# candidate answers "what is new since the last release people are running", and so does the release
+# it becomes.
+#
+# Explicit rather than letting the generator choose, because it would otherwise pick the most recent
+# release of any kind — and `dev.yml` publishes a prerelease on every push to every branch, so
+# "since the last release" would usually mean "since twenty minutes ago".
+previous="$(gh release list --limit 100 --json tagName,isPrerelease,isDraft \
+    --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName]
+          | map(select(startswith("daemon-v")))
+          | first // empty' 2>/dev/null || true)"
+
+# Not fatal if it is missing or fails. Notes without a changelog are worse than notes with one and
+# better than a failed release: this runs after the artifact is signed and verified.
+changelog=""
+if [ -n "$previous" ] && [ "$previous" != "$TAG" ]; then
+    changelog="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+        -f "tag_name=${TAG}" \
+        -f "previous_tag_name=${previous}" \
+        --jq .body 2>/dev/null || true)"
+else
+    # No previous stable release, or this is it. The generator handles that on its own.
+    changelog="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+        -f "tag_name=${TAG}" \
+        --jq .body 2>/dev/null || true)"
+fi
+
+printf '%s\n' "$PROVENANCE"
+if [ -n "$changelog" ]; then
+    printf '\n---\n\n%s\n' "$changelog"
+else
+    printf '\n_No changelog could be generated for this release._\n'
+fi


### PR DESCRIPTION
Two things cutting 0.4.0 exposed, both about the release as a thing people *read* rather than as bytes.

## The stable release said nothing about itself

Its notes were `Promoted from daemon-staging-v0.4.0`, and the changelog lived on the staging release — which promotion deletes. So the release everybody opens had no account of what was in it.

`scripts/ci-release-notes.sh` composes what both workflows publish: provenance, then a changelog from GitHub's own generator. Tried against the real repo, for `daemon-v0.4.0`:

```
Promoted from `daemon-staging-v0.4.0`. …

---

## What's Changed
* One command to pair a gamepad, and Start to bring the robot up by @pierre-rouanet in #49
* ci: the releases page is the entry point, and it decides what you meant by @pierre-rouanet in #57
… 15 entries …

**Full Changelog**: …/compare/daemon-v0.3.0...daemon-v0.4.0
```

Two decisions inside it:

- **The generator, not a `CHANGELOG.md`.** A hand-maintained file is a second place to forget, and the generator already knows the merged pull requests — which is what this project's history is made of.
- **The left edge is the previous *stable* tag, named explicitly.** Letting GitHub choose means "since the most recent release of any kind", and `dev.yml` publishes a prerelease on every push to every branch — so the changelog would usually cover the last twenty minutes.

Notes are only written when there are none: anything typed into the UI is somebody's deliberate description and outranks a generated one.

## A cancelled run reports as a failed check

Publishing in the UI fired both the tag `push` **and** `release: published`. The concurrency group cancelled one, and the tag then showed a red ✗ for a release that was completely fine — worse than the duplicate it was fixing, because a badge that lies teaches people to ignore it.

Publishing in the UI creates the tag, so `push` covers that path by itself — verified both ways while cutting 0.4.0. So the `release` trigger is gone, and `cancel-in-progress` with it (a queued second run should wait, not make the first look broken). What one trigger gives up: publishing a release against a tag that *already exists* does nothing — and that tag built on its own push anyway.

## Verification

All four workflows parse with the expected triggers; every `run:` block passes `bash -n`; the notes script passes `sh -n` and shellcheck and was run for real against this repository (output above). `xtask`'s packaging tripwires still pass.

`ci-release-notes.sh` joins CI's shellcheck list — unlike `ci-cross-deps.sh`, because this one runs *during a release*, which is the worst moment to discover a typo.

## For 0.4.0, which is already out

Its notes can be filled in retroactively with the same script, so the current release reads like the ones after it will:

```bash
PROVENANCE="Promoted from \`daemon-staging-v0.4.0\`." TAG=daemon-v0.4.0 \
  GITHUB_REPOSITORY=pollen-robotics/microduck_daemon \
  ./scripts/ci-release-notes.sh | gh release edit daemon-v0.4.0 --notes-file -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)