### PR TITLE
Every spawn retries ETXTBSY, not just the hooks

### DIFF
--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1543,8 +1543,16 @@ impl Engine {
             }
             HealthCheck::Command { program, args, .. } => {
                 let mut command = tokio::process::Command::new(program);
-                command.args(args).kill_on_drop(true);
-                let output = tokio::time::timeout(timeout, command.output())
+                command
+                    .args(args)
+                    .kill_on_drop(true)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped());
+                let child = crate::spawn::retrying_busy(&mut command)
+                    .await
+                    .map_err(|e| Error::Health(format!("could not run probe: {e}")))?;
+                let output = tokio::time::timeout(timeout, child.wait_with_output())
                     .await
                     .map_err(|_| {
                         Error::Health(format!("probe timed out after {}s", timeout.as_secs()))
@@ -1745,19 +1753,39 @@ async fn self_test_updaterd(release_dir: &Path) -> Result<(), Error> {
     let mut command = tokio::process::Command::new(&binary);
     command.arg("--self-test");
 
-    let output = match tokio::time::timeout(SELF_TEST_TIMEOUT, command.output()).await {
-        Ok(Ok(output)) => output,
+    // Through the retry, and this is the call that most needs it: the binary being exec'd was
+    // written by *this update*, moments ago, while hooks and `systemctl` were spawning around it —
+    // the exact conditions `spawn::retrying_busy` documents. An `ETXTBSY` here is an `Error::SelfTest`,
+    // which rolls back a release that was fine.
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let spawned = crate::spawn::retrying_busy(&mut command).await;
+    let output = match spawned {
+        Ok(child) => {
+            match tokio::time::timeout(SELF_TEST_TIMEOUT, child.wait_with_output()).await {
+                Ok(Ok(output)) => output,
+                Ok(Err(e)) => {
+                    return Err(Error::SelfTest(format!(
+                        "{} could not be waited for: {e}",
+                        binary.display()
+                    )));
+                }
+                Err(_) => {
+                    return Err(Error::SelfTest(format!(
+                        "{} did not finish within {SELF_TEST_TIMEOUT:?}",
+                        binary.display()
+                    )));
+                }
+            }
+        }
         // Could not be executed at all: the wrong architecture, a missing interpreter, a corrupt
         // file. Exactly what this exists to catch.
-        Ok(Err(e)) => {
+        Err(e) => {
             return Err(Error::SelfTest(format!(
                 "could not run {}: {e}",
-                binary.display()
-            )));
-        }
-        Err(_) => {
-            return Err(Error::SelfTest(format!(
-                "{} did not finish within {SELF_TEST_TIMEOUT:?}",
                 binary.display()
             )));
         }
@@ -1825,7 +1853,12 @@ async fn schedule_deferred_restarts(systemd_run: &str) {
         // `tokio::process`, not `std::process`: this runs inside the async engine, and a blocking
         // `status()` here stalls the runtime — which showed up as unrelated operations later
         // failing with `Busy`, because the update lock had not been released yet.
-        match command.status().await {
+        let spawned = crate::spawn::retrying_busy(&mut command).await;
+        let waited = match spawned {
+            Ok(mut child) => child.wait().await,
+            Err(e) => Err(e),
+        };
+        match waited {
             Ok(status) if status.success() => {
                 tracing::info!(unit, delay = DEFERRED_RESTART_DELAY, "restart scheduled");
             }
@@ -1958,7 +1991,14 @@ async fn unit_is_absent(systemctl: &str, unit: &str) -> bool {
         .arg(unit);
     c.kill_on_drop(true);
 
-    match tokio::time::timeout(APPLY_ACTION_TIMEOUT, c.output()).await {
+    c.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let Ok(child) = crate::spawn::retrying_busy(&mut c).await else {
+        return false;
+    };
+    match tokio::time::timeout(APPLY_ACTION_TIMEOUT, child.wait_with_output()).await {
         Ok(Ok(output)) => String::from_utf8_lossy(&output.stdout).trim() == "not-found",
         _ => false,
     }
@@ -1967,7 +2007,20 @@ async fn unit_is_absent(systemctl: &str, unit: &str) -> bool {
 async fn run_systemctl(mut command: tokio::process::Command, what: &str) -> Result<(), Error> {
     command.kill_on_drop(true);
 
-    let output = tokio::time::timeout(APPLY_ACTION_TIMEOUT, command.output())
+    // `spawn` + `wait_with_output` rather than `output()`, so the spawn can go through the
+    // `ETXTBSY` retry — `output()` spawns internally and gives nothing to retry. `output()` also
+    // pipes both streams for you, and this does not, so they are set explicitly: without them the
+    // child inherits ours and the stderr this reports back would be empty.
+    let child = crate::spawn::retrying_busy(
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped()),
+    )
+    .await
+    .map_err(|e| Error::Internal(format!("running systemctl: {e}")))?;
+
+    let output = tokio::time::timeout(APPLY_ACTION_TIMEOUT, child.wait_with_output())
         .await
         .map_err(|_| Error::Internal(format!("{what} timed out")))?
         .map_err(|e| Error::Internal(format!("running systemctl: {e}")))?;
@@ -2185,6 +2238,41 @@ esac
                 .is_ok(),
             "a missing unit must not fail the update"
         );
+    }
+
+    /// A `systemctl` that is briefly busy for exec is retried, not reported as a failed restart.
+    ///
+    /// This is the flake that prompted the change, reproduced deterministically. These tests write a
+    /// stub `systemctl` and exec it from parallel threads of one process; a fork in another test
+    /// duplicates the write handle to *this* stub into its child, and for a few microseconds the
+    /// kernel refuses to exec it. Holding a write handle here is the same condition, on purpose.
+    ///
+    /// On a board the consequence is worse than a red CI job: the same race reaches
+    /// `self_test_updaterd`, which execs a binary the update wrote moments earlier, and an `ETXTBSY`
+    /// there rolls back a release that was fine.
+    ///
+    /// Linux-only, and deliberately not made portable: macOS permits the exec, so on a Mac this
+    /// would pass without ever provoking the condition. `hooks.rs`'s
+    /// `a_hook_busy_forever_still_fails` is the control that keeps the pair honest — if the platform
+    /// stopped producing `ETXTBSY`, that test fails and this one becomes vacuous.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn a_systemctl_busy_for_exec_is_retried_rather_than_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = stub_recorder(dir.path(), "systemctl");
+
+        let holder = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        // Well inside the ~100 ms budget, and long enough that the first attempts do fail.
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            drop(holder);
+        });
+
+        restart_one(path.to_str().unwrap(), "robotd")
+            .await
+            .expect("a transiently busy systemctl must be retried, not reported as a failure");
+
+        releaser.await.unwrap();
     }
 
     /// The other half, and the reason this is not just "ignore failures": a unit that exists and

--- a/updater/src/hooks.rs
+++ b/updater/src/hooks.rs
@@ -103,55 +103,6 @@ pub struct HookOutcome {
 /// the update log.
 const MAX_OUTPUT: usize = 8 * 1024;
 
-/// How many times to retry a spawn that fails with `ETXTBSY`, and how long to wait between.
-///
-/// Ten attempts over ~100 ms. The window this closes is the few microseconds between a
-/// `fork` and the child's `execve`, so the first retry almost always succeeds; the budget
-/// exists so a pathological case gives up rather than hanging an update.
-const BUSY_RETRIES: u32 = 10;
-const BUSY_BACKOFF: Duration = Duration::from_millis(10);
-
-/// `ETXTBSY`, which is not a real failure here.
-///
-/// The kernel refuses to `exec` a file that *any* process has open for writing. We extract a
-/// release — writing `hooks/preinstall` — and then exec it moments later, while also
-/// spawning other children around the same time: the other hook, `systemctl` for `on_apply`,
-/// a command-style health probe. A child inherits a duplicate of the whole fd table at fork
-/// and only drops `O_CLOEXEC` descriptors at its own `execve`, so for a few microseconds
-/// some unrelated child holds a write handle to the hook we are about to run, and the exec
-/// fails with "Text file busy".
-///
-/// Left unhandled that is a failed hook, which fails the update, which rolls back a release
-/// that was fine — rarely, unreproducibly, and reported on the robot as
-/// "failed at RunningPreHook" with nothing anyone can act on. It first showed up as a
-/// intermittently red CI job, which is the same bug wearing a costume.
-///
-/// Retrying is the remedy because nothing else addresses it: the offending descriptor
-/// belongs to a *different* process, so closing or syncing ours changes nothing, and
-/// `rename` keeps the same inode.
-async fn spawn_retrying_busy(
-    command: &mut tokio::process::Command,
-) -> std::io::Result<tokio::process::Child> {
-    for attempt in 1..=BUSY_RETRIES {
-        match command.spawn() {
-            Ok(child) => {
-                if attempt > 1 {
-                    tracing::debug!(attempt, "spawned after ETXTBSY");
-                }
-                return Ok(child);
-            }
-            // `raw_os_error`, not `kind`: ETXTBSY has no stable `ErrorKind` — it maps to
-            // `Uncategorized`, which is unstable to match on.
-            Err(e) if e.raw_os_error() == Some(libc::ETXTBSY) && attempt < BUSY_RETRIES => {
-                tracing::debug!(attempt, "hook is busy for exec; retrying");
-                tokio::time::sleep(BUSY_BACKOFF).await;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    unreachable!("the loop returns on the final attempt")
-}
-
 /// Run a hook if present.
 ///
 /// A missing hook is success (`ran: false`) — most releases won't have one. A
@@ -194,7 +145,7 @@ pub async fn run(
         command.env(key, value);
     }
 
-    let child = spawn_retrying_busy(&mut command)
+    let child = crate::spawn::retrying_busy(&mut command)
         .await
         .map_err(|e| Error::Hook {
             hook: hook_name.clone(),

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -45,6 +45,7 @@ pub mod reconcile;
 pub use duck_ipc_proto as proto;
 pub mod robot;
 pub mod source;
+mod spawn;
 pub mod store;
 pub mod verify;
 

--- a/updater/src/reconcile.rs
+++ b/updater/src/reconcile.rs
@@ -146,10 +146,12 @@ fn running_release(unit: &str) -> Option<semver::Version> {
 }
 
 async fn restart(systemctl: &str, unit: &str) -> Result<(), String> {
-    let status = tokio::process::Command::new(systemctl)
-        .arg("restart")
-        .arg(unit)
-        .status()
+    let mut command = tokio::process::Command::new(systemctl);
+    command.arg("restart").arg(unit);
+    let status = crate::spawn::retrying_busy(&mut command)
+        .await
+        .map_err(|e| e.to_string())?
+        .wait()
         .await
         .map_err(|e| e.to_string())?;
     if status.success() {

--- a/updater/src/spawn.rs
+++ b/updater/src/spawn.rs
@@ -1,0 +1,119 @@
+//! Spawning a child that the kernel may refuse to `exec` yet.
+//!
+//! One function, and the reason it exists is worth more than the code.
+
+use std::time::Duration;
+
+/// How many times to retry a spawn that fails with `ETXTBSY`, and how long to wait between.
+///
+/// Ten attempts over ~100 ms. The window this closes is the few microseconds between a
+/// `fork` and the child's `execve`, so the first retry almost always succeeds; the budget
+/// exists so a pathological case gives up rather than hanging an update.
+const BUSY_RETRIES: u32 = 10;
+const BUSY_BACKOFF: Duration = Duration::from_millis(10);
+
+/// Spawn, retrying `ETXTBSY` — which is not a real failure here.
+///
+/// The kernel refuses to `exec` a file that *any* process has open for writing, tracked on the
+/// inode. We extract a release — writing `hooks/preinstall` — and then exec it moments later, while
+/// also spawning other children around the same time: the other hook, `systemctl` for `on_apply`, a
+/// command-style health probe. A child inherits a duplicate of the whole fd table at fork and only
+/// drops `O_CLOEXEC` descriptors at its own `execve`, so for a few microseconds some unrelated child
+/// holds a write handle to the file we are about to run, and the exec fails with "Text file busy".
+///
+/// Left unhandled that is a failed hook, which fails the update, which rolls back a release that was
+/// fine — rarely, unreproducibly, and reported on the robot as "failed at RunningPreHook" with
+/// nothing anyone can act on. It first showed up as an intermittently red CI job, which is the same
+/// bug wearing a costume.
+///
+/// Retrying is the remedy because nothing else addresses it: the offending descriptor belongs to a
+/// *different* process, so closing or syncing ours changes nothing, and `rename` keeps the same
+/// inode.
+///
+/// **Every spawn in this crate goes through here, including ones whose program we never write.**
+/// `systemctl` is not a file the updater rewrites, so on a board it cannot be busy for this reason —
+/// but the test suite writes stub `systemctl` scripts and executes them from parallel threads of one
+/// process, which is the same race with the same cause, and it failed a pull request that had touched
+/// nothing but documentation. A spawn helper that some callers skip is a helper that will be skipped
+/// by the next caller too.
+pub(crate) async fn retrying_busy(
+    command: &mut tokio::process::Command,
+) -> std::io::Result<tokio::process::Child> {
+    for attempt in 1..=BUSY_RETRIES {
+        match command.spawn() {
+            Ok(child) => {
+                if attempt > 1 {
+                    tracing::debug!(attempt, "spawned after ETXTBSY");
+                }
+                return Ok(child);
+            }
+            // `raw_os_error`, not `kind`: ETXTBSY has no stable `ErrorKind` — it maps to
+            // `Uncategorized`, which is unstable to match on.
+            Err(e) if e.raw_os_error() == Some(libc::ETXTBSY) && attempt < BUSY_RETRIES => {
+                tracing::debug!(attempt, "busy for exec; retrying");
+                tokio::time::sleep(BUSY_BACKOFF).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!("the loop returns on the final attempt")
+}
+
+#[cfg(test)]
+mod tests {
+    /// Nothing in this crate may spawn a process except through [`retrying_busy`].
+    ///
+    /// The doc above claims every spawn goes through here, and a claim in a comment is exactly what
+    /// drifted: `hooks.rs` had the retry, `engine.rs` did not, and the paragraph explaining the race
+    /// already named `systemctl` as one of the processes causing it. What that cost was an
+    /// intermittently red `check` job — including on a pull request that changed only documentation —
+    /// and, on a board, an `ETXTBSY` from `self_test_updaterd` rolling back a release that was fine.
+    ///
+    /// A source grep rather than a type: `tokio::process::Command` is not ours to seal, and a
+    /// newtype wrapping it would have to re-export every builder method to be worth anything.
+    #[test]
+    fn every_spawn_in_the_crate_goes_through_the_retry() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+
+        let mut dirs = vec![src.clone()];
+        while let Some(dir) = dirs.pop() {
+            for entry in std::fs::read_dir(&dir).expect("readable src dir").flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                    continue;
+                }
+                if path.extension().is_some_and(|e| e == "rs")
+                    && path.file_name().is_some_and(|n| n != "spawn.rs")
+                {
+                    let text = std::fs::read_to_string(&path).expect("readable source");
+                    // Only files that build a `Command`, which is what makes the three method names
+                    // below unambiguous: `engine.status().await` is the engine's own status, and
+                    // `response.status()` is HTTP's. A file that spawns has to name `Command` to do
+                    // it, so nothing escapes by being new.
+                    if !text.contains("tokio::process::Command") {
+                        continue;
+                    }
+                    for (n, line) in text.lines().enumerate() {
+                        let spawns = line.contains(".output()")
+                            || line.contains(".spawn()")
+                            || line.contains(".status().await");
+                        if spawns {
+                            let name = path.strip_prefix(&src).unwrap_or(&path).display();
+                            offenders.push(format!("{name}:{} {}", n + 1, line.trim()));
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "spawn a child with `spawn::retrying_busy(&mut command)` and then `wait()` or \
+             `wait_with_output()`, rather than `output()`/`status()`/`spawn()` — see the module \
+             docs for what the kernel does otherwise. Offenders:\n{}",
+            offenders.join("\n")
+        );
+    }
+}


### PR DESCRIPTION
`check` failed on #36 — a pull request that changed nothing but documentation:

```
engine::restart_tests::a_unit_that_exists_but_fails_is_still_an_error
panicked: Internal("running systemctl: Text file busy (os error 26)")
```

**The cause was already written down in this crate, one function away from the code that hit it.** `hooks.rs::spawn_retrying_busy` explains it in full: the kernel refuses to exec a file any process holds open for writing, a child inherits the whole fd table at fork and only drops it at its own execve, so for a few microseconds an unrelated child holds a write handle to the file we are about to run. That comment even names `systemctl` as one of the concurrent spawners. The retry was wired into hook spawns only.

In the suite the offender is another test: these write a stub `systemctl` and exec it from parallel threads of one process, so a fork in test B holds test A's stub open across A's exec. The same comment rules out the tempting test-side fix — the descriptor belongs to a *different* process, so closing or syncing ours changes nothing, and `rename` keeps the inode.

## The part that is not test hygiene

**The same race reaches `self_test_updaterd`**, which execs a binary the update wrote moments earlier, while hooks and `systemctl` are spawning around it. An `ETXTBSY` there is an `Error::SelfTest`, which rolls back a release that was fine — rarely, unreproducibly, and reported on the robot as a self-test failure with nothing anyone can act on. That is the same shape the hook version of this bug had before it was fixed, and it is a real defect.

## What changed

The helper moves to `spawn.rs` with its explanation, and all six spawn sites go through it: both `systemctl` paths in `engine.rs`, `unit_is_absent`, the `systemd-run` that schedules the deferred restarts, the command-style health probe, and `reconcile::restart`.

`output()` and `status()` spawn internally and give nothing to retry, so those become `spawn` + `wait_with_output()`/`wait()`. The streams `output()` used to pipe for us are now piped explicitly — without that the child inherits ours and the stderr these report back would be empty, which would have quietly emptied the "restart failed: …" messages.

## Enforced rather than asserted

A test greps the crate for `output()`, `spawn()` and `status().await` in files that build a `Command`, because a comment claiming every spawn goes through the retry is exactly what drifted. Scoped to files naming `Command` so that `engine.status()` and a `reqwest` response's `status()` are not mistaken for processes — and so a new file that spawns cannot escape by being new. I checked it fails when a call site is put back.

## Notes

- `a_systemctl_busy_for_exec_is_retried_rather_than_failed` reproduces the flake deterministically: hold a write handle, release it inside the ~100 ms budget, require a successful restart. Linux-only, because macOS permits the exec and the test would pass there without provoking anything. `hooks.rs`'s `a_hook_busy_forever_still_fails` is the existing control that keeps the pair honest — if the platform stopped producing `ETXTBSY`, that one fails and this one becomes vacuous.
- Workspace suite green, clippy clean on host and `aarch64-unknown-linux-gnu`, `cargo fmt` clean.
- One flake this does **not** explain: `applying_the_same_version_is_a_no_op` failed once under a full `cargo test --workspace` and passed alone and with the rest of the apply suite. That looks like the update-lock contention the fixture comments already warn about, and it wants its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
