### PR TITLE
Observe the two restarts nothing could observe

### DIFF
--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1613,9 +1613,18 @@ async fn schedule_restarts_if_applied(enabled: bool, outcome: &Result<ApplyResul
         return;
     }
     if matches!(outcome, Ok(ApplyResult::Applied { .. })) {
-        schedule_deferred_restarts().await;
+        schedule_deferred_restarts(SYSTEMD_RUN).await;
     }
 }
+
+/// The program that schedules the deferred restarts.
+///
+/// A constant taken as a parameter below, for exactly the reason `SYSTEMCTL` is: a test needs to
+/// hand it a stub and assert what was asked. Hardcoded at the call site, this was the one command in
+/// the update path that no test could observe — `--on-active` could have been misspelled and every
+/// test would still have passed, while on a board the only symptom is a restart that silently never
+/// happens.
+const SYSTEMD_RUN: &str = "systemd-run";
 
 /// Restart the deferred units, detached, a few seconds from now.
 ///
@@ -1628,9 +1637,9 @@ async fn schedule_restarts_if_applied(enabled: bool, outcome: &Result<ApplyResul
 /// update that succeeded must not be reported as failed because a restart could not be scheduled.
 /// Swallowing them is affordable because they are not the last word: [`crate::reconcile`] checks at
 /// the next start that each unit is on the active release and restarts what is not.
-async fn schedule_deferred_restarts() {
+async fn schedule_deferred_restarts(systemd_run: &str) {
     for unit in RESTART_AFTER_REPLYING {
-        let mut command = tokio::process::Command::new("systemd-run");
+        let mut command = tokio::process::Command::new(systemd_run);
         command
             .arg(format!("--on-active={DEFERRED_RESTART_DELAY}"))
             .arg("--timer-property=AccuracySec=100ms")
@@ -2028,6 +2037,75 @@ esac
             .await
             .unwrap_err();
         assert!(format!("{err:?}").contains("restart failed"), "{err:?}");
+    }
+
+    /// A stub that records its whole argument list and nothing else. `stub_systemctl` above answers
+    /// `show` and branches on units; here the argv *is* the thing under test, so recording it is all
+    /// this needs to do.
+    fn stub_recorder(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        std::fs::write(
+            &path,
+            "#!/bin/sh\necho \"$@\" >> \"$(dirname \"$0\")/calls\"\n",
+        )
+        .expect("write stub");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    /// The deferred restarts, as an actual command line. Until this existed nothing in the repository
+    /// could observe that call: the program name was hardcoded, so `--on-active` could have been
+    /// wrong and every test would still pass — while on a board the only symptom is `btd` quietly
+    /// never restarting, which is the exact failure `RESTART_AFTER_REPLYING` was added to fix.
+    ///
+    /// Four claims, and each one is load-bearing rather than incidental:
+    #[tokio::test]
+    async fn the_deferred_restarts_are_scheduled_as_transient_timers() {
+        let dir = tempfile::tempdir().unwrap();
+        let systemd_run = stub_recorder(dir.path(), "systemd-run");
+
+        schedule_deferred_restarts(systemd_run.to_str().unwrap()).await;
+
+        let log = calls(dir.path());
+        let lines: Vec<&str> = log.lines().collect();
+
+        // One transient unit per deferred unit, not one command naming both — the same lesson as
+        // `units_are_restarted_one_at_a_time`.
+        assert_eq!(lines.len(), RESTART_AFTER_REPLYING.len(), "{log}");
+
+        for (line, unit) in lines.iter().zip(RESTART_AFTER_REPLYING) {
+            // The delay is what lets the reply reach the client first. Without it the engine hands
+            // whoever asked a broken pipe instead of the outcome they waited minutes for.
+            assert!(
+                line.contains(&format!("--on-active={DEFERRED_RESTART_DELAY}")),
+                "{line}"
+            );
+            // `systemd-run … -- systemctl restart <unit>`: the transient unit *wraps* systemctl, so
+            // the restart runs outside updaterd's cgroup and survives its own parent being killed.
+            assert!(
+                line.ends_with(&format!("-- systemctl restart {unit}")),
+                "{line}"
+            );
+        }
+
+        // Both, and by name. A list that quietly lost one would leave that daemon on the old binary
+        // until the next `updaterd` start noticed.
+        assert!(log.contains("restart updaterd"), "{log}");
+        assert!(log.contains("restart btd"), "{log}");
+    }
+
+    /// Scheduling that fails must not propagate. The update is already committed and journalled by
+    /// this point, so an unschedulable restart cannot be allowed to report a good update as failed —
+    /// `reconcile` picks it up at the next start instead.
+    #[tokio::test]
+    async fn a_scheduler_that_cannot_be_run_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nothing at this path, so the spawn fails outright.
+        schedule_deferred_restarts(dir.path().join("absent").to_str().unwrap()).await;
     }
 
     /// One invocation per unit, which is the fix. `systemctl restart a b` fails as a whole when

--- a/updater/src/reconcile.rs
+++ b/updater/src/reconcile.rs
@@ -223,4 +223,106 @@ mod tests {
             Verdict::Current
         );
     }
+
+    /// Write what a daemon would have published, so the reader has a real file to read.
+    ///
+    /// Constructed rather than produced by `publish_identity`, which publishes *this* process — and
+    /// the test binary's own exe path names no release, so every unit would come back `Unknown` and
+    /// the test would pass while asserting nothing.
+    fn publish(root: &std::path::Path, service: &str, release: &str) {
+        let dir = root.join(service);
+        std::fs::create_dir_all(&dir).expect("a runtime dir");
+        let identity = proto::Identity {
+            service: service.to_owned(),
+            version: release.to_owned(),
+            revision: None,
+            built_at: None,
+            exe: Some(format!(
+                "/opt/robot/daemon/releases/{release}/bin/{service}"
+            )),
+            pid: 4242,
+        };
+        std::fs::write(
+            dir.join("identity.json"),
+            serde_json::to_vec(&identity).expect("serialising an identity"),
+        )
+        .expect("publishing");
+    }
+
+    /// A `systemctl` that records every call and refuses one named unit, so both the acting path and
+    /// the failure path are exercised by the same run.
+    fn stub_systemctl(dir: &std::path::Path, failing_unit: &str) -> std::path::PathBuf {
+        let path = dir.join("systemctl");
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\n\
+                 echo \"$@\" >> \"$(dirname \"$0\")/calls\"\n\
+                 [ \"$2\" = {failing_unit} ] && {{ echo 'job failed' >&2; exit 1; }}\n\
+                 exit 0\n"
+            ),
+        )
+        .expect("write stub");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    fn verdict_of(findings: &[Finding], unit: &str) -> Verdict {
+        findings
+            .iter()
+            .find(|f| f.unit == unit)
+            .unwrap_or_else(|| panic!("no finding for {unit}: {findings:?}"))
+            .verdict
+    }
+
+    /// The whole function, over real files and a real subprocess — every verdict in one run.
+    ///
+    /// **One test rather than five, and that is about the environment variable rather than about
+    /// taste.** `DUCK_RUNTIME_DIR` is process-wide, so two tests setting it would race inside one
+    /// test binary and the loser would read the other's runtime directory. Driving every case through
+    /// a single root sidesteps that entirely, and costs only that the failures name a unit.
+    ///
+    /// Until this existed the module's tests covered `verdict_for` and nothing else — so what a
+    /// startup actually *did* about a stale unit, which is the point of the module, was unobserved.
+    #[tokio::test]
+    async fn every_verdict_over_real_files() {
+        let root = tempfile::tempdir().expect("a temp runtime root");
+        let bin = tempfile::tempdir().expect("a temp bin dir");
+        // SAFETY: set once, in a single test, and nothing else in this crate reads the variable.
+        unsafe { std::env::set_var("DUCK_RUNTIME_DIR", root.path()) };
+
+        let active = v("0.4.0");
+        publish(root.path(), "configd", "0.3.0"); // stale → restarted
+        publish(root.path(), "robotd", "0.4.0"); // already right → untouched
+        publish(root.path(), "updaterd", "0.3.0"); // stale, but is self → reported only
+        publish(root.path(), "btd", "0.3.0"); // stale, and its restart fails
+        // `padd` publishes nothing: stopped, or a build too old to say. Left alone either way.
+
+        let systemctl = stub_systemctl(bin.path(), "btd");
+        let units = ["btd", "configd", "padd", "robotd", "updaterd"]
+            .map(str::to_owned)
+            .to_vec();
+
+        let findings = check(systemctl.to_str().unwrap(), &active, "updaterd", units).await;
+
+        assert_eq!(verdict_of(&findings, "configd"), Verdict::Restarted);
+        assert_eq!(verdict_of(&findings, "robotd"), Verdict::Current);
+        assert_eq!(verdict_of(&findings, "updaterd"), Verdict::ReportedOnly);
+        assert_eq!(verdict_of(&findings, "btd"), Verdict::RestartFailed);
+        assert_eq!(verdict_of(&findings, "padd"), Verdict::Unknown);
+
+        // And what it actually asked systemd to do, which no assertion on verdicts can show.
+        let calls = std::fs::read_to_string(bin.path().join("calls")).unwrap_or_default();
+        assert!(calls.contains("restart configd"), "{calls}");
+        assert!(calls.contains("restart btd"), "{calls}");
+        // The three that must never be touched: the one that is current, the one that published
+        // nothing, and — most importantly — this process's own unit.
+        assert!(!calls.contains("restart robotd"), "{calls}");
+        assert!(!calls.contains("restart padd"), "{calls}");
+        assert!(!calls.contains("restart updaterd"), "{calls}");
+    }
 }


### PR DESCRIPTION
The two tests from #70's first item. No new infrastructure, in-process, milliseconds — they belong in the default `cargo test` by the rule that PR proposes.

Both mechanisms that make an update self-healing had their *deciding* half tested and their *acting* half untested, which is the wrong way round: the decision is the easy part to read, and what actually reached systemd is what a board suffers.

## `systemd-run` was unobservable

`schedule_deferred_restarts` hardcoded `Command::new("systemd-run")`, while `SYSTEMCTL` two functions away is a `const` precisely so `restart_tests` can substitute a stub. Same treatment, and then the assertions that were impossible before:

- **one transient unit per deferred unit**, not one command naming both — the same lesson `units_are_restarted_one_at_a_time` already learned about `systemctl restart a b`;
- **`--on-active=5s` is present**, which is what lets the reply reach the client before its transport restarts;
- **the command is shaped `systemd-run … -- systemctl restart <unit>`**, so the restart runs outside `updaterd`'s cgroup and survives its own parent being killed — the file's central claim, previously unasserted;
- **both `updaterd` and `btd` are named.**

`--on-active` could have been misspelled and the entire suite would have passed. On a board the only symptom is `btd` quietly never restarting, which is the exact failure `RESTART_AFTER_REPLYING` was added to fix.

A second, one-line test pins that a scheduler that cannot even be spawned is not an error: the update is committed and journalled by that point, so it must not be reported as failed over a restart it could not arrange.

## `reconcile::check` had no test, only its verdict function

#65 tested `verdict_for` five ways and never called `check`. It already took `systemctl` as a parameter and read identities through `DUCK_RUNTIME_DIR` — a seam whose own comment says it exists so this is testable — so this needed no production change at all, only writing.

Real identity files, a real subprocess, every verdict in one run: stale is restarted, current is untouched, **this process's own unit is reported and never restarted**, a failing restart reports itself, and a unit that published nothing is left alone. It then asserts what was actually asked of systemd, which no assertion on verdicts can show.

One test rather than five, and that is about the environment variable rather than taste: `DUCK_RUNTIME_DIR` is process-wide, so two tests setting it would race inside one test binary and the loser would read the other's runtime directory.

One detail worth flagging, because getting it wrong makes the test pass while asserting nothing: the identities are constructed rather than produced by `publish_identity`, which publishes *this* process — and the test binary's exe path names no release, so every unit would come back `Unknown`.

## Notes

- `-p updater` green: 133 lib tests, up from 131. `cargo clippy -p updater --all-targets` clean.
- The only production change is threading one constant as a parameter, matching the existing `restart_one(SYSTEMCTL, &unit)` idiom.