### PR TITLE
Check every daemon is running what was pushed

### DIFF
--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -300,17 +300,28 @@ packaged would be wrong rather than strict.
 **What is still genuinely missing here is nothing.** The remaining items are the two below, and they
 cover different things rather than more of this one.
 
-### 3. One scripted scenario on a real board
+### 3. The board check — done, inside `dev-push.sh`
 
-**On demand, before a promotion. Never in CI.** Depends on `scripts/dev-push.sh`, which builds here,
-signs with the dev key and applies to a board in about a minute: install the previous release, apply
-the new one, then assert every daemon's `/run/<service>/identity.json` names the new release, that
-`robotctl health` is clean, and that the update log holds one success.
+**Done, and not as a separate scenario script.** `dev-push.sh` used to end at "is live", which means
+the swap happened and the health gate passed — not that the five daemons are running what was swapped
+in. That gap is where an afternoon goes: four wifi fixes were once verified as broken against a
+`configd` that had never restarted.
 
-That one pass is the only thing that observes the transient timer actually firing, `RuntimeDirectory=`
-behaving under `ProtectSystem=strict`, real unit states reaching `robotctl health`, and the startup
-reconciliation closing the loop for real. For the timing-dependent parts a board is *higher* fidelity
-than any container, and it is now cheaper than one.
+So the check runs on every push rather than before a promotion. It reads the identity each daemon
+publishes at startup, compares the release named there against the board's `current`, and — separately,
+because everything agreeing on the *previous* release would otherwise pass — against the version this
+push built. `robotd`, `configd` and `padd` are expected to match at once; `updaterd` and `btd` are
+polled for up to 30 s, because they restart five seconds after the reply.
+
+This is the only thing that observes the whole restart mechanism end to end, and nothing in CI can
+replace it: the transient timer, the `RuntimeDirectory=` holding each identity, and the five-second
+delay are all systemd, on real timing. A stale unit fails the push and names what to look at.
+
+Two deliberate non-failures. A daemon that published nothing is reported and not failed — systemd
+removes the runtime directory when a unit stops, so it is also what a deliberately disabled `padd`
+looks like. And `robotctl health` only has to *answer*: a bench board with no servo power reports
+degraded, which is a fact about the bench rather than about the build, exactly as the health gate
+treats it.
 
 ### 4. Real systemd, locally, for failure injection only
 

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -300,3 +300,102 @@ else
     fi
     exit "$status"
 fi
+
+# ── did every daemon actually move? ──
+#
+# The apply reporting success means the swap happened and the health gate passed. It does not mean
+# the five daemons are running the release that was swapped in, and the gap between those two is
+# where an afternoon goes: four wifi fixes were once verified as broken against a `configd` that
+# had never restarted. `robotd`, `configd` and `padd` restart during the update; `updaterd` and
+# `btd` restart five seconds after it replies, because the first cannot restart itself mid-update
+# and the second may be carrying the reply (docs/design/restart-order.md).
+#
+# So this is the one check that observes the whole mechanism end to end, on real systemd, with real
+# timing — and nothing else in the repository can. A container cannot: the transient timer, the
+# `RuntimeDirectory=` that holds each identity, and the five-second delay are all systemd.
+#
+# Polled rather than slept: a fixed sleep is either a wrong answer or a slow one, and the interesting
+# case is a restart that never happens, which no length of sleep improves.
+[ "$DRY_RUN" = no ] || exit 0
+
+echo "==> checking every daemon is running it"
+
+# Sent on stdin, so nothing here is expanded by this laptop's shell and the quoting stays readable.
+# The board derives what it expects from its own `current` symlink; the version this push built is
+# compared against that separately, below.
+if ssh "$BOARD" sh -s -- "$VERSION" <<'REMOTE'
+set -u
+pushed="${1:-}"
+current="$(readlink /opt/robot/daemon/current || true)"
+want="${current#releases/}"
+[ -n "$want" ] || { echo "    no release is live: current -> ${current:-nothing}"; exit 1; }
+echo "    current -> $want"
+
+# That the daemons agree with `current` is not enough on its own: they could all agree on the
+# release this push was supposed to replace. `apply` reported success, so this should be
+# impossible — which is the reason to check it rather than the reason not to.
+[ "$want" = "$pushed" ] || {
+    echo "    [FAIL] current is $want, but this push built $pushed"
+    exit 1
+}
+
+# The identity each daemon publishes at startup, which names the release directory it was launched
+# from. A file rather than a question, so this needs no socket and no privilege — and `btd` serves
+# no socket at all, so for that one it is the only answer available.
+deadline=$(($(date +%s) + 30))
+stale=""
+for svc in robotd configd padd updaterd btd; do
+    while :; do
+        if [ ! -f "/run/${svc}/identity.json" ]; then
+            state="silent"
+        elif grep -q "releases/${want}/bin/${svc}" "/run/${svc}/identity.json"; then
+            state="ok"
+        else
+            state="stale"
+        fi
+        # Only the two deferred ones are worth waiting for; the rest restarted before the reply, so
+        # a mismatch there is already a fault rather than a race.
+        case "$state:$svc" in
+            ok:*) break ;;
+            stale:updaterd|stale:btd|silent:updaterd|silent:btd)
+                [ "$(date +%s)" -lt "$deadline" ] || break
+                sleep 1
+                ;;
+            *) break ;;
+        esac
+    done
+
+    case "$state" in
+        ok) echo "    [ok] $svc" ;;
+        silent)
+            # Not treated as a failure: systemd removes the runtime directory when a unit stops, so
+            # this is also what a deliberately disabled `padd` looks like.
+            echo "    [--] $svc published nothing — stopped, or a build too old to say"
+            ;;
+        stale)
+            echo "    [FAIL] $svc is not running $want"
+            stale="${stale} ${svc}"
+            ;;
+    esac
+done
+
+[ -z "$stale" ] || {
+    echo
+    echo "  Stale:${stale}. The release is installed and those are not running it, which reads as"
+    echo "  a fix that did not work. What to look at:"
+    echo "    robotctl health                     # the units block names the release each one runs"
+    echo "    journalctl -u updaterd -b | tail    # 'restart scheduled', or why it could not be"
+    echo "    sudo systemctl restart <unit>       # and then why it needed doing by hand"
+    exit 1
+}
+
+# Answerable, not healthy. A bench board with no servo power reports degraded and that is a fact
+# about the bench, not about this build — the health gate draws the same distinction.
+robotctl health >/dev/null 2>&1 || echo "    [--] robotctl health did not answer cleanly; worth a look"
+REMOTE
+then
+    echo "==> every daemon on $BOARD is running $VERSION"
+else
+    echo "==> the release is live but not everything is running it" >&2
+    exit 1
+fi


### PR DESCRIPTION
Item 3 of the plan in `install-path-gap.md`, now that #59 has landed — and it turned out to belong inside `dev-push.sh` rather than in a scenario script run before a promotion.

## The gap

`dev-push.sh` ended at `==> <version> is live`. That means the swap happened and the health gate passed. It does **not** mean the five daemons are running the release that was swapped in, and the distance between those two statements is where an afternoon goes: four wifi fixes were once verified as broken against a `configd` that had never restarted.

Nothing else can close it. `robotd`, `configd` and `padd` restart during the update; `updaterd` and `btd` restart five seconds after the reply, through a systemd transient timer, and each daemon's identity lives in a `RuntimeDirectory=` systemd creates and deletes. Timer, directory, delay — all systemd, on real timing. A container cannot stand in, which is why this is the item the plan put on a board.

## What it checks

It reads the identity each daemon publishes at startup, which names the release directory it was launched from. A file read rather than a question, and that matters for `btd`: it serves no socket, so there is nothing else to ask it.

Three comparisons, not one:

- every daemon against the board's `current`;
- **`current` against the version this push built** — five daemons agreeing on the release this push was meant to *replace* would otherwise read as success;
- `robotd`, `configd` and `padd` must match immediately, since they restart before the reply, so a mismatch there is a fault rather than a race. `updaterd` and `btd` are polled for up to 30 s.

Polled rather than slept: a fixed sleep is either a wrong answer or a slow one, and the interesting case is a restart that never happens, which no length of sleep improves. In the ordinary case it returns as soon as the two deferred units appear, about six seconds.

A stale unit fails the push and names what to look at — `robotctl health`, the `restart scheduled` line in updaterd's journal, and the manual restart plus the fact that it should not have been needed.

## Two deliberate non-failures

- **A daemon that published nothing is reported, not failed.** systemd removes the runtime directory when a unit stops, so this is also exactly what a deliberately disabled `padd` looks like.
- **`robotctl health` only has to answer.** A bench board with no servo power reports degraded, which is a fact about the bench rather than about this build — the same distinction the health gate draws.

## Verification

It needs a board, so CI cannot run it. The decision logic is pure shell, so I ran it against a fake board tree: a stale unit fails and names itself; all five current passes; a `current` that is not what was pushed fails immediately without waiting; and the poll gives up after its budget rather than spinning. `sh -n` and `shellcheck --shell=sh` clean, which CI now enforces for this file.

**Not yet run against a real board** — that is the one thing left, and it is also the first thing it will tell you.

With this, the plan's remaining item is #4: `systemd-nspawn` locally, for the failure injections a board should not be asked to do repeatedly.