### PR TITLE
The pad this was tested against is LE, not classic

### DIFF
--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -15,7 +15,9 @@
 //!
 //!  - `Connect()` on a device BlueZ has never bonded with can answer
 //!    `br-connection-profile-unavailable` — there is no profile to connect to *yet*. Refusing there
-//!    would reject a pad that `Pair()` would have bonded a moment later, so it is soft-failed.
+//!    would reject a pad that `Pair()` would have bonded a moment later, so it is soft-failed. The
+//!    `br-` prefix is BlueZ trying BR/EDR first and finding nothing there; the pad this was seen
+//!    against bonds over LE, so that error names a transport which was never going to carry it.
 //!  - `Connect()` on a pad that *does* bond **returns before the bond has completed.** A HID profile
 //!    requires an encrypted link, so connecting triggers bonding, and it lands a moment afterwards.
 //!  - `Pair()` on a bond already in flight **never answers.** Not `AlreadyExists` — outstanding,
@@ -68,15 +70,48 @@
 //! it cost most of a day: retrying does not help, `JustWorksRepairing` does not help, and neither
 //! does clearing the bond on either side.
 //!
+//! It is also the first clue about which transport is in play: resolvable private addresses are an LE
+//! mechanism, so a setting that breaks bonding this way can only be breaking an LE bond.
+//!
+//! ## Which transport, and what that leaves untested
+//!
+//! Nothing here picks one. `StartDiscovery()` runs with no filter, so BlueZ's default `auto` sweeps
+//! BR/EDR and LE together, and every property `Snapshot` reads is optional partly because the two
+//! transports present different ones.
+//!
+//! But the pad all of this has been run against is **LE-only**. Its bond stores long-term keys and no
+//! `[LinkKey]`, and BlueZ reports no `Class` for it at all:
+//!
+//! ```text
+//! # /var/lib/bluetooth/<adapter>/<pad>/info
+//! SupportedTechnologies=LE;
+//! [IdentityResolvingKey]
+//! [PeripheralLongTermKey]
+//! ```
+//!
+//! So the BR/EDR half of this file comes from the specification rather than from a radio. That
+//! includes the class-of-device branch in [`looks_like_a_gamepad`], which cannot have fired — an LE
+//! pad has no class to match — and the `br-connection-profile-unavailable` soft-fail above.
+//!
+//! Discovery stays on `auto` regardless, because the pads the heuristic names that are *not* LE — a
+//! DualShock, a DualSense — are BR/EDR HID, and filtering to LE would make hardware this claims to
+//! recognise unreachable. The thing to know is which way the risk runs: dropping BR/EDR would cost
+//! nothing yet observed, and the first classic pad to arrive exercises that path for the first time.
+//!
 //! ## Where this has and has not run
 //!
 //! **Run against a real BlueZ on a Radxa Zero 3W with an Xbox Wireless Controller**, which is where
 //! everything above about asynchronous bonding comes from. What has been seen work: discovery finds
-//! the pad and the heuristic identifies it, the bond completes, `Trusted` sticks, the pad reconnects
-//! by itself across a reboot, `padd` drives from it, and `pad forget` drops it.
+//! the pad and the heuristic identifies it — on `Icon`, which BlueZ derived from the LE appearance —
+//! the bond completes, `Trusted` sticks, the pad reconnects by itself across a reboot, `padd` drives
+//! from it, and `pad forget` drops it.
 //!
-//! What has **not** been exercised on hardware: a DualSense, two pads in pairing mode at once, and
-//! pairing by explicit address.
+//! That reconnection is worth naming rather than assuming, because over LE the *robot* is the one
+//! that re-initiates: the adapter scans as a central for a bonded peripheral while `btd` advertises
+//! as a peripheral itself. Both roles at once hold on this board's radio.
+//!
+//! What has **not** been exercised on hardware: a pad that bonds over BR/EDR at all, a DualSense, two
+//! pads in pairing mode at once, and pairing by explicit address.
 //!
 //! And one case that cannot be fixed from here: `pad forget` removes only the robot's half of the
 //! bond. A pad that still holds its half will not pair again until it is put back into pairing mode

--- a/configd/src/pad.rs
+++ b/configd/src/pad.rs
@@ -81,13 +81,15 @@ pub fn pair_timeout(requested: Option<u32>) -> Duration {
 ///
 ///  - **`icon`** is BlueZ's own classification, derived from the class or the appearance. When it
 ///    says `input-gaming` the question is settled, and this is the signal an Xbox controller
-///    actually presents on this board.
+///    actually presents on this board — from its LE appearance, since that pad has no class.
 ///  - **`class`** is the BR/EDR class-of-device: bits 8-12 are the major device class, and `0x05`
 ///    is Peripheral. Bits 6-7 of the minor field distinguish keyboard from pointing device from
 ///    gamepad — `0x01` in bits 2-5 with the keyboard/pointer bits clear is a joystick or gamepad.
-///    Present for a classic pad, absent for a BLE-only one.
+///    Present for a classic pad, absent for a BLE-only one — and every pad tried so far has been
+///    LE-only, so this arm is from the specification and has never fired on hardware.
 ///  - **`appearance`** is the BLE equivalent: category 15 (`0x03C0..=0x03C4`) is HID, and `0x03C4`
-///    is specifically Gamepad. Many pads never set it, which is why it cannot stand alone.
+///    is specifically Gamepad. Many pads never set it, which is why it cannot stand alone. Only the
+///    gamepad value counts, so an LE pad advertising generic HID falls through to its name.
 ///  - **the name**, last and deliberately: it is the signal that works when the other three are
 ///    absent, which for a pad still in pairing mode is common, and it is the one that can be wrong.
 ///
@@ -285,7 +287,8 @@ mod tests {
     }
 
     /// A classic pad, identified by class-of-device with no icon and no name — which is what
-    /// discovery reports before a device is queried.
+    /// discovery reports before a device is queried. Synthetic in a way the others are not: no pad
+    /// bonded to this robot has ever presented a class, so this arm is only ever exercised here.
     #[test]
     fn a_peripheral_joystick_class_is_a_gamepad() {
         // Major 0x05 (peripheral), minor 0x01 (joystick): 0x000504.


### PR DESCRIPTION
The bond stored for the Xbox Wireless Controller this robot pairs with says
`SupportedTechnologies=LE;`, holds long-term keys and no `[LinkKey]`, and BlueZ
reports no `Class` for the device at all:

```text
# /var/lib/bluetooth/<adapter>/<pad>/info
SupportedTechnologies=LE;
[IdentityResolvingKey]
[PeripheralLongTermKey]
```

So the transport `configd::bluez`'s comments implied had been exercised is the
one that never ran. Two arms read differently once that is known: the
class-of-device branch of `looks_like_a_gamepad` cannot have fired, because an
LE pad has no class to match, and `br-connection-profile-unavailable` is BlueZ
trying BR/EDR before falling through to the transport that worked — not
evidence that classic bonding works here.

The docs now record which half is specification and which half is a radio, so
the next person reading either arm knows what evidence sits behind it.

Two things worth keeping rather than losing:

- Reconnect-across-reboot is an **LE** result. Over LE the robot is the central
  that re-initiates, while `btd` advertises as a peripheral — both roles at
  once, which is a claim about this board's radio and not a given.
- Discovery stays on `auto`. Filtering to LE would cost nothing yet observed,
  but the DualShock and DualSense the name heuristic matches are BR/EDR HID, so
  the filter would make hardware this claims to recognise unreachable. The first
  classic pad to arrive exercises that path for the first time.

Comments only — no behaviour change. `cargo test -p configd`: 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
