### PR TITLE
btd: advertise often enough to be found

### DIFF
--- a/btd/examples/advwatch.rs
+++ b/btd/examples/advwatch.rs
@@ -1,0 +1,241 @@
+//! `advwatch` — how often does a robot's advertisement actually arrive?
+//!
+//! `btctl` scans for eight seconds and either finds a robot or does not, which makes a slow
+//! advertiser look like a broken one. This watches continuously instead and prints the arrival
+//! pattern, so "found it on the second try" can be read as a number.
+//!
+//! It exists because that number is the only way to tell three failures apart: the robot is not
+//! advertising, the robot is advertising too rarely to be caught in a scan window, or the client is
+//! at fault. **Every other device in range is measured alongside it**, which is what makes the
+//! answer conclusive — a robot heard ten times less often than a beacon 55 dB weaker than it is not
+//! suffering from range or interference.
+//!
+//! ```text
+//! cargo run -p btd --example advwatch -- <robot-name>
+//! ```
+//!
+//! Reads as: arrivals per device with signal strength, then a one-character-per-second timeline for
+//! the robot, then the gaps. A gap as long as `btctl`'s scan window is a run that reports no robot.
+
+use std::time::{Duration, Instant};
+
+use btd::gatt::SERVICE_UUID;
+use btleplug::api::{Central, CentralEvent, Manager as _, Peripheral as _, ScanFilter};
+use btleplug::platform::Manager;
+use futures::StreamExt;
+
+/// How long to watch.
+///
+/// Two minutes because the thing being measured is *silences*, and a window has to be long enough to
+/// contain several of the worst ones to say anything about how often they happen.
+const WATCH: Duration = Duration::from_secs(120);
+
+struct Device {
+    arrivals: usize,
+    last: f64,
+    name: Option<String>,
+    rssi: Option<i16>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let wanted = std::env::args().nth(1).unwrap_or("radxa-zero3".to_owned());
+
+    let manager = Manager::new().await?;
+    let adapter = manager
+        .adapters()
+        .await?
+        .into_iter()
+        .next()
+        .ok_or("no Bluetooth adapter")?;
+
+    let mut events = adapter.events().await?;
+    adapter.start_scan(ScanFilter::default()).await?;
+    eprintln!("watching for {wanted:?} for {WATCH:?}…");
+
+    let start = Instant::now();
+    let mut robot: Option<String> = None;
+    let mut hits: Vec<f64> = Vec::new();
+    let mut total = 0usize;
+    // Per-device counts, so the robot's rate is read against the other radios in the same room
+    // rather than against a guess at what "normal" is. This is the control, and it is the reason the
+    // measurement can rule out range and interference rather than merely suspect them.
+    let mut per_device: std::collections::HashMap<String, Device> =
+        std::collections::HashMap::new();
+
+    loop {
+        let left = WATCH.saturating_sub(start.elapsed());
+        if left.is_zero() {
+            break;
+        }
+        let Ok(Some(event)) = tokio::time::timeout(left, events.next()).await else {
+            break;
+        };
+        total += 1;
+
+        let id = match &event {
+            CentralEvent::DeviceDiscovered(id)
+            | CentralEvent::DeviceUpdated(id)
+            | CentralEvent::DeviceConnected(id)
+            | CentralEvent::DeviceDisconnected(id) => id.clone(),
+            CentralEvent::ServicesAdvertisement { id, .. }
+            | CentralEvent::ManufacturerDataAdvertisement { id, .. }
+            | CentralEvent::ServiceDataAdvertisement { id, .. } => id.clone(),
+            _ => continue,
+        };
+
+        let Ok(peripheral) = adapter.peripheral(&id).await else {
+            continue;
+        };
+        let Some(properties) = peripheral.properties().await? else {
+            continue;
+        };
+
+        // Arrivals, not events: one advertisement reception fires several btleplug events
+        // (DeviceUpdated, ServicesAdvertisement, ManufacturerDataAdvertisement…) at the same
+        // instant, so counting events overstates how often a device is actually heard by 3-4x.
+        let now = start.elapsed().as_secs_f64();
+        let entry = per_device.entry(id.to_string()).or_insert(Device {
+            arrivals: 0,
+            last: -1.0,
+            name: properties.local_name.clone(),
+            rssi: properties.rssi,
+        });
+        if now - entry.last > 0.2 {
+            entry.arrivals += 1;
+            entry.last = now;
+        }
+        if entry.name.is_none() {
+            entry.name = properties.local_name.clone();
+        }
+        if properties.rssi.is_some() {
+            entry.rssi = properties.rssi;
+        }
+
+        // Properties accumulate in btleplug, so a name or a UUID seen once keeps identifying this
+        // peripheral — which is what makes the id enough after the first sighting.
+        let is_robot = properties.local_name.as_deref() == Some(wanted.as_str())
+            || properties.services.contains(&SERVICE_UUID)
+            || robot.as_deref() == Some(id.to_string().as_str());
+        if !is_robot {
+            continue;
+        }
+        if robot.is_none() {
+            robot = Some(id.to_string());
+            eprintln!(
+                "  first sighting at {:.1}s: id={} name={:?} services={}",
+                start.elapsed().as_secs_f64(),
+                id,
+                properties.local_name,
+                properties.services.len()
+            );
+        }
+        hits.push(start.elapsed().as_secs_f64());
+    }
+    let _ = adapter.stop_scan().await;
+
+    println!(
+        "\n{total} events from all devices, {} from the robot",
+        hits.len()
+    );
+
+    let mut ranked: Vec<(&String, &Device)> = per_device.iter().collect();
+    ranked.sort_by_key(|device| std::cmp::Reverse(device.1.arrivals));
+    println!("heard most often in the same room, over {WATCH:?}:");
+    for (id, device) in ranked.iter().take(8) {
+        let mine = if robot.as_deref() == Some(id.as_str()) {
+            "  <-- the robot"
+        } else {
+            ""
+        };
+        println!(
+            "  {:4} arrivals  {:>5}  {}{mine}",
+            device.arrivals,
+            device
+                .rssi
+                .map(|r| format!("{r}dBm"))
+                .unwrap_or_else(|| "?".to_owned()),
+            device.name.as_deref().unwrap_or("(no name)")
+        );
+    }
+    if let Some(id) = &robot {
+        let device = &per_device[id];
+        println!(
+            "  the robot: {} arrivals, {} — one every {:.1}s",
+            device.arrivals,
+            device
+                .rssi
+                .map(|r| format!("{r}dBm"))
+                .unwrap_or_else(|| "?".to_owned()),
+            WATCH.as_secs_f64() / device.arrivals.max(1) as f64
+        );
+    }
+    if let Some(robot) = &robot {
+        let rank = ranked.iter().position(|(id, _)| *id == robot);
+        println!(
+            "the robot ranks {} of {} devices heard",
+            rank.map(|r| r + 1).unwrap_or(0),
+            ranked.len()
+        );
+    }
+    if hits.is_empty() {
+        println!("the robot was never heard from in {WATCH:?}");
+        return Ok(());
+    }
+
+    // One character per second: '#' is a second with at least one report, '.' is silence. The gap
+    // structure is the whole question — 8s of '.' is a failed `btctl` run.
+    let seconds = WATCH.as_secs() as usize;
+    let mut timeline = vec![b'.'; seconds];
+    for hit in &hits {
+        let slot = (*hit as usize).min(seconds - 1);
+        timeline[slot] = b'#';
+    }
+    println!("{}", String::from_utf8(timeline).unwrap());
+
+    let mut gaps: Vec<f64> = Vec::new();
+    let mut previous = 0.0;
+    for hit in &hits {
+        gaps.push(hit - previous);
+        previous = *hit;
+    }
+    gaps.push(WATCH.as_secs_f64() - previous);
+    gaps.sort_by(|a, b| b.partial_cmp(a).unwrap());
+    println!(
+        "gaps between reports: worst {:.1}s, then {:?}",
+        gaps[0],
+        gaps.iter()
+            .take(6)
+            .map(|g| format!("{g:.1}s"))
+            .collect::<Vec<_>>()
+    );
+    // The *smallest* gaps are the advertising interval: consecutive reports that both arrived cannot
+    // be closer together than the robot advertises. Reading it off the arrivals costs nothing, where
+    // asking the controller needs root on the board.
+    let mut closest = gaps.clone();
+    closest.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    println!(
+        "closest reports: {:?}",
+        closest
+            .iter()
+            .take(8)
+            .map(|g| format!("{:.0}ms", g * 1000.0))
+            .collect::<Vec<_>>()
+    );
+    let buckets = [0.2, 0.5, 1.0, 2.0, 4.0, 8.0, f64::MAX];
+    let mut counts = vec![0usize; buckets.len()];
+    for gap in &gaps {
+        let slot = buckets.iter().position(|b| gap < b).unwrap();
+        counts[slot] += 1;
+    }
+    println!(
+        "gap histogram  <200ms:{} <500ms:{} <1s:{} <2s:{} <4s:{} <8s:{} 8s+:{}",
+        counts[0], counts[1], counts[2], counts[3], counts[4], counts[5], counts[6]
+    );
+
+    let over_scan = gaps.iter().filter(|g| **g >= 8.0).count();
+    println!(
+        "{over_scan} gap(s) of 8s or more — each one is a `btctl` run that would report no robot"
+    );
+    Ok(())
+}

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -73,6 +73,11 @@ const FLOOR_MTU: usize = 20;
 /// shouting is taken from the things the robot is for. A *range* rather than one value because a
 /// fixed interval can keep colliding with the same neighbour's, which the controller avoids by
 /// jittering inside the window.
+///
+/// Measured again with this installed, same Mac and same two minutes: **151 arrivals, one every
+/// 0.8 s, worst silence 3.8 s, and not one silence of 8 s or more.** The failure it was diagnosed
+/// from cannot happen at that spacing, which is the point — the margin against an eight-second scan
+/// is now a factor of two rather than a coin toss.
 const ADV_INTERVAL_MIN: Duration = Duration::from_millis(100);
 const ADV_INTERVAL_MAX: Duration = Duration::from_millis(150);
 

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -53,6 +53,29 @@ use crate::upstream::Sockets;
 /// support — which is slower than necessary on a good link and correct on every link.
 const FLOOR_MTU: usize = 20;
 
+/// How often to advertise, and this is the difference between a robot that is found and one that is
+/// not.
+///
+/// Left unset, BlueZ takes the kernel's default of **1.28 s**, and that was measured against this
+/// board from a Mac scanning continuously for two minutes: the robot arrived once every 7.5 s on
+/// average with silences of 9 s, 14 s, 17 s and once 31 s. Every other radio in the room — a smart
+/// plug at −66 dBm, a beacon at −91 dBm — arrived 130 to 212 times over the same window, against the
+/// robot's 16, while the robot was the *strongest* signal there at −36 dBm. So it was not range,
+/// not interference and not the client: it simply spoke too rarely to be caught.
+///
+/// A central scans at a low duty cycle, which is what turns "6× slower" into "absent for seconds at
+/// a time" — an eight-second scan that lands in one of those silences finds nothing, and roughly
+/// half of them did. The large gaps came out as near-integer multiples of 1.28 s, which is what
+/// identified the interval from the arrivals rather than from a guess.
+///
+/// 100-150 ms is the range ordinary peripherals use, and it is 8-12× the default. Not the 20 ms
+/// floor the spec allows: one antenna carries this, a gamepad's LE link and wifi, so airtime spent
+/// shouting is taken from the things the robot is for. A *range* rather than one value because a
+/// fixed interval can keep colliding with the same neighbour's, which the controller avoids by
+/// jittering inside the window.
+const ADV_INTERVAL_MIN: Duration = Duration::from_millis(100);
+const ADV_INTERVAL_MAX: Duration = Duration::from_millis(150);
+
 /// How long to wait between attempts to find a usable adapter.
 ///
 /// Measured on the board: `hci0` does not exist until roughly 73 seconds after power-on —
@@ -132,6 +155,8 @@ pub async fn serve(sockets: Sockets, name: String, require_pairing: bool) -> blu
         service_uuids: [SERVICE_UUID].into_iter().collect(),
         discoverable: Some(true),
         local_name: Some(name),
+        min_interval: Some(ADV_INTERVAL_MIN),
+        max_interval: Some(ADV_INTERVAL_MAX),
         ..Default::default()
     };
     let _adv = adapter.advertise(advertisement).await?;

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -313,9 +313,16 @@ is for.
 `btd/examples/advwatch.rs` is the measurement, kept because the claim is only checkable by re-running
 it: arrivals per device with signal strength, then the robot's silences.
 
-The diagnosis above is measured; **the interval that answers it is not yet confirmed on hardware.**
-Installing a release carrying it and re-running `advwatch` is the check, and the number to expect is a
-few hundred arrivals rather than sixteen.
+**Confirmed on the board.** With 100-150 ms installed, the same two-minute watch from the same Mac:
+
+| | arrivals in 120 s | mean spacing | worst silence | silences ≥ 8 s |
+|---|---|---|---|---|
+| 1.28 s, the default | 16 | 7.5 s | 30.8 s | 7 |
+| 100-150 ms | 151 | 0.8 s | 3.8 s | **0** |
+
+Nine times as often, and — the part that matters — nothing left within a factor of two of `btctl`'s
+eight-second window, so the failure it was diagnosed from cannot occur. The robot went from 34th of
+106 devices heard to 7th of 74.
 
 ## 5. Pairing: just-works, and a PIN the transport checks
 

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -276,6 +276,47 @@ Also worth knowing: a single snapshot taken after a fixed sleep is not enough. A
 periodic and the adapter's view of a bonded peripheral comes and goes, so poll until a candidate
 appears.
 
+### 3.4 The robot has to advertise often enough to be caught  · **measured**
+
+`btctl` reported `no robot found` on roughly half its runs, and for a while that was read as flakiness
+in the tool — or as the gamepad, whose LE link shares the radio. It was neither. `btd` registered its
+advertisement without an interval, so BlueZ used the kernel's default of **1.28 s**, and a central
+scanning at a low duty cycle does not catch a 1.28 s advertiser reliably.
+
+Measured from a Mac scanning continuously for two minutes, counting arrivals per device:
+
+| device | signal | arrivals in 120 s |
+|---|---|---|
+| smart plug | −66 dBm | 130 |
+| beacon | −91 dBm | 159 |
+| the robot | **−36 dBm** | **16** |
+
+The robot was the strongest signal in the room and was heard an order of magnitude less often than
+anything else in it, so range, interference and the client were all ruled out rather than argued
+about. It arrived once every 7.5 s on average, with silences of 9 s, 14 s, 17 s and once 31 s; the
+large gaps came out as near-integer multiples of 1.28 s, which is what identified the interval from
+the arrivals. An eight-second scan landing in one of those silences finds nothing.
+
+Two things follow for the app.
+
+**A phone does not escape this by being a phone.** First connection is a scan, so onboarding hits the
+same silences — and that is the moment a robot has to be findable. What §3.3's
+`retrievePeripherals(withIdentifiers:)` buys is narrower than it looks: a stored identifier lets iOS
+connect *without* a fresh sighting, so reconnection degrades to latency instead of failure. It does
+nothing for the first connection, which is the one that matters most.
+
+**The advertising interval is a property of the robot, so it is `btd`'s to get right**: 100-150 ms,
+8-12× the default, which is what ordinary peripherals use. Not the 20 ms the spec allows — one antenna
+carries this, the gamepad's LE link and wifi, and airtime spent shouting comes out of what the robot
+is for.
+
+`btd/examples/advwatch.rs` is the measurement, kept because the claim is only checkable by re-running
+it: arrivals per device with signal strength, then the robot's silences.
+
+The diagnosis above is measured; **the interval that answers it is not yet confirmed on hardware.**
+Installing a release carrying it and re-running `advwatch` is the check, and the number to expect is a
+few hundred arrivals rather than sixteen.
+
 ## 5. Pairing: just-works, and a PIN the transport checks
 
 A six-digit PIN, stored by `configd`, checked by `btd` before it serves anything. **Not** by the


### PR DESCRIPTION
`btctl` reported `no robot found` on roughly half its runs. That was read as flakiness in the tool, and before that as the gamepad — whose LE link shares the radio. It was neither: the advertisement is registered without an interval, so BlueZ uses the kernel default of **1.28 s**, and a central scanning at a low duty cycle does not catch a 1.28 s advertiser reliably.

## The measurement

A Mac scanning continuously for two minutes, counting arrivals per device:

| device | signal | arrivals in 120 s |
|---|---|---|
| LP195 | −79 dBm | 212 |
| beacon | −91 dBm | 159 |
| smart plug | −66 dBm | 130 |
| **the robot** | **−36 dBm** | **16** |

The robot was the strongest signal in the room and was heard an order of magnitude less often than anything else in it — so range, interference and the client are ruled out rather than argued about. It arrived once every 7.5 s on average, with silences of 9 s, 14 s, 17 s and once 31 s. An eight-second scan landing in one of those finds nothing.

Two things confirmed it is the interval rather than loss: the large gaps are near-integer multiples of 1.28 s (24.06×, 13.05×, 12.03×, 11.02×, 9.06×, 7.02×), and `ActiveInstances` on the board stayed at `1` across 60 samples over the same window, so BlueZ was never dropping the advertisement.

## The change

100-150 ms, 8-12× the default and what ordinary peripherals use. Not the 20 ms floor the spec allows: one antenna carries this, the gamepad's LE link and wifi, so airtime spent shouting is taken from what the robot is for. A range rather than a single value so the controller can jitter inside it rather than colliding with the same neighbour's interval repeatedly.

BlueZ 5.82 on the board documents `MinInterval`/`MaxInterval` as optional and **not** experimental — checked, because `bluetoothd` there runs without `--experimental` — with an accepted range of 20 ms to 10,485 s. `bluer 0.17.4` maps both.

## Why this is not just a test-tool problem

A phone does not escape it by being a phone: first connection is a scan, so onboarding hits the same silences, and that is the moment a robot has to be findable. `retrievePeripherals(withIdentifiers:)` — §3.3's advice — lets iOS connect without a fresh sighting, so *reconnection* degrades to latency instead of failure. It does nothing for the first connection.

## Checked

- `cargo clippy -p btd --all-targets` clean for host and `aarch64-unknown-linux-gnu`.
- **The interval itself is not confirmed on hardware.** Install a release carrying it and re-run `cargo run -p btd --example advwatch -- <robot-name>`; the number to expect is a few hundred arrivals rather than sixteen.

`advwatch` is committed because that check is the only way to hold the claim: it prints arrivals per device with signal strength, a one-character-per-second timeline, and the gaps. Drop it from the PR if you would rather it lived outside the repo.