### PR TITLE
A recovery path that does not go through updaterd

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -128,6 +128,7 @@ jobs:
             --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
+            --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "configd/systemd/configd.service=systemd/configd.service" \
             --include "btd/systemd/btd.service=systemd/btd.service" \
             --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -116,6 +116,7 @@ jobs:
             --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
+            --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "configd/systemd/configd.service=systemd/configd.service" \
             --include "btd/systemd/btd.service=systemd/btd.service" \
             --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -250,6 +250,36 @@ sudo robotctl update pin daemon
 
 The second form unpins.
 
+### When `updaterd` itself will not start
+
+Everything above goes through `updaterd`, so none of it works when `updaterd` is the daemon that is
+down. Check which one it is:
+
+```
+systemctl status updaterd robotd btd configd
+```
+
+Then go back to golden without it:
+
+```
+sudo robot-rescue --dry-run
+```
+
+```
+sudo robot-rescue --reboot
+```
+
+`--dry-run` says what it would do and changes nothing. Without `--reboot` it swaps the release and
+prints the reboot command rather than running it: every daemon execs through `current`, so nothing
+picks up the swap until it restarts, and a robot that is standing should be caught first.
+
+It declines, and says why, when no golden is configured or when `current` is already golden — if the
+daemons are failing on golden itself, a rollback is not the answer and the journal is:
+
+```
+journalctl -b -u robotd -u updaterd -u btd -u configd
+```
+
 ### Three things that are easy to get wrong
 
 **`rollback` needs a predecessor, but an update creates one.** A freshly provisioned board has

--- a/hooks/postinstall
+++ b/hooks/postinstall
@@ -30,8 +30,20 @@ set -eu
 
 UNIT_DIR=/etc/systemd/system
 SYSUSERS_DIR=/usr/lib/sysusers.d
+SBIN_DIR=/usr/local/sbin
 
 # Hooks run with the release directory as their working directory.
+
+# The rescue script, copied out for the same reason as the units below and one more: it is what an
+# operator runs when this release cannot start, so it must not be read through `current`. A warning
+# and not a failure — a release that cannot install its rescue script is still a release worth
+# having, and `install.sh` puts one there on a fresh board.
+if [ -f scripts/robot-rescue ]; then
+    mkdir -p "$SBIN_DIR"
+    install -m 755 scripts/robot-rescue "${SBIN_DIR}/robot-rescue" \
+        || echo "postinstall: cannot install robot-rescue; the board keeps the previous copy" >&2
+fi
+
 [ -d systemd ] || exit 0
 
 # Users and groups before units: a unit naming a `User=` that does not exist fails to start, and

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -638,6 +638,20 @@ install_units() {
     # purpose here: it is a tool an operator invokes, not a file systemd caches.
     ln -sfn "${INSTALL_DIR}/current/bin/robotctl" /usr/local/bin/robotctl
 
+    # `robot-rescue` on root's PATH, and *copied* — the opposite decision to `robotctl` above, for
+    # the same reason the units are copied. It exists for boards whose release cannot start, so
+    # reading it through `current` would route the rescue through the thing being rescued.
+    #
+    # Absent from releases predating it, which is every release on a first install from a branch.
+    src="${INSTALL_DIR}/current/scripts/robot-rescue"
+    if [ -f "$src" ]; then
+        mkdir -p /usr/local/sbin
+        install -m 755 "$src" /usr/local/sbin/robot-rescue
+    else
+        warn "the release carries no scripts/robot-rescue; a board whose daemons cannot start
+  has no recovery path that does not need updaterd. The next update installs it."
+    fi
+
     install_completions
 
     systemctl daemon-reload

--- a/scripts/robot-rescue
+++ b/scripts/robot-rescue
@@ -1,0 +1,156 @@
+#!/bin/sh
+# Put the board back on the golden release, without the update daemon.
+#
+# `robotctl update rollback` and `reset-to-golden` are IPC calls into `updaterd`. That is fine for
+# every failure except the one that matters most: a release whose `updaterd` cannot start. Recovery
+# then lives inside the process that is failing to start, `Restart=` gives up, and a board with a
+# perfectly good older release on disk has no way back to it — not even for a human at a console.
+# This is that way back.
+#
+# WHY THIS IS A SHELL SCRIPT, AND WHY IT IS COPIED OUT OF THE RELEASE. A rescue that ships as a
+# binary in the release payload is broken by exactly the releases it exists to survive: the wrong
+# architecture, a missing shared library, a panic on startup. `install.sh` and `hooks/postinstall`
+# copy this into /usr/local/sbin the way they already copy unit files, and for the same reason — the
+# copy that runs must not change under anyone's feet when `current` moves.
+#
+# WHY IT READS SYMLINKS AND PARSES NOTHING. The likeliest thing this rescues is a release whose
+# `updaterd` rejects the board's `updater.toml` — the operator's file, preserved across installs,
+# while a release is free to change what it expects. A rescue that parses that same file dies of the
+# disease it is treating. `updaterd` publishes golden as a symlink on every start
+# (`Engine::refresh_golden_links`) so that the answer is one `readlink` away and survives the daemon.
+#
+# There is no loop guard here yet, on purpose: nothing invokes this automatically, and a human is
+# rate-limited by being a human. The guard arrives with the boot-deadline timer that calls it — see
+# `docs/project/boot-recovery-net.md`.
+#
+# Usage:  robot-rescue [--dry-run] [--reboot]
+#
+# Exit: 0 swapped (or would have), 2 declined with nothing to do, 1 something went wrong.
+set -eu
+
+# Overridable so the decision can be tested against a temporary tree. The defaults are the only
+# values a board ever uses; `install.sh` hardcodes the same install dir.
+INSTALL_DIR="${ROBOT_INSTALL_DIR:-/opt/robot/daemon}"
+STATE_DIR="${ROBOT_STATE_DIR:-/var/lib/robot/updater}"
+
+DRY_RUN=
+REBOOT=
+
+# Reboot is opt-in, not the default. The units all exec through `current`, so nothing picks up the
+# swap until they restart — but this script is also runnable on a board that is merely suspect, and
+# a robot that is standing when its daemons die is a robot that falls. Whoever is holding it decides.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --reboot)  REBOOT=1 ;;
+        -h|--help)
+            cat <<'USAGE'
+usage: robot-rescue [--dry-run] [--reboot]
+
+Point /opt/robot/daemon/current at the golden release, without going through updaterd.
+For a board whose daemons will not start: see docs/project/boot-recovery-net.md.
+
+  --dry-run   report the decision and change nothing
+  --reboot    reboot after the swap, instead of printing the command
+
+Exit: 0 swapped (or would have), 2 declined with nothing to do, 1 something went wrong.
+USAGE
+            exit 0
+            ;;
+        *)
+            echo "robot-rescue: unknown argument: $1" >&2
+            echo "usage: robot-rescue [--dry-run] [--reboot]" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+say() {
+    echo "robot-rescue: $*" >&2
+    # The journal is where an operator looks after the fact, and after a reboot it is the only
+    # place left. Optional because a board without `logger` must still be rescuable.
+    command -v logger >/dev/null 2>&1 && logger -t robot-rescue "$*"
+    return 0
+}
+
+decline() {
+    say "$*"
+    exit 2
+}
+
+golden_link="${INSTALL_DIR}/golden"
+current_link="${INSTALL_DIR}/current"
+
+# No golden means no rollback target. That is the state of every board until 1.0.0 exists, so it is
+# a declined run and not an error — but say which of the two reasons it is, because "unset in
+# updater.toml" and "updaterd has not started since it was set" need different fixes.
+[ -L "$golden_link" ] || decline "no golden release published at ${golden_link}.
+  Set \`golden\` for the daemon component in /etc/robot/updater.toml, then restart updaterd —
+  it publishes the symlink on every start. If it is already set, updaterd has not started since."
+
+golden_target="$(readlink "$golden_link")"
+golden_version="$(basename "$golden_target")"
+[ -d "${INSTALL_DIR}/${golden_target}" ] || decline \
+    "golden names ${golden_version}, which is not installed at ${INSTALL_DIR}/${golden_target}."
+
+# A missing `current` is not an obstacle: a board with no live release is exactly a board that
+# should be put on golden.
+if [ -L "$current_link" ]; then
+    current_version="$(basename "$(readlink "$current_link")")"
+else
+    current_version="(none)"
+fi
+
+# Already on golden means the daemons are failing on the release that carries the standing
+# guarantee, so this cannot be a release fault. Swapping would change nothing and reboot anyway,
+# which is how a hardware fault becomes a reboot loop.
+[ "$current_version" != "$golden_version" ] || decline \
+    "current is already golden (${golden_version}); a rollback cannot fix this.
+  Look at what the failing daemon says:  journalctl -b -u robotd -u updaterd -u btd -u configd"
+
+if [ -n "$DRY_RUN" ]; then
+    say "would swap current from ${current_version} to golden ${golden_version}"
+    exit 0
+fi
+
+# The requirement rather than a proxy for it: on a board only root can write here, and testing
+# what the next four lines actually need keeps the swap exercisable against a temporary tree.
+[ -w "$INSTALL_DIR" ] || { echo "robot-rescue: ${INSTALL_DIR} is not writable; run as root" >&2; exit 1; }
+
+# The breadcrumb before the swap, matching the order the engine arms its boot counter in: a record
+# of an attempt that did not happen is recoverable, a swap nothing recorded is not. Outside
+# `install_dir`, so it survives the swap it is describing.
+mkdir -p "$STATE_DIR"
+printf '%s rescued from %s to golden %s\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$current_version" "$golden_version" \
+    >> "${STATE_DIR}/rescued"
+
+# `ln -sfn` unlinks and recreates, which leaves a window where `current` does not exist — and a
+# daemon starting in that window fails to exec. Rename over the top instead: `rename(2)` within one
+# directory is atomic, which is what `Store::link_to` does for the same reason.
+#
+# `rename(2)` does not follow symlinks, but `mv`'s own path resolution does: `current` points at a
+# directory, so plain `mv tmp current` moves the temporary link *into* releases/<version> and leaves
+# `current` untouched. GNU spells the fix `-T`, BSD spells it `-h`, and neither accepts the other's
+# flag — the board is GNU, and a laptop running the tests is not.
+tmp="${INSTALL_DIR}/.current.tmp"
+rm -f "$tmp"
+ln -s "$golden_target" "$tmp"
+if mv --version >/dev/null 2>&1; then
+    mv -fT "$tmp" "$current_link"
+else
+    mv -fh "$tmp" "$current_link"
+fi
+sync
+
+say "current is now golden ${golden_version} (was ${current_version})"
+
+if [ -z "$REBOOT" ]; then
+    say "nothing has restarted yet: every unit execs through current.
+  Reboot when the robot is safe to drop:  systemctl reboot"
+    exit 0
+fi
+
+say "rebooting onto ${golden_version}"
+systemctl reboot

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1089,6 +1089,8 @@ impl Engine {
             }
         }
 
+        self.refresh_golden_links();
+
         // Every component's trial advances, independently. A model transition must
         // not consume or clear a daemon update's budget.
         let mut outcomes = Vec::new();
@@ -1214,6 +1216,47 @@ impl Engine {
     fn store(&self, component: &str) -> Result<Store, Error> {
         let cfg = self.config.component(component)?;
         Ok(Store::new(cfg.install_dir.clone()))
+    }
+
+    /// Publish each component's configured golden release as a `golden` symlink.
+    ///
+    /// `scripts/robot-rescue` runs when `updaterd` does not, so it cannot ask this process for
+    /// golden and must not parse `updater.toml` to find it — a release whose `updaterd` rejects
+    /// that file is the likeliest thing the rescue exists for. The link is how the answer survives
+    /// the daemon.
+    ///
+    /// Never fatal. Failing to publish golden loses the rescue path; refusing to start over it
+    /// loses the update path as well, which is strictly worse.
+    fn refresh_golden_links(&self) {
+        for (name, cfg) in &self.config.components {
+            let Some(golden) = &cfg.golden else {
+                continue;
+            };
+            let store = Store::new(cfg.install_dir.clone());
+
+            // A configured golden that is not installed is not a rollback target, and a dangling
+            // link would make the rescue believe otherwise. Loud, because it means the never-brick
+            // guarantee is currently void on this board — `prune` protects golden once it is here,
+            // but nothing installs it retroactively.
+            if !store.release_dir(golden).is_dir() {
+                tracing::warn!(
+                    component = %name,
+                    version = %golden,
+                    "golden is configured but not installed; no rollback target for the recovery path"
+                );
+                continue;
+            }
+
+            match store.mark_golden(golden) {
+                Ok(()) => tracing::debug!(component = %name, version = %golden, "golden published"),
+                Err(e) => tracing::warn!(
+                    component = %name,
+                    version = %golden,
+                    error = %e,
+                    "could not publish the golden symlink; robot-rescue will decline to act"
+                ),
+            }
+        }
     }
 
     /// The manifest kept inside an installed release, if it's readable.

--- a/updater/src/store.rs
+++ b/updater/src/store.rs
@@ -31,6 +31,18 @@ const RELEASES_DIR: &str = "releases";
 /// Symlink consumers read through.
 const CURRENT_LINK: &str = "current";
 
+/// Symlink naming the release with a standing known-good guarantee.
+///
+/// A cache of `ComponentConfig::golden`, refreshed on every `updaterd` start, and it exists for
+/// one reader: `scripts/robot-rescue`, which runs when `updaterd` does not. The rescue path must
+/// not parse `updater.toml`, because a release whose `updaterd` rejects that file is the likeliest
+/// thing it has to rescue — so golden has to be readable with one `readlink` and no parser.
+///
+/// A cache rather than a second source of truth, and it fails safe: if `updaterd` stops starting,
+/// the link is stale but still names a release that was golden when it was last written, which is a
+/// release that was known good.
+const GOLDEN_LINK: &str = "golden";
+
 pub struct Store {
     root: PathBuf,
 }
@@ -47,6 +59,11 @@ impl Store {
     /// Path of the symlink consumers read through.
     pub fn link_path(&self) -> PathBuf {
         self.root.join(CURRENT_LINK)
+    }
+
+    /// Path of the golden symlink. See [`GOLDEN_LINK`].
+    pub fn golden_link_path(&self) -> PathBuf {
+        self.root.join(GOLDEN_LINK)
     }
 
     pub fn release_dir(&self, version: &semver::Version) -> PathBuf {
@@ -68,13 +85,25 @@ impl Store {
     /// `Ok(None)` when the link is absent (a fresh robot) or dangling — both are
     /// recoverable states, not errors.
     pub fn current(&self) -> Result<Option<semver::Version>, Error> {
-        let link = self.link_path();
-        let target = match fs::read_link(&link) {
+        self.link_version(&self.link_path())
+    }
+
+    /// Version the golden symlink points at, if it has been written.
+    ///
+    /// `Ok(None)` on a board whose `updater.toml` sets no golden, which is every board until 1.0.0
+    /// exists — the same answer as for a link that is absent, because the two are the same
+    /// situation to anything that has to decide whether a rollback target exists.
+    pub fn golden(&self) -> Result<Option<semver::Version>, Error> {
+        self.link_version(&self.golden_link_path())
+    }
+
+    fn link_version(&self, link: &Path) -> Result<Option<semver::Version>, Error> {
+        let target = match fs::read_link(link) {
             Ok(t) => t,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => {
                 return Err(Error::Io {
-                    path: link,
+                    path: link.to_path_buf(),
                     source: e,
                 });
             }
@@ -113,13 +142,27 @@ impl Store {
         Ok(versions)
     }
 
-    /// Point the symlink at `version` atomically.
+    /// Point `current` at `version` atomically.
+    pub fn swap_to(&self, version: &semver::Version) -> Result<(), Error> {
+        self.link_to(CURRENT_LINK, version)
+    }
+
+    /// Point `golden` at `version`, so the rescue path can find it without a parser.
+    ///
+    /// Idempotent, and called on every `updaterd` start rather than only when golden changes:
+    /// the link has to appear on boards that already have a golden configured, and re-writing a
+    /// symlink that already says the right thing costs one `rename`.
+    pub fn mark_golden(&self, version: &semver::Version) -> Result<(), Error> {
+        self.link_to(GOLDEN_LINK, version)
+    }
+
+    /// Point one of this store's symlinks at `version` atomically.
     ///
     /// Writes a temporary symlink beside the real one and `rename`s it over the
     /// top: `rename(2)` on the same directory is atomic, so a concurrent reader
     /// sees either the old target or the new one, never a missing link. Removing
     /// and recreating the symlink would open exactly that window.
-    pub fn swap_to(&self, version: &semver::Version) -> Result<(), Error> {
+    fn link_to(&self, name: &str, version: &semver::Version) -> Result<(), Error> {
         let release = self.release_dir(version);
         if !release.is_dir() {
             return Err(Error::Corrupt(format!(
@@ -132,8 +175,8 @@ impl Store {
         // moves (and so it reads sensibly in a shell).
         let target = Path::new(RELEASES_DIR).join(version.to_string());
 
-        let link = self.link_path();
-        let tmp = self.root.join(format!(".{CURRENT_LINK}.tmp"));
+        let link = self.root.join(name);
+        let tmp = self.root.join(format!(".{name}.tmp"));
 
         // A leftover tmp link from a crashed run must not block the swap.
         let _ = fs::remove_file(&tmp);
@@ -151,10 +194,11 @@ impl Store {
             }
         })?;
 
-        // Durability, not just atomicity. The boot counter is armed before this
-        // swap; if the swap reached disk and the pending record did not, a power cut
-        // would leave a bad release live with no trial to revert it — the one state
-        // §7 says cannot happen.
+        // Durability, not just atomicity. For `current`: the boot counter is armed before the
+        // swap, so if the swap reached disk and the pending record did not, a power cut would
+        // leave a bad release live with no trial to revert it — the one state §7 says cannot
+        // happen. For `golden`: a link that did not survive the power cut is a rescue that has
+        // nothing to aim at, on a board that just lost power mid-update.
         crate::fsutil::fsync_parent(&link)
     }
 
@@ -289,6 +333,37 @@ mod tests {
         // And back, which is the rollback path.
         store.swap_to(&v("1.0.0")).unwrap();
         assert_eq!(store.current().unwrap(), Some(v("1.0.0")));
+    }
+
+    /// `golden` is a second link in the same directory, and the two must not interfere: the rescue
+    /// reads golden precisely when `current` has been swapped to something that will not start.
+    #[test]
+    fn golden_is_published_independently_of_current() {
+        let (_dir, store) = scratch();
+        fs::create_dir_all(store.release_dir(&v("1.0.0"))).unwrap();
+        fs::create_dir_all(store.release_dir(&v("1.1.0"))).unwrap();
+
+        assert_eq!(store.golden().unwrap(), None, "nothing published yet");
+
+        store.mark_golden(&v("1.0.0")).unwrap();
+        store.swap_to(&v("1.1.0")).unwrap();
+
+        assert_eq!(store.golden().unwrap(), Some(v("1.0.0")));
+        assert_eq!(store.current().unwrap(), Some(v("1.1.0")));
+
+        // Called on every `updaterd` start, so re-publishing the same answer has to be a no-op
+        // rather than an error.
+        store.mark_golden(&v("1.0.0")).unwrap();
+        assert_eq!(store.golden().unwrap(), Some(v("1.0.0")));
+    }
+
+    /// A dangling `golden` would tell the rescue it has a target when it does not, and swapping
+    /// onto it leaves a board that can exec nothing at all.
+    #[test]
+    fn marking_golden_refuses_a_release_that_is_not_installed() {
+        let (_dir, store) = scratch();
+        assert!(store.mark_golden(&v("9.9.9")).is_err());
+        assert_eq!(store.golden().unwrap(), None);
     }
 
     #[test]

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -1280,6 +1280,56 @@ async fn failed_transition_leaves_no_armed_trial() {
     assert!(engine.recover_on_start().await.unwrap().is_empty());
 }
 
+/// `scripts/robot-rescue` runs when `updaterd` does not, so it cannot ask this process which
+/// release is golden and must not parse `updater.toml` to find out — a release whose `updaterd`
+/// rejects that file is the likeliest thing it exists to rescue. Every start publishes the answer
+/// as a symlink instead.
+#[tokio::test]
+async fn starting_up_publishes_golden_as_a_symlink() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    fx.publish("1.1.0", None);
+
+    let mut engine = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults::none(),
+        r#"golden = "1.0.0""#,
+    );
+    apply_exact(&mut engine, "1.0.0").await.unwrap();
+    apply_latest(&mut engine).await.unwrap();
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+
+    engine.recover_on_start().await.unwrap();
+
+    assert_eq!(
+        std::fs::read_link(fx.install.join("golden")).unwrap(),
+        std::path::Path::new("releases/1.0.0"),
+        "golden must be published relative, like `current`, so the tree survives a moved mount"
+    );
+}
+
+/// A configured golden that was never installed is not a rollback target. A link pointing at it
+/// would tell the rescue otherwise, and swapping onto it leaves a board that can exec nothing.
+#[tokio::test]
+async fn a_golden_that_is_not_installed_is_not_published() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+
+    let mut engine = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults::none(),
+        r#"golden = "9.9.9""#,
+    );
+    apply_latest(&mut engine).await.unwrap();
+
+    engine.recover_on_start().await.unwrap();
+
+    assert!(
+        !fx.install.join("golden").exists(),
+        "a dangling golden link is worse than none"
+    );
+}
+
 /// **#7** `select` on a version that isn't installed reported UNKNOWN_COMPONENT,
 /// telling clients the wrong thing — the component exists, the version doesn't.
 #[tokio::test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -354,8 +354,10 @@ fn package(args: PackageArgs) -> Result<(), Box<dyn std::error::Error>> {
             let (src, dest) = include
                 .split_once('=')
                 .ok_or_else(|| format!("--include expects src=dest, got {include:?}"))?;
-            // Hooks must be executable; everything else needn't be.
-            let mode = if dest.starts_with("hooks/") {
+            // Hooks and scripts must be executable; everything else needn't be. `scripts/` is
+            // there for `robot-rescue`, which an operator may well run straight out of the
+            // release directory on a board where nothing else works.
+            let mode = if dest.starts_with("hooks/") || dest.starts_with("scripts/") {
                 0o755
             } else {
                 0o644

--- a/xtask/tests/artifact.rs
+++ b/xtask/tests/artifact.rs
@@ -211,6 +211,22 @@ fn the_artifact_carries_what_install_sh_reads() {
              /usr/local/bin/robotctl at nothing"
         );
 
+        // `install -m 755 .../current/scripts/robot-rescue /usr/local/sbin/robot-rescue`, which
+        // `hooks/postinstall` repeats on every update. Executable in the artifact as well as at the
+        // destination: a board where nothing else works is a board where someone runs it in place.
+        let (mode, _) = entries.get("scripts/robot-rescue").unwrap_or_else(|| {
+            panic!(
+                "{workflow}'s artifact has no scripts/robot-rescue, so a board whose release \
+                 cannot start has no recovery path that does not go through updaterd"
+            )
+        });
+        assert_eq!(
+            mode & 0o111,
+            0o111,
+            "{workflow} packages scripts/robot-rescue with mode {mode:o}; an operator runs it \
+             out of the release directory"
+        );
+
         // install.sh globs `current/systemd/*.service` rather than asserting a list, so a unit
         // landing anywhere else is silently not installed.
         let units: Vec<&String> = entries

--- a/xtask/tests/rescue.rs
+++ b/xtask/tests/rescue.rs
@@ -1,0 +1,281 @@
+//! What `scripts/robot-rescue` decides, exercised against a temporary tree.
+//!
+//! The rescue path is the code that has to work when everything else does not, and it is the code
+//! least amenable to a test: on a real board it only runs when a release cannot start. So the
+//! decision is deliberately a pure function of two symlinks — `current` and `golden` — and the
+//! script takes `ROBOT_INSTALL_DIR`/`ROBOT_STATE_DIR` from the environment so that function can be
+//! asked every question here, on a laptop, with no systemd and no board.
+//!
+//! In `xtask` because this tests a *repository script* rather than any crate's behaviour, which is
+//! what the rest of this directory is for. `sh` and not `bash`: the script runs on a board where
+//! the interpreter is whatever `/bin/sh` is, and the flag detection inside it (`mv -T` on GNU,
+//! `mv -h` on BSD) exists precisely because the same script has to work here and there.
+//!
+//! What is *not* covered: whether anything ever calls it. Nothing does yet — see
+//! `docs/project/boot-recovery-net.md` for the boot deadline that will.
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// A board tree: `releases/<version>` directories, and whichever symlinks the case needs.
+struct Board {
+    dir: tempfile::TempDir,
+}
+
+impl Board {
+    fn with_releases(versions: &[&str]) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for version in versions {
+            std::fs::create_dir_all(dir.path().join("releases").join(version)).expect("release");
+        }
+        std::fs::create_dir_all(dir.path().join("state")).expect("state dir");
+        Self { dir }
+    }
+
+    fn install(&self) -> PathBuf {
+        self.dir.path().to_path_buf()
+    }
+
+    fn state(&self) -> PathBuf {
+        self.dir.path().join("state")
+    }
+
+    /// Link `name` at a release the way the store does: a target relative to the install dir.
+    fn link(&self, name: &str, version: &str) -> &Self {
+        symlink(
+            Path::new("releases").join(version),
+            self.dir.path().join(name),
+        )
+        .expect("symlink");
+        self
+    }
+
+    fn link_target(&self, name: &str) -> Option<String> {
+        std::fs::read_link(self.dir.path().join(name))
+            .ok()
+            .map(|t| t.to_string_lossy().into_owned())
+    }
+
+    fn breadcrumb(&self) -> Option<String> {
+        std::fs::read_to_string(self.state().join("rescued")).ok()
+    }
+
+    /// Run the script, with a stub `systemctl` on `PATH` recording whatever it is asked to do.
+    fn rescue(&self, args: &[&str]) -> Rescue {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent")
+            .join("scripts/robot-rescue");
+
+        let stub_dir = self.dir.path().join("stub");
+        std::fs::create_dir_all(&stub_dir).expect("stub dir");
+        let log = stub_dir.join("systemctl.log");
+        std::fs::write(
+            stub_dir.join("systemctl"),
+            format!("#!/bin/sh\necho \"$@\" >> {}\n", log.display()),
+        )
+        .expect("stub");
+        std::fs::set_permissions(
+            stub_dir.join("systemctl"),
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o755),
+        )
+        .expect("stub mode");
+
+        let output = Command::new("sh")
+            .arg(&script)
+            .args(args)
+            .env("ROBOT_INSTALL_DIR", self.install())
+            .env("ROBOT_STATE_DIR", self.state())
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    stub_dir.display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .output()
+            .expect("run robot-rescue");
+
+        Rescue {
+            output,
+            systemctl: std::fs::read_to_string(&log).unwrap_or_default(),
+        }
+    }
+}
+
+struct Rescue {
+    output: Output,
+    systemctl: String,
+}
+
+impl Rescue {
+    fn code(&self) -> i32 {
+        self.output.status.code().expect("exited")
+    }
+
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.output.stderr).into_owned()
+    }
+}
+
+/// No golden means no rollback target, which is every board until 1.0.0 exists. Declining is the
+/// answer, and it has to name both reasons: unset in the config, or set but never published.
+#[test]
+fn declines_when_no_golden_is_published() {
+    let board = Board::with_releases(&["1.2.0"]);
+    board.link("current", "1.2.0");
+
+    let run = board.rescue(&[]);
+
+    assert_eq!(run.code(), 2, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("no golden release published"));
+    assert!(
+        run.stderr().contains("updater.toml"),
+        "an operator needs to be told where golden is set: {}",
+        run.stderr()
+    );
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+}
+
+/// A configured golden that was pruned or never installed. The link resolves to nothing, and
+/// swapping onto it would leave `current` pointing at an empty path — a board that cannot exec
+/// anything at all, which is worse than the failure being rescued.
+#[test]
+fn declines_when_golden_is_not_installed() {
+    let board = Board::with_releases(&["1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    let run = board.rescue(&[]);
+
+    assert_eq!(run.code(), 2, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("not installed"), "{}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+}
+
+/// The check that keeps a hardware fault from becoming a reboot loop: if the daemons are down on
+/// the release carrying the standing guarantee, this is not a release fault and a swap changes
+/// nothing except adding a reboot.
+#[test]
+fn declines_when_current_is_already_golden() {
+    let board = Board::with_releases(&["1.0.0"]);
+    board.link("current", "1.0.0").link("golden", "1.0.0");
+
+    let run = board.rescue(&["--reboot"]);
+
+    assert_eq!(run.code(), 2, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("already golden"), "{}", run.stderr());
+    assert!(
+        run.systemctl.is_empty(),
+        "declining must not reboot, even when asked to: {:?}",
+        run.systemctl
+    );
+}
+
+#[test]
+fn swaps_current_to_golden_and_records_it() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    let run = board.rescue(&[]);
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.0.0"),
+        "current must point at golden, and at a *relative* target like the store writes"
+    );
+
+    let breadcrumb = board.breadcrumb().expect("a breadcrumb in the state dir");
+    assert!(
+        breadcrumb.contains("1.2.0") && breadcrumb.contains("1.0.0"),
+        "the breadcrumb has to say what was swapped for what: {breadcrumb:?}"
+    );
+}
+
+/// A board with no live release at all — a swap interrupted before it linked, or a `current`
+/// deleted by hand. There is nothing to lose and golden is exactly where it should be put.
+#[test]
+fn acts_when_there_is_no_current_at_all() {
+    let board = Board::with_releases(&["1.0.0"]);
+    board.link("golden", "1.0.0");
+
+    let run = board.rescue(&[]);
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.0.0")
+    );
+}
+
+/// `--reboot` is opt-in because the robot may be standing: every unit execs through `current`, so
+/// the swap does nothing until they restart, and whoever is holding the robot decides when that is.
+#[test]
+fn does_not_reboot_unless_asked() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    let quiet = board.rescue(&[]);
+    assert_eq!(quiet.code(), 0, "stderr: {}", quiet.stderr());
+    assert!(
+        quiet.systemctl.is_empty(),
+        "swapped and rebooted without being asked: {:?}",
+        quiet.systemctl
+    );
+    assert!(
+        quiet.stderr().contains("systemctl reboot"),
+        "having declined to reboot, it must say how: {}",
+        quiet.stderr()
+    );
+
+    // Back to a release that is not golden, so the second run has something to do.
+    std::fs::remove_file(board.install().join("current")).expect("unlink current");
+    board.link("current", "1.2.0");
+
+    let loud = board.rescue(&["--reboot"]);
+    assert_eq!(loud.code(), 0, "stderr: {}", loud.stderr());
+    assert_eq!(loud.systemctl.trim(), "reboot");
+}
+
+/// `--dry-run` is what an operator reaches for first, and on a board that is merely suspect it must
+/// not be the thing that changes the release.
+#[test]
+fn dry_run_decides_but_changes_nothing() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    let run = board.rescue(&["--dry-run"]);
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("would swap"), "{}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+    assert!(board.breadcrumb().is_none(), "a dry run left a breadcrumb");
+    assert!(run.systemctl.is_empty());
+}
+
+/// An unknown flag must not be ignored. A timer that grows a typo in its `ExecStart` should fail
+/// loudly rather than silently rescue on the wrong terms.
+#[test]
+fn refuses_an_argument_it_does_not_understand() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    let run = board.rescue(&["--force"]);
+
+    assert_eq!(run.code(), 1, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+}


### PR DESCRIPTION
Step 1 of #36, which is the design record. Read that one for why the later steps exist; this PR stands alone.

**`rollback`, `select` and `reset-to-golden` are all IPC calls into `updaterd`.** That covers every failure except the one that matters most: a release whose `updaterd` cannot start. Recovery then lives inside the process that is failing to start, `Restart=` gives up, and a board with a perfectly good older release on disk has no way back to it — not even for a human at a console. `BootCounter::record_boot` runs from `recover_on_start`, so the never-brick guarantee closes through that same process.

`scripts/robot-rescue` is that way back: read `current` and `golden`, swap, record, reboot when asked. **Nothing calls it automatically yet** — the boot deadline that will is step 3 in #36.

## Why a shell script, copied out of the release

A rescue that ships as a binary in the release payload is broken by exactly the releases it exists to survive: the wrong architecture, a missing shared library, a panic on startup. So it is `/bin/sh`, and `install.sh` and `hooks/postinstall` copy it into `/usr/local/sbin` the way they already copy unit files — `install_units` gives the reason, and this adds one: reading it through `current` would route the rescue through the thing being rescued.

## Why it parses nothing

The likeliest thing it rescues is a release whose `updaterd` rejects the board's `updater.toml` — the operator's file, preserved across installs, while a release is free to change what it expects. A rescue that parses that file dies of the disease it is treating.

Golden lives in that file today, so `Engine::refresh_golden_links` publishes it as a `golden` symlink beside `current` on every start: one `readlink`, nothing to reject. A cache rather than a second source of truth, and it fails safe — if `updaterd` stops starting, the link still names the release that was golden when it was last written, which is a release that was known good. A configured golden that is *not installed* publishes no link at all, because a dangling one would tell the rescue it has a target when it does not.

## Three decisions worth naming

- **It declines when `current` is already golden.** The daemons are then failing on the release carrying the standing guarantee, which is not a release fault; swapping would change nothing except adding a reboot, and that is how a hardware fault becomes a reboot loop.
- **`--reboot` is opt-in.** Every unit execs through `current`, so the swap does nothing until they restart, and a robot that is standing when its daemons die is a robot that falls. Whoever is holding it decides. `--dry-run` reports the decision and touches nothing.
- **The swap renames a temporary symlink over `current`** rather than `ln -sfn`, which unlinks and recreates and leaves a window where a daemon cannot exec. `rename(2)` does not follow symlinks but `mv`'s path resolution does, so plain `mv tmp current` moves the link *into* `releases/<version>` and leaves `current` untouched — found by watching the swap silently do nothing. GNU spells the fix `-T`, BSD spells it `-h`, and the board is one while a laptop running the tests is the other.

## Notes

- The decision is a pure function of two symlinks and a file, so `xtask/tests/rescue.rs` asks it every question against a temporary tree with a stub `systemctl` on `PATH`: no golden, golden not installed, already golden, no `current` at all, the swap itself, declining never rebooting even when asked, a dry run changing nothing, and an unknown flag failing loudly rather than rescuing on the wrong terms.
- `Store::swap_to` and the new `mark_golden` now share one atomic-symlink path, and `fsync_parent` covers both — a golden link that did not survive a power cut is a rescue with nothing to aim at.
- The artifact test gains `scripts/robot-rescue` and its executable bit: an operator on a broken board may well run it out of the release directory, so `package` ships `scripts/` at 0755 like `hooks/`.
- Workspace suite green; clippy clean on host; `shellcheck` clean on all three scripts. **Not** cross-checked against `aarch64` and **not** exercised on hardware — the interesting path needs a board whose release cannot start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
