### PR TITLE
One page owns a mechanism

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,14 @@ Start at the [README](../README.md) if you have a robot and want to use it.
 How it works and why. These change rarely; when behaviour and a design doc disagree, the doc is
 the bug.
 
+**One page owns a mechanism, and the others link to it.** The table below is that assignment: if a
+fact belongs to a page listed here, every other page says one sentence and points, rather than
+explaining it again. A fact written down in six places drifts in six directions, each of them locally
+reasonable — which is how six documents came to promise that `updaterd` and `btd` kept their old
+binaries until the next reboot, two releases after they stopped doing so, including the two pages
+someone reads while diagnosing exactly that. So when two documents disagree, the one that does not
+own the mechanism is the bug.
+
 | | |
 |---|---|
 | [`architecture.md`](design/architecture.md) | The service split, the IPC contract, state ownership, safety and authority. |


### PR DESCRIPTION
This was meant to be the third commit of #66 and arrived a few minutes after it merged, so it was stranded on the branch. Same change, rebased onto current `main`. Eight lines in `docs/README.md`.

The rule that #66's two other commits are an instance of: six documents promised that `updaterd` and `btd` kept their old binaries until the next reboot, two releases after they stopped doing so, and each of the six was locally reasonable — nobody wrote a wrong thing, they wrote a true thing next to code that later changed.

Stating the rule is cheaper than another pass. The index table already assigns scope per page, so this only says the assignment is binding, and that a page which does not own a mechanism gets a sentence and a link.