### PR TITLE
updaterd: check the restarts happened, and fix what did not

### DIFF
--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1082,6 +1082,46 @@ impl Engine {
     /// [`MAX_BOOT_ATTEMPTS`] boots, and delete staging leftovers. This is the path
     /// that catches a release which doesn't start at all — the in-process health
     /// gate can't, because it died with it.
+    /// Check that the restarts an update scheduled actually happened, and fix what did not.
+    ///
+    /// Runs at startup, beside [`Self::recover_on_start`], because that is the first moment the
+    /// answer exists: `updaterd` cannot watch its own replacement land, so the check belongs to the
+    /// successor. See [`crate::reconcile`] for why scheduling a restart is not evidence one
+    /// happened.
+    ///
+    /// Per component, since each has its own active release and ships its own units. Failures are
+    /// logged rather than returned, for the same reason the scheduling is: this must never be a
+    /// reason to refuse to serve.
+    pub async fn reconcile_running_units(&self) -> Vec<crate::reconcile::Finding> {
+        let mut findings = Vec::new();
+
+        for name in self.config.components.keys() {
+            let Ok(store) = self.store(name) else {
+                continue;
+            };
+            let Ok(Some(active)) = store.current() else {
+                // No active release: a component that has never been installed. Nothing to compare
+                // against, and nothing to fix.
+                continue;
+            };
+
+            let configured = match &self.config.components[name].on_apply {
+                ApplyAction::Restart { units } => units.clone(),
+                _ => Vec::new(),
+            };
+            // The *shipped* set rather than the restart set: `updaterd` and `btd` are excluded from
+            // an update's own restarts, which makes them the two this check exists for.
+            let units = units_shipped(&store.release_dir(&active), &configured);
+            if units.is_empty() {
+                continue;
+            }
+
+            findings.extend(crate::reconcile::check(SYSTEMCTL, &active, SELF_UNIT, units).await);
+        }
+
+        findings
+    }
+
     pub async fn recover_on_start(&mut self) -> Result<Vec<ApplyResult>, Error> {
         for name in self.config.components.keys().cloned().collect::<Vec<_>>() {
             if let Ok(store) = self.store(&name) {
@@ -1473,6 +1513,12 @@ impl Engine {
 /// The program that drives units. A constant so tests can substitute a stub for it.
 const SYSTEMCTL: &str = "systemctl";
 
+/// This process's own unit, which the reconciliation must recognise and never restart.
+///
+/// The bare name rather than `updaterd.service`, matching what [`units_shipped`] yields — it takes
+/// the file stem, and `systemctl` accepts either.
+const SELF_UNIT: &str = "updaterd";
+
 /// Restart one unit, skipping it if this board does not have it installed.
 ///
 /// `systemctl` is a parameter rather than hardcoded so a test can hand it a stub. That is the
@@ -1646,7 +1692,7 @@ const NEVER_RESTART: [&str; 2] = ["updaterd", "btd"];
 ///
 /// An unreadable or absent `systemd/` directory yields the configured list unchanged. Older releases
 /// predate the directory, and a rollback to one must still work.
-fn units_to_restart(release_dir: &Path, configured: &[String]) -> Vec<String> {
+fn units_shipped(release_dir: &Path, configured: &[String]) -> Vec<String> {
     let mut units: Vec<String> = Vec::new();
 
     match std::fs::read_dir(release_dir.join("systemd")) {
@@ -1678,6 +1724,13 @@ fn units_to_restart(release_dir: &Path, configured: &[String]) -> Vec<String> {
     // because the config and the release will usually name the same daemons.
     units.sort();
     units.dedup();
+    units
+}
+
+/// The subset an update restarts in flight: everything shipped, less the two it cannot touch while
+/// it is running.
+fn units_to_restart(release_dir: &Path, configured: &[String]) -> Vec<String> {
+    let mut units = units_shipped(release_dir, configured);
     units.retain(|unit| !NEVER_RESTART.contains(&unit.as_str()));
     units
 }

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -38,6 +38,7 @@ pub mod ipc;
 pub mod journal;
 pub mod manifest;
 pub mod preflight;
+pub mod reconcile;
 /// The IPC contract, re-exported from the [`duck_ipc_proto`] crate. Re-exported under this
 /// path so the engine's own code and `updater::proto::*` users need not care where it lives.
 pub use duck_ipc_proto as proto;

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -571,6 +571,23 @@ async fn serve(args: Args) -> ExitCode {
         }
     }
 
+    // After recovery, because recovery can change which release is active — checking before it
+    // would compare every unit against a version this robot is in the middle of abandoning.
+    //
+    // This is where a deferred restart that never happened gets caught. `updaterd` cannot observe
+    // its own restart, so the successor does it; see `updater::reconcile`.
+    let findings = engine.reconcile_running_units().await;
+    let stale = findings
+        .iter()
+        .filter(|f| f.verdict != updater::reconcile::Verdict::Current)
+        .count();
+    if stale == 0 {
+        tracing::info!(
+            units = findings.len(),
+            "every unit is on the active release"
+        );
+    }
+
     if args.check_only {
         tracing::info!("--check-only: recovery done, not serving");
         return ExitCode::SUCCESS;

--- a/updater/src/reconcile.rs
+++ b/updater/src/reconcile.rs
@@ -1,0 +1,226 @@
+//! Did the restarts an update scheduled actually happen?
+//!
+//! An update restarts the units a release ships, then — five seconds after its reply is on the wire
+//! — restarts the two it could not touch while running: itself, and `btd`, which may be carrying
+//! the reply. Both are scheduled through `systemd-run`, and **scheduling is all that is checked
+//! today.** `systemd-run` succeeding means a transient timer was created, not that the restart ran,
+//! and not that the new binary started. Failures are logged and swallowed on purpose, because an
+//! update that worked must not report failure over a restart it could not arrange.
+//!
+//! That leaves one way for a robot to end up running a release it did not install, and it is silent.
+//! This closes it: on every `updaterd` start, each unit's running binary is compared with the
+//! release its component has active, and anything stale is restarted.
+//!
+//! ## What it reads
+//!
+//! Each daemon publishes its own identity at startup — see [`duck_ipc_proto::Identity`] — so this
+//! reads a file rather than interrogating a process. A daemon that published nothing is *not* treated
+//! as stale: it is either stopped, or too old to publish, and restarting a robot's daemons because
+//! they are old is a decision nobody asked for. The next update makes them able to answer.
+//!
+//! ## Why startup is the right moment
+//!
+//! It is the first moment the answer can be trusted. `updaterd` cannot watch its own restart land —
+//! it is the process being replaced — so the check has to run in the *successor*, which is exactly
+//! what a fresh start is. It also catches everything, not merely a missed timer: a restart that
+//! failed, a new binary that would not start, a unit someone stopped mid-update, a rollback that
+//! left one daemon behind.
+//!
+//! At boot this is a no-op, since everything starts from the same symlink. It costs one file read
+//! per unit.
+//!
+//! ## Restarting rather than only reporting
+//!
+//! Reporting alone would leave a robot running the wrong code with a warning in a journal nobody is
+//! reading — the situation this exists to end. So a stale unit is restarted.
+//!
+//! **Except this one.** `updaterd` restarting itself here would be a loop if the new binary ever
+//! disagreed about what "current" is, and a loop in the process that owns recovery is the one
+//! failure with no way out. It is reported and left alone, which is safe: it has just started, so
+//! anything stale about it was decided before this code ran.
+
+use duck_ipc_proto as proto;
+
+/// What the check found for one unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub unit: String,
+    /// The release the running process was started from. `None` when the unit is stopped, or its
+    /// binary sits outside the release layout — a hand-built one on a dev board.
+    pub running: Option<semver::Version>,
+    pub expected: semver::Version,
+    pub verdict: Verdict,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Running the release its component has active.
+    Current,
+    /// Stale, and restarted.
+    Restarted,
+    /// Stale, and deliberately not restarted: `updaterd` must not restart itself from its own
+    /// startup path.
+    ReportedOnly,
+    /// Stale, and the restart failed. The journal has systemd's reason.
+    RestartFailed,
+    /// Nothing to compare: stopped, or running a binary outside the release layout.
+    Unknown,
+}
+
+/// Decide what to do about one unit, given what it is running and what it should be.
+///
+/// Pure, and separated from every syscall in this file for one reason: the decisions are the part
+/// that can be wrong, and they are impossible to arrange on a real board — a unit running a release
+/// that is not the active one is precisely the state that requires a broken update to produce.
+pub fn verdict_for(
+    running: Option<&semver::Version>,
+    expected: &semver::Version,
+    is_self: bool,
+) -> Verdict {
+    match running {
+        // A stopped unit is not a stale unit. Something stopped it deliberately, and starting it
+        // here would override that decision on every `updaterd` restart.
+        None => Verdict::Unknown,
+        Some(running) if running == expected => Verdict::Current,
+        Some(_) if is_self => Verdict::ReportedOnly,
+        Some(_) => Verdict::Restarted,
+    }
+}
+
+/// The release each unit is running, checked against what its component has active.
+///
+/// `systemctl` is a parameter for the same reason it is one in `engine`: a test hands it a stub. It
+/// is only used to *act* now — the reading is a file read, needing nothing.
+pub async fn check(
+    systemctl: &str,
+    expected: &semver::Version,
+    self_unit: &str,
+    units: Vec<String>,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for unit in units {
+        let running = running_release(&unit);
+        let is_self = unit == self_unit;
+        let mut verdict = verdict_for(running.as_ref(), expected, is_self);
+
+        if verdict == Verdict::Restarted {
+            tracing::warn!(
+                unit = %unit,
+                running = %running.as_ref().map(|v| v.to_string()).unwrap_or_default(),
+                %expected,
+                "still running the release it had before the update; restarting it now"
+            );
+            if let Err(e) = restart(systemctl, &unit).await {
+                tracing::error!(unit = %unit, error = %e, "could not restart it");
+                verdict = Verdict::RestartFailed;
+            }
+        } else if verdict == Verdict::ReportedOnly {
+            tracing::warn!(
+                unit = %unit,
+                running = %running.as_ref().map(|v| v.to_string()).unwrap_or_default(),
+                %expected,
+                "this process is not running the active release, and will not restart itself"
+            );
+        }
+
+        findings.push(Finding {
+            unit,
+            running,
+            expected: expected.clone(),
+            verdict,
+        });
+    }
+
+    findings
+}
+
+/// The release the unit's process says it is running.
+///
+/// From the identity the daemon published, so the answer comes from the process rather than from a
+/// path someone inferred — and needs no privilege, no D-Bus and no `/proc` read. `None` when nothing
+/// was published: stopped, or a build predating the mechanism.
+fn running_release(unit: &str) -> Option<semver::Version> {
+    let service = unit.strip_suffix(".service").unwrap_or(unit);
+    proto::read_identity(service)?.release()
+}
+
+async fn restart(systemctl: &str, unit: &str) -> Result<(), String> {
+    let status = tokio::process::Command::new(systemctl)
+        .arg("restart")
+        .arg(unit)
+        .status()
+        .await
+        .map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(status.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> semver::Version {
+        semver::Version::parse(s).expect("a test version")
+    }
+
+    /// The case this exists for: an update's deferred restart never happened, so `btd` is still on
+    /// the release it had before. Nothing else on the robot would ever say so.
+    #[test]
+    fn a_unit_left_on_the_old_release_is_restarted() {
+        assert_eq!(
+            verdict_for(Some(&v("0.3.0")), &v("0.4.0"), false),
+            Verdict::Restarted
+        );
+    }
+
+    /// A dev release differs from the stable one it precedes only in the prerelease suffix, and
+    /// both report the same crate version. Comparing the *release* rather than the build is what
+    /// makes those distinguishable at all.
+    #[test]
+    fn a_dev_release_is_not_the_stable_one_it_precedes() {
+        assert_eq!(
+            verdict_for(Some(&v("0.4.0-dev.271.7610e6e")), &v("0.4.0"), false),
+            Verdict::Restarted
+        );
+        assert_eq!(
+            verdict_for(
+                Some(&v("0.4.0-dev.271.7610e6e")),
+                &v("0.4.0-dev.271.7610e6e"),
+                false
+            ),
+            Verdict::Current
+        );
+    }
+
+    /// **`updaterd` must never restart itself from here.** If the successor disagreed about which
+    /// release is active it would restart, disagree again, and loop — in the one process that owns
+    /// recovery, so nothing would be left to break the cycle.
+    #[test]
+    fn updaterd_reports_itself_but_does_not_restart_itself() {
+        assert_eq!(
+            verdict_for(Some(&v("0.3.0")), &v("0.4.0"), true),
+            Verdict::ReportedOnly
+        );
+    }
+
+    /// A stopped unit is not a stale unit. Starting one here would override, on every `updaterd`
+    /// start, whoever stopped it — someone with no gamepad who disabled `padd`, most likely.
+    #[test]
+    fn a_stopped_unit_is_left_stopped() {
+        assert_eq!(verdict_for(None, &v("0.4.0"), false), Verdict::Unknown);
+    }
+
+    /// The matching case has to stay quiet: this runs on every start, and a check that acts when
+    /// nothing is wrong is a restart loop with extra steps.
+    #[test]
+    fn a_current_unit_is_left_alone() {
+        assert_eq!(
+            verdict_for(Some(&v("0.4.0")), &v("0.4.0"), false),
+            Verdict::Current
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #64 — it reuses the `/proc/<pid>/exe` mechanism from there. Review that one first.

**Scheduling a restart is not evidence one happened, and scheduling is all that was ever checked.** `systemd-run` returning success means a transient timer was created — not that the restart ran, not that the new binary started. Those failures are logged and swallowed on purpose, and rightly: an update that worked must not report failure over a restart it could not arrange.

That leaves exactly one way for a robot to end up running a release it did not install, and it is silent. It also lands on the two units with nothing watching them, because they are the two an update cannot restart while it is running: `updaterd` and `btd`.

## What it does

Every `updaterd` start compares each unit's running binary against the release its component has active, and restarts anything stale.

Startup is the first moment that answer can be trusted: `updaterd` cannot watch its own replacement land, so the check belongs to the successor. It catches more than a missed timer — a restart that failed, a binary that would not start, a unit stopped mid-update, a rollback that left one daemon behind. At boot it is a no-op, since everything starts from the same symlink, and it costs one `systemctl show` and one `readlink` per unit.

## Two things it deliberately does not do

- **It never restarts `updaterd` itself.** A successor that disagreed about which release is active would restart, disagree again, and loop — in the one process that owns recovery, so nothing would be left to break the cycle. Reported, not acted on, which is safe: it has just started, so anything stale about it was decided before this code ran.
- **It leaves a stopped unit stopped.** Someone stopped it. Starting it here would override that on every `updaterd` start — most likely against whoever has no gamepad and disabled `padd`.

## Restarting rather than only reporting

You asked for the check; this also fixes what it finds. Reporting alone leaves a robot running the wrong code with a warning in a journal nobody reads, which is the situation this exists to end. The acting part is one call site (`reconcile::check`) if you would rather it only reported.

## Notes

- `release_from_path` moves to `duck-ipc-proto` so `configd` and `updaterd` cannot drift on what a release path means. It is pure and needs only `semver`, which that crate already has.
- The decision is a pure function with the syscalls kept out of it, and that is the point: a unit running a release that is not the active one is a state only a broken update produces, so it cannot be arranged on a board and has to be testable without one. Five tests cover stale, dev-vs-stable suffixes, self, stopped, and current.
- Workspace suite green; clippy clean on host and `aarch64-unknown-linux-gnu`.
- **Not exercised on hardware** — it needs an install, and the interesting path needs an install whose restart failed.