### PR TITLE
One page for what restarts, and when

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -457,9 +457,10 @@ change fleet-wide.
 ## Versions, for support
 
 The question is always "what was running?", and on this robot it has **two answers at once**:
-`updaterd` never restarts itself during an update (`updater-design.md` §4.1), so the running
-binary legitimately lags the installed release until the next reboot. Anything reporting a single
-version number is therefore misleading.
+`updaterd` cannot restart itself mid-update (`updater-design.md` §4.1), so for a few seconds after
+one the running binary legitimately lags the installed release. Anything reporting a single version
+number is therefore misleading. If the lag outlives those seconds it is a fault, not the design —
+see `../docs/design/restart-order.md` §7.
 
 `robotctl version` reports both and flags the disagreement. It deliberately works when `updaterd`
 is **down**, reporting that as a line rather than exiting — that is when someone is most likely

--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -129,8 +129,8 @@ action = "restart"
 #     the progress stream and never learns the outcome. That is the whole app-driven flow, and
 #     it is why `updater/src/config.rs` has a test refusing to let btd appear here.
 #
-# Both therefore keep running the old binary until the next reboot. That is expected rather than
-# a fault, exactly as §8.3 describes for updaterd.
+# Neither waits for a reboot. Both are restarted 5s after the update replies, and the next updaterd
+# start checks that happened and fixes what did not (docs/design/restart-order.md §1 and §5).
 #
 # configd *is* restarted: it holds no long-lived session state, the progress stream a client
 # watches comes from updaterd rather than from it, and a config change that never takes effect

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ the bug.
 | [`architecture.md`](design/architecture.md) | The service split, the IPC contract, state ownership, safety and authority. |
 | [`robotd-design.md`](design/robotd-design.md) | The control loop: model, bus, sensing, observations, policy, safety. |
 | [`updater-design.md`](design/updater-design.md) | The update engine: verification, atomic swap, health gate, rollback, release format. |
+| [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 
 ## `project/` — you are running the project

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -533,10 +533,12 @@ itself.
   revisiting if `bluer` grows a `zbus` backend.
 - **A vendored libdbus** is ours to keep current rather than the distro's. Acceptable for a library
   reached only over a local socket by a daemon we wrote.
-- **`btd` is deliberately absent from `on_apply`'s restart set**, so it runs the old binary until
-  the next reboot. It may be the *transport the update was requested over*: restarting it drops the
-  connection carrying `update.subscribe`, and the phone that started the update never learns the
-  outcome. Same reason `updaterd` does not restart itself (§8.3).
+- **`btd` is deliberately absent from `on_apply`'s restart set.** It may be the *transport the update
+  was requested over*: restarting it drops the connection carrying `update.subscribe`, and the phone
+  that started the update never learns the outcome. Same reason `updaterd` does not restart itself
+  mid-update. The cost is bounded rather than open-ended — the exclusion expires once the reply is on
+  the wire, so the engine restarts `btd` 5 s later and the next `updaterd` start verifies that it
+  happened (`restart-order.md` §1 and §5).
 
 ## 8. Next
 
@@ -592,12 +594,7 @@ Directions, roughly in dependency order:
 `hello` should refuse only when the client is *newer* than the daemon —
 `install-path-gap.md` covers it. Small, self-contained, and it has already cost an hour twice.
 
-### 8.4 Derive the restart set from the release
-
-`on_apply`'s unit list lives in the board's own `updater.toml`, so a release that adds a daemon never
-restarts it and reports success anyway. `install-path-gap.md` §4 has the full account and the fix.
-
-### 8.5 PIN attempts across reconnects
+### 8.4 PIN attempts across reconnects
 
 §5.6. Three wrong PINs close the session; nothing counts across reconnects, so a peer retries
 indefinitely at the cost of a bond per three guesses. Needs somewhere to keep per-address state.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -407,14 +407,20 @@ case, not the ideal one.
 
 ### 8.3 The running version and the installed version are different questions
 
-`updaterd` never restarts itself during an update (`updater-design.md` §4.1), so **after
-every update the running binary legitimately lags the installed release until the next
-reboot**. Any tool reporting one version number is therefore wrong half the time, and wrong
-in the direction that makes a working robot look broken.
+`updaterd` cannot restart itself mid-update (`updater-design.md` §4.1), so for a few seconds
+after every update the running binary legitimately lags the installed release. Any tool
+reporting one version number is therefore wrong for that window, and wrong in the direction
+that makes a working robot look broken.
+
+Seconds, not "until a reboot": the engine schedules its own restart and `btd`'s 5 s after it
+replies, and the next `updaterd` start checks that those landed and restarts what did not
+(`restart-order.md` §5).
 
 `robotctl version` reports both and names the disagreement:
 
-- `updaterd` behind the installed release → expected, resolves at reboot;
+- `updaterd` behind the installed release → expected briefly, and the one skew nothing
+  self-heals: the successor reports it rather than restarting itself, so if it persists the
+  scheduled restart did not happen;
 - `robotd` behind it → *not* expected, because it is in `on_apply`'s restart set, so the
   restart did not take effect.
 

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -1,0 +1,354 @@
+# What restarts, and when
+
+The authoritative sequence for every path that moves the `current` symlink, and for boot. Written
+because "which daemon restarted, and at what point" has been answered three different ways from
+three different documents, and the answer decides how a skew is diagnosed.
+
+Everything here is read from the code, and each step names the function that owns it. Where a
+narrative comment elsewhere disagrees with this page, the comment is the bug.
+
+## 1. The five units
+
+A release ships five `systemd/*.service` files: `robotd`, `configd`, `btd`, `padd`, `updaterd`. All
+five `ExecStart` a path under `/opt/robot/daemon/current/bin/`, so all five are stale the instant the
+symlink moves, and each one is either restarted by the update or restarted after it.
+
+| unit | restarted mid-update | restarted ~5 s after the reply |
+|---|---|---|
+| `robotd` | yes | — |
+| `configd` | yes | — |
+| `padd` | yes | — |
+| `updaterd` | **never** — it is the process performing the update | yes |
+| `btd` | **never** — it may be the transport the update arrived over | yes |
+
+Both halves are one decision, and a test (`every_unit_held_back_is_restarted_once_the_answer_is_out`)
+asserts the two lists in `engine.rs` are the same set: `NEVER_RESTART` and `RESTART_AFTER_REPLYING`.
+
+Nothing is held back until a reboot. That was true before `RESTART_AFTER_REPLYING` existed and is the
+single most common stale claim about this system.
+
+And because scheduling a restart is not evidence that one happened, the next `updaterd` start checks
+each unit against the active release and restarts anything stale — §5.
+
+### How the set is computed
+
+Two sets, one function apart. `engine.rs::units_shipped` is everything the release provides:
+
+```
+(the release's own systemd/*.service stems)  ∪  (on_apply.units from /etc/robot/updater.toml)
+```
+
+sorted and deduplicated. `engine.rs::units_to_restart` is that, minus `NEVER_RESTART`:
+
+```
+units_shipped(…)  −  {updaterd, btd}
+```
+
+An update restarts `units_to_restart`; the startup check in §5 reads `units_shipped`, because the two
+units an update cannot touch are exactly the two it exists to watch.
+
+On today's release `units_to_restart` is exactly:
+
+```
+configd, padd, robotd
+```
+
+in that order — alphabetical, so the order is identical on every board and in every test.
+
+Two consequences of deriving it from the release rather than from the board:
+
+- `padd` is restarted even though `deploy/updater.toml` never mentions it. The config list is
+  **additive**, not authoritative; it only needs to name units the release does *not* ship.
+- A board whose `updater.toml` predates a daemon still restarts that daemon. That file belongs to the
+  operator and `install.sh` preserves it, which is how `configd` went unrestarted for a while
+  (`../project/install-path-gap.md` §4).
+
+Each unit is restarted by its own `systemctl restart <unit>` invocation, never batched — a single
+`systemctl restart a b` fails as a whole when either unit is unknown, *without* restarting the one
+that exists. A unit systemd reports as `LoadState=not-found` is skipped with a warning; a unit that
+exists and fails to restart **fails the update and rolls it back**.
+
+## 2. `robotctl update apply` / `update.apply` over BLE
+
+`engine.rs::apply` → `apply_inner` → `stage_and_swap` → `post_swap`. Nothing before step 8 touches a
+live path.
+
+| # | step | restarts anything? |
+|---|---|---|
+| 1 | preflight: clock, robot stopped, no live session | no |
+| 2 | fetch manifest, verify its signature, channel / pin / downgrade / compatibility checks | no |
+| 3 | preflight again, now for disk space (the requirement comes from the manifest) | no |
+| 4 | download to `releases/.staging-<ver>/dl/` | no |
+| 5 | verify sha256, then verify the artifact signature | no |
+| 6 | extract to `releases/.staging-<ver>/root/`, write `.updater-manifest.json` | no |
+| 7 | **`hooks/preinstall`** (cwd = the staged tree) — installs ONNX Runtime if below the floor | no |
+| 8 | `rename` the staged tree to `releases/<ver>/` | no |
+| 9 | arm the boot counter (`pending.json`), *before* the swap | no |
+| 10 | swap `current` → `releases/<ver>` | no |
+| 11 | **`hooks/postinstall`** (cwd = `releases/<ver>`) | **starts newly shipped units** |
+| 12 | `on_apply` — `systemctl restart` each unit from §1, one at a time | **configd, padd, robotd** |
+| 13 | `releases/<ver>/bin/updaterd --self-test` | no |
+| 14 | health gate: poll `robotd` over its socket, every 500 ms, up to 30 s | no |
+| 15 | confirm the boot counter, prune old releases | no |
+| 16 | release the update lock, schedule the deferred restarts | **schedules updaterd, btd** |
+| 17 | the reply goes out to `robotctl` / the app | — |
+| 18 | ~5 s after step 16 | **updaterd, btd** |
+
+Any failure from step 11 onward rolls back: swap `current` back, re-run `on_apply` against the
+previous release, confirm the boot counter, journal it. Steps 1–10 fail with the old release still
+live and nothing to undo.
+
+### Step 11 in detail — `hooks/postinstall`
+
+The hook ships inside the signed artifact and runs with the release directory as its cwd. In order:
+
+1. `install` every `systemd/sysusers.d/*.conf` to `/usr/lib/sysusers.d/`, then run
+   `systemd-sysusers`. Accounts before units, because a unit naming a missing `User=` fails to start
+   and reads as a broken daemon.
+2. `install` every `systemd/*.service` to `/etc/systemd/system/`, overwriting. **All five**, including
+   `updaterd.service` and `btd.service` — the hook has no exclusion list, and does not need one.
+3. `systemctl daemon-reload`.
+4. `systemctl enable --now` each of the five.
+
+Step 4 is why the exclusions in §1 still hold: `--now` means *start*, and starting an already-running
+unit is a no-op. It does not restart `updaterd` or `btd`. What it does do is start a unit the board
+has never had — which is the whole point of the hook, and means **a newly introduced daemon starts
+twice on the release that introduces it**: once here, then again at step 12.
+
+Every failure inside the hook is a warning except a failed `install` of a unit or sysusers file, which
+exits non-zero and therefore rolls the update back. A service that will not start is deliberately not
+fatal: `btd` legitimately fails on a board whose radio has not appeared yet.
+
+### Step 13 — the self-test
+
+`updaterd` does not restart itself during the update, so a replacement binary that cannot start would
+otherwise be discovered at the next boot, after the commit, with recovery living inside the process
+that is failing. Instead the *new* `bin/updaterd` is run with `--self-test`: it loads
+`/etc/robot/updater.toml`, constructs the engine, and exits before touching any state. 10 s ceiling.
+
+A failure is `Error::SelfTest` carrying the binary's last line of stderr, and rolls back. A release
+with no `bin/updaterd` (a model component) passes trivially. Skipped entirely unless `on_apply` is a
+restart, which is what keeps it out of the bootstrap install's way.
+
+### Steps 16–18 — the deferred restarts
+
+`engine.rs::schedule_deferred_restarts`, for `updaterd` then `btd`:
+
+```
+systemd-run --on-active=5s --timer-property=AccuracySec=100ms -- systemctl restart <unit>
+```
+
+Four details that are load-bearing:
+
+- **A transient unit, not a child process.** `systemctl restart updaterd` kills `updaterd`'s whole
+  cgroup, and a child of `updaterd` is *in* that cgroup — it would be killed partway through
+  restarting its own parent. A `systemd-run` timer lives outside it.
+- **The update lock is dropped first** (step 16, before the spawn). A fork duplicates every open
+  descriptor, so spawning while holding the lock hands a copy to the child.
+- **Only on `Applied`.** A rollback leaves the resident `updaterd` already matching `current`, so
+  restarting there would be churn with nothing to fix.
+- **Failures are logged, never returned.** An update that succeeded is not reported as failed because
+  a restart could not be scheduled; the cost of that is a daemon on an old binary until the next boot.
+
+The timer is scheduled *before* the reply is written (the engine runs inside the `update.apply` call),
+so the 5 s is measured from step 16, not from when the client sees the answer. A client sees its
+outcome and then a dropped connection — for BLE, an ordinary reconnect.
+
+### What the restarted `updaterd` then does
+
+It is a normal start, so it runs §4's startup sequence in full: `clean_staging`, `record_boot`, the
+reconciliation of §5 — which is where a `btd` restart that did not happen gets caught — then serve.
+Two things follow that are easy to miss:
+
+- **The boot counter counts `updaterd` starts, not literal boots.** A successful apply confirms its
+  own trial at step 15, so there is nothing outstanding to advance — but a trial left armed by an
+  *earlier* interrupted update is advanced by this restart.
+- **The periodic-check clock resets.** `INITIAL_CHECK_DELAY` is 60 s from process start, and
+  `check_interval` counts from there.
+
+## 3. The other transitions
+
+`select`, `rollback` and `reset-to-golden` share `engine.rs::transition_to`: arm, swap, `on_apply`,
+health gate, revert on failure. They do **not** run hooks and do **not** self-test — no artifact was
+extracted, so there is nothing new to install or prove.
+
+| | hooks | `on_apply` (configd, padd, robotd) | self-test | deferred updaterd/btd restart |
+|---|---|---|---|---|
+| `update apply` | yes | yes | yes | **yes** |
+| `update select <ver>` | no | yes | no | **yes** |
+| `update rollback` | no | yes | no | **no** |
+| `update reset-to-golden` | no | yes | no | **no** |
+| auto-rollback inside a failed apply | no | yes | no | **no** |
+| boot-counter revert at startup | no | yes | no | **no** |
+
+The two `no`s at the bottom are correct by construction: in a failed apply and in a boot-counter
+revert, `updaterd` and `btd` were never restarted, so they are still the binaries belonging to the
+release being returned to.
+
+The `no` for an explicit `rollback` / `reset-to-golden` is a different case and worth knowing:
+if the release being left was applied successfully at some earlier point, `updaterd` and `btd` *were*
+restarted onto it, and an explicit revert leaves them there. `robotd`, `configd` and `padd` move back;
+those two stay **ahead** of the active release.
+
+That resolves itself at the next `updaterd` start rather than at a reboot: §5 compares in both
+directions, so `btd` running a release newer than `current` is stale by the same test and gets
+restarted. `updaterd` is the one process that does not self-heal there, by design.
+
+Because `select` and the reverts skip `hooks/postinstall`, they also never *remove* a unit file. A
+downgrade to a release predating a daemon leaves that daemon's unit installed, pointing at a binary
+the older release does not contain; the unit fails, and since it is in the restart set, the failed
+restart fails the transition (`../project/install-path-gap.md`).
+
+## 4. At boot
+
+systemd starts all five units from `multi-user.target`. There is **no ordering between the daemons**
+beyond `padd` after `robotd` (advisory — `padd` exits and retries every 5 s if the socket is absent)
+and `btd` after `dbus`/`bluetooth`. Nothing waits on `updaterd`, and `updaterd` waits on nothing but
+`network-online.target`, which is `Wants` rather than `Requires`.
+
+On this board `hci0` does not exist until roughly 73 s after power-on, so `btd` retries for an
+adapter rather than failing.
+
+`updaterd`'s own startup, in order (`main.rs::serve`):
+
+1. Log the startup identity line at `warn` — version, revision, **`exe` path**, pid. The `exe` path is
+   what tells you which release directory the process actually came from.
+2. Load `/etc/robot/updater.toml` and the trusted keys. Either failing is fatal.
+3. Construct the engine.
+4. `--self-test` returns here, before any state is touched.
+5. `Engine::recover_on_start`, **before the socket is served**, so a robot that booted into a bad
+   release has already begun reverting by the time anything can ask it to do something else:
+   - `clean_staging` for every component: delete `releases/.staging-*`.
+   - `record_boot`: increment `boots` on every armed trial in `pending.json`.
+   - For each trial with `boots >= 2` (`MAX_BOOT_ATTEMPTS`): revert to `previous`, escalating to
+     `golden` when `previous` is absent, missing from disk, or itself recorded as rolled back. That
+     means swap the symlink, confirm the trial, and re-run `on_apply` — **so a boot-counter revert
+     restarts `configd`, `padd` and `robotd`.** It runs no hooks and schedules nothing, so the
+     `updaterd` and `btd` processes systemd has just launched are left running from the release being
+     abandoned. Step 6 then catches `btd`, since it runs after this and compares against the release
+     the revert made active; `updaterd` is reported and left, and is stale until the next boot.
+   - Journal the outcome. A failure here is logged and serving continues: refusing to serve would
+     remove the only way to fix it.
+6. `Engine::reconcile_running_units` — §5. **After** recovery, because recovery can change which
+   release is active, and before it a unit would be compared against a version the robot is in the
+   middle of abandoning. This step can restart units.
+7. `--check-only` returns here. Note that it *performs* both recovery and the reconciliation of step 6
+   — it is an operator tool, not a probe, and it can revert a release and restart daemons.
+8. Serve `/run/updaterd.sock`.
+9. If `check_interval` is set, spawn the scheduler: first pass 60 s after start, then every interval.
+   `auto_apply` decides what it may install with no client attached.
+
+A trial only exists if an apply was interrupted between step 9 and step 15 of §2 — a power cut, a
+`kill -9`, or a cancelled RPC after the swap. A committed update leaves nothing armed. And since
+`exhausted` is `boots >= 2` while `arm` writes `boots = 0`, the *first* `updaterd` start after the
+interruption logs "update still on trial" and the *second* reverts.
+
+## 5. The startup reconciliation — did the restarts happen?
+
+`systemd-run` returning success means a transient timer was created. It does not mean the restart ran,
+and it does not mean the new binary started; §2's step 16 swallows those failures on purpose. That
+leaves one silent way for a robot to end up running a release it did not install, and it lands on the
+two units nothing else watches. `updater/src/reconcile.rs` closes it.
+
+### What it reads
+
+Each daemon publishes its own identity at startup — `duck_ipc_proto::publish_identity`, called from
+the `log_startup_identity!` macro every daemon opens with:
+
+```
+/run/<service>/identity.json    { service, version, revision, built_at, exe, pid }
+```
+
+The `exe` field comes from `/proc/self/exe`, so it resolves through the `current` symlink and names
+the release directory the process was actually launched from. `Identity::release()` parses the
+`releases/<ver>` component out of it.
+
+Self-published rather than read from outside: a process knows its own version and revision and can
+read its own `exe` with no privilege, where reading another user's needs root. `RuntimeDirectory=<service>`
+in each unit creates the directory owned by that unit's `User=`, survives `ProtectSystem=strict`, and
+is **removed by systemd when the unit stops** — so a stopped daemon cannot leave behind an identity
+claiming to be running.
+
+### What it decides
+
+Per component, for each unit in `units_shipped` (§1) — so `updaterd` and `btd` are included, which is
+the point — compare the published release against the component's active release. `verdict_for` is a
+pure function; every syscall is kept outside it.
+
+| verdict | when | action |
+|---|---|---|
+| `Current` | published release == active | nothing, silently |
+| `Restarted` | they differ | `systemctl restart <unit>`, at `warn` |
+| `ReportedOnly` | they differ **and the unit is `updaterd`** | logged, never acted on |
+| `RestartFailed` | the restart was attempted and failed | logged at `error` |
+| `Unknown` | no identity file | nothing |
+
+Three deliberate non-actions:
+
+- **`updaterd` never restarts itself here.** A successor that disagreed about which release is active
+  would restart, disagree again, and loop — in the one process that owns recovery, so nothing would be
+  left to break the cycle. It is safe to only report: the process has just started, so anything stale
+  about it was decided before this code ran. This is the one skew that still needs a reboot or a
+  manual `systemctl restart updaterd`.
+- **A stopped unit is left stopped.** No identity file means either stopped or too old to publish, and
+  both read the same here. Starting it would override, on every `updaterd` start, whoever stopped it.
+- **A daemon that published nothing is not treated as stale.** Restarting a robot's daemons for being
+  old is a decision nobody asked for; the next update makes them able to answer.
+
+The comparison is direction-agnostic — any difference is stale — which is what makes it cover a
+release left *ahead* of `current` by an explicit rollback, not only one left behind.
+
+It runs on every `updaterd` start, so at boot it is a no-op: everything started from the same symlink.
+The cost is one file read per unit.
+
+## 6. First install
+
+`scripts/install.sh` on a bare board, in order (`main`):
+
+1. Write `/etc/robot/updater.toml` and the trusted keys.
+2. `bootstrap_first_release`: fetch a standalone `updaterd` binary and run
+   `updaterd install [--from <dir>]`. That is the ordinary `Engine::apply` with two settings forced,
+   because on a board with no release they are facts rather than policy: `on_apply = none` (the units
+   live inside the release being installed) and `health = none` (there is no `robotd` to probe).
+   So §2 runs with steps 12, 13 and 14 skipped — but **step 11 still runs**, and
+   `hooks/postinstall` is what installs the units and `enable --now`s all five. The daemons first
+   start there, from inside the hook. Step 16 is not skipped either: the bootstrap install schedules
+   the `updaterd` and `btd` restarts for 5 s later, while `install.sh` is still running.
+3. `install_units`: copy the units again, `daemon-reload`, then `enable --now` `updaterd`, `robotd`,
+   `configd`, `btd`, `padd` in that order — `configd` before `btd` because `btd` asks `configd` for the
+   pairing PIN. Redundant with the hook and harmless; it is also the path for a release older than the
+   hook. A unit the release ships that this function does not know is installed, reported, and left
+   alone.
+4. `install_token_dropin`: write the `GITHUB_TOKEN` drop-in, `daemon-reload`, and
+   `systemctl try-restart updaterd` — `daemon-reload` alone would leave the *running* `updaterd`
+   without the token, which is every board.
+
+`DUCK_FORCE_REINSTALL=1` adds `stop_for_reinstall` before step 2: `systemctl stop` on `padd`, `btd`,
+`configd`, `robotd`, `updaterd`, in that order. Nothing is live while the swap happens, and there is
+no health gate behind it.
+
+## 7. Diagnosing a skew
+
+Two version numbers are legitimately different at once, and which pair it is decides the diagnosis.
+
+| observation | means |
+|---|---|
+| `updaterd` or `btd` behind the installed release, for a few seconds after an update | expected — the deferred restart has not fired yet |
+| `btd`, `robotd`, `configd` or `padd` disagreeing with `current` at all, persistently | the restart did not take effect *and* §5 did not fix it — so either `updaterd` has not restarted since, or its restart failed (journal, at `error`) |
+| `updaterd` behind it, persistently | the deferred restart never landed, and §5 will not fix this one. `systemctl restart updaterd`, then read the journal for why |
+| any daemon reporting `build unknown (old)` | it predates the identity mechanism, so §5 leaves it alone. One update makes it answerable |
+
+Ask the robot rather than inferring:
+
+```bash
+robotctl health
+```
+
+The `units` block prints one line per daemon with the release its process was launched from, and warns
+when that disagrees with what is installed.
+
+By hand, the same answer from the file the daemon published:
+
+```bash
+cat /run/configd/identity.json; readlink /opt/robot/daemon/current
+```

--- a/docs/robot/cheatsheet-dev.md
+++ b/docs/robot/cheatsheet-dev.md
@@ -58,17 +58,16 @@ filter's only opt-in, it applies to the one command, and it leaves nothing switc
 
 ## After an update — the part that bites
 
-Three things are true at once, and together they cost an afternoon if you do not know them:
-
-- **`btd` is never restarted by an update.** Deliberate: restarting it drops the BLE connection
-  carrying the update's own progress stream. So a `btd` fix needs a manual restart or a reboot.
-- **`configd` used to be restarted only if the board's `/etc/robot/updater.toml` listed it** — that
-  file belongs to the operator and is preserved across installs, so a board set up before `configd`
-  existed kept `units = ["robotd"]` and silently ran the old binary. Fixed: the restart set now comes
-  from the units the release ships. A board running an older `updaterd` still has the old behaviour
-  until it restarts, because `updaterd` never restarts itself.
-- **`robotctl update apply` then reports `already_current` and does nothing**, so the obvious
-  recovery command is a no-op.
+- **`robotd`, `configd` and `padd` restart during the update. `updaterd` and `btd` restart 5 seconds
+  after it replies** — the first cannot restart itself mid-update, and the second may be carrying the
+  reply. So a `btd` fix is live a few seconds later, with no manual step. Reconnect and it is there.
+- **If one of those two restarts does not happen, the next `updaterd` start fixes it.** Except
+  `updaterd` itself, which reports the disagreement rather than restarting itself — that one is a
+  `systemctl restart updaterd` by hand.
+- **A board running an `updaterd` older than 0.4.0 has none of that** and keeps both on the old binary
+  until you restart them. One update fixes it, and only the update after that behaves.
+- **`robotctl update apply` reports `already_current` and does nothing** if you try to reinstall the
+  same version, so it is not the command to reach for when a fix looks absent.
 
 The symptom is a fix that is definitely installed and definitely not working. Ask which release each
 daemon is running:
@@ -81,21 +80,21 @@ The `units` block prints one line per daemon with the release its process was la
 warning naming the restart when that disagrees with what is installed. `build unknown (old)` means
 that daemon predates the release which taught it to say — restart it and it will answer.
 
+If a daemon is genuinely stale, restart it — this should not be necessary, so it is worth reading the
+journal for why it was:
+
 ```
 sudo systemctl restart configd
 ```
 
-```
-sudo systemctl restart btd
-```
-
-Editing the board's `updater.toml` is no longer needed — the restart set is derived from the release.
-The one thing that still requires a manual step is `updaterd` itself, which never restarts itself, so
-the fix above only takes effect once it has:
+`updaterd` is the one that never fixes itself:
 
 ```
 sudo systemctl restart updaterd
 ```
+
+Editing the board's `updater.toml` is not needed — the restart set comes from the units the release
+ships. `../design/restart-order.md` is the full sequence, step by step.
 
 ## From a laptop — `btctl`
 

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1626,8 +1626,8 @@ async fn schedule_restarts_if_applied(enabled: bool, outcome: &Result<ApplyResul
 ///
 /// Failures are logged, never returned. This runs after the update is committed and journalled; an
 /// update that succeeded must not be reported as failed because a restart could not be scheduled.
-/// The cost of that is the situation we already have today — a daemon running an old binary until
-/// the next boot — which `robotctl version` reports.
+/// Swallowing them is affordable because they are not the last word: [`crate::reconcile`] checks at
+/// the next start that each unit is on the active release and restarts what is not.
 async fn schedule_deferred_restarts() {
     for unit in RESTART_AFTER_REPLYING {
         let mut command = tokio::process::Command::new("systemd-run");
@@ -1649,12 +1649,14 @@ async fn schedule_deferred_restarts() {
             Ok(status) => tracing::warn!(
                 unit,
                 %status,
-                "could not schedule the restart; it keeps the old binary until the next boot"
+                "could not schedule the restart; it keeps the old binary until the next updaterd \
+                 start notices"
             ),
             Err(e) => tracing::warn!(
                 unit,
                 error = %e,
-                "could not run systemd-run; the unit keeps the old binary until the next boot"
+                "could not run systemd-run; the unit keeps the old binary until the next updaterd \
+                 start notices"
             ),
         }
     }

--- a/updater/updater.example.toml
+++ b/updater/updater.example.toml
@@ -123,7 +123,8 @@ manifest_asset = "manifest.json"
 #   - restarting itself would kill the executor mid-swap/mid-health-gate — the update
 #     would die at its most dangerous moment;
 #   - restarting `btd` would drop the connection reporting progress to the app.
-# Both pick up the new binary at the next boot, or an explicit later restart. This is
+# Neither waits for a reboot: both are restarted 5s after the update replies, and the next
+# updaterd start checks that happened (docs/design/restart-order.md §1 and §5). This is
 # why the updater must be resident and separate from `btd` (architecture.md §1.1).
 #
 # `mediad` is absent because it does not exist yet: naming a unit that isn't installed


### PR DESCRIPTION
Contradictory answers to "which daemon restarted, and at which point" have come out of five different documents. Two of them were what someone reads while diagnosing exactly that, and both told you to restart `btd` by hand — advice that outlived its mechanism by two PRs.

So: read the sequence out of the code once, put it on one page, and fix what disagreed with it.

## `docs/design/restart-order.md`

The whole path, step by step, each step naming the function that owns it:

- the shipped set (`units_shipped`) versus the restart set (`units_to_restart`), and why the difference is the point
- `apply` end to end, including what `hooks/postinstall`'s `enable --now` does and does not restart — it touches all five units and restarts none of the running ones
- the self-test, the 5 s deferred restarts, and the four load-bearing details of doing them through `systemd-run`
- what `select` / `rollback` / `reset-to-golden` each skip, as a table
- boot: no ordering between the daemons, then `updaterd`'s startup in order, and the boot counter counting `updaterd` *starts* rather than literal boots
- the startup reconciliation from #65, and the identity file from #64 it reads
- the first install, where the hook starts the daemons and `install.sh` starts them again
- how to tell an expected skew from a fault

Two things it states that were not written down anywhere. An explicit `robotctl update rollback` after a successful update leaves `updaterd` and `btd` *ahead* of the active release — no deferred restart is scheduled for a revert — and only `btd` self-heals at the next start. And `--check-only` now performs recovery *and* the reconciliation, so it can revert a release and restart daemons; it was already not a probe, and it is less of one now.

## The six places that still promised a reboot

`architecture.md` §8.3, `deploy/README.md`, `app-path-design.md` §7, `cheatsheet-dev.md`'s "after an update", `deploy/updater.toml`, `updater.example.toml` — plus the engine's own scheduling-failure log, which said the unit keeps the old binary until the next boot when it is the next `updaterd` start that picks it up.

Also drops `app-path-design.md` §8.4, which listed deriving the restart set from the release as future work.

## Notes

- Nothing here changes behaviour. The one code change is two log strings and a doc comment.
- `updater` builds clean.
- The `cheatsheet-dev.md` rewrite is the part worth reading as a user rather than as a reviewer: it now says what happens on its own, and keeps a manual `systemctl restart` only for `updaterd`, which genuinely never fixes itself.