### PR TITLE
The recovery net fires without a human

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -129,6 +129,9 @@ jobs:
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
+            --include "scripts/robot-boot-check=scripts/robot-boot-check" \
+            --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \
+            --include "updater/systemd/robot-boot-check.timer=systemd/robot-boot-check.timer" \
             --include "configd/systemd/configd.service=systemd/configd.service" \
             --include "btd/systemd/btd.service=systemd/btd.service" \
             --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -117,6 +117,9 @@ jobs:
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
+            --include "scripts/robot-boot-check=scripts/robot-boot-check" \
+            --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \
+            --include "updater/systemd/robot-boot-check.timer=systemd/robot-boot-check.timer" \
             --include "configd/systemd/configd.service=systemd/configd.service" \
             --include "btd/systemd/btd.service=systemd/btd.service" \
             --include "btd/systemd/sysusers.d/btd.conf=systemd/sysusers.d/btd.conf" \

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -280,6 +280,35 @@ daemons are failing on golden itself, a rollback is not the answer and the journ
 journalctl -b -u robotd -u updaterd -u btd -u configd
 ```
 
+### The robot may have done this already
+
+Three minutes into every boot, a timer asks whether the release brought its daemons up, and falls back
+to golden if it did not. So a robot that rebooted on its own and is running an older release than you
+installed has probably rescued itself. What it did:
+
+```
+robotctl update log
+```
+
+The entry reads as a rollback, with the daemon that failed named in its reason. To see the decision
+being made rather than its result:
+
+```
+journalctl -b -u robot-boot-check
+```
+
+```
+sudo robot-boot-check --dry-run
+```
+
+It acts once. A second rescue is refused while the first is still on record — `updaterd` clears that
+when it next starts, so being refused means the daemons did not come up on golden either, and the
+answer is the journal rather than another reboot. Past it, if you have read the journal and decided:
+
+```
+sudo robot-rescue --force --reboot
+```
+
 ### Three things that are easy to get wrong
 
 **`rollback` needs a predecessor, but an update creates one.** A freshly provisioned board has

--- a/hooks/postinstall
+++ b/hooks/postinstall
@@ -34,15 +34,16 @@ SBIN_DIR=/usr/local/sbin
 
 # Hooks run with the release directory as their working directory.
 
-# The rescue script, copied out for the same reason as the units below and one more: it is what an
-# operator runs when this release cannot start, so it must not be read through `current`. A warning
-# and not a failure — a release that cannot install its rescue script is still a release worth
-# having, and `install.sh` puts one there on a fresh board.
-if [ -f scripts/robot-rescue ]; then
+# The recovery scripts, copied out for the same reason as the units below and one more: they are what
+# runs when this release cannot start, so they must not be read through `current`. A warning and not
+# a failure — a release that cannot install them is still a release worth having, and `install.sh`
+# puts them there on a fresh board.
+for script in robot-rescue robot-boot-check; do
+    [ -f "scripts/${script}" ] || continue
     mkdir -p "$SBIN_DIR"
-    install -m 755 scripts/robot-rescue "${SBIN_DIR}/robot-rescue" \
-        || echo "postinstall: cannot install robot-rescue; the board keeps the previous copy" >&2
-fi
+    install -m 755 "scripts/${script}" "${SBIN_DIR}/${script}" \
+        || echo "postinstall: cannot install ${script}; the board keeps the previous copy" >&2
+done
 
 [ -d systemd ] || exit 0
 
@@ -68,7 +69,7 @@ fi
 # release, and the supported way to customise one is a drop-in under
 # /etc/systemd/system/<unit>.d/, which this does not touch.
 units=""
-for unit in systemd/*.service; do
+for unit in systemd/*.service systemd/*.timer; do
     [ -f "$unit" ] || continue
     name="$(basename "$unit")"
     install -m 644 "$unit" "${UNIT_DIR}/${name}" \
@@ -96,7 +97,28 @@ systemctl daemon-reload || echo "postinstall: daemon-reload failed" >&2
 # Every failure is a warning. `on_apply` restarts the units in its own list moments after this, so
 # a unit that is merely slow is not a problem; and a unit that genuinely cannot start must not fail
 # an otherwise good update.
+#
+# Two exceptions, both about not running something *now* that is meant to run at boot:
+#
+#   - a unit with no `[Install]` section cannot be enabled at all, and the recovery net's oneshot
+#     has none on purpose. `enable --now` on it would run a rollback check in the middle of the
+#     update that installed it, with daemons legitimately mid-restart — which is exactly what a
+#     rollback check reads as a release that cannot start;
+#   - a timer is enabled but not started. An `OnBootSec=` timer started past its deadline fires
+#     immediately, and this hook runs mid-update. It arms on the next boot, which is the boot it is
+#     about.
 for name in $units; do
+    if ! grep -q '^\[Install\]' "${UNIT_DIR}/${name}"; then
+        echo "postinstall: ${name} installed; it has no [Install] and is started by something else" >&2
+        continue
+    fi
+    case "$name" in
+        *.timer)
+            systemctl enable "$name" \
+                || echo "postinstall: ${name} did not enable; it arms at the next boot" >&2
+            continue
+            ;;
+    esac
     systemctl enable --now "$name" \
         || echo "postinstall: ${name} did not start; check: journalctl -u ${name} -b" >&2
 done

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -850,7 +850,7 @@ for src in "$REL"/systemd/*.service "$REL"/systemd/*.timer; do
     #   - a timer: enabled, not started. An `OnBootSec=` timer started past its deadline fires at
     #     once, and this hook runs mid-update;
     #   - everything else: enabled and started, which is the whole point of the hook.
-    if ! grep -q '^\[Install\]' "$src"; then
+    if ! grep -q "^\[Install\]" "$src"; then
         grep -q " ${name}$" /stub/systemctl.log \
             && { echo "    [FAIL] postinstall touched ${name}, which has no [Install]"; exit 1; }
         continue

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -765,6 +765,21 @@ test "$configd_at" -lt "$btd_at" \
     || { echo "    [FAIL] btd was enabled before configd"; exit 1; }
 echo "    [ok] daemon-reload precedes every enable, and configd precedes btd"
 
+# The boot recovery net, whose whole job is to be armed for the *next* boot.
+#
+# `enable`, never `enable --now`: an `OnBootSec=` timer started past its deadline fires at once, and
+# at once here is the middle of provisioning — daemons still being started by the lines above, on a
+# board that has no golden release yet anyway.
+grep -q "^enable robot-boot-check.timer$" /stub/systemctl.log \
+    || { echo "    [FAIL] the boot recovery timer was never enabled"; exit 1; }
+grep -q "^enable --now robot-boot-check" /stub/systemctl.log \
+    && { echo "    [FAIL] the boot recovery check was started during provisioning"; exit 1; }
+for script in robot-rescue robot-boot-check; do
+    test -x "/usr/local/sbin/${script}" \
+        || { echo "    [FAIL] ${script} is not installed, so a broken release has no way back"; exit 1; }
+done
+echo "    [ok] the recovery net is installed and armed for the next boot, not this one"
+
 grep -q "keeping the existing /etc/robot/updater.toml" /tmp/install.log
 grep -q "keeping the existing /etc/robot/robotd.toml" /tmp/install.log
 echo "    [ok] the operator config files are preserved, not overwritten"
@@ -811,7 +826,8 @@ echo "    [ok] a unit install.sh does not recognise is installed and reported, n
 #
 # Hooks run with the release directory as the working directory; the hook exits early without
 # one, so getting this wrong would make the whole check vacuous.
-rm -f /etc/systemd/system/*.service /usr/lib/sysusers.d/*.conf /stub/systemctl.log
+rm -f /etc/systemd/system/*.service /etc/systemd/system/*.timer /usr/lib/sysusers.d/*.conf \
+    /stub/systemctl.log
 # The journald drop-in and the robotctl symlink go too, so the asymmetry asserted at the end is
 # a real absence rather than a leftover from the install above.
 rm -f /etc/systemd/journald.conf.d/10-robot.conf /usr/local/bin/robotctl
@@ -820,16 +836,48 @@ rm -f /etc/systemd/journald.conf.d/10-robot.conf /usr/local/bin/robotctl
     cat /tmp/hook.log
     exit 1
 }
-for src in "$REL"/systemd/*.service; do
+for src in "$REL"/systemd/*.service "$REL"/systemd/*.timer; do
+    [ -f "$src" ] || continue
     name="$(basename "$src")"
     test -f "/etc/systemd/system/${name}" \
         || { echo "    [FAIL] postinstall did not install ${name}"; exit 1; }
+
+    # Three outcomes, not one, and which one a unit gets is a property of the unit file:
+    #
+    #   - no `[Install]` section: installed and left alone. The oneshot in the boot recovery
+    #     net is deliberately like this, because `enable --now` on it would run a rollback check in the
+    #     middle of the update that installed it, with daemons legitimately mid-restart;
+    #   - a timer: enabled, not started. An `OnBootSec=` timer started past its deadline fires at
+    #     once, and this hook runs mid-update;
+    #   - everything else: enabled and started, which is the whole point of the hook.
+    if ! grep -q '^\[Install\]' "$src"; then
+        grep -q " ${name}$" /stub/systemctl.log \
+            && { echo "    [FAIL] postinstall touched ${name}, which has no [Install]"; exit 1; }
+        continue
+    fi
+    case "$name" in
+        *.timer)
+            grep -q "^enable ${name}$" /stub/systemctl.log \
+                || { echo "    [FAIL] postinstall did not enable ${name}"; exit 1; }
+            grep -q "^enable --now ${name}$" /stub/systemctl.log \
+                && { echo "    [FAIL] postinstall started ${name}; it arms at the next boot"; exit 1; }
+            continue
+            ;;
+    esac
     grep -q "^enable --now ${name}$" /stub/systemctl.log \
         || { echo "    [FAIL] postinstall did not enable ${name}"; exit 1; }
 done
 test -f /usr/lib/sysusers.d/robot.conf
 grep -q "^daemon-reload$" /stub/systemctl.log
-echo "    [ok] postinstall alone installs and enables every unit the release ships"
+echo "    [ok] postinstall alone installs every unit, and starts the ones meant to start now"
+
+# The recovery scripts, which are what runs when a release cannot start — so they are copied into
+# /usr/local/sbin rather than read through `current`, and an update has to refresh them.
+for script in robot-rescue robot-boot-check; do
+    test -x "/usr/local/sbin/${script}" \
+        || { echo "    [FAIL] postinstall did not install ${script}"; exit 1; }
+done
+echo "    [ok] postinstall refreshes the recovery scripts in /usr/local/sbin"
 
 # The asymmetry, pinned because it is easy to assume otherwise: the hook places units and
 # accounts and nothing else. Both of these were deleted above and the hook did not restore

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -614,7 +614,7 @@ install_units() {
     #
     # The release is the authority on what it contains. This script's job is to install it.
     shipped=""
-    for src in "${unit_src}"/*.service; do
+    for src in "${unit_src}"/*.service "${unit_src}"/*.timer; do
         [ -f "$src" ] || continue
         unit="$(basename "$src")"
         install -m 644 "$src" "${UNIT_DIR}/${unit}"
@@ -638,19 +638,21 @@ install_units() {
     # purpose here: it is a tool an operator invokes, not a file systemd caches.
     ln -sfn "${INSTALL_DIR}/current/bin/robotctl" /usr/local/bin/robotctl
 
-    # `robot-rescue` on root's PATH, and *copied* — the opposite decision to `robotctl` above, for
-    # the same reason the units are copied. It exists for boards whose release cannot start, so
-    # reading it through `current` would route the rescue through the thing being rescued.
+    # The recovery scripts on root's PATH, and *copied* — the opposite decision to `robotctl` above,
+    # for the same reason the units are copied. They exist for boards whose release cannot start, so
+    # reading them through `current` would route the recovery through the thing being recovered.
     #
-    # Absent from releases predating it, which is every release on a first install from a branch.
-    src="${INSTALL_DIR}/current/scripts/robot-rescue"
-    if [ -f "$src" ]; then
-        mkdir -p /usr/local/sbin
-        install -m 755 "$src" /usr/local/sbin/robot-rescue
-    else
-        warn "the release carries no scripts/robot-rescue; a board whose daemons cannot start
-  has no recovery path that does not need updaterd. The next update installs it."
-    fi
+    # Absent from releases predating them, which is every release on a first install from a branch.
+    for script in robot-rescue robot-boot-check; do
+        src="${INSTALL_DIR}/current/scripts/${script}"
+        if [ -f "$src" ]; then
+            mkdir -p /usr/local/sbin
+            install -m 755 "$src" "/usr/local/sbin/${script}"
+        else
+            warn "the release carries no scripts/${script}; a board whose daemons cannot start
+  has less recovery than it should. The next update installs it."
+        fi
+    done
 
     install_completions
 
@@ -688,6 +690,21 @@ install_units() {
   The robot works without it — only the gamepad is unavailable."
     fi
 
+    # The boot-time recovery net: three minutes into each boot, ask whether this release brought
+    # its daemons up, and fall back to golden if it did not.
+    #
+    # `enable`, deliberately **without** `--now`. An `OnBootSec=` timer started later than its
+    # deadline fires at once, and "at once" here is the middle of provisioning — daemons still being
+    # started by the lines above, on a board that has no golden yet anyway. It is a boot check, so
+    # the first boot it should apply to is the next one.
+    #
+    # `robot-boot-check.service` is not enabled and must not be: it carries no `[Install]` section
+    # precisely so that nothing enables it, and the timer is what starts it.
+    if [ -f "${UNIT_DIR}/robot-boot-check.timer" ]; then
+        systemctl enable robot-boot-check.timer || warn "the boot recovery timer did not enable;
+  a release whose daemons cannot start will need robot-rescue by hand."
+    fi
+
     # Anything the release ships that this script does not know how to start. Reported rather
     # than started blindly: a unit may be a template, or something another unit pulls in, and
     # guessing is how a robot ends up running a service nobody chose. Named, so adding a daemon
@@ -695,6 +712,9 @@ install_units() {
     for unit in $shipped; do
         case "$unit" in
             updaterd.service|robotd.service|configd.service|btd.service|padd.service) ;;
+            robot-boot-check.timer) ;;
+            # Started by its timer, never enabled. See above.
+            robot-boot-check.service) ;;
             *) warn "${unit} was installed but not enabled — this script does not know where
   it belongs in the start order. Add it to install_units, or start it by hand." ;;
         esac

--- a/scripts/robot-boot-check
+++ b/scripts/robot-boot-check
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Did the release that just booted actually come up? If not, hand over to `robot-rescue`.
+#
+# Run once per boot by `robot-boot-check.timer`, three minutes in. See
+# `docs/project/boot-recovery-net.md` for why this exists at all and why it is a deadline rather
+# than `OnFailure=` on each daemon.
+#
+# WHAT COUNTS AS "DID NOT COME UP". Two conditions, both positive evidence that systemd tried to run
+# a daemon and could not keep it running:
+#
+#   - the unit is `failed`;
+#   - the unit has restarted at least 3 times this boot, whatever it happens to be doing right now.
+#
+# Everything else is left alone, and that asymmetry is the point. A unit an operator stopped by hand
+# is `inactive` with no restarts, and must not cost the board its release. A unit a release predates
+# is not loaded, which reads the same way. A daemon still waiting for hardware is `active` — all four
+# members wait rather than exit, which is what makes them members at all — and a single crash that
+# recovered leaves one or two restarts, not three. A false negative here costs an operator a
+# diagnosis; a false positive costs a good release.
+#
+# WHY THESE FOUR. A unit may join only if it waits for its hardware rather than exiting, so that a
+# unit which is down means the *binary* is broken — which is what a rollback fixes. `padd` is
+# excluded because it exits cleanly when robotd's socket is absent, by design. `btd` is included on
+# merit rather than symmetry: with no network, BLE is the only way in, so a robot that boots with no
+# `btd` and no known wifi cannot be reached at all.
+#
+# Usage:  robot-boot-check [--dry-run]
+#
+# Exit: 0 nothing to do, or the rescue was handed the decision; 2 declined; 1 something went wrong.
+set -eu
+
+MEMBERS="updaterd.service robotd.service configd.service btd.service"
+
+# Three, not one. `Restart=always` plus a 2-5s `RestartSec` means a genuine loop passes three within
+# the deadline several times over, while a daemon that died once on a transient and came back does
+# not. One would fire on the latter.
+MAX_RESTARTS=3
+
+# This is a *boot* check. Being invoked well after boot means something other than the timer started
+# it — a hand-typed `systemctl start`, or an installer enabling units — and the honest answer then is
+# that the question is not this script's business. Without this guard, `hooks/postinstall` running
+# `enable --now` over the units it installs would run a rollback check in the middle of an update,
+# with daemons legitimately mid-restart.
+MAX_UPTIME=600
+
+RESCUE="${ROBOT_RESCUE:-/usr/local/sbin/robot-rescue}"
+UPTIME_FILE="${ROBOT_UPTIME_FILE:-/proc/uptime}"
+
+DRY_RUN=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            cat <<'USAGE'
+usage: robot-boot-check [--dry-run]
+
+Decide whether the booted release brought its daemons up, and hand over to robot-rescue if not.
+Run once per boot by robot-boot-check.timer. See docs/project/boot-recovery-net.md.
+
+  --dry-run   report the verdict, and do not invoke robot-rescue
+
+Exit: 0 nothing to do or handed over, 2 declined, 1 something went wrong.
+USAGE
+            exit 0
+            ;;
+        *)
+            echo "robot-boot-check: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+say() {
+    echo "robot-boot-check: $*" >&2
+    command -v logger >/dev/null 2>&1 && logger -t robot-boot-check "$*"
+    return 0
+}
+
+# Seconds since boot, or empty when there is nothing to read it from — which is not a reason to
+# refuse to run, only a reason not to enforce the guard.
+uptime_secs() {
+    [ -r "$UPTIME_FILE" ] || return 0
+    cut -d' ' -f1 < "$UPTIME_FILE" | cut -d. -f1
+}
+
+up="$(uptime_secs)"
+if [ -n "$up" ] && [ "$up" -gt "$MAX_UPTIME" ]; then
+    say "up for ${up}s, which is well past the boot deadline; this is not a boot check.
+  Nothing done. To act anyway, decide for yourself and run: robot-rescue --dry-run"
+    exit 2
+fi
+
+# One property per call. `systemctl show -p A -p B` prints them in systemd's own order rather than
+# the order asked for, which makes a two-line parse quietly wrong the day that order changes.
+property() {
+    # $1 property, $2 unit
+    systemctl show -p "$1" --value "$2" 2>/dev/null || true
+}
+
+failed=""
+for unit in $MEMBERS; do
+    state="$(property ActiveState "$unit")"
+    restarts="$(property NRestarts "$unit")"
+
+    # An unloaded unit answers with an empty string for both. Treated as zero rather than special
+    # cased: it then fails both conditions below, which is the answer we want anyway.
+    case "$restarts" in
+        ''|*[!0-9]*) restarts=0 ;;
+    esac
+
+    if [ "$state" = failed ] || [ "$restarts" -ge "$MAX_RESTARTS" ]; then
+        say "${unit} did not come up (state=${state:-unknown} restarts=${restarts})"
+        failed="${failed}${failed:+, }${unit} (${state:-unknown}, ${restarts} restarts)"
+    else
+        say "${unit} ok (state=${state:-unloaded} restarts=${restarts})"
+    fi
+done
+
+if [ -z "$failed" ]; then
+    say "every daemon came up; nothing to do"
+    exit 0
+fi
+
+if [ -n "$DRY_RUN" ]; then
+    say "would hand over to robot-rescue because: ${failed}"
+    exit 0
+fi
+
+[ -x "$RESCUE" ] || {
+    say "no rescue at ${RESCUE}, so there is nothing to hand over to.
+  The board is running a release whose daemons did not start: ${failed}"
+    exit 1
+}
+
+# The rescue owns every remaining decision — whether a golden exists, whether `current` is already
+# golden, whether a previous attempt already tried this. It exits 2 when it declines, which is not a
+# failure of this check: the question was asked and answered.
+say "handing over to robot-rescue: ${failed}"
+"$RESCUE" --reboot --because "boot check: ${failed}" || {
+    status=$?
+    [ "$status" = 2 ] && exit 0
+    exit "$status"
+}

--- a/scripts/robot-rescue
+++ b/scripts/robot-rescue
@@ -19,11 +19,20 @@
 # disease it is treating. `updaterd` publishes golden as a symlink on every start
 # (`Engine::refresh_golden_links`) so that the answer is one `readlink` away and survives the daemon.
 #
-# There is no loop guard here yet, on purpose: nothing invokes this automatically, and a human is
-# rate-limited by being a human. The guard arrives with the boot-deadline timer that calls it — see
-# `docs/project/boot-recovery-net.md`.
+# THE LOOP GUARD. `robot-boot-check` invokes this without a human, so "swap and reboot" has to be
+# something that cannot happen twice on its own. Two independent things stop it:
 #
-# Usage:  robot-rescue [--dry-run] [--reboot]
+#   - it refuses when `current` is already golden, which covers the ordinary case, because a
+#     successful rescue leaves exactly that state;
+#   - and it refuses when a breadcrumb from a previous attempt is still there, which covers the case
+#     the first check misses — an update moved `current` away from golden and failed again.
+#
+# The breadcrumb is cleared by `updaterd` on its next start, once it has copied the record into the
+# update log (`Engine::record_rescue`). So the guard releases itself exactly when the board proves it
+# can run the update daemon again, and stays shut when it cannot: a robot sitting still with a clear
+# journal beats one rebooting forever. `--force` is the way past it by hand.
+#
+# Usage:  robot-rescue [--dry-run] [--reboot] [--force] [--because <text>]
 #
 # Exit: 0 swapped (or would have), 2 declined with nothing to do, 1 something went wrong.
 set -eu
@@ -35,6 +44,8 @@ STATE_DIR="${ROBOT_STATE_DIR:-/var/lib/robot/updater}"
 
 DRY_RUN=
 REBOOT=
+FORCE=
+BECAUSE="invoked by hand"
 
 # Reboot is opt-in, not the default. The units all exec through `current`, so nothing picks up the
 # swap until they restart — but this script is also runnable on a board that is merely suspect, and
@@ -43,15 +54,23 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1 ;;
         --reboot)  REBOOT=1 ;;
+        --force)   FORCE=1 ;;
+        --because)
+            [ $# -ge 2 ] || { echo "robot-rescue: --because needs a value" >&2; exit 1; }
+            BECAUSE="$2"
+            shift
+            ;;
         -h|--help)
             cat <<'USAGE'
-usage: robot-rescue [--dry-run] [--reboot]
+usage: robot-rescue [--dry-run] [--reboot] [--force] [--because <text>]
 
 Point /opt/robot/daemon/current at the golden release, without going through updaterd.
 For a board whose daemons will not start: see docs/project/boot-recovery-net.md.
 
-  --dry-run   report the decision and change nothing
-  --reboot    reboot after the swap, instead of printing the command
+  --dry-run        report the decision and change nothing
+  --reboot         reboot after the swap, instead of printing the command
+  --force          act even though a previous attempt left a breadcrumb
+  --because TEXT   why, recorded in the breadcrumb and in the update log
 
 Exit: 0 swapped (or would have), 2 declined with nothing to do, 1 something went wrong.
 USAGE
@@ -59,7 +78,7 @@ USAGE
             ;;
         *)
             echo "robot-rescue: unknown argument: $1" >&2
-            echo "usage: robot-rescue [--dry-run] [--reboot]" >&2
+            echo "usage: robot-rescue [--dry-run] [--reboot] [--force] [--because <text>]" >&2
             exit 1
             ;;
     esac
@@ -81,6 +100,23 @@ decline() {
 
 golden_link="${INSTALL_DIR}/golden"
 current_link="${INSTALL_DIR}/current"
+breadcrumb="${STATE_DIR}/rescued"
+
+# The loop guard, checked before anything else so that a jammed board says so rather than
+# re-deriving a decision it is not going to act on.
+#
+# Still here means `updaterd` has not started since the last attempt — it clears this once it has
+# copied the record into the update log. So the release the last rescue chose is not starting either,
+# and the fault is not one a rollback fixes.
+if [ -f "$breadcrumb" ] && [ -z "$FORCE" ]; then
+    decline "a previous rescue is still on record, and updaterd has not started since:
+
+$(cat "$breadcrumb")
+
+  So golden did not fix it, and swapping again would only reboot the robot a second time.
+  Read the journal:  journalctl -b -u robotd -u updaterd -u btd -u configd
+  Then, to try anyway:  robot-rescue --force --reboot"
+fi
 
 # No golden means no rollback target. That is the state of every board until 1.0.0 exists, so it is
 # a declined run and not an error — but say which of the two reasons it is, because "unset in
@@ -121,10 +157,21 @@ fi
 # The breadcrumb before the swap, matching the order the engine arms its boot counter in: a record
 # of an attempt that did not happen is recoverable, a swap nothing recorded is not. Outside
 # `install_dir`, so it survives the swap it is describing.
+#
+# `key=value` and not JSON, though `updaterd` reads it: this file is written by a shell script on a
+# board where things are already going wrong, and quoting JSON correctly in `sh` is a way to produce
+# a record nothing can read. It is also read by a human first — it is the evidence.
+#
+# Overwritten rather than appended. It is a guard and the latest record, one attempt at a time; the
+# history that must not be lost goes into the update log, which is append-only and bounded.
 mkdir -p "$STATE_DIR"
-printf '%s rescued from %s to golden %s\n' \
-    "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$current_version" "$golden_version" \
-    >> "${STATE_DIR}/rescued"
+cat > "$breadcrumb" <<EOF
+at=$(date -u '+%s')
+install_dir=${INSTALL_DIR}
+from=${current_version}
+to=${golden_version}
+because=${BECAUSE}
+EOF
 
 # `ln -sfn` unlinks and recreates, which leaves a window where `current` does not exist — and a
 # daemon starting in that window fails to exec. Rename over the top instead: `rename(2)` within one

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1089,6 +1089,12 @@ impl Engine {
             }
         }
 
+        // Before the boot counter, and that ordering is load-bearing: a rescue has already made the
+        // decision an armed trial was going to make, and further than the trial would have gone.
+        // Left in place, `record_boot` below would advance that trial and eventually revert to
+        // `previous` — moving `current` off the golden release the rescue just chose.
+        self.record_rescue();
+
         self.refresh_golden_links();
 
         // Every component's trial advances, independently. A model transition must
@@ -1216,6 +1222,89 @@ impl Engine {
     fn store(&self, component: &str) -> Result<Store, Error> {
         let cfg = self.config.component(component)?;
         Ok(Store::new(cfg.install_dir.clone()))
+    }
+
+    /// Turn a `robot-rescue` breadcrumb into a permanent record, and clear it.
+    ///
+    /// The rescue swaps `current` to golden and reboots with no daemon running, so this start is the
+    /// first moment anything can write that down where it will be found. Three things happen, and
+    /// each is one of the constraints the design names:
+    ///
+    /// - **the update log gets an entry**, because the breadcrumb is deleted below and a rollback
+    ///   nobody can see afterwards is how a day goes to "it works on my board";
+    /// - **any armed trial for that component is cleared**, since the rescue already decided it;
+    /// - **the breadcrumb is removed**, which is what releases the rescue's loop guard. It refuses to
+    ///   act while one is on record, so the guard opens exactly when the board proves it can run its
+    ///   update daemon again, and stays shut when it cannot.
+    ///
+    /// Never fatal. A board that has just been rescued must not be a board whose `updaterd` refuses
+    /// to serve.
+    fn record_rescue(&mut self) {
+        let path = self
+            .config
+            .state_dir
+            .join(crate::journal::RESCUE_BREADCRUMB);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return;
+        };
+
+        let crumb = crate::journal::Breadcrumb::parse(&text);
+        tracing::warn!(
+            from = crumb.from.as_deref().unwrap_or("(none)"),
+            to = crumb.to.as_deref().unwrap_or("(unknown)"),
+            because = crumb.because.as_deref().unwrap_or("(unrecorded)"),
+            "this board was rescued to golden since the last start"
+        );
+
+        // Matched on `install_dir` rather than on the name `daemon`: the rescue knows which tree it
+        // swapped and nothing else about the config, and a hardcoded component name would be a
+        // second place that has to agree with `updater.toml`.
+        let component = crumb.install_dir.as_deref().and_then(|dir| {
+            self.config
+                .components
+                .iter()
+                .find(|(_, cfg)| cfg.install_dir == std::path::Path::new(dir))
+                .map(|(name, _)| name.clone())
+        });
+
+        match component {
+            Some(name) => {
+                let entry = crate::proto::LogEntry {
+                    at: crate::journal::now_unix(),
+                    component: crate::proto::ComponentId(name.clone()),
+                    from: crumb.from.as_deref().and_then(|v| v.parse().ok()),
+                    to: crumb.to.as_deref().and_then(|v| v.parse().ok()),
+                    outcome: crate::proto::Outcome::RolledBack {
+                        reason: format!(
+                            "boot recovery swapped to golden without updaterd ({})",
+                            crumb.because.as_deref().unwrap_or("no reason recorded")
+                        ),
+                    },
+                };
+                if let Err(e) = self.journal.append(&entry) {
+                    tracing::error!(error = %e, "could not record the rescue in the update log");
+                }
+                if let Err(e) = self.boot_counter.confirm(&name) {
+                    tracing::error!(error = %e, "could not clear the trial the rescue superseded");
+                }
+            }
+            // Not attributed to a component we guessed. The journal warning above is the record in
+            // this case, and the breadcrumb is still cleared: a guard that never opens would leave
+            // the board unable to rescue itself a second time, which is worse than a missing log
+            // line for a state only a moved `install_dir` produces.
+            None => tracing::warn!(
+                install_dir = crumb.install_dir.as_deref().unwrap_or("(unrecorded)"),
+                "the rescued tree matches no configured component; not recording it in the log"
+            ),
+        }
+
+        // Durable, because the guard depends on this being gone: a delete that did not reach disk
+        // means the next start declines to act on a board that has already been rescued once.
+        if let Err(e) = std::fs::remove_file(&path) {
+            tracing::error!(error = %e, "could not clear the rescue breadcrumb; robot-rescue will decline until it is removed by hand");
+        } else {
+            let _ = crate::fsutil::fsync_parent(&path);
+        }
     }
 
     /// Publish each component's configured golden release as a `golden` symlink.

--- a/updater/src/journal.rs
+++ b/updater/src/journal.rs
@@ -260,6 +260,62 @@ impl Pins {
     }
 }
 
+/// What `scripts/robot-rescue` leaves in the state dir when it swaps `current` to golden.
+///
+/// The file it writes, verbatim:
+///
+/// ```text
+/// at=1786453421
+/// install_dir=/opt/robot/daemon
+/// from=1.2.0
+/// to=1.0.0
+/// because=boot check: robotd.service (failed, 7 restarts)
+/// ```
+///
+/// `key=value` rather than JSON because the writer is a shell script running on a board where things
+/// are already going wrong, and quoting JSON correctly in `sh` is a way to produce a record nothing
+/// can read. Which makes this the reader for it — and a lenient one on purpose: **every field is
+/// optional**. A breadcrumb that is half-written, or written by an older rescue that did not carry
+/// `install_dir`, still has to be recognised, because the alternative is a board whose loop guard
+/// never opens (`Engine::record_rescue` clears the file, and only recognises it here).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Breadcrumb {
+    pub at: Option<i64>,
+    pub install_dir: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub because: Option<String>,
+}
+
+/// Name of that file inside the state dir.
+pub const RESCUE_BREADCRUMB: &str = "rescued";
+
+impl Breadcrumb {
+    pub fn parse(text: &str) -> Self {
+        let mut crumb = Self::default();
+        for line in text.lines() {
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            // Trimmed, because a human may well have looked at this file — and `from=(none)` is
+            // what the rescue writes for a board that had no live release, which is not a version.
+            let value = value.trim();
+            if value.is_empty() || value == "(none)" {
+                continue;
+            }
+            match key.trim() {
+                "at" => crumb.at = value.parse().ok(),
+                "install_dir" => crumb.install_dir = Some(value.to_owned()),
+                "from" => crumb.from = Some(value.to_owned()),
+                "to" => crumb.to = Some(value.to_owned()),
+                "because" => crumb.because = Some(value.to_owned()),
+                _ => {}
+            }
+        }
+        crumb
+    }
+}
+
 /// Counts boots since an update that has not yet proven itself healthy.
 ///
 /// Catches the failure the in-process health gate cannot: a release that doesn't
@@ -529,6 +585,39 @@ mod tests {
             previous: Some(semver::Version::new(1, 0, 0)),
             boots,
         }
+    }
+
+    /// Exactly what `scripts/robot-rescue` writes, so the two cannot drift without this failing.
+    #[test]
+    fn a_breadcrumb_is_read_the_way_the_rescue_writes_it() {
+        let crumb = Breadcrumb::parse(
+            "at=1786453421\n\
+             install_dir=/opt/robot/daemon\n\
+             from=1.2.0\n\
+             to=1.0.0\n\
+             because=boot check: robotd.service (failed, 7 restarts)\n",
+        );
+
+        assert_eq!(crumb.at, Some(1786453421));
+        assert_eq!(crumb.install_dir.as_deref(), Some("/opt/robot/daemon"));
+        assert_eq!(crumb.from.as_deref(), Some("1.2.0"));
+        assert_eq!(crumb.to.as_deref(), Some("1.0.0"));
+        assert!(crumb.because.unwrap().contains("robotd.service"));
+    }
+
+    /// Lenient on purpose. A breadcrumb this cannot read is a board whose loop guard never opens,
+    /// so a torn write, an unknown key from a newer rescue, or `from=(none)` on a board that had no
+    /// live release must all still parse.
+    #[test]
+    fn a_partial_breadcrumb_is_still_a_breadcrumb() {
+        let crumb = Breadcrumb::parse(
+            "at=1786453421\nfrom=(none)\nto=1.0.0\nsomething_new=42\nnot a pair at all\nbeca",
+        );
+
+        assert_eq!(crumb.from, None, "(none) is not a version");
+        assert_eq!(crumb.to.as_deref(), Some("1.0.0"));
+        assert_eq!(crumb.install_dir, None);
+        assert_eq!(crumb.because, None);
     }
 
     #[test]

--- a/updater/systemd/robot-boot-check.service
+++ b/updater/systemd/robot-boot-check.service
@@ -1,0 +1,31 @@
+# Did the release that just booted actually come up? If not, fall back to golden.
+#
+# The last uncovered failure in the update path. `updaterd` cannot watch its own replacement start,
+# and its boot counter only advances when `updaterd` itself starts — so a release whose daemons do
+# not come up at boot leaves a board with a good release on disk, a trial armed to revert to it, and
+# nothing running that can act on either. See `docs/project/boot-recovery-net.md`.
+#
+# Started by `robot-boot-check.timer` and by nothing else. **There is deliberately no `[Install]`
+# section**: `scripts/install.sh` and `hooks/postinstall` `enable --now` every unit with one, and
+# doing that here would run a rollback check in the middle of the update that installed it — with
+# daemons legitimately mid-restart, which is exactly what this reads as a broken release.
+
+[Unit]
+Description=Fall back to the golden release if this one did not come up
+
+# Never on the way down. A daemon killed during shutdown can be recorded as `failed`, and without
+# this a `systemctl poweroff` at the wrong moment eventually reboots a robot into golden.
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+
+# /usr/local/sbin, not the release. This runs when the release cannot, so reading it through
+# `current` would route the recovery through the thing being recovered. `install.sh` and
+# `hooks/postinstall` copy it out of the artifact, the way they already copy this unit file.
+ExecStart=/usr/local/sbin/robot-boot-check
+
+# Nothing here is fatal to anything: the script decides, and its own refusals are exit 0 or 2.
+# A non-zero exit is a bug in it, worth seeing in `systemctl status` rather than retrying.
+Restart=no

--- a/updater/systemd/robot-boot-check.timer
+++ b/updater/systemd/robot-boot-check.timer
@@ -1,0 +1,28 @@
+# When to ask whether the release came up.
+#
+# A deadline rather than `OnFailure=` on each daemon, and that is a decision worth keeping written
+# down. `OnFailure=` fires when a unit enters `failed`, which these units are configured to avoid:
+# all four use `Restart=always` for reasons argued in their own unit files, and none overrides
+# systemd's default start limit — so a `btd` restarting every 5s crash-loops indefinitely without
+# ever entering `failed`. Making `OnFailure=` fire would mean retuning those units so the daemons
+# give up, which degrades the normal case to enable the rescue case.
+#
+# Asking at a deadline needs no unit changes, catches the forever-restarter, and asks the question
+# that matters — did this release come up? — rather than "did systemd give up on something?".
+
+[Unit]
+Description=Deadline for deciding whether the booted release came up
+
+[Timer]
+# 180s because the board is slower than it looks: `hci0` does not exist until roughly 73 seconds
+# after power-on, of which `bluetooth.service` spends 26 blocked behind `dbus`. The daemons wait for
+# their hardware rather than exiting, so a slow boot is not a failed one — but the check must not run
+# while it is still ordinary for a daemon to be waiting.
+OnBootSec=180
+
+# This is a once-per-boot decision with a 3-minute deadline; a few seconds either way is noise, and
+# a loose timer costs no wakeups.
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -1308,6 +1308,124 @@ async fn starting_up_publishes_golden_as_a_symlink() {
     );
 }
 
+/// `robot-rescue` swaps `current` and reboots with no daemon running, so this start is the first
+/// moment anything can write that down where it will be found — and the breadcrumb it left is also
+/// the rescue's loop guard, which stays shut until this clears it.
+#[tokio::test]
+async fn starting_up_records_a_rescue_and_releases_its_guard() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    fx.publish("1.1.0", None);
+
+    let mut engine = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults::none(),
+        r#"golden = "1.0.0""#,
+    );
+    apply_exact(&mut engine, "1.0.0").await.unwrap();
+    apply_latest(&mut engine).await.unwrap();
+
+    // What the rescue leaves behind after putting the board back on golden.
+    let breadcrumb = fx.root.join("var/lib/robot/updater/rescued");
+    std::fs::write(
+        &breadcrumb,
+        format!(
+            "at=1786453421\ninstall_dir={}\nfrom=1.1.0\nto=1.0.0\nbecause=boot check: \
+             robotd.service (failed, 7 restarts)\n",
+            fx.install.display()
+        ),
+    )
+    .unwrap();
+
+    let mut engine = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults::none(),
+        r#"golden = "1.0.0""#,
+    );
+    engine.recover_on_start().await.unwrap();
+
+    assert!(
+        !breadcrumb.exists(),
+        "the breadcrumb is the rescue's loop guard; not clearing it leaves the board unable to \
+         rescue itself again"
+    );
+
+    let entry = engine
+        .log(1)
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("an entry in the update log");
+    assert_eq!(entry.component.0, "daemon", "matched by install_dir");
+    assert_eq!(entry.from, Some(semver::Version::new(1, 1, 0)));
+    assert_eq!(entry.to, Some(semver::Version::new(1, 0, 0)));
+    match entry.outcome {
+        updater::proto::Outcome::RolledBack { reason } => assert!(
+            reason.contains("robotd.service"),
+            "the reason the check gave has to survive into the log: {reason}"
+        ),
+        other => panic!("a rescue is a rollback, got {other:?}"),
+    }
+}
+
+/// A rescue outranks an armed trial, and the order inside `recover_on_start` is what enforces it.
+///
+/// The trial would revert to `previous`; the rescue already went further, to golden. Left armed, the
+/// boot counter would advance it and eventually move `current` *off* the release the rescue chose —
+/// the recovery net and the never-brick guarantee undoing each other, one boot apart.
+#[tokio::test]
+async fn a_rescue_supersedes_the_trial_it_interrupted() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+
+    let golden = r#"golden = "1.0.0""#;
+    let mut engine = fx.engine(Box::new(FakeRobot::healthy()), Faults::none(), golden);
+    apply_latest(&mut engine).await.unwrap();
+
+    // 1.1.0 goes in and the process dies after the swap, which is what arms a trial.
+    fx.publish("1.1.0", None);
+    let mut crashing = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults {
+            abort_after_swap: true,
+            ..Faults::none()
+        },
+        golden,
+    );
+    let _ = apply_latest(&mut crashing).await;
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+    assert!(fx.pending_file_exists(), "a trial should be armed");
+
+    // Now 1.1.0's daemons do not come up, and the rescue puts the board on golden without any of
+    // this code running: it swaps the symlink and leaves a breadcrumb.
+    let current = fx.install.join("current");
+    std::fs::remove_file(&current).unwrap();
+    std::os::unix::fs::symlink("releases/1.0.0", &current).unwrap();
+    std::fs::write(
+        fx.root.join("var/lib/robot/updater/rescued"),
+        format!(
+            "at=1786453421\ninstall_dir={}\nfrom=1.1.0\nto=1.0.0\nbecause=boot check\n",
+            fx.install.display()
+        ),
+    )
+    .unwrap();
+
+    // Two starts, because `exhausted` is `boots >= 2`: the first would only count, the second would
+    // act. Neither may move the release.
+    let mut engine = fx.engine(Box::new(FakeRobot::healthy()), Faults::none(), golden);
+    assert!(engine.recover_on_start().await.unwrap().is_empty());
+    assert!(
+        !fx.pending_file_exists(),
+        "the rescue already decided; leaving the trial armed lets the boot counter overrule it"
+    );
+    assert!(engine.recover_on_start().await.unwrap().is_empty());
+    assert_eq!(
+        fx.live_version().as_deref(),
+        Some("1.0.0"),
+        "the board must still be on the golden release the rescue chose"
+    );
+}
+
 /// A configured golden that was never installed is not a rollback target. A link pointing at it
 /// would tell the rescue otherwise, and swapping onto it leaves a board that can exec nothing.
 #[tokio::test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1150,6 +1150,49 @@ mod tests {
         assert!(rendered.contains("ONNX_TARGET=\"1.28.0\""));
     }
 
+    /// `board-test.sh` hands its whole container script to `sh -c` inside **one single-quoted
+    /// string**, so a single quote anywhere in it ends that string early.
+    ///
+    /// Both ways this fails are quiet. An apostrophe in a comment — "the oneshot's job" — leaves the
+    /// file syntactically broken, which at least fails loudly. Worse is a quoted argument:
+    /// `grep -q '^\[Install\]'` arrives at the container as `grep -q ^\[Install\]`, and the shell
+    /// there strips the backslashes, so grep is handed `^[Install]` — a bracket expression matching
+    /// one character from `I n s t a l`. It runs, it exits 0 or 1 for the wrong reason, and the
+    /// assertion built on it reports something that was never checked. That is how this test came to
+    /// exist, and finding it took a CI round trip and a while.
+    ///
+    /// Comments are *not* exempt, unlike the check below: the shell does not know it is reading one.
+    #[test]
+    fn the_board_test_container_script_contains_no_single_quotes() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent");
+        let script = std::fs::read_to_string(root.join("scripts/board-test.sh"))
+            .expect("scripts/board-test.sh must exist");
+
+        // The container script is assigned as `CHECKS='` … `'` at the start of a line.
+        let (_, rest) = script
+            .split_once("\nCHECKS='")
+            .expect("board-test.sh no longer assigns CHECKS with a single-quoted string");
+        let (checks, _) = rest
+            .split_once("\n'\n")
+            .expect("the CHECKS string is no longer closed by a lone quote on its own line");
+
+        let offenders: Vec<(usize, &str)> = checks
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| line.contains('\''))
+            .map(|(i, line)| (i + 1, line.trim()))
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "single quotes inside the CHECKS string end it early. Use double quotes for grep \
+             patterns (\"^\\\\[Install\\\\]\" survives; '^\\\\[Install\\\\]' does not) and reword \
+             any apostrophe. Offending lines, numbered from the start of CHECKS: {offenders:#?}"
+        );
+    }
+
     /// Advice the provisioning scripts print must be runnable from where the operator is
     /// standing, which is their home directory and not wherever the file was downloaded to.
     ///

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -859,6 +859,13 @@ mod tests {
 
     /// Where promotion happens: the stable manifest, the artifact carried forward, the retire step.
     const PROMOTE_WORKFLOW: &str = "_promote-release.yml";
+
+    /// Where a unit's `ExecStart` points when it runs a program out of the live release.
+    ///
+    /// Nearly all of them do, and for those the binary has to be staged and packaged or the unit
+    /// fails with `203/EXEC`. The exception is the boot recovery net, which execs out of the base
+    /// precisely so that a broken release cannot break it.
+    const RELEASE_BIN_DIR: &str = "/opt/robot/daemon/current/bin/";
     /// Every unit `install.sh` installs must actually be in the artifact.
     ///
     /// The packaging workflows name each shipped file with an explicit `--include`, and
@@ -1066,14 +1073,28 @@ mod tests {
                 });
 
                 // `ExecStart=/opt/robot/daemon/current/bin/<name> [args]`
-                let Some(exec) = unit
+                let Some(exec_path) = unit
                     .lines()
                     .find(|l| l.starts_with("ExecStart="))
                     .and_then(|l| l.split_whitespace().next())
-                    .and_then(|l| l.rsplit('/').next())
+                    .and_then(|l| l.strip_prefix("ExecStart="))
                 else {
                     panic!("{src} has no ExecStart naming a binary");
                 };
+
+                // A unit that execs out of the *base* rather than the release, which the boot
+                // recovery net does on purpose: it runs when the release cannot, so reading its
+                // program through `current` would route the recovery through the thing being
+                // recovered. Nothing to stage, and `xtask/tests/artifact.rs` checks that the
+                // script it names is packaged and installed.
+                if !exec_path.starts_with(RELEASE_BIN_DIR) {
+                    continue;
+                }
+
+                let exec = exec_path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or_else(|| panic!("{src}: ExecStart={exec_path} names nothing"));
 
                 let staged = format!("release/{exec} staged/");
                 assert!(

--- a/xtask/tests/artifact.rs
+++ b/xtask/tests/artifact.rs
@@ -240,15 +240,20 @@ fn the_artifact_carries_what_install_sh_reads() {
     }
 }
 
-/// Every unit in the artifact must be able to exec its binary out of the same artifact.
+/// Every unit in the artifact must be able to exec what it names, out of wherever it names it.
 ///
 /// This is bug 3, asserted against the tarball instead of against the workflow that builds it.
 /// The unit files were packaged and the binaries were not, so `btd.service` failed with
 /// `203/EXEC` — systemd could not execute `current/bin/btd`, because the release did not contain
 /// it. Derived from the units rather than from a list kept by hand: adding a service and
 /// forgetting to stage its binary fails here.
+///
+/// Two destinations, because the boot recovery net execs out of `/usr/local/sbin` on purpose — it
+/// runs when the release cannot, so reading its program through `current` would route the recovery
+/// through the thing being recovered. That path is checked too, against the `scripts/` entry the
+/// installers copy there, so an `ExecStart` pointing at neither still fails.
 #[test]
-fn every_unit_in_the_artifact_can_exec_its_binary_from_it() {
+fn every_unit_in_the_artifact_can_exec_what_it_names() {
     for workflow in PACKAGING_WORKFLOWS {
         let entries = packaged_release(workflow);
 
@@ -261,17 +266,74 @@ fn every_unit_in_the_artifact_can_exec_its_binary_from_it() {
                 .lines()
                 .find(|l| l.starts_with("ExecStart="))
                 .and_then(|l| l.split_whitespace().next())
-                .and_then(|l| l.rsplit('/').next())
-                .unwrap_or_else(|| panic!("{path} has no ExecStart naming a binary"));
+                .and_then(|l| l.strip_prefix("ExecStart="))
+                .unwrap_or_else(|| panic!("{path} has no ExecStart naming a program"));
+            let name = exec.rsplit('/').next().expect("a path has a last segment");
+
+            let expected = match exec.strip_prefix("/opt/robot/daemon/current/bin/") {
+                Some(_) => format!("bin/{name}"),
+                None => {
+                    assert_eq!(
+                        exec,
+                        format!("/usr/local/sbin/{name}"),
+                        "{workflow} packages {path}, whose ExecStart is {exec:?} — neither in the \
+                         release ({}) nor in the base (/usr/local/sbin/). Nothing installs a \
+                         program there, so the unit is 203/EXEC on the board",
+                        "/opt/robot/daemon/current/bin/"
+                    );
+                    format!("scripts/{name}")
+                }
+            };
 
             assert!(
-                entries.contains_key(&format!("bin/{exec}")),
-                "{workflow} packages {path}, which execs {exec:?} — not in the artifact. On a \
-                 board that is 203/EXEC, and it reads as a broken daemon rather than an \
-                 incomplete release. Stage it in {workflow}:  \
-                 cp target/aarch64-unknown-linux-gnu/release/{exec} staged/"
+                entries.contains_key(&expected),
+                "{workflow} packages {path}, which execs {exec:?}, but the artifact has no \
+                 {expected}. On a board that is 203/EXEC, and it reads as a broken daemon rather \
+                 than an incomplete release"
             );
         }
+    }
+}
+
+/// The recovery net has to arrive whole, and the two halves land differently.
+///
+/// A timer with no oneshot never runs anything; a oneshot with no timer is never triggered; and
+/// either script missing from the artifact leaves a unit pointing at `/usr/local/sbin` with nothing
+/// installed there. Each of those is silent until a board needs the recovery it does not have.
+#[test]
+fn the_boot_recovery_net_is_packaged_whole() {
+    for workflow in PACKAGING_WORKFLOWS {
+        let entries = packaged_release(workflow);
+
+        for path in [
+            "systemd/robot-boot-check.timer",
+            "systemd/robot-boot-check.service",
+            "scripts/robot-boot-check",
+            "scripts/robot-rescue",
+        ] {
+            assert!(
+                entries.contains_key(path),
+                "{workflow}'s artifact has no {path}. Contents: {:?}",
+                entries.keys().collect::<Vec<_>>()
+            );
+        }
+
+        // The oneshot must carry no `[Install]`. Both installers `enable --now` every unit that has
+        // one, and doing that here runs a rollback check in the middle of the update that installed
+        // it — with daemons legitimately mid-restart, which is what it reads as a broken release.
+        let (_, oneshot) = &entries["systemd/robot-boot-check.service"];
+        let oneshot = String::from_utf8_lossy(oneshot);
+        // A section header at the start of a line, which is what systemd parses and what
+        // `hooks/postinstall` greps for. Matching the word anywhere would fire on the comment in
+        // the unit that explains why the section is absent.
+        assert!(
+            !oneshot.lines().any(|l| l.starts_with("[Install]")),
+            "robot-boot-check.service has an [Install] section, so the installers will enable and \
+             start it during an update rather than leaving it to its timer"
+        );
+
+        let (mode, _) = &entries["scripts/robot-boot-check"];
+        assert_eq!(mode & 0o111, 0o111, "the check ships without its exec bit");
     }
 }
 

--- a/xtask/tests/rescue.rs
+++ b/xtask/tests/rescue.rs
@@ -1,18 +1,23 @@
-//! What `scripts/robot-rescue` decides, exercised against a temporary tree.
+//! What the boot recovery net decides: `scripts/robot-boot-check` and `scripts/robot-rescue`,
+//! exercised against a temporary tree.
 //!
-//! The rescue path is the code that has to work when everything else does not, and it is the code
-//! least amenable to a test: on a real board it only runs when a release cannot start. So the
-//! decision is deliberately a pure function of two symlinks — `current` and `golden` — and the
-//! script takes `ROBOT_INSTALL_DIR`/`ROBOT_STATE_DIR` from the environment so that function can be
-//! asked every question here, on a laptop, with no systemd and no board.
+//! This is the code that has to work when everything else does not, and the code least amenable to a
+//! test: on a real board it runs only when a release cannot start. So both halves are written to be
+//! askable without a board — the rescue's decision is a pure function of two symlinks and a
+//! breadcrumb, and the check's is a pure function of what `systemctl show` answers. `ROBOT_*`
+//! environment variables move the tree, the state dir, the rescue's path and the uptime source, and a
+//! stub `systemctl` on `PATH` supplies unit states and records whether a reboot was asked for.
 //!
-//! In `xtask` because this tests a *repository script* rather than any crate's behaviour, which is
-//! what the rest of this directory is for. `sh` and not `bash`: the script runs on a board where
-//! the interpreter is whatever `/bin/sh` is, and the flag detection inside it (`mv -T` on GNU,
-//! `mv -h` on BSD) exists precisely because the same script has to work here and there.
+//! What that leaves uncovered is real and worth naming: **systemd itself**. Whether the timer fires
+//! at `OnBootSec=180`, whether the oneshot's `Conflicts=shutdown.target` keeps it off the way down,
+//! and whether `NRestarts` reads the way this assumes on a crash-looping unit — none of that is here.
+//! It needs a privileged container with systemd as pid 1 (`docs/project/install-path-gap.md` option
+//! C), which is the same infrastructure this argues for.
 //!
-//! What is *not* covered: whether anything ever calls it. Nothing does yet — see
-//! `docs/project/boot-recovery-net.md` for the boot deadline that will.
+//! In `xtask` because these are *repository scripts* rather than any crate's behaviour, which is what
+//! the rest of this directory is for. `sh` and not `bash`: they run on a board where the interpreter
+//! is whatever `/bin/sh` is, and the flag detection inside the rescue (`mv -T` on GNU, `mv -h` on
+//! BSD) exists precisely because the same script has to work here and there.
 
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
@@ -61,21 +66,57 @@ impl Board {
         std::fs::read_to_string(self.state().join("rescued")).ok()
     }
 
-    /// Run the script, with a stub `systemctl` on `PATH` recording whatever it is asked to do.
+    /// Leave a breadcrumb from an earlier rescue, in the format the script writes.
+    fn with_breadcrumb(&self, from: &str, to: &str) -> &Self {
+        std::fs::write(
+            self.state().join("rescued"),
+            format!(
+                "at=1786453421\ninstall_dir={}\nfrom={from}\nto={to}\nbecause=boot check\n",
+                self.install().display()
+            ),
+        )
+        .expect("breadcrumb");
+        self
+    }
+
+    /// Run `robot-rescue`, with a stub `systemctl` on `PATH` recording whatever it is asked to do.
     fn rescue(&self, args: &[&str]) -> Rescue {
-        let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        self.run("scripts/robot-rescue", args, &[])
+    }
+
+    /// Run `robot-boot-check` against stubbed unit states.
+    ///
+    /// `units` is what the stub `systemctl show` answers: `(unit, ActiveState, NRestarts)`. Anything
+    /// not listed answers empty, which is what a real `systemctl` does for a unit that is not
+    /// loaded — a release that predates the unit, on a board that must not be rolled back for it.
+    fn boot_check(&self, args: &[&str], units: &[(&str, &str, u32)]) -> Rescue {
+        self.run("scripts/robot-boot-check", args, units)
+    }
+
+    fn run(&self, script: &str, args: &[&str], units: &[(&str, &str, u32)]) -> Rescue {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .expect("xtask/ has a parent")
-            .join("scripts/robot-rescue");
+            .expect("xtask/ has a parent");
 
         let stub_dir = self.dir.path().join("stub");
         std::fs::create_dir_all(&stub_dir).expect("stub dir");
         let log = stub_dir.join("systemctl.log");
-        std::fs::write(
-            stub_dir.join("systemctl"),
-            format!("#!/bin/sh\necho \"$@\" >> {}\n", log.display()),
-        )
-        .expect("stub");
+
+        // `systemctl show -p <Property> --value <unit>`, so the property is `$3` and the unit is
+        // `$5`. Anything that is not a `show` is recorded instead, which is how a test asserts on
+        // `reboot` — and, more often, on the absence of one.
+        let mut stub = String::from("#!/bin/sh\nif [ \"$1\" = show ]; then\n  case \"$5\" in\n");
+        for (unit, state, restarts) in units {
+            stub.push_str(&format!(
+                "    {unit}) case \"$3\" in ActiveState) echo {state} ;; NRestarts) echo {restarts} ;; esac ;;\n"
+            ));
+        }
+        // An empty `case` body is not portable, and a unit the table does not mention must answer
+        // nothing — which is what a real `systemctl` does for one that is not loaded.
+        stub.push_str("    *) ;;\n  esac\n  exit 0\nfi\n");
+        stub.push_str(&format!("echo \"$@\" >> {}\n", log.display()));
+
+        std::fs::write(stub_dir.join("systemctl"), stub).expect("stub");
         std::fs::set_permissions(
             stub_dir.join("systemctl"),
             <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o755),
@@ -83,10 +124,14 @@ impl Board {
         .expect("stub mode");
 
         let output = Command::new("sh")
-            .arg(&script)
+            .arg(repo.join(script))
             .args(args)
             .env("ROBOT_INSTALL_DIR", self.install())
             .env("ROBOT_STATE_DIR", self.state())
+            .env("ROBOT_RESCUE", repo.join("scripts/robot-rescue"))
+            // A boot check that read the host's real uptime would decline on any machine that has
+            // been up for more than ten minutes, which is every CI runner and every laptop.
+            .env("ROBOT_UPTIME_FILE", self.uptime_file())
             .env(
                 "PATH",
                 format!(
@@ -96,12 +141,29 @@ impl Board {
                 ),
             )
             .output()
-            .expect("run robot-rescue");
+            .unwrap_or_else(|e| panic!("run {script}: {e}"));
 
         Rescue {
             output,
             systemctl: std::fs::read_to_string(&log).unwrap_or_default(),
         }
+    }
+
+    /// What `updaterd` does on its next start: copy the breadcrumb into the update log and remove
+    /// it, which is what releases the rescue's loop guard.
+    fn updaterd_started(&self) -> &Self {
+        let _ = std::fs::remove_file(self.state().join("rescued"));
+        self
+    }
+
+    /// Pretend the board booted `secs` ago.
+    fn booted_secs_ago(&self, secs: u32) -> &Self {
+        std::fs::write(self.uptime_file(), format!("{secs}.42 1234.00\n")).expect("uptime");
+        self
+    }
+
+    fn uptime_file(&self) -> PathBuf {
+        self.dir.path().join("uptime")
     }
 }
 
@@ -236,9 +298,10 @@ fn does_not_reboot_unless_asked() {
         quiet.stderr()
     );
 
-    // Back to a release that is not golden, so the second run has something to do.
+    // Back to a release that is not golden, so the second run has something to do — and past the
+    // loop guard, which is what a successful `updaterd` start does for real.
     std::fs::remove_file(board.install().join("current")).expect("unlink current");
-    board.link("current", "1.2.0");
+    board.link("current", "1.2.0").updaterd_started();
 
     let loud = board.rescue(&["--reboot"]);
     assert_eq!(loud.code(), 0, "stderr: {}", loud.stderr());
@@ -271,11 +334,268 @@ fn refuses_an_argument_it_does_not_understand() {
     let board = Board::with_releases(&["1.0.0", "1.2.0"]);
     board.link("current", "1.2.0").link("golden", "1.0.0");
 
-    let run = board.rescue(&["--force"]);
+    let run = board.rescue(&["--yolo"]);
 
     assert_eq!(run.code(), 1, "stderr: {}", run.stderr());
     assert_eq!(
         board.link_target("current").as_deref(),
         Some("releases/1.2.0")
     );
+}
+
+/// The loop guard. `robot-boot-check` invokes the rescue without a human, so a swap that did not fix
+/// the board must not become a reboot loop. A breadcrumb is still on record when `updaterd` has not
+/// started since — which means the release the last rescue chose is not starting either.
+#[test]
+fn declines_while_a_previous_rescue_is_still_on_record() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board
+        .link("current", "1.2.0")
+        .link("golden", "1.0.0")
+        .with_breadcrumb("1.1.0", "1.0.0");
+
+    let run = board.rescue(&["--reboot"]);
+
+    assert_eq!(run.code(), 2, "stderr: {}", run.stderr());
+    assert!(
+        run.stderr().contains("updaterd has not started since"),
+        "the reason has to name what is stuck: {}",
+        run.stderr()
+    );
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+    assert!(
+        run.systemctl.is_empty(),
+        "a guarded run must not reboot: {:?}",
+        run.systemctl
+    );
+}
+
+/// And the way past it by hand, for an operator who has read the journal and decided.
+#[test]
+fn force_gets_past_the_breadcrumb() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board
+        .link("current", "1.2.0")
+        .link("golden", "1.0.0")
+        .with_breadcrumb("1.1.0", "1.0.0");
+
+    let run = board.rescue(&["--force"]);
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.0.0")
+    );
+}
+
+/// The breadcrumb is read by `updaterd` (`journal::Breadcrumb`) as well as by a person, so its shape
+/// is a contract. Overwritten rather than appended: one attempt at a time, with the history that
+/// must survive going into the update log instead.
+#[test]
+fn the_breadcrumb_carries_what_the_update_log_will_need() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+
+    board.rescue(&[
+        "--because",
+        "boot check: robotd.service (failed, 7 restarts)",
+    ]);
+
+    let crumb = board.breadcrumb().expect("a breadcrumb");
+    let fields: Vec<&str> = crumb.lines().collect();
+    assert!(fields.iter().any(|l| l.starts_with("at=")), "{crumb:?}");
+    assert!(
+        fields
+            .iter()
+            .any(|l| *l == format!("install_dir={}", board.install().display())),
+        "updaterd matches the component by install_dir: {crumb:?}"
+    );
+    assert!(fields.contains(&"from=1.2.0"), "{crumb:?}");
+    assert!(fields.contains(&"to=1.0.0"), "{crumb:?}");
+    assert!(
+        fields
+            .iter()
+            .any(|l| l.starts_with("because=boot check: robotd.service")),
+        "{crumb:?}"
+    );
+}
+
+/// The ordinary boot: every daemon up, nothing to do. This is the case that runs on every robot
+/// every time, so it has to be silent about everything except its own verdict.
+#[test]
+fn the_boot_check_does_nothing_when_every_daemon_came_up() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(180);
+
+    let run = board.boot_check(
+        &[],
+        &[
+            ("updaterd.service", "active", 0),
+            ("robotd.service", "active", 0),
+            ("configd.service", "active", 0),
+            ("btd.service", "active", 1),
+        ],
+    );
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("every daemon came up"));
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0"),
+        "a healthy boot must not move the release"
+    );
+    assert!(run.systemctl.is_empty(), "{:?}", run.systemctl);
+}
+
+#[test]
+fn the_boot_check_rescues_a_failed_daemon() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(180);
+
+    let run = board.boot_check(
+        &[],
+        &[
+            ("updaterd.service", "active", 0),
+            ("robotd.service", "failed", 5),
+            ("configd.service", "active", 0),
+            ("btd.service", "active", 0),
+        ],
+    );
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.0.0"),
+        "stderr: {}",
+        run.stderr()
+    );
+    assert_eq!(run.systemctl.trim(), "reboot");
+
+    let crumb = board.breadcrumb().expect("a breadcrumb");
+    assert!(
+        crumb.contains("robotd.service"),
+        "the reason has to reach the update log: {crumb:?}"
+    );
+}
+
+/// A daemon that is `active` at this instant but has died five times is not a daemon that came up.
+/// With `Restart=always` and a 2-5s `RestartSec`, a crash-looper is `active` a good fraction of the
+/// time — a check that only looked at the state would call this a healthy boot.
+#[test]
+fn the_boot_check_rescues_a_daemon_that_keeps_restarting() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(200);
+
+    let run = board.boot_check(
+        &[],
+        &[
+            ("updaterd.service", "active", 0),
+            ("robotd.service", "active", 0),
+            ("configd.service", "active", 0),
+            ("btd.service", "active", 5),
+        ],
+    );
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.0.0")
+    );
+}
+
+/// Someone stopped it. That is `inactive` with no restarts, and it must not cost the board its
+/// release — the same decision the startup reconciliation makes when it leaves a stopped unit
+/// stopped.
+#[test]
+fn the_boot_check_leaves_a_stopped_daemon_alone() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(180);
+
+    let run = board.boot_check(
+        &[],
+        &[
+            ("updaterd.service", "active", 0),
+            ("robotd.service", "active", 0),
+            ("configd.service", "inactive", 0),
+            ("btd.service", "active", 0),
+        ],
+    );
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+}
+
+/// A release older than one of the units answers nothing at all for it. Reading that as a failure
+/// would roll back every board running a release that predates a daemon.
+#[test]
+fn the_boot_check_ignores_a_unit_the_release_does_not_carry() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(180);
+
+    let run = board.boot_check(
+        &[],
+        &[
+            ("updaterd.service", "active", 0),
+            ("robotd.service", "active", 0),
+        ],
+    );
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+}
+
+/// It is a *boot* check. Invoked long after boot, something other than the timer started it — most
+/// likely an installer running `enable --now` over the units it just wrote, mid-update, with daemons
+/// legitimately restarting. Rolling back there would be the worst thing this could do.
+#[test]
+fn the_boot_check_declines_long_after_boot() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(4 * 60 * 60);
+
+    let run = board.boot_check(&[], &[("robotd.service", "failed", 9)]);
+
+    assert_eq!(run.code(), 2, "stderr: {}", run.stderr());
+    assert!(
+        run.stderr().contains("not a boot check"),
+        "{}",
+        run.stderr()
+    );
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+    assert!(board.breadcrumb().is_none());
+}
+
+#[test]
+fn the_boot_check_dry_run_hands_over_nothing() {
+    let board = Board::with_releases(&["1.0.0", "1.2.0"]);
+    board.link("current", "1.2.0").link("golden", "1.0.0");
+    board.booted_secs_ago(180);
+
+    let run = board.boot_check(&["--dry-run"], &[("btd.service", "failed", 4)]);
+
+    assert_eq!(run.code(), 0, "stderr: {}", run.stderr());
+    assert!(run.stderr().contains("would hand over"), "{}", run.stderr());
+    assert_eq!(
+        board.link_target("current").as_deref(),
+        Some("releases/1.2.0")
+    );
+    assert!(board.breadcrumb().is_none());
+    assert!(run.systemctl.is_empty());
 }


### PR DESCRIPTION
Step 3 of #36, the last one. **Stacked on #67** — it extends `scripts/robot-rescue`, so review and merge that first. **Do not merge before #69** either: #69 is what makes the membership rule true, and until it lands a board with no D-Bus can reach `failed` for a reason a rollback cannot fix.

Steps 1 and 2 built the parts — a rescue that can put a board back on golden with no update daemon, and four daemons that wait for their hardware rather than exiting, so that a unit which is down means a broken release rather than a broken board. This is what asks the question.

`robot-boot-check.timer` fires 180 seconds into every boot; its oneshot asks `systemctl show` about each member and hands over to `robot-rescue` when the answer is bad. 180 because `hci0` does not exist until roughly 73 seconds in and the daemons wait rather than exit, so a slow boot must not read as a failed one.

## Why a deadline and not `OnFailure=`

`OnFailure=` fires when a unit enters `failed`, which these units are configured to avoid: all four use `Restart=always` for reasons argued in their own unit files, and none overrides the default start limit — so a `btd` restarting every 5s crash-loops indefinitely without ever entering `failed`. Making `OnFailure=` fire would mean retuning those units so the daemons *give up*, degrading the normal case to enable the rescue case. Asking at a deadline needs no unit changes and catches the forever-restarter, which is the case `OnFailure=` structurally cannot see.

## The predicate: two conditions, both positive evidence

A member is `failed`, or it has restarted three or more times this boot. Everything else is left alone, and the asymmetry is the point:

- a unit an operator stopped is `inactive` with no restarts, and must not cost the board its release — the same call #65 makes when it leaves a stopped unit stopped;
- a unit the release predates answers nothing, and reads the same way;
- a daemon still waiting for its hardware is `active`;
- one crash that recovered leaves one or two restarts, not three.

A false negative costs an operator a diagnosis. A false positive costs a good release.

Three restarts rather than one because `Restart=always` with a 2–5s `RestartSec` means a genuine loop passes three well within the deadline, while a daemon that died once on a transient does not.

## Three ways it refuses to fire when it should not

- **`Conflicts=shutdown.target`** on the oneshot. A daemon killed on the way down can be recorded as `failed`; without this, `systemctl poweroff` eventually reboots a robot into golden.
- **An uptime guard.** Being invoked well after boot means something other than the timer started it, and the honest answer then is that the question is not this script's business.
- **No `[Install]` section on the oneshot**, which both installers now read as "do not enable this". Without it, `hooks/postinstall` running `enable --now` over the units it just wrote would run a rollback check in the middle of the update that installed it — with daemons legitimately mid-restart, which is exactly what a rollback check reads as a release that cannot start. Timers are enabled but not started for the same reason: an `OnBootSec=` timer started past its deadline fires at once.

That last one is the sharpest edge in this PR. Both installers now grow a rule rather than a special case: a unit with no `[Install]` is installed and left alone, a timer is enabled but not started, everything else is enabled and started.

## The loop guard, and what opens it

The rescue already refused when `current` is already golden, which covers the ordinary case because a successful rescue leaves exactly that state. It now also refuses while a breadcrumb from a previous attempt is on record — the case that misses, where an update moved `current` away from golden and failed again.

`Engine::record_rescue` clears the breadcrumb on the next `updaterd` start, after copying it into the update log. So the guard opens exactly when the board proves it can run its update daemon again, and stays shut when it cannot: a robot sitting still with a clear journal beats one rebooting forever. `--force` is the way past by hand.

**That clearing runs before the boot counter, and the ordering is load-bearing.** An armed trial would revert to `previous`; the rescue already went further, to golden. Left armed, `record_boot` would advance the trial and eventually move `current` *off* the release the rescue chose — the recovery net and the never-brick guarantee undoing each other one boot apart. `a_rescue_supersedes_the_trial_it_interrupted` pins it.

## Notes

- The breadcrumb is `key=value` rather than JSON, though `updaterd` parses it: the writer is a shell script on a board where things are already going wrong, and quoting JSON correctly in `sh` is a way to produce a record nothing can read. The reader is lenient for the same reason — every field optional — because a breadcrumb that cannot be parsed is a guard that never opens.
- The rescue is recorded as `Outcome::RolledBack` with the failing unit named in its reason, so `robotctl update log` is where an operator finds it without knowing to look. No proto change.
- `xtask/tests/rescue.rs` grows nine cases for the check, with a stub `systemctl` supplying unit states and recording whether a reboot was asked for. `board-test.sh` gains the installer half: the timer enabled and never started, the oneshot installed and never touched, both scripts in `/usr/local/sbin`.
- `every_unit_in_the_artifact_can_exec_its_binary_from_it` became `..._can_exec_what_it_names`: a unit may exec out of the release *or* out of `/usr/local/sbin`, and an `ExecStart` naming neither still fails. Same exception in the workflow-side guard in `xtask/src/main.rs`.
- Workspace suite green, clippy clean, `shellcheck` clean on all five scripts. **What is not covered is systemd itself** — whether the timer fires at `OnBootSec=180`, whether `Conflicts=shutdown.target` keeps the oneshot off the way down, and whether `NRestarts` reads the way this assumes on a crash-looping unit. That needs a privileged container with systemd as pid 1 (`install-path-gap.md` option C), which this is now the second argument for. **Not exercised on hardware.**
- `#36`'s doc still says `Status: proposed, not built`. It is accurate until these three merge; it wants flipping in whichever PR lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
