### PR TITLE
An unreadable answer is not a safe one

### DIFF
--- a/updater/src/preflight.rs
+++ b/updater/src/preflight.rs
@@ -124,13 +124,24 @@ impl Preflight<'_> {
     async fn check_robot_stopped(&self) -> CheckResult {
         let verdict = self.robot.safe_to_restart(self.robot_query_timeout).await;
         // Unreachable counts as safe: if the control loop isn't running, nothing is
-        // moving — and that is precisely the case where an update is the fix.
+        // moving — and that is precisely the case where an update is the fix. An answer
+        // that arrived and could not be read does not, because the loop *is* running.
         let passed = verdict.permits_restart();
         CheckResult {
             check: Check::RobotStopped,
             passed,
             detail: match &verdict {
                 SafeToRestart::No(reason) => Some(reason.clone()),
+                // Names the contract rather than the robot, and names the way out. Without the
+                // second half this is a refusal with no stated remedy, on a board where the
+                // remedy is not guessable: the robot looks fine, because it is.
+                SafeToRestart::Incompatible(detail) => Some(format!(
+                    "robotd answered in a shape this updaterd cannot read ({detail}), so whether \
+                     it is moving is unknown and a restart is refused. The robot may be perfectly \
+                     healthy and the contract is what disagrees — usually a release that added a \
+                     field. To update anyway, make it genuinely stopped rather than unreadable: \
+                     systemctl stop robotd"
+                )),
                 _ => None,
             },
         }
@@ -239,6 +250,54 @@ mod tests {
     async fn unreachable_robot_passes_preflight() {
         let report = preflight(&AbsentRobot, 0, 1_000).run().await.unwrap();
         assert!(report.passed(), "{:?}", report.first_failure());
+    }
+
+    /// The pair above and below are one decision, and it used to be made the wrong way: an
+    /// unreadable reply was mapped to `Unreachable`, which permits a restart, so a `robotd`
+    /// answering "I am walking" in a shape one field newer was read as "go ahead".
+    ///
+    /// Silence means the control loop is not running. An answer means it is. Those must not
+    /// share a verdict, whatever else changes here.
+    #[tokio::test]
+    async fn an_unreadable_answer_blocks_the_restart() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Incompatible("missing field `safe`".into()),
+            session: false,
+        };
+        let report = preflight(&robot, 0, 1_000).run().await.unwrap();
+
+        let failure = report.first_failure().expect("must not pass");
+        assert_eq!(failure.check, Check::RobotStopped);
+        let detail = failure.detail.as_deref().unwrap_or_default();
+        // The reason serde gave, so the field that broke it is in the message.
+        assert!(detail.contains("missing field"), "{detail}");
+        // And the way out, which is not guessable from a robot that looks healthy.
+        assert!(detail.contains("systemctl stop robotd"), "{detail}");
+    }
+
+    /// A refusal that cannot be escaped is a bricked update path, and the escape here is not a
+    /// flag: stopping `robotd` turns an unreadable answer into an absent one, which is the
+    /// honest version of "nothing is moving".
+    #[tokio::test]
+    async fn stopping_the_robot_is_the_way_past_it() {
+        let unreadable = FakeRobot {
+            safe: SafeToRestart::Incompatible("missing field `safe`".into()),
+            session: false,
+        };
+        assert!(
+            !preflight(&unreadable, 0, 1_000)
+                .run()
+                .await
+                .unwrap()
+                .passed()
+        );
+        assert!(
+            preflight(&AbsentRobot, 0, 1_000)
+                .run()
+                .await
+                .unwrap()
+                .passed()
+        );
     }
 
     #[tokio::test]

--- a/updater/src/robot.rs
+++ b/updater/src/robot.rs
@@ -18,6 +18,23 @@ pub enum SafeToRestart {
     Yes,
     /// Actively moving or otherwise mid-task. Carries a displayable reason.
     No(String),
+    /// Answered, in a shape this `updaterd` cannot read. Does **not** permit a restart.
+    ///
+    /// The distinction from [`Self::Unreachable`] is the whole point, and getting it wrong is
+    /// what this variant exists to fix: a reply that *arrived* is evidence of a `robotd` whose
+    /// control loop is running, and reading its "no, I am mid-task" as "sure, go ahead" because
+    /// a field was renamed is how an update restarts a walking robot. Silence is safe; an
+    /// unreadable answer is not, and the two used to collapse into one variant that permitted
+    /// the restart either way — against what that variant's own comment promised.
+    ///
+    /// Same split, for the same reason, as [`Health::Incompatible`] against
+    /// [`Health::Unreachable`]. Carries serde's message, which names the field.
+    ///
+    /// The escape, when this blocks an update that needs to happen, is to make the robot
+    /// genuinely silent — `systemctl stop robotd` — which is honest rather than a bypass: a
+    /// stopped robot cannot be moving, and cannot be misread about it either. The refusal says
+    /// so.
+    Incompatible(String),
     /// `robotd` did not answer.
     ///
     /// Treated as **safe**: if the control loop isn't running, nothing is moving,
@@ -28,7 +45,7 @@ pub enum SafeToRestart {
 
 impl SafeToRestart {
     pub fn permits_restart(&self) -> bool {
-        !matches!(self, SafeToRestart::No(_))
+        !matches!(self, SafeToRestart::No(_) | SafeToRestart::Incompatible(_))
     }
 }
 
@@ -153,8 +170,8 @@ impl RobotClient for SocketRobotClient {
         let Some(result) = self.ask(&call, timeout).await else {
             return SafeToRestart::Unreachable;
         };
-        // An answer we cannot parse is treated as unreachable rather than guessed at:
-        // guessing "safe" could restart a walking robot.
+        // An answer we cannot parse is not guessed at, and specifically is not read as safe:
+        // guessing "safe" is what could restart a walking robot.
         match serde_json::from_value::<crate::proto::SafeToRestartResult>(result) {
             Ok(answer) if answer.safe => SafeToRestart::Yes,
             Ok(answer) => SafeToRestart::No(
@@ -164,7 +181,7 @@ impl RobotClient for SocketRobotClient {
             ),
             Err(e) => {
                 tracing::warn!(error = %e, "robotd answered safeToRestart in an unexpected shape");
-                SafeToRestart::Unreachable
+                SafeToRestart::Incompatible(e.to_string())
             }
         }
     }


### PR DESCRIPTION
Item 2 of #45, which recommended it first: it is the only one of the three where the current behaviour is unsafe rather than merely unhelpful, and the code contradicts its own comment, so one of the two was wrong today whatever got decided.

## The contradiction

`SocketRobotClient::safe_to_restart` maps a reply it cannot parse to `SafeToRestart::Unreachable`, and says why:

> An answer we cannot parse is treated as unreachable rather than guessed at: guessing "safe" could restart a walking robot.

`permits_restart` is `!matches!(self, No(_))`. So `Unreachable` *is* safe, and the code guessed "safe" — the outcome the comment was written to prevent. A `robotd` answering "no, I am mid-task" one field newer than the parser reading it was heard as "go ahead".

## The decision

Silence and an unreadable answer are opposite evidence, and the fix is to stop them sharing a verdict rather than to pick one:

- **`Unreachable` stays safe, deliberately.** A `robotd` that does not answer has no control loop running, so nothing is moving, and that is precisely when an update is the fix. Making absence an error would block recovery on the robots that need it most — invariant 1 in `architecture.md` §1.1.
- **A reply that arrived means the loop is running.** `SafeToRestart::Incompatible(String)`, which does not permit a restart. The same split `Health::Incompatible` already draws against `Health::Unreachable`, for the same reason.

#45 left open whether blocking is right at all, and offered a middle: block, but let a bypass override it. This takes the block without a new bypass, because one already exists and is better than a flag — **`systemctl stop robotd`**. It turns an unreadable answer into an absent one, which is honest rather than a workaround: a stopped robot cannot be moving, and cannot be misread about it either. It needs no flag, no config, and no `API_VERSION` bump, and it is the same move `install --force` already documents for the neighbouring case.

The refusal therefore names three things — the contract, that the robot is probably fine, and the way past it:

```
robotd answered in a shape this updaterd cannot read (missing field `safe`), so whether
it is moving is unknown and a restart is refused. The robot may be perfectly healthy and
the contract is what disagrees — usually a release that added a field. To update anyway,
make it genuinely stopped rather than unreadable: systemctl stop robotd
```

Without that last clause this is a refusal with no stated remedy on a board where the remedy is not guessable, which is worse than the bug.

## How narrow this is today

`SafeToRestartResult` has exactly one required field, `safe` — `reason` is already `#[serde(default)]`. So nothing short of a real shape disagreement reaches the new variant, and no current robotd hits it. The field-addition class that motivated the whole thing is `#[serde(default)]` discipline on *nested* reply structs, which is `install-path-gap.md` §1 and still open.

`safe` deliberately stays required: defaulting it to `false` would mean "not safe" on any garbage, blocking updates for the opposite reason.

## Notes

- Two tests, and the first is written as a pin rather than a check — silence and an unreadable answer must not share a verdict, whatever else changes here. The second asserts the escape works, because a refusal with no way past it is a bricked update path.
- `-p updater` green (132 lib tests), clippy clean, `robotd`'s tests still compile against the new variant.
- **#45 still stands** for items 1 and 3. Item 1 (accepting older clients) rests on a premise nothing enforces — that `API_VERSION` bumps are additive — and that rule wants writing down before the promise is made. Item 3's stated mechanism needs a correction I would rather settle in that PR than here: preflight cannot see the candidate's file list, because it runs before the artifact is downloaded, so an orphaned-unit check belongs after extraction and before the swap.