### PR TITLE
Refuse a release that would leave a unit with nothing to exec

### DIFF
--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -520,8 +520,9 @@ fetch manifest ──► verify manifest signature ──► compare version, ch
 download artifact ──► verify sha256 ──► verify artifact signature
         │
         ▼
-extract to releases/<ver>.tmp/  ──► [pre_install hook]
-        │
+extract to releases/<ver>.tmp/  ──► orphaned-unit check (§7.3) ──► [pre_install hook]
+        │                                    │ (an installed unit execs a binary this release lacks)
+        │                                    └─► report + exit, nothing swapped
         ▼
 atomic symlink swap:  current → releases/<ver>        (rename(2), same fs)
         │
@@ -579,6 +580,52 @@ side effects:
 - **Disk space.** Storage is eMMC (finite, wear less of a concern than SD, but
   space still is). Verify free space for download + extract + `keep_previous`
   before starting.
+
+### 7.3 Would this release orphan an installed unit?
+
+`hooks/postinstall` installs the units a release ships and leaves them behind on a
+rollback (§9). For a rollback that is right — the next successful update reinstalls
+whatever it ships. For a **downgrade past the release that introduced a daemon** it is
+not: the unit stays, its `ExecStart` names a binary the older release does not contain,
+systemd fails it with `203/EXEC`, and since that daemon is in the derived restart set
+the failed restart fails the update, which reverts. Observed on a board that resolved
+to stable `0.2.0`, which predates `configd`.
+
+So a candidate that lacks a binary some installed unit execs is refused —
+`updater/src/orphan.rs`, `Error::WouldOrphanUnit`. It reads `/etc/systemd/system/*.service`
+filtered to units whose `Exec*=` points into the component's `current` symlink: the live
+directory is the only place an orphan appears, since it outlived the release that
+installed it, and the filter is what keeps out units no release of ours shipped. Anything
+it cannot parse produces no finding — refusing an update over a unit file the parser
+merely did not understand is the worse failure.
+
+Three placement decisions worth keeping:
+
+- **Not preflight (§7.2).** Both preflight passes run before the artifact is downloaded,
+  so the candidate's file list does not exist yet. This runs after extraction and before
+  the swap, which is still "no side effects": staging is disposable, the boot counter is
+  unarmed, `current` has not moved. It costs a download to find out.
+- **Before the dry run returns**, because "will this downgrade work?" is what a dry run
+  is asked.
+- **No target is exempt**, unlike the `WouldDowngrade` guard which fires on `Latest`
+  alone. That one is about a mirror serving a stale manifest; this one is about a unit
+  that will not start, which does not care how the target was named — and `Ref` is how
+  the case was observed.
+
+Not on rollback, reset-to-golden or `select`: those move backwards deliberately and are
+how a board gets off a bad release, so nothing that can refuse belongs in the recovery
+path ([`architecture.md`](architecture.md) §1.1).
+
+The refusal names the unit, the missing binary, and the way past it — remove the unit:
+
+```
+systemctl disable --now configd.service && rm /etc/systemd/system/configd.service
+```
+
+Deliberately not a `--force` flag. Removing the unit is what the operator means anyway,
+since a board below the release that introduced a daemon should not be running that
+daemon; it makes the situation true rather than overriding a check that says it is not,
+and the next update that ships the unit reinstalls it.
 
 ## 8. Health gate & rollback
 

--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -128,11 +128,24 @@ and said so. The outcome is right — a board should not silently downgrade belo
 introduced a daemon it is now running — but nothing states the rule, and the error names a systemd
 failure rather than the cause.
 
-Worth deciding rather than leaving as emergent behaviour, and **still open**: whether preflight should
-refuse a target that lacks a binary some installed unit execs, so the refusal arrives before the swap
-and names the real reason. Today the only downgrade guard is `Error::WouldDowngrade`, which fires on
-`Latest` alone — `Exact` and `Ref` bypass it deliberately, and `Ref` is precisely how this was
+**Now stated rather than emergent.** `updater/src/orphan.rs` refuses a candidate that lacks a binary
+some installed unit execs, and the refusal names the unit, the missing binary and the way past it —
+remove the unit, `systemctl disable --now configd.service && rm /etc/systemd/system/configd.service`.
+There is no override flag: removing the unit is what the operator means anyway, since a board below
+the release that introduced a daemon should not be running that daemon, and the next update that
+ships the unit reinstalls it.
+
+Two things about where it runs. It is **not** in preflight, which cannot see the candidate's file
+list — both preflight passes run before the artifact is downloaded — so it runs after extraction and
+before the swap, where staging is still disposable and nothing is armed. And **no target is exempt**,
+unlike `Error::WouldDowngrade`, which fires on `Latest` alone: that guard is about a mirror serving a
+stale manifest, this one is about a unit that will not start, and `Ref` is precisely how it was
 observed.
+
+It does not run on rollback, reset-to-golden or `select`. Those move backwards on purpose and are how
+a board gets off a bad release, so a check that can refuse must not sit in the recovery path
+(`docs/design/architecture.md` §1.1) — rolling back onto an orphaned unit stays the documented
+behaviour above, and stays self-correcting.
 
 ## Why the existing tests could not have caught them
 

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -17,7 +17,7 @@
 //!    health check is still recoverable. The reverse order would leave an
 //!    unrecorded bad release live.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::{ApplyAction, ComponentConfig, Config, HealthCheck};
@@ -106,6 +106,12 @@ pub struct Engine {
     /// On a robot, always. Off only in the test binaries, and for a reason that is about processes
     /// rather than about restarts — see [`Engine::without_deferred_restarts`].
     deferred_restarts: bool,
+    /// Where systemd's installed unit files live, for the orphan check ([`crate::orphan`]).
+    ///
+    /// A field so a test can point it at a directory it owns, and **not** a config key, for the
+    /// reason `NEVER_RESTART` is not one: `/etc/systemd/system` is a property of the system rather
+    /// than a choice, and a board that got it wrong would silently stop checking.
+    unit_dir: PathBuf,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -133,7 +139,18 @@ impl Engine {
             pins,
             faults,
             deferred_restarts: true,
+            unit_dir: PathBuf::from(UNIT_DIR),
         })
+    }
+
+    /// Look for orphaned units somewhere other than `/etc/systemd/system`.
+    ///
+    /// For tests, which cannot write to the real one — and must not, since the check reads whatever
+    /// the machine running them happens to have installed.
+    #[doc(hidden)]
+    pub fn with_unit_dir(mut self, dir: PathBuf) -> Self {
+        self.unit_dir = dir;
+        self
     }
 
     /// Stop this engine spawning anything when a release is applied.
@@ -573,6 +590,28 @@ impl Engine {
                 source: e,
             }
         })?;
+
+        // 5b. Would this release leave an installed unit with nothing to exec? See
+        //     [`crate::orphan`] — a downgrade past the release that introduced a daemon leaves
+        //     that daemon's unit behind, and it then fails with `203/EXEC`, which fails the
+        //     restart, which reverts the update.
+        //
+        //     Here rather than in `preflight` because the candidate's file list does not exist
+        //     until now, and before the dry run returns because "will this downgrade work?" is
+        //     exactly what a dry run is asked. Nothing has moved yet: staging is disposable, the
+        //     boot counter is unarmed, `current` still points where it did.
+        //
+        //     No target is exempt. `WouldDowngrade` above guards only `Latest`, because it is
+        //     about a mirror serving a stale manifest; this is about a unit that will not start,
+        //     which does not care how the target was named — and `Ref` is how the case was
+        //     observed.
+        let orphans = crate::orphan::would_orphan(&self.unit_dir, &store.link_path(), extract_dir);
+        if !orphans.is_empty() {
+            return Err(Error::WouldOrphanUnit(crate::orphan::refusal(
+                &manifest.version,
+                &orphans,
+            )));
+        }
 
         if options.dry_run {
             return Ok(ApplyResult::DryRunPassed {
@@ -1555,6 +1594,9 @@ impl Engine {
 
 /// The program that drives units. A constant so tests can substitute a stub for it.
 const SYSTEMCTL: &str = "systemctl";
+
+/// Where `hooks/postinstall` installs unit files, and so where the orphan check reads them.
+const UNIT_DIR: &str = "/etc/systemd/system";
 
 /// This process's own unit, which the reconciliation must recognise and never restart.
 ///

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -37,6 +37,7 @@ pub mod hooks;
 pub mod ipc;
 pub mod journal;
 pub mod manifest;
+pub mod orphan;
 pub mod preflight;
 pub mod reconcile;
 /// The IPC contract, re-exported from the [`duck_ipc_proto`] crate. Re-exported under this
@@ -71,6 +72,13 @@ pub enum Error {
         installed: semver::Version,
         candidate: semver::Version,
     },
+
+    /// The candidate does not contain a binary an installed unit execs.
+    ///
+    /// Carries a preformatted message rather than its parts, because the useful half is the
+    /// remedy — see [`crate::orphan::refusal`], which builds and tests it.
+    #[error("{0}")]
+    WouldOrphanUnit(String),
 
     #[error("another update is already in progress")]
     Busy,
@@ -143,6 +151,11 @@ impl Error {
             Error::Network(_) => code::NETWORK,
             Error::Verification(_) => code::VERIFICATION_FAILED,
             Error::Incompatible(_) => code::INCOMPATIBLE,
+            // Shares the incompatible code rather than adding one, for the reason `SelfTest`
+            // shares health's: to a client this is the same answer — "that release will not run
+            // on this board as it stands" — and what distinguishes it is the message. A new code
+            // would also be an `API_VERSION` bump for a refusal no client branches on.
+            Error::WouldOrphanUnit(_) => code::INCOMPATIBLE,
             Error::ArchiveTooLarge(_) => code::ARCHIVE_TOO_LARGE,
             Error::Preflight(_) => code::PREFLIGHT_FAILED,
             Error::Hook { .. } => code::HOOK_FAILED,

--- a/updater/src/orphan.rs
+++ b/updater/src/orphan.rs
@@ -1,0 +1,352 @@
+//! Would this release leave an installed unit with nothing to exec?
+//!
+//! `hooks/postinstall` installs the units a release ships and, by design, leaves them behind on a
+//! rollback: the next successful update reinstalls whatever it ships, so recording what was added
+//! is not worth it. That reasoning holds for a rollback and stops holding for a **downgrade to a
+//! release that predates a daemon**. The unit stays, its `ExecStart` names a binary the older
+//! release does not contain, and systemd fails it with `203/EXEC`. Since that daemon is also in the
+//! derived restart set, the failed restart fails the *update*, which reverts.
+//!
+//! Observed exactly that way: `apply daemon` on a board running a dev build resolved to stable
+//! `0.2.0`, which predates `configd`; `configd.service` could not start; the engine rolled back and
+//! said so. The outcome was right and the diagnosis was a systemd error code — nothing named the
+//! cause, and nothing *stated* the rule that a board should not silently drop below the release
+//! that introduced a daemon it is running. This states it.
+//!
+//! ## What it reads, and why the live directory
+//!
+//! `/etc/systemd/system/*.service`, filtered to units whose `Exec*=` points into the component's
+//! `current` symlink. Both halves matter. The live directory is the only place the orphan appears —
+//! it outlived the release that installed it, so the previous release's `systemd/` cannot name it
+//! by construction. And the filter is what keeps out units no release of ours ever shipped, put
+//! there by hand or by an unrelated package, which is the objection to reading the live directory
+//! at all.
+//!
+//! ## Failing open
+//!
+//! A unit whose file cannot be read, or whose `Exec*=` this cannot resolve to a path under
+//! `current`, produces no finding. The cost of a false negative is the `203/EXEC` rollback that
+//! happens today; the cost of a false positive is refusing an update over a unit file this parser
+//! merely did not understand — and refusing updates is the one thing the update system may not do
+//! wrongly.
+//!
+//! ## Where it is not
+//!
+//! Not in `preflight`, which cannot see the candidate's file list: both passes run before the
+//! artifact is downloaded. The engine runs this after extraction and before the swap, where the
+//! files exist and staging is still disposable — see [`crate::engine`].
+//!
+//! Not on rollback, reset-to-golden or `select` either, and that is deliberate rather than
+//! unfinished. Those paths move backwards on purpose, they are how a board gets off a bad release,
+//! and a check that can refuse must never sit in the recovery path (`docs/design/architecture.md`
+//! §1.1). Rolling back onto an orphaned unit is the documented behaviour of `hooks/postinstall`,
+//! and it is self-correcting: the next update that ships the unit reinstalls it.
+
+use std::path::{Path, PathBuf};
+
+/// An installed unit the candidate release would leave with nothing to exec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Orphan {
+    /// As systemd knows it: `configd.service`.
+    pub unit: String,
+    /// The unit file itself, so the refusal can name the thing to remove.
+    pub path: PathBuf,
+    /// What it execs, relative to a release root: `bin/configd`.
+    pub missing: String,
+}
+
+/// Every installed unit that execs something this candidate does not contain.
+///
+/// `unit_dir` and `current` are parameters rather than constants for the reason `systemctl` is one
+/// in [`crate::engine`]: a test needs to hand it a directory it controls. On a board they are
+/// always `/etc/systemd/system` and the component's `current` symlink.
+///
+/// One finding per unit — the first missing path. A unit with two broken execs is one broken unit,
+/// and the operator's move is the same either way.
+pub fn would_orphan(unit_dir: &Path, current: &Path, candidate_root: &Path) -> Vec<Orphan> {
+    let Ok(entries) = std::fs::read_dir(unit_dir) else {
+        // No unit directory at all: a container, a test box, a dev laptop. Nothing to orphan.
+        return Vec::new();
+    };
+
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("service"))
+        .collect();
+    // Sorted so a board with several orphans reports them in the same order every time.
+    files.sort();
+
+    let mut orphans = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if let Some(missing) = execs_under(&text, current)
+            .into_iter()
+            .find(|rel| !candidate_root.join(rel).exists())
+        {
+            orphans.push(Orphan {
+                unit: name.to_owned(),
+                path: path.clone(),
+                missing,
+            });
+        }
+    }
+
+    orphans
+}
+
+/// The paths a unit execs from inside `current`, relative to the release root.
+///
+/// Every `Exec*=` directive, not `ExecStart` alone: an `ExecStartPre` naming a missing binary fails
+/// the unit in exactly the same way, and it is the same parse.
+pub fn execs_under(unit: &str, current: &Path) -> Vec<String> {
+    let prefix = format!("{}/", current.display());
+
+    logical_lines(unit)
+        .iter()
+        .filter_map(|line| {
+            let (key, value) = line.split_once('=')?;
+            if !key.trim().starts_with("Exec") {
+                return None;
+            }
+            let path = exec_path(value)?;
+            let rel = path.strip_prefix(&prefix)?;
+            (!rel.is_empty()).then(|| rel.to_owned())
+        })
+        .collect()
+}
+
+/// Unit-file lines with systemd's `\` continuations joined.
+///
+/// Not a nicety: `updaterd.service` writes its own `ExecStart` across three lines, so a
+/// line-at-a-time parse reads a truncated command. It gets the right answer there by luck — the
+/// binary is on the first line — and would not on a unit that wrapped anywhere else.
+fn logical_lines(text: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut pending = String::new();
+
+    for raw in text.lines() {
+        let piece = raw.trim();
+        if !pending.is_empty() {
+            // A continuation: its indentation is layout, and joining without a separator would
+            // glue the last word of one line to the first of the next.
+            pending.push(' ');
+        }
+
+        match piece.strip_suffix('\\') {
+            Some(head) => pending.push_str(head.trim_end()),
+            None => {
+                pending.push_str(piece);
+                lines.push(std::mem::take(&mut pending));
+            }
+        }
+    }
+
+    // A file ending mid-continuation. Malformed, but systemd would still read the command.
+    if !pending.is_empty() {
+        lines.push(pending);
+    }
+
+    lines
+}
+
+/// The executable an `Exec*=` value names, before its arguments.
+///
+/// `None` for a value this cannot resolve, which includes the bare `ExecStart=` that resets the
+/// list. See the module's note on failing open.
+fn exec_path(value: &str) -> Option<String> {
+    // systemd's prefix characters — `@ - : + ! !!` — in any order and repeatable.
+    let mut rest = value.trim();
+    while let Some(stripped) = rest.strip_prefix(['@', '-', ':', '+', '!']) {
+        rest = stripped.trim_start();
+    }
+
+    let token = match rest.strip_prefix('"') {
+        Some(quoted) => quoted.split('"').next()?,
+        None => rest.split_whitespace().next()?,
+    };
+
+    (!token.is_empty()).then(|| token.to_owned())
+}
+
+/// What the operator is told, and what to do about it.
+///
+/// The remedy is the load-bearing half. Without it this is a refusal whose way past is not
+/// guessable from the board, which is worse than the `203/EXEC` rollback it replaces. And it is
+/// deliberately *not* a new `--force` flag: removing the unit is what the operator actually means —
+/// a board downgraded below the release that introduced a daemon should not be running that daemon
+/// — so it makes the situation true rather than overriding a check that says it is not. The next
+/// update that ships the unit reinstalls it, so nothing is lost by removing it.
+///
+/// The same move `install --force` and `systemctl stop robotd` already make elsewhere: an existing
+/// mechanism, named in the message, rather than a flag that exists to be typed.
+pub fn refusal(version: &semver::Version, orphans: &[Orphan]) -> String {
+    let listed = orphans
+        .iter()
+        .map(|o| format!("  {} execs {}", o.unit, o.missing))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let remedy = orphans
+        .iter()
+        .map(|o| {
+            format!(
+                "  systemctl disable --now {} && rm {}",
+                o.unit,
+                o.path.display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "{version} does not contain a binary that an installed unit runs:\n\
+         {listed}\n\
+         That unit would fail with 203/EXEC after the swap, its failed restart would fail the \
+         update, and the update would roll back — so it is refused now, while nothing has moved. \
+         This is the ordinary shape of a downgrade past the release that introduced a daemon; the \
+         release being installed is not broken. To install it anyway, remove the unit that would \
+         be orphaned:\n{remedy}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current() -> PathBuf {
+        PathBuf::from("/opt/robot/daemon/current")
+    }
+
+    /// The plain case, and the one every unit in this repo is written as.
+    #[test]
+    fn an_execstart_into_current_is_relative_to_the_release() {
+        let unit = "[Service]\nExecStart=/opt/robot/daemon/current/bin/configd --allow-user btd\n";
+        assert_eq!(execs_under(unit, &current()), ["bin/configd"]);
+    }
+
+    /// `updaterd.service` is written this way today. A line-at-a-time parser gets the right answer
+    /// here by accident — the binary is on the first line — and the accident is the point: nothing
+    /// stops the next unit from wrapping before its path.
+    #[test]
+    fn a_continued_execstart_is_one_command() {
+        let unit = "[Service]\n\
+                    ExecStart=/opt/robot/daemon/current/bin/updaterd \\\n\
+                    \x20   --config /etc/robot/updater.toml \\\n\
+                    \x20   --socket /run/updaterd.sock\n";
+        assert_eq!(execs_under(unit, &current()), ["bin/updaterd"]);
+    }
+
+    /// Every `Exec*=`, because a missing `ExecStartPre` fails the unit just as thoroughly.
+    #[test]
+    fn every_exec_directive_counts_not_only_execstart() {
+        let unit = "[Service]\n\
+                    ExecStartPre=-/opt/robot/daemon/current/bin/migrate\n\
+                    ExecStart=@/opt/robot/daemon/current/bin/robotd argv0\n\
+                    ExecStopPost=!/opt/robot/daemon/current/bin/cleanup\n";
+        assert_eq!(
+            execs_under(unit, &current()),
+            ["bin/migrate", "bin/robotd", "bin/cleanup"]
+        );
+    }
+
+    /// Anything not under `current` belongs to someone else. Reading the live unit directory is
+    /// only defensible because of this line.
+    #[test]
+    fn units_pointing_outside_the_release_are_not_ours() {
+        let unit = "[Unit]\n\
+                    Documentation=file:///opt/robot/daemon/current/docs/architecture.md\n\
+                    [Service]\n\
+                    ExecStart=/usr/bin/sshd -D\n\
+                    ExecStart=/opt/robot/other-component/current/bin/thing\n";
+        assert!(execs_under(unit, &current()).is_empty());
+    }
+
+    /// Failing open, in the two shapes it arrives in: a reset directive, and a value with no path.
+    #[test]
+    fn a_value_with_no_path_yields_nothing() {
+        assert_eq!(exec_path(""), None);
+        assert_eq!(exec_path("  -@ "), None);
+        assert_eq!(
+            exec_path("\"/opt/robot/daemon/current/bin/a b\" --flag").as_deref(),
+            Some("/opt/robot/daemon/current/bin/a b")
+        );
+    }
+
+    fn write_unit(dir: &Path, name: &str, exec: &str) {
+        std::fs::write(
+            dir.join(name),
+            format!("[Service]\nExecStart={exec}\n[Install]\nWantedBy=multi-user.target\n"),
+        )
+        .expect("writing a unit");
+    }
+
+    /// The whole scan over real files: one unit the candidate can run, one it cannot, one that is
+    /// not ours, and one that is not a unit file at all.
+    #[test]
+    fn only_units_the_candidate_cannot_run_are_reported() {
+        let dir = tempfile::tempdir().expect("a temp unit dir");
+        let candidate = tempfile::tempdir().expect("a temp release root");
+        std::fs::create_dir_all(candidate.path().join("bin")).unwrap();
+        std::fs::write(candidate.path().join("bin/robotd"), b"elf").unwrap();
+
+        write_unit(
+            dir.path(),
+            "robotd.service",
+            "/opt/robot/daemon/current/bin/robotd",
+        );
+        write_unit(
+            dir.path(),
+            "configd.service",
+            "/opt/robot/daemon/current/bin/configd",
+        );
+        write_unit(dir.path(), "sshd.service", "/usr/sbin/sshd -D");
+        std::fs::write(dir.path().join("notes.txt"), "not a unit").unwrap();
+
+        let found = would_orphan(dir.path(), &current(), candidate.path());
+
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].unit, "configd.service");
+        assert_eq!(found[0].missing, "bin/configd");
+    }
+
+    /// A board with no `/etc/systemd/system` must not be an update failure — that is every
+    /// container and every dev laptop this code also runs on.
+    #[test]
+    fn no_unit_directory_is_not_a_finding() {
+        let candidate = tempfile::tempdir().expect("a temp release root");
+        let missing = candidate.path().join("nowhere");
+        assert!(would_orphan(&missing, &current(), candidate.path()).is_empty());
+    }
+
+    /// The refusal has to carry the way past it, or this is a bricked update path on a board where
+    /// the remedy is not guessable.
+    #[test]
+    fn the_refusal_names_the_unit_the_binary_and_the_way_past() {
+        let text = refusal(
+            &semver::Version::parse("0.2.0").unwrap(),
+            &[Orphan {
+                unit: "configd.service".into(),
+                path: "/etc/systemd/system/configd.service".into(),
+                missing: "bin/configd".into(),
+            }],
+        );
+
+        assert!(text.contains("0.2.0"), "{text}");
+        assert!(text.contains("configd.service execs bin/configd"), "{text}");
+        assert!(
+            text.contains("systemctl disable --now configd.service"),
+            "{text}"
+        );
+        assert!(
+            text.contains("rm /etc/systemd/system/configd.service"),
+            "{text}"
+        );
+    }
+}

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -243,6 +243,41 @@ health = {{ probe = "socket", timeout = "2s" }}
         self.engine(Box::new(FakeRobot::healthy()), Faults::none(), "")
     }
 
+    /// A stand-in for `/etc/systemd/system`, which a test can neither read nor write meaningfully:
+    /// on a CI runner it holds whatever that machine has installed, and on a robot it holds the
+    /// real units.
+    fn unit_dir(&self) -> PathBuf {
+        let dir = self.root.join("etc/systemd/system");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Install a unit that execs `bin/<name>` through this component's `current` symlink — what
+    /// `hooks/postinstall` leaves on the board.
+    fn install_unit(&self, name: &str) {
+        std::fs::write(
+            self.unit_dir().join(format!("{name}.service")),
+            format!(
+                "[Service]\nExecStart={}/current/bin/{name}\n",
+                self.install.display()
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A release carrying binaries, so a unit installed on the board has something to exec.
+    fn publish_with_binaries(&self, version: &str, binaries: &[&str]) {
+        let mut release = self.publisher.release(version);
+        for name in binaries {
+            release = release.file(&format!("bin/{name}"), b"#!/bin/true\n", 0o755);
+        }
+        release.write();
+    }
+
+    fn engine_seeing_units(&self) -> Engine {
+        self.engine_healthy().with_unit_dir(self.unit_dir())
+    }
+
     fn release_exists(&self, version: &str) -> bool {
         self.install.join("releases").join(version).is_dir()
     }
@@ -553,6 +588,89 @@ async fn refuses_when_disk_is_full() {
     let err = apply_latest(&mut engine).await.unwrap_err();
     assert!(matches!(err, updater::Error::Preflight(_)), "got {err:?}");
     assert_eq!(fx.live_version(), None, "must abort before downloading");
+}
+
+/// The case that motivated the check, as it happened: a board running a release with `configd`
+/// resolves to one that predates it, `configd.service` stays behind, and its binary is gone.
+///
+/// What it used to do — install, fail the restart with `203/EXEC`, roll back, and report a systemd
+/// error code — was the right outcome reached by the most expensive route, and named nothing.
+#[tokio::test]
+async fn refuses_a_release_that_would_orphan_an_installed_unit() {
+    let fx = Fixture::new();
+    fx.install_unit("robotd");
+    fx.install_unit("configd");
+    // The candidate predates `configd`: it still ships `robotd`, and that unit must not be
+    // reported — otherwise this would pass while refusing every release for the wrong reason.
+    fx.publish_with_binaries("1.0.0", &["robotd"]);
+
+    let mut engine = fx.engine_seeing_units();
+    let err = apply_latest(&mut engine).await.unwrap_err();
+
+    let updater::Error::WouldOrphanUnit(message) = &err else {
+        panic!("got {err:?}");
+    };
+    assert!(
+        message.contains("configd.service execs bin/configd"),
+        "{message}"
+    );
+    assert!(!message.contains("robotd.service"), "{message}");
+    // The refusal is only useful if the way past it is in the text.
+    assert!(
+        message.contains("systemctl disable --now configd.service"),
+        "{message}"
+    );
+
+    assert_eq!(fx.live_version(), None, "nothing may be installed");
+    assert_eq!(fx.staging_leftovers(), 0);
+}
+
+/// The escape, pinned: removing the unit is the whole remedy, and there is no flag. An operator who
+/// follows the refusal text must end up with the release installed, or this is a bricked update
+/// path on a board where nothing else would get them off a bad release.
+#[tokio::test]
+async fn removing_the_orphaned_unit_lets_the_release_through() {
+    let fx = Fixture::new();
+    fx.install_unit("configd");
+    fx.publish_with_binaries("1.0.0", &["robotd"]);
+
+    let mut engine = fx.engine_seeing_units();
+    assert!(apply_latest(&mut engine).await.is_err());
+
+    std::fs::remove_file(fx.unit_dir().join("configd.service")).unwrap();
+
+    let result = apply_latest(&mut engine).await.unwrap();
+    assert!(matches!(result, ApplyResult::Applied { .. }), "{result:?}");
+    assert_eq!(fx.live_version().as_deref(), Some("1.0.0"));
+}
+
+/// A dry run is how "will this downgrade work?" gets asked, so it has to answer — which is why the
+/// check runs before the dry run returns rather than at the swap.
+#[tokio::test]
+async fn a_dry_run_reports_the_orphan_rather_than_passing() {
+    let fx = Fixture::new();
+    fx.install_unit("configd");
+    fx.publish_with_binaries("1.0.0", &["robotd"]);
+
+    let mut engine = fx.engine_seeing_units();
+    let (tx, _rx) = progress_channel();
+    let err = engine
+        .apply(
+            "daemon",
+            Target::Latest,
+            ApplyOptions {
+                dry_run: true,
+                ..Default::default()
+            },
+            tx,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, updater::Error::WouldOrphanUnit(_)),
+        "got {err:?}"
+    );
 }
 
 // ── rollback ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Item 3 of #45, and the last one there that needed code.

## The case

`hooks/postinstall` installs the units a release ships and leaves them behind on a rollback. That is right for a rollback — the next successful update reinstalls whatever it ships — and stops being right for a **downgrade past the release that introduced a daemon**: the unit stays, its `ExecStart` names a binary the older release does not contain, systemd fails it with `203/EXEC`, and since that daemon is in the derived restart set the failed restart fails the update, which reverts.

Observed exactly that way: `apply daemon` on a board running a dev build resolved to stable `0.2.0`, which predates `configd`. The outcome was correct and was reached by the most expensive route — download, extract, swap, restart, roll back — and named a systemd error code rather than the cause.

## What it reads

`/etc/systemd/system/*.service`, filtered to units whose `Exec*=` points into the component's `current` symlink. Both halves are load-bearing: the live directory is the only place an orphan appears, since it outlived the release that installed it and the previous release's `systemd/` cannot name it by construction; and the filter is what keeps out units no release of ours ever shipped, which was the objection to reading that directory at all.

Every `Exec*=`, not `ExecStart` alone — a missing `ExecStartPre` fails the unit just as thoroughly, and it is the same parse.

## Three placement decisions

- **Not preflight**, which is what #45 proposed. Both preflight passes run before the artifact is downloaded, so the candidate's file list does not exist yet. This runs after extraction and before the swap: staging is disposable, the boot counter is unarmed, `current` has not moved. It costs a download to find out.
- **Before the dry run returns**, because "will this downgrade work?" is what a dry run is asked.
- **No target is exempt**, unlike `WouldDowngrade`, which fires on `Latest` alone. That guard is about a mirror serving a stale manifest; this one is about a unit that will not start, which does not care how the target was named — and `Ref` is how the case was observed.

It stays out of rollback, reset-to-golden and `select` entirely. Those move backwards on purpose and are how a board gets off a bad release, so nothing that can refuse belongs in the recovery path (`architecture.md` §1.1). Rolling back onto an orphaned unit remains the documented, self-correcting behaviour of `hooks/postinstall`.

## The remedy, which is not a flag

```
0.2.0 does not contain a binary that an installed unit runs:
  configd.service execs bin/configd
That unit would fail with 203/EXEC after the swap, its failed restart would fail the update, and
the update would roll back — so it is refused now, while nothing has moved. This is the ordinary
shape of a downgrade past the release that introduced a daemon; the release being installed is not
broken. To install it anyway, remove the unit that would be orphaned:
  systemctl disable --now configd.service && rm /etc/systemd/system/configd.service
```

#45 left refuse-versus-warn open and said a refusal needs a discoverable override. This refuses, with no new override, for the reason #68 took `systemctl stop robotd` over a bypass flag: removing the unit is what the operator means anyway — a board below the release that introduced a daemon should not be running that daemon — so it makes the situation true rather than overriding a check that says it is not. Nothing is lost by it either, since the next update that ships the unit reinstalls it.

## Failing open

A unit file that cannot be read, or an `Exec*=` that does not resolve to a path under `current`, produces no finding. A false negative costs the `203/EXEC` rollback that happens today; a false positive refuses an update over a unit file the parser merely did not understand, and refusing updates wrongly is the one thing this system may not do. Continuations are joined because `updaterd.service` writes its own `ExecStart` across three lines — it gets the right answer today by luck, its binary being on the first line.

`Error::WouldOrphanUnit` shares `code::INCOMPATIBLE` rather than adding a code, for the reason `SelfTest` shares health's: to a client it is the same answer, and a new code would be an `API_VERSION` bump for a refusal nothing branches on.

## Notes

- 8 unit tests on the parse and the scan, 3 in `apply.rs`: the refusal names only the unit that is actually orphaned, removing the unit lets the release through (the escape is pinned, not incidental), and a dry run reports it rather than passing.
- `-p updater` green (145 lib, 59 apply), clippy clean, `cargo fmt` applied.
- #45's item 1 is untouched and should stay that way until the additive-bump rule is written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)