### PR TITLE
btd and configd wait for their hardware instead of exiting

### DIFF
--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -90,14 +90,59 @@ const ADV_INTERVAL_MAX: Duration = Duration::from_millis(150);
 /// waiting for the motor bus rather than giving up on it.
 const ADAPTER_RETRY: Duration = Duration::from_secs(5);
 
-/// Wait for an adapter, then advertise and serve until cancelled.
+/// Serve BLE for as long as this process lives, across an adapter that comes and goes.
+///
+/// Waiting for an adapter to *appear* was never enough. Everything after that wait — powering the
+/// adapter, registering the agent, advertising, publishing the GATT application — used to propagate
+/// its error out of this function and exit the process, so an adapter that appeared and then
+/// misbehaved took `btd` down where an adapter that never appeared did not. On a robot with no
+/// network that is the difference between "wifi is unavailable" and "unreachable".
+///
+/// So the whole bring-up retries in place, on the same 5s cadence as the wait it already did:
+///
+/// - **radio faults never leave this function.** A `failed` `btd` therefore means a broken binary,
+///   which is what admits it to the boot recovery net — see `docs/project/boot-recovery-net.md`;
+/// - **and it self-heals.** Exiting non-zero got the same retry from `Restart=always`, but only by
+///   spending a process death on it, and only until the day the unit gains a start limit.
 ///
 /// `require_pairing` controls whether writing a request needs an authenticated, encrypted link.
 /// It defaults on, because §7 requires it for anything carrying wifi credentials and
 /// `net.connect` now does. The opt-out exists for bench work against a client that cannot pair.
 pub async fn serve(sockets: Sockets, name: String, require_pairing: bool) -> bluer::Result<()> {
+    loop {
+        match serve_on_an_adapter(&sockets, &name, require_pairing).await {
+            Ok(()) => tracing::warn!(
+                retry_in = ?ADAPTER_RETRY,
+                "the adapter is gone; waiting for it to come back"
+            ),
+            // Not fatal, deliberately: every failure reachable here is a property of the radio or
+            // of BlueZ, and none of them is fixed by dying. See this function's own doc comment.
+            Err(e) => tracing::warn!(
+                error = %e,
+                retry_in = ?ADAPTER_RETRY,
+                "BLE bring-up failed"
+            ),
+        }
+        tokio::time::sleep(ADAPTER_RETRY).await;
+    }
+}
+
+/// One bring-up: acquire an adapter, advertise, serve, and return when the adapter goes away.
+///
+/// The advertisement, GATT application and agent handles all deregister on drop, so returning here
+/// is what releases them before the next attempt registers its own.
+async fn serve_on_an_adapter(
+    sockets: &Sockets,
+    name: &str,
+    require_pairing: bool,
+) -> bluer::Result<()> {
+    let sockets = sockets.clone();
+    let name = name.to_owned();
     let bt = bluer::Session::new().await?;
 
+    // Kept as its own loop rather than folded into the caller's: "no adapter yet" is the ordinary
+    // state of a board for its first 73 seconds and reads as progress, while a failure after this
+    // point is a fault. Collapsing them would log a fault every 5s during a normal boot.
     let adapter = loop {
         match bt.default_adapter().await {
             Ok(adapter) => break adapter,
@@ -366,8 +411,40 @@ pub async fn serve(sockets: Sockets, name: String, require_pairing: bool) -> blu
 
     tracing::info!("GATT application registered; waiting for a central");
 
-    // The advertisement and application handles deregister on drop, so this task must outlive
-    // the service.
-    std::future::pending::<()>().await;
+    // The advertisement and application handles deregister on drop, so this must not return while
+    // the adapter is usable — which used to mean `pending()`, waiting forever. Forever was wrong in
+    // one direction: an adapter that disappeared left this task parked on a dead radio, holding
+    // handles to nothing and advertising nothing, with no way back short of a restart nobody knew
+    // to perform. Returning hands the caller a bring-up on the adapter's next appearance.
+    watch_adapter(&adapter).await;
     Ok(())
+}
+
+/// Return once the adapter stops being usable.
+///
+/// A poll, not an event stream. `bluer` can report adapter removal, but the failure this has to
+/// catch is broader than removal — an adapter still on the bus that answers nothing is the case
+/// that used to kill the process — and reading one property covers both without depending on which
+/// events BlueZ emits for a radio that is wedged rather than absent.
+///
+/// The interval is [`ADAPTER_RETRY`] because the cost of noticing late is exactly the cost of
+/// retrying late: BLE stays dark a few more seconds, on a daemon that is otherwise idle.
+async fn watch_adapter(adapter: &bluer::Adapter) {
+    loop {
+        tokio::time::sleep(ADAPTER_RETRY).await;
+        match adapter.is_powered().await {
+            Ok(true) => {}
+            // Powered off underneath us — by `bluetoothctl power off`, by a driver reset, or by a
+            // suspend. The next bring-up powers it again: on a robot whose only front door may be
+            // BLE, an unpowered adapter is not a state to preserve out of politeness.
+            Ok(false) => {
+                tracing::warn!("the adapter is no longer powered");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "the adapter stopped answering");
+                return;
+            }
+        }
+    }
 }

--- a/btd/src/main.rs
+++ b/btd/src/main.rs
@@ -129,12 +129,14 @@ async fn main() -> ExitCode {
 #[cfg(target_os = "linux")]
 async fn run(sockets: Sockets, name: String, require_pairing: bool) -> ExitCode {
     tokio::select! {
+        // `serve` retries the radio in place and is not expected to return at all: an adapter that
+        // is missing, unpowered or wedged is handled there rather than by dying and letting
+        // `Restart=always` do it. Both arms are therefore a bug in `serve`, not a radio fault — kept
+        // because the signature allows them, and non-zero because a `btd` that has stopped serving
+        // BLE must not look healthy.
         result = btd::bluez::serve(sockets, name, require_pairing) => match result {
-            // `serve` only returns when BlueZ closes the control stream, which means the
-            // adapter went away. Exiting non-zero lets systemd restart us into the retry loop
-            // rather than leaving a daemon that is advertising nothing.
             Ok(()) => {
-                tracing::error!("BLE service ended unexpectedly");
+                tracing::error!("the BLE service returned; it is supposed to retry instead");
                 ExitCode::FAILURE
             }
             Err(e) => {

--- a/configd/src/main.rs
+++ b/configd/src/main.rs
@@ -179,18 +179,24 @@ async fn main() -> ExitCode {
     let args = Args::parse();
     duck_ipc_proto::log_startup_identity!("configd");
 
+    // Neither backend is a reason to refuse to start. `configd` answers `net.*`, `pad.*` and
+    // `system.*`, and `system.pin` is where `btd` gets the PIN a phone authenticates with — so a
+    // `configd` that exits over one missing dependency turns "wifi is unavailable" into "the robot
+    // cannot be reached at all", on a board where the phone is the only way in.
+    //
+    // It is also what admits `configd` to the boot recovery net: a unit may join the set only if it
+    // waits for its dependency rather than exiting, so that a `failed` unit means a broken release
+    // and not a broken board (`docs/project/boot-recovery-net.md`).
     let net: Arc<dyn Net> = match backend(args.fake_net).await {
         Ok(net) => net,
         Err(e) => {
-            tracing::error!(error = %e, "no wifi backend");
-            return ExitCode::FAILURE;
+            tracing::error!(error = %e, "no wifi backend; net.* will report unavailable");
+            Arc::new(configd::net::UnavailableNet::new(e))
         }
     };
 
-    // Unlike wifi, an unreachable radio is **not** a reason to refuse to start. `configd` answers
-    // `net.*` and `system.*` too, and a board whose Bluetooth has not appeared yet — which on this
-    // one takes about 73 seconds — must not lose its wifi provisioning path over it. So a failure
-    // here degrades to "no pads" and says why.
+    // A board whose Bluetooth has not appeared yet — which on this one takes about 73 seconds —
+    // degrades to "no pads" and says why.
     let pads: Arc<dyn Pads> = match pad_backend(args.fake_pads).await {
         Ok(pads) => pads,
         Err(e) => {
@@ -239,18 +245,15 @@ async fn backend(fake: bool) -> Result<Arc<dyn Net>, String> {
         tracing::warn!("serving a FAKE wifi stack; nothing here touches a real network");
         return Ok(Arc::new(FakeNet::new()));
     }
-    // A failure here means NetworkManager is not on the bus at all, which on this board means
-    // the wifi migration was never run. Say that, rather than reporting a D-Bus error nobody
-    // can act on.
+    // `NetworkManager::new` opens the **system bus**; it does not look for NM on it. So a failure
+    // here is a board with no reachable D-Bus, not a board with no NetworkManager — and the advice
+    // to run `migrate-network.sh` belonged to the other case, which is diagnosed in `wifi_device`
+    // and already reports `Unavailable` without any of this. Naming the wrong cause sends whoever
+    // reads it to a script that will not help.
     configd::nm::NetworkManager::new()
         .await
         .map(|nm| Arc::new(nm) as Arc<dyn Net>)
-        .map_err(|e| {
-            format!(
-                "cannot reach NetworkManager on the system bus ({e}). If this board still runs \
-                 netplan, run scripts/migrate-network.sh first."
-            )
-        })
+        .map_err(|e| format!("cannot reach the system D-Bus ({e}); is dbus running?"))
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/configd/src/net.rs
+++ b/configd/src/net.rs
@@ -24,6 +24,72 @@ pub trait Net: Send + Sync {
     async fn forget(&self, ssid: &str) -> NetResult<proto::ForgetResult>;
 }
 
+/// No wifi stack at all: every call answers, and every answer says why.
+///
+/// What `configd` serves when it cannot reach the system bus. Refusing to start was the obvious
+/// alternative and it is the wrong one — `configd` also answers `system.*`, which is where `btd`
+/// gets the pairing PIN, so a `configd` that exits takes BLE provisioning down with it. That turns
+/// "wifi is unavailable" into "the robot cannot be reached at all", on a board where the phone is
+/// the only way in.
+///
+/// It is also what makes `configd` eligible for the boot recovery net: a unit may only join the set
+/// if it waits for its dependency rather than exiting, so that a `failed` unit means a broken
+/// release rather than a broken board (`docs/project/boot-recovery-net.md`).
+///
+/// `reason` is the bus error, carried into every reply rather than logged once at startup, because
+/// the person who needs it is holding a phone and cannot see the journal.
+pub struct UnavailableNet {
+    reason: String,
+    mac: Option<String>,
+    iface: Option<String>,
+}
+
+impl UnavailableNet {
+    pub fn new(reason: String) -> Self {
+        Self {
+            reason,
+            mac: None,
+            iface: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Net for UnavailableNet {
+    /// `Unavailable` and not an error: "there is no wifi stack here" is a diagnosable answer, and
+    /// the state exists in the protocol precisely to distinguish a provisioning problem from a
+    /// network one. A client that gets an error instead cannot tell which it has.
+    async fn status(&self) -> NetResult<proto::NetStatusResult> {
+        Ok(proto::NetStatusResult {
+            state: proto::NetState::Unavailable,
+            ssid: None,
+            signal: None,
+            ip4: None,
+            ip6: None,
+            mac: self.mac.clone(),
+            iface: self.iface.clone(),
+        })
+    }
+
+    /// Empty rather than an error, for the same reason: a phone shows "no networks found", which is
+    /// true, next to a status that says why.
+    async fn scan(&self) -> NetResult<proto::NetScanResult> {
+        Ok(proto::NetScanResult {
+            networks: Vec::new(),
+        })
+    }
+
+    /// Joining *is* an error. Reporting success for a network it did not join would be a lie, and
+    /// silently doing nothing is worse than saying what is wrong.
+    async fn connect(&self, _ssid: &str, _psk: Option<&str>) -> NetResult<proto::ConnectResult> {
+        Err(self.reason.clone())
+    }
+
+    async fn forget(&self, _ssid: &str) -> NetResult<proto::ForgetResult> {
+        Err(self.reason.clone())
+    }
+}
+
 /// A wifi stack that exists only in memory.
 ///
 /// Used by every test and by `--fake`, which is how the whole `net.*` surface can be exercised
@@ -182,6 +248,26 @@ impl Net for FakeNet {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The whole point of degrading rather than exiting: every call still answers. `status` and
+    /// `scan` report the truth, and only joining — which cannot be faked — is an error, carrying
+    /// the reason to a client that has no way to read the journal.
+    #[tokio::test]
+    async fn an_unavailable_stack_answers_everything_and_joins_nothing() {
+        let net = UnavailableNet::new("cannot reach the system D-Bus (no socket)".to_owned());
+
+        assert_eq!(
+            net.status().await.unwrap().state,
+            proto::NetState::Unavailable,
+            "an error here would leave a client unable to tell a provisioning problem from a \
+             network one"
+        );
+        assert!(net.scan().await.unwrap().networks.is_empty());
+
+        let err = net.connect("Pollen", Some("key")).await.unwrap_err();
+        assert!(err.contains("D-Bus"), "the reason has to travel: {err}");
+        assert!(net.forget("Pollen").await.is_err());
+    }
 
     #[tokio::test]
     async fn a_wrong_key_is_reported_as_a_wrong_key() {


### PR DESCRIPTION
Step 2 of #36. Independent of #67 — different files, either order.

**Both daemons had a path where a missing *dependency* killed the process**, which is the one thing a member of the boot recovery net may not do. If a daemon can reach `failed` because the board is broken rather than because the release is, then acting on a `failed` unit reverts a good release over a hardware fault.

## `btd` waited for an adapter to appear, then stopped waiting

The retry loop in `bluez::serve` covers "no `hci0` yet", which is the board's ordinary state for its first 73 seconds. Everything after that loop — `set_powered`, the agent, `advertise`, `serve_gatt_application` — propagated its error out of `serve` and exited the process. So an adapter that appeared and then misbehaved took the daemon down where one that never appeared did not. `Restart=always` did retry it, but by spending a process death per attempt, and only until the day that unit gains a start limit (which step 3 gives it).

`serve` also parked on `pending()` once the GATT application was registered — forever, in the wrong direction. An adapter that disappeared left the task holding handles to a dead radio, advertising nothing, with no way back short of a restart nobody knew to perform.

Now: the bring-up retries in place on the same 5s cadence as the wait it already did, and instead of `pending()` it polls the adapter and returns when it stops being usable, which sends the caller back through bring-up on the adapter's next appearance. A poll rather than a `bluer` event stream because the case that used to kill the process is an adapter still on the bus that answers nothing — that is not a removal, and one property read covers both.

## `configd` exited when it could not reach the system bus

Narrower than the error message claimed, and worth spelling out because the code said otherwise: `NetworkManager::new` opens the **system bus** and does not look for NM on it. The board-still-on-netplan case its message named never took that path — `wifi_device` diagnoses that one and already answers `Unavailable`. So the exit was reachable only with no D-Bus at all, and the advice to run `migrate-network.sh` sent whoever read it to a script that could not help. (This corrects what I claimed in #36; the doc there is updated.)

The cost of exiting was never wifi. `configd` also answers `system.pin`, which is where `btd` gets the PIN a phone authenticates with — so one missing dependency turned "wifi is unavailable" into "the robot cannot be reached at all", on a board where the phone is the only way in.

`UnavailableNet` answers everything instead: `Unavailable` for status, an empty scan, and the bus error itself for `connect`/`forget`. The reason travels in the reply rather than being logged once at startup, because the person who needs it is holding a phone and cannot read the journal. Joining stays an error — reporting success for a network it did not join would be a lie, and silently doing nothing is worse than saying what is wrong.

`configd` already had the right shape one block down, where an unreachable BlueZ degrades to "no pads" and says why. This is the same decision for wifi.

## Notes

- `UnavailableNet` is unit-tested: status reports `Unavailable` rather than erroring (a client that gets an error cannot tell a provisioning problem from a network one), scan is empty, and the bus error reaches `connect`.
- `btd/src/bluez.rs` cannot be unit-tested — it needs a radio, and the interesting path needs a radio that fails *after* appearing. `cargo check` and clippy are clean for `aarch64-unknown-linux-gnu`, which is the only thing that covers this file at all. **Not exercised on hardware.**
- `btd/src/main.rs`'s comment about exiting non-zero to get a restart described a mechanism that no longer exists; both arms of that `match` are now a bug in `serve` rather than a radio fault, and say so.
- Unrelated flake seen once: `applying_the_same_version_is_a_no_op` failed during a full `cargo test --workspace` and passed both alone and with the rest of `updater`'s apply suite. Nothing here touches `updater`; it looks like the update-lock contention the fixture already warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
