### PR TITLE
A protocol mismatch says which side is behind, and what to do

### DIFF
--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -43,11 +43,25 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// `system.authenticate`, which a BLE client must now pass before anything else is served — a v3
 /// client would otherwise have every call refused with no idea why. v5 added the `pad.*`
 /// namespace, which is additive — a v4 client loses nothing by not knowing it — and bumps anyway,
-/// because the version's job is to say "these two peers were not built together". During
-/// v6 added `robot.init` and `robot.relax`, so powering the joints stops being a subcommand that
-/// fights the daemon for the motor bus. During
-/// prototyping the wire shape simply changes and this bumps; no accommodation is made for
-/// peers that predate a field, because there are none in the field yet.
+/// because the version's job is to say "these two peers were not built together". v6 added
+/// `robot.init` and `robot.relax`, so powering the joints stops being a subcommand that fights the
+/// daemon for the motor bus. During prototyping the wire shape simply changes and this bumps; no
+/// accommodation is made for peers that predate a field, because there are none in the field yet.
+///
+/// # The rule, since a bump has consequences and nothing else states them
+///
+/// **A bump promises nothing in either direction.** It is not "additive unless stated": v5 was
+/// additive and v4 was not, and the constant does not distinguish them. So `updaterd` refuses on an
+/// exact `!=`, and that stays deliberate rather than pending — accepting an older client would
+/// promise backward compatibility on every past and future bump, with no mechanism to keep it and
+/// no way to make a non-additive change afterwards. There is one user and one robot; a promise is
+/// worth less here than the freedom to change the wire shape.
+///
+/// **What a bump therefore costs.** Every client on a board must come from the same release as
+/// `updaterd`, and for a few seconds after an update they do not: `robotctl` is a symlink into
+/// `current`, so it follows the new release immediately, while `updaterd` is mid-restart of itself.
+/// Retrying is the fix. A client that is *persistently* older is a copy taken from somewhere other
+/// than `/usr/local/bin/robotctl`. Both directions are named in the refusal — `updater/src/ipc.rs`.
 pub const API_VERSION: u32 = 6;
 
 pub const DEFAULT_SOCKET: &str = "/run/updaterd.sock";

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -608,13 +608,11 @@ impl Client {
             api_version: proto::API_VERSION,
         }))?;
         if let Some(error) = response.error {
-            return Err(Failure::new(
-                exit::FAILED,
-                format!(
-                    "{}\nrobotctl and updaterd are out of step; install matching versions.",
-                    error.message
-                ),
-            ));
+            // The daemon's message is passed through unadorned. It used to gain
+            // "robotctl and updaterd are out of step; install matching versions" here, which was
+            // true and not actionable — the daemon now says which of the two is behind and what
+            // to do, which this side cannot know, and two remedies would disagree.
+            return Err(Failure::new(exit::FAILED, error.message));
         }
         response
             .result

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -495,11 +495,7 @@ impl Server {
                         Some(id),
                         proto::Error::new(
                             proto::code::PROTOCOL_MISMATCH,
-                            format!(
-                                "client speaks API v{}, daemon speaks v{}",
-                                params.api_version,
-                                proto::API_VERSION
-                            ),
+                            protocol_mismatch(params.api_version),
                         ),
                     );
                 }
@@ -857,6 +853,35 @@ impl Server {
             }
         }
     }
+}
+
+/// Why the handshake failed, and what the operator does about it.
+///
+/// The refusal is an exact `!=` in both directions, and stays one — see [`proto::API_VERSION`] for
+/// why accepting an older client is a promise this protocol cannot keep. What was missing is not
+/// leniency but a remedy: the old text named both versions and stopped there, on a board where the
+/// two halves are a symlink and a running process and neither is obvious to reach.
+///
+/// The direction is the whole diagnosis, so it decides the sentence:
+///
+/// - **Client newer.** Almost always the seconds after an update, while `updaterd` is restarting
+///   itself into the release `robotctl` already follows. Retrying is the fix, and saying so stops
+///   this reading as a broken install.
+/// - **Client older.** `robotctl` on PATH is a symlink into `current`, so it cannot lag by
+///   construction; a client that does is a copy from somewhere else — a scp'd binary, a laptop
+///   build, a shell open since before the update.
+fn protocol_mismatch(client: u32) -> String {
+    let daemon = proto::API_VERSION;
+    let remedy = if client > daemon {
+        "this client is from a newer release than the running updaterd, which is normal for a few \
+         seconds after an update while updaterd restarts itself — retry, and if it persists, \
+         `systemctl restart updaterd`"
+    } else {
+        "this client is from an older release than the running updaterd. `/usr/local/bin/robotctl` \
+         is a symlink into `current` and follows the installed release, so a client this old is a \
+         copy from somewhere else — use that one"
+    };
+    format!("client speaks API v{client}, daemon speaks v{daemon}: {remedy}")
 }
 
 async fn write_line<T: serde::Serialize>(

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -332,7 +332,30 @@ async fn hello_accepts_matching_version_and_refuses_a_mismatch() {
     let response = client
         .call(method::HELLO, serde_json::json!({ "api_version": 999 }))
         .await;
-    assert_eq!(response.error.unwrap().code, proto::code::PROTOCOL_MISMATCH);
+    let error = response.error.unwrap();
+    assert_eq!(error.code, proto::code::PROTOCOL_MISMATCH);
+    // Client newer than the daemon is what the seconds after an update look like, so the refusal
+    // has to say "retry" rather than leave an operator reinstalling a board that is already fine.
+    assert!(error.message.contains("newer release"), "{}", error.message);
+    assert!(
+        error.message.contains("systemctl restart updaterd"),
+        "{}",
+        error.message
+    );
+
+    // The other direction is a different situation with a different remedy, and a refusal naming
+    // only the two numbers made them look like one problem.
+    let response = client
+        .call(method::HELLO, serde_json::json!({ "api_version": 1 }))
+        .await;
+    let error = response.error.unwrap();
+    assert_eq!(error.code, proto::code::PROTOCOL_MISMATCH);
+    assert!(error.message.contains("older release"), "{}", error.message);
+    assert!(
+        error.message.contains("/usr/local/bin/robotctl"),
+        "{}",
+        error.message
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Item 1 of #45, resolved the other way from what that PR proposed: the exact `!=` stays, and the change goes into the message.

## Why not accept older clients

#45's proposal — refuse only a client *newer* than the daemon — rests on a premise nothing enforces: that `API_VERSION` bumps are additive. They are not, and the constant does not distinguish them: v5 was additive, v4 was not (`system.authenticate` became mandatory, so a v3 client would have had every call refused with no idea why). Accepting older clients would quietly promise backward compatibility on every past and future bump, with no mechanism to keep it and no way to make a non-additive change afterwards.

There is one user and one robot. The freedom to change the wire shape is worth more here than a promise the protocol cannot keep, so `API_VERSION` now says so outright rather than leaving it implicit: **a bump promises nothing in either direction**, and the cost it carries is that every client on a board must come from the same release as `updaterd`.

## What was actually missing

Not leniency — a remedy. The refusal named both version numbers and stopped there, on a board where the two halves of the disagreement are a symlink and a running process, and neither is obvious to reach. The urgency #45 recorded is gone (`updaterd` restarts itself, so the window is seconds rather than until someone reboots), which is exactly why the remaining cost is the message rather than the policy.

The direction is the whole diagnosis, so it now decides the sentence:

```
client speaks API v7, daemon speaks v6: this client is from a newer release than the running
updaterd, which is normal for a few seconds after an update while updaterd restarts itself —
retry, and if it persists, `systemctl restart updaterd`
```

```
client speaks API v3, daemon speaks v6: this client is from an older release than the running
updaterd. `/usr/local/bin/robotctl` is a symlink into `current` and follows the installed
release, so a client this old is a copy from somewhere else — use that one
```

The second case cannot happen through the installed `robotctl`, which is why naming the symlink is the answer: a client that lags is a scp'd binary or a laptop build.

## `robotctl` stops adding its own line

It appended "robotctl and updaterd are out of step; install matching versions" to whatever the daemon said. True, not actionable, and it would now contradict a daemon that knows which side is behind. The daemon's message goes through unadorned — it is also what a BLE client gets, where there is no client-side text at all.

## Notes

- The existing handshake test now asserts both directions carry their own remedy; a refusal naming only two numbers made them look like one problem.
- `-p updater` and `-p robotctl` green, clippy clean.
- With #75 (item 3) this closes out #45's three items — that PR's doc can be updated or closed as a record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)