### PR TITLE
The binary each unit execs, in the artifact that shipped it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,40 @@ jobs:
       #
       # `migrate-network.sh` was missing from this list while being the riskiest of them —
       # it is the one step that can make a headless board unreachable, and the one nobody
-      # re-runs once their own board is migrated. `board-test.sh` is deliberately absent:
-      # it runs in CI, so CI failing is already the feedback.
+      # re-runs once their own board is migrated. `robot-rescue` is here because it is the script
+      # that runs when a board cannot start its update daemon — the worst possible moment to find a
+      # typo, and it ships as text like the rest.
+      #
+      # `board-test.sh` is linted by the step below rather than here, because it needs two codes
+      # excluded. It used to be skipped entirely on the grounds that CI failing is already the
+      # feedback, which was true and too expensive: that feedback is four QEMU minutes away.
       #
       # POSIX sh, not bash: the script is piped to `sh` by the documented one-liner, and
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.
             test -x "$script"
           done
+
+      # `board-test.sh` separately, because it needs different flags and was excluded for it.
+      #
+      # It builds the container-side checks as one enormous single-quoted string, so two codes fire on
+      # that construction itself and mean nothing: SC2037 reads `CHECKS='` as a command assignment,
+      # SC2016 objects to expressions that are *meant* not to expand until the container runs them.
+      #
+      # What is left is worth having, and is the failure that actually happens: an apostrophe inside
+      # that string closes it early, and everything after it is then expanded by this shell instead of
+      # the container's. It cost a full `board` run twice in one afternoon — four QEMU minutes to be
+      # told `unexpected EOF`, when SC2211 names the line. `sh -n` alone is not enough: two
+      # apostrophes balance, so the syntax is valid and the content is silently mangled.
+      - name: Lint the board checks
+        run: |
+          sh -n scripts/board-test.sh
+          shellcheck --shell=sh --exclude=SC2037,SC2016 scripts/board-test.sh
 
       # The publish tooling must keep working, or a release can't be cut. Cheap to
       # assert here rather than discovering it at tag time.

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -721,6 +721,32 @@ for src in "$REL"/systemd/*.service; do
 done
 echo "    [ok] every unit the release ships is installed, unmodified, mode 644"
 
+# The binary each unit execs, in the artifact that shipped the unit.
+#
+# This is bug 3 of install-path-gap.md, and the only class of the four with no strong test: the
+# packaging step stages binaries with an explicit `cp` per binary, `btd` and `configd` were built and
+# never staged, and `btd.service` failed with `203/EXEC` — which reads as a broken daemon rather than
+# an incomplete artifact. `xtask/tests/artifact.rs` covers it by comparing two *source* files, which
+# is the weaker form the doc criticises; here the tarball is already unpacked and `current` already
+# points at it, so asking is three lines.
+#
+# Only `ExecStart` paths inside the release are checked. A unit may deliberately exec out of the base
+# — the boot recovery net does, precisely so a broken release cannot break it — and demanding those
+# be in the artifact would be wrong rather than strict.
+for src in "$REL"/systemd/*.service; do
+    name="$(basename "$src")"
+    exec_line="$(grep -m1 "^ExecStart=" "$src")"
+    exec_path="${exec_line#ExecStart=}"
+    exec_path="${exec_path%% *}"
+    case "$exec_path" in
+        /opt/robot/daemon/current/*) ;;
+        *) continue ;;
+    esac
+    test -x "$exec_path" \
+        || { echo "    [FAIL] ${name} execs ${exec_path}, which the artifact does not contain"; exit 1; }
+done
+echo "    [ok] the ExecStart binary of every unit is in the release that shipped it"
+
 # Accounts before units, or a unit naming a User= that does not exist fails to start and the
 # failure reads as a broken daemon.
 test -f /usr/lib/sysusers.d/robot.conf


### PR DESCRIPTION
Bug 3 of `install-path-gap.md` is the only one of the four with no strong test, and it turns out to be the only thing #70's artifact-install item was still missing — the rest of that item has been done since #47.

## The gap

The packaging step stages binaries with an explicit `cp` per binary. `btd` and `configd` were built and never staged, and `btd.service` failed with `203/EXEC` — which reads as a broken daemon rather than an incomplete artifact, and cost an afternoon.

`board-test.sh` already unpacks a real release and asserts eleven things about installing it, but never that the binary a unit `ExecStart`s is *in* that release. The only protection was `xtask/tests/artifact.rs`, comparing a workflow against `install.sh` — the two-files-agree form that document criticises.

So ask the artifact. The tarball is already unpacked there and `current` already points at it, which makes the check three lines.

Only `ExecStart` paths inside the release are checked: a unit may deliberately exec out of the base — the boot recovery net does, precisely so a broken release cannot break it — and requiring those to be packaged would be wrong rather than strict. Verified against all five shipped units; each resolves to `/opt/robot/daemon/current/bin/<name>`.

## The second commit is why the first took two attempts

The whole container-side script is one enormous single-quoted string, so **an apostrophe inside it closes the string early** and everything after is expanded by the wrong shell. That is what broke #74's board run, fixed there in `2317c81`; I then reproduced it in the first draft of this check, with `unit's` in a message.

`board-test.sh` was deliberately excluded from the lint step on the grounds that it runs in CI, so CI failing is already the feedback. True, and too expensive — that feedback is four QEMU minutes away and arrives as `unexpected EOF` with no line number. Now linted:

- **`sh -n` is not sufficient**, which is worth knowing: two apostrophes *balance*, so the syntax stays valid while the content is silently mangled. My second draft passed `sh -n` and was still wrong.
- **shellcheck catches it** (SC2211 names the line), with two codes excluded that fire on the `CHECKS='` construction itself and mean nothing there: SC2037 reads it as a command assignment, SC2016 objects to expressions that are *meant* not to expand until the container runs them. Verified clean against untouched `main` with those two excluded, so the gate is viable rather than aspirational.

While there: **`scripts/robot-rescue` was never added to the lint loop.** It arrived with #67 and is the script that runs when a board cannot start its update daemon — the worst possible moment to find a typo. It lints clean today.

## Verification

Both lint steps simulated locally against all eight scripts: clean. The `ExecStart` parse dry-run against every real unit gives the expected path. `sh -n` and shellcheck clean on the patched `board-test.sh`.

The `board` job is what exercises the new assertion, so its own CI run is the real test of this PR.