### PR TITLE
Stop paying twice for coverage, and not at all for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,35 @@
 # Checks on every push and pull request.
 #
-# Split into two jobs deliberately: `check` is fast and catches most things, `board`
-# is slower and catches the class of problem that only appears off the dev machine
-# (cross-linking, glibc floors, unix-socket and permission semantics).
+# Split into three parallel jobs deliberately, so the wait is the slowest one rather than the
+# total: `check` is fast and catches most things, `board` catches the class of problem that only
+# appears off the dev machine (cross-linking, glibc floors, unix-socket and permission
+# semantics), and `coverage` needs its own instrumented build.
 name: ci
 
+# Documentation is excluded from all of it. Editing a markdown file used to cross-compile for
+# aarch64 under QEMU *and* build the workspace under instrumentation — minutes of waiting for a
+# change that cannot affect a single one of those results.
+#
+# Safe here specifically because `main` has no required status checks. A skipped job reports no
+# status at all, so filtering one that *was* required leaves every docs pull request permanently
+# pending, which is worse than the wait it removes. Re-check this before turning protection on.
+#
+# `paths-ignore` rather than `paths`, deliberately: the default stays "run". A new top-level
+# directory is tested because nobody remembered to list it, which is the right way round for a
+# filter whose failure mode is skipping everything.
+#
+# The list is written twice because GitHub Actions does not support YAML anchors, so `&docs`/`*docs`
+# is not available here however much this asks for it. Keep the two copies identical.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 # Cancel superseded runs: during a hot iteration week the queue is otherwise mostly
 # obsolete builds.
@@ -139,6 +160,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      # The floor, in one place. It is both enforced and quoted in the comment, and two copies
+      # of a number are one copy and one thing to forget.
+      COVERAGE_FLOOR: 72
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -163,31 +188,21 @@ jobs:
       # a few points under today's ~77% so ordinary work does not trip it, while a genuine
       # collapse still fails. Lowering it should be a deliberate, explained commit.
       - name: Coverage
-        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines 72 | tee "$RUNNER_TEMP/head.txt"
+        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines "$COVERAGE_FLOOR" | tee "$RUNNER_TEMP/head.txt"
 
-      # The base branch, built separately, purely to get a number to subtract. Only on
-      # pull requests: a push to main has nothing to compare against, and paying for a
-      # second instrumented build there would be waste.
+      # There is deliberately no second run against the base branch. This job used to check
+      # the base out separately and build it instrumented a second time, purely to subtract
+      # one number from another and print a delta — doubling the slowest job on every pull
+      # request for a nicety, while `--fail-under-lines` above is the part that actually
+      # catches a regression.
       #
-      # A second checkout rather than a git worktree, so the two builds keep separate
-      # target directories and cannot poison each other's incremental state.
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.base_ref }}
-          path: base
-
-      - name: Coverage on the base branch
-        if: github.event_name == 'pull_request'
-        working-directory: base
-        # No `--fail-under-lines`: the base is a measurement, not a gate. If main is
-        # already below the floor that is main's problem, and failing here would block an
-        # unrelated pull request from merging.
-        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' | tee "$RUNNER_TEMP/base.txt"
+      # What that costs is real and worth naming: a pull request that lowers coverage while
+      # staying over the floor no longer says so. The ratchet is the mechanism now — raise the
+      # floor when the number rises, and a collapse still fails the job.
 
       # Column 10 of the TOTAL row is line coverage. The whole table goes in the run
       # summary, where it renders without anyone opening a log; the comment carries the
-      # numbers that matter.
+      # number that matters.
       - name: Report
         if: always() && github.event_name == 'pull_request'
         env:
@@ -195,7 +210,6 @@ jobs:
         run: |
           pct() { awk '/^TOTAL/ {gsub("%","",$10); print $10}' "$1" 2>/dev/null; }
           head_pct=$(pct "$RUNNER_TEMP/head.txt")
-          base_pct=$(pct "$RUNNER_TEMP/base.txt")
           : "${head_pct:=unknown}"
 
           {
@@ -203,11 +217,8 @@ jobs:
             echo
             if [ "$head_pct" = "unknown" ]; then
               echo "The coverage run did not produce a total — it most likely failed before finishing."
-            elif [ -n "$base_pct" ]; then
-              delta=$(awk -v a="$head_pct" -v b="$base_pct" 'BEGIN { printf "%+.2f", a - b }')
-              echo "**${head_pct}% lines** on this branch, ${base_pct}% on \`${{ github.base_ref }}\` — **${delta}**."
             else
-              echo "**${head_pct}% lines** on this branch. No base measurement to compare against."
+              echo "**${head_pct}% lines** on this branch, against a floor of ${COVERAGE_FLOOR}%."
             fi
             echo
             echo "<details><summary>Per-file</summary>"


### PR DESCRIPTION
The two removals named in #70. Neither changes what CI catches; both change what it costs, which is the thing slowing iteration.

## The base-branch coverage run goes

`coverage` checked the base branch out a second time and built it instrumented, purely to subtract one number from another and print a delta — **doubling the slowest job on every pull request** for a nicety. `--fail-under-lines` is the part that catches a regression, and it stays.

The cost is real and is named in the file rather than glossed: a change that lowers coverage while staying over the floor no longer says so. The ratchet is the mechanism now — raise the floor when the number rises, and a collapse still fails.

## Documentation stops triggering any of it

`on:` carried no path filter, so editing a markdown file cross-compiled for aarch64 under QEMU *and* built the workspace under instrumentation. #66, #70 and #71 each paid that in full this afternoon, which is what prompted this.

**Safe here specifically, and I checked rather than assumed:** the branch-protection API returns 403 for this repository (private, on a plan without protected branches), so `main` has no required status checks. That matters because a skipped job reports *no status at all* — filtering a required check leaves docs pull requests permanently pending, which is worse than the wait it removes. The comment says so for whoever turns protection on.

`paths-ignore` rather than `paths`, so the default stays "run": a new top-level directory is tested because nobody remembered to list it, which is the right way round for a filter whose failure mode is skipping everything. The list appears twice because GitHub Actions does not support YAML anchors — also commented, so nobody spends an afternoon discovering that `&docs` silently does not work.

## Two smaller things while in there

The coverage floor was about to exist in two places — enforced in the gate, quoted in the comment — so it is a job-level `COVERAGE_FLOOR` env var. And the header described "two jobs" when there are three, which is the same drift class this week has been about.

Nothing in `check` or `board` changes.