### PR TITLE
Drive a real update against real systemd

### DIFF
--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -312,17 +312,41 @@ behaving under `ProtectSystem=strict`, real unit states reaching `robotctl healt
 reconciliation closing the loop for real. For the timing-dependent parts a board is *higher* fidelity
 than any container, and it is now cheaper than one.
 
-### 4. Real systemd, locally, for failure injection only
+### 4. Real systemd — done, as `scripts/systemd-test.sh`
 
-`systemd-nspawn` on a Linux box — **not** a privileged container in CI. After the three items above,
-what is left is a short list of things nobody should ask a board to do repeatedly: a unit that exists
-and will not start, `kill -9` between the swap and the commit, `systemd-run` itself failing,
-`enable --now` on a unit whose `User=` does not exist. **Would have caught bug 1**, which is the only
-one the items above miss — and it is also the only way to watch the postinstall hook do its real job
-of enabling and starting a unit, which no stub can show.
+**Done, and it paid for itself before asserting anything.** `scripts/systemd-test.sh` boots systemd as
+pid 1, mints three signed releases carrying real units and a real `updaterd`, installs one, applies
+the next through the running daemon, and then applies one that ships a unit which cannot start.
 
-Last for a reason beyond cost: it can only run on Linux, so never on the machine this is developed on,
-and a test that runs somewhere else stops being read.
+Four things it observes that nothing else in the tree can, because everything else has a stub
+`systemctl`:
+
+- **`on_apply` really restarts** what the release ships — asserted on the unit's main PID changing,
+  not on the command having been issued;
+- **the deferred transient timer really fires and really replaces `updaterd`**, in about four
+  seconds, and the successor is running the new release. A child process could not do this: it would
+  sit in the cgroup being killed, which is the reason for `systemd-run` and was until now an
+  untested claim;
+- **`hooks/postinstall` really installs, enables and starts** a unit the board has never had;
+- **a unit that installs cleanly and cannot start fails the update and names itself** —
+  `restart failed: Job for broken.service failed` — rather than reverting with
+  `not healthy within 30s: unreachable`. That is bug 1, and it is the one class the items above
+  cannot reach.
+
+**Docker rather than `systemd-nspawn`**, which is a change from what this section used to propose.
+The objection to privileged containers *in CI* stands and this is not CI. What decided it is the
+argument this section itself made for ranking real systemd last: a check that can only run on a
+machine nobody develops on stops being read. Docker Desktop runs a privileged container with systemd
+as pid 1 on the laptop this is developed on; nspawn does not.
+
+It found a bug on its first run, in the code rather than in itself. `self_test_updaterd` ran the new
+binary with no `--config`, so it validated `/etc/robot/updater.toml` however the running daemon was
+started — defeating the check's whole purpose, which is to catch a new binary that rejects *the
+board's* config file.
+
+Two injections named here are still worth adding now that the harness exists, and neither needs new
+machinery: `systemd-run` failing (the update must still succeed, and the successor must reconcile the
+stale unit), and `enable --now` on a unit whose `User=` does not exist.
 
 ### Not doing
 

--- a/scripts/systemd-test.Dockerfile
+++ b/scripts/systemd-test.Dockerfile
@@ -1,0 +1,21 @@
+# The image `scripts/systemd-test.sh` boots, and the only place in this repository where systemd
+# runs as pid 1.
+#
+# Trixie, unlike `dev-build.Dockerfile`: this one *runs* what a board runs rather than building it,
+# so it should be the userland we ship rather than the older one binaries are built against.
+#
+# `systemd` and `dbus` only. The point is a real init with real cgroups and real transient timers,
+# and everything else the update needs — the binaries, the units, the hook — arrives inside the
+# signed releases the harness mints, exactly as it does on a board.
+FROM debian:trixie-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends systemd dbus \
+    && rm -rf /var/lib/apt/lists/*
+
+# systemd's own convention for "stop, cleanly". Without it `docker stop` sends SIGTERM, which pid 1
+# systemd reads as a request to re-exec rather than to shut down.
+STOPSIGNAL SIGRTMIN+3
+
+# `/lib/systemd/systemd`, because Debian's slim images ship no `/sbin/init` symlink — the harness
+# passes it explicitly and this only records why.
+CMD ["/lib/systemd/systemd"]

--- a/scripts/systemd-test.sh
+++ b/scripts/systemd-test.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+# Drive a real update against real systemd, on demand.
+#
+# Usage:  scripts/systemd-test.sh
+#
+# Needs Docker and nothing else. Not run by CI, deliberately — see the bottom of this comment.
+#
+# **What only this can answer.** Everything else in the tree tests the engine's decisions against a
+# stub `systemctl`: which units it would restart, in what order, and what it does when one is
+# missing. None of it can see whether a restart *happened*, because none of it has systemd. Three
+# mechanisms are therefore untested everywhere else, and all three are what a board depends on after
+# every update (docs/design/restart-order.md):
+#
+#   1. `on_apply` really restarts the units a release ships;
+#   2. the deferred `systemd-run --on-active=5s` transient timer really fires, and really replaces
+#      `updaterd` — a child process could not, because it would sit in the cgroup being killed;
+#   3. `hooks/postinstall` really installs, enables and starts a unit a board has never had.
+#
+# And one failure only systemd can produce: a unit that installs cleanly and **cannot start**. That
+# is bug 1 of `install-path-gap.md`, whose symptom on a board was `not healthy within 30s:
+# unreachable` — a message naming neither the unit nor the command.
+#
+# **Docker rather than `systemd-nspawn`.** The plan in `install-path-gap.md` said nspawn on a Linux
+# box, and rejected privileged containers *in CI*. That rejection stands; this is not CI. What
+# changed the choice is the plan's own argument against putting this last: a check that can only run
+# on a machine nobody develops on stops being read. Docker Desktop runs a privileged arm64 container
+# with systemd as pid 1 on the laptop this is written on, which nspawn cannot, and the fidelity that
+# matters here — real units, real cgroups, real transient timers — is identical.
+#
+# **Why not in CI.** It needs `--privileged` and the host's cgroup filesystem, which is a much
+# larger thing to hand a workflow than any check here is worth, and the `board` job is already the
+# slowest thing in the loop. This is the one to run when `on_apply`, the deferred restarts or the
+# hook change — which is rarely, and is exactly when a stub stops being evidence.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+WORK=target/systemd-test
+FIXTURE="$WORK/fixture"
+# Where the tree is mounted in the container. Every path in the generated updater.toml is written
+# for this, not for the host.
+MOUNT=/fixture
+IMAGE=duck-systemd-test
+NAME=duck-systemd-test
+
+command -v docker >/dev/null || {
+    echo "docker is required: this needs systemd as pid 1, which a container provides and this" >&2
+    echo "host does not." >&2
+    exit 1
+}
+
+pass() { echo "    [ok] $*"; }
+fail() { echo "    [FAIL] $*"; exit 1; }
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT INT TERM
+
+# ── the binaries ──
+#
+# Built inside the same userland the container runs, reusing the image `dev-push.sh --docker`
+# already defines. On an arm64 host that is a native build and the target is the host.
+echo "==> building updaterd and robotctl for the container"
+docker build -q -t duck-dev-build -f scripts/dev-build.Dockerfile scripts/ >/dev/null
+docker run --rm --platform linux/arm64 \
+    -v "$PWD:/src" -w /src \
+    -v duck-dev-cargo-registry:/usr/local/cargo/registry \
+    -e CARGO_TARGET_DIR=/src/target/docker \
+    duck-dev-build \
+    cargo build --release -p updater -p robotctl --bins >/dev/null
+BIN=target/docker/release
+
+# ── the fixture ──
+#
+# Three releases: one to start on, one to move to, and one that installs a unit which cannot start.
+echo "==> minting three signed releases"
+rm -rf "$FIXTURE"
+mkdir -p "$WORK"
+cargo run -q -p test-support --example systemd-fixture -- "$FIXTURE" \
+    --updaterd "$BIN/updaterd" \
+    --robotctl "$BIN/robotctl" \
+    --postinstall hooks/postinstall \
+    --prefix "$MOUNT" \
+    1.0.0 1.1.0 1.2.0:broken-unit | sed 's/^/    /'
+
+# `local_dir` serves the newest version it can see, so what is offered is decided by what has been
+# copied in. One at a time, and the harness controls when.
+cp "$FIXTURE"/r/1.0.0/* "$FIXTURE/published/"
+
+# ── the container ──
+#
+# systemd as pid 1 needs the host's cgroup tree and privileges. `/lib/systemd/systemd` rather than
+# `/sbin/init`, which Debian's slim images do not provide.
+echo "==> booting systemd"
+docker build -q -t "$IMAGE" -f scripts/systemd-test.Dockerfile scripts/ >/dev/null
+cleanup
+docker run -d --name "$NAME" --privileged --cgroupns=host \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    -v "$PWD/$FIXTURE:$MOUNT" \
+    "$IMAGE" /lib/systemd/systemd >/dev/null
+
+waited=0
+until state="$(docker exec "$NAME" systemctl is-system-running 2>/dev/null || true)"
+      [ "$state" = running ] || [ "$state" = degraded ]; do
+    waited=$((waited + 1))
+    [ "$waited" -lt 30 ] || fail "systemd did not come up: ${state:-no answer}"
+    sleep 1
+done
+pass "systemd is pid 1 (${state})"
+
+in_container() { docker exec "$NAME" sh -c "$1"; }
+
+# ── the first install, which is a board's bootstrap ──
+#
+# Run from the tree rather than from a release, because on a bare board nothing is installed yet.
+# `install` forces `on_apply` and the gate off — but the hook still runs, and installing the units is
+# the hook's job, so this is also the first observation: does postinstall bring up a daemon a board
+# has never had?
+echo "==> installing 1.0.0 (the bootstrap path)"
+in_container "$MOUNT/bin/updaterd --config $MOUNT/updater.toml install --from $MOUNT/published" \
+    > "$WORK/install.log" 2>&1 || { sed 's/^/    /' "$WORK/install.log"; fail "install failed"; }
+
+in_container "test -f /etc/systemd/system/fake-robotd.service" \
+    || fail "postinstall did not install a unit the board had never seen"
+in_container "systemctl is-active --quiet fake-robotd" \
+    || fail "postinstall installed fake-robotd but it is not running"
+in_container "systemctl is-active --quiet updaterd" \
+    || fail "postinstall installed updaterd.service but it is not running"
+pass "postinstall installed, enabled and started units on a board that had none"
+
+live() { docker exec "$NAME" readlink "$MOUNT/opt/daemon/current" | sed 's|releases/||'; }
+main_pid() { docker exec "$NAME" systemctl show -p MainPID --value "$1" | tr -d '\r'; }
+
+[ "$(live)" = 1.0.0 ] || fail "current is $(live), expected 1.0.0"
+pass "1.0.0 is live"
+
+# ── the update, through the daemon ──
+robotd_before="$(main_pid fake-robotd)"
+updaterd_before="$(main_pid updaterd)"
+
+cp "$FIXTURE"/r/1.1.0/* "$FIXTURE/published/"
+echo "==> applying 1.1.0 through the running updaterd"
+in_container "$MOUNT/opt/daemon/current/bin/robotctl update apply daemon" \
+    > "$WORK/apply.log" 2>&1 || { sed 's/^/    /' "$WORK/apply.log"; fail "apply failed"; }
+
+[ "$(live)" = 1.1.0 ] || fail "current is $(live) after applying 1.1.0"
+pass "1.1.0 is live"
+
+# 1. `on_apply` restarted what the release ships. The gate above already implies the unit came back;
+#    the PID is what says it was replaced rather than left alone.
+robotd_after="$(main_pid fake-robotd)"
+[ -n "$robotd_before" ] && [ "$robotd_before" != "$robotd_after" ] \
+    || fail "fake-robotd was not restarted (pid $robotd_before throughout)"
+pass "on_apply restarted the daemon the release ships (pid $robotd_before -> $robotd_after)"
+
+# 2. The deferred restart. Scheduled five seconds after the reply, through a transient unit, so this
+#    is the one observation a child process could not make: `updaterd` is replaced *by systemd*
+#    after the operation it was performing has finished.
+echo "==> waiting for the deferred updaterd restart"
+waited=0
+until [ "$(main_pid updaterd)" != "$updaterd_before" ]; do
+    waited=$((waited + 1))
+    [ "$waited" -lt 40 ] || fail "updaterd was never restarted (pid $updaterd_before after ${waited}s)"
+    sleep 1
+done
+pass "the transient timer replaced updaterd after ${waited}s (pid $updaterd_before -> $(main_pid updaterd))"
+
+# And the successor is the *new* binary, which is the point of restarting it at all. Its own
+# published identity is the answer, because that is what the startup reconciliation reads.
+waited=0
+until in_container "grep -q 'releases/1.1.0/bin/updaterd' /run/updaterd/identity.json 2>/dev/null"; do
+    waited=$((waited + 1))
+    [ "$waited" -lt 20 ] || fail "the restarted updaterd is not running 1.1.0"
+    sleep 1
+done
+pass "the restarted updaterd is running 1.1.0"
+
+# And its startup reconciliation found nothing to fix. Asserted as an absence, because the positive
+# line is only logged when *every* unit is accounted for and `fake-robotd` is a `sleep` that publishes
+# no identity — which reads as `Unknown`, and being left alone is exactly right for it.
+if in_container "journalctl -u updaterd -b --no-pager | grep -q 'still running the release it had'"
+then
+    fail "the successor found a unit stale, so a restart during the update did not take"
+fi
+pass "its startup reconciliation restarted nothing, as it should"
+
+# ── the injection: a unit that installs and cannot start ──
+#
+# Bug 1's class. The unit arrives with the release, postinstall installs and enables it, `enable
+# --now` fails and is only a warning — and then `on_apply` restarts it, which is not. The update must
+# fail, roll back, and say which unit.
+cp "$FIXTURE"/r/1.2.0/* "$FIXTURE/published/"
+echo "==> applying 1.2.0, which ships a unit that cannot start"
+# Exit status is deliberately not the check. A rollback is a *successful* call that reports an
+# unsuccessful outcome — `robotctl` exits 0 having told you what happened, and reading the status
+# instead would assert a different contract than the one that matters here.
+in_container "$MOUNT/opt/daemon/current/bin/robotctl update apply daemon" \
+    > "$WORK/broken.log" 2>&1 || true
+grep -q rolled_back "$WORK/broken.log" \
+    || { sed 's/^/    /' "$WORK/broken.log"; fail "the update did not roll back"; }
+grep -q '"outcome": "applied"' "$WORK/broken.log" \
+    && fail "the update reported success despite a unit that cannot start"
+pass "the update rolled back rather than reporting success"
+
+[ "$(live)" = 1.1.0 ] || fail "rolled back to $(live), expected 1.1.0"
+pass "rolled back to 1.1.0"
+
+grep -qi "broken" "$WORK/broken.log" \
+    || { sed 's/^/    /' "$WORK/broken.log"; fail "the reason does not name the unit that failed"; }
+pass "the reason names the unit, not 'unreachable'"
+
+in_container "systemctl is-active --quiet fake-robotd" \
+    || fail "fake-robotd is down after the rollback"
+pass "the daemon is running again after the rollback"
+
+echo
+echo "==> systemd checks passed"

--- a/test-support/examples/systemd-fixture.rs
+++ b/test-support/examples/systemd-fixture.rs
@@ -1,0 +1,197 @@
+//! Mint releases that carry systemd units and a real `updaterd`, for the one harness that needs
+//! real systemd: `scripts/systemd-test.sh`.
+//!
+//! Its sibling `fake-release` deliberately mints releases with **no units** and a config whose
+//! `on_apply` is `none`, because it exists to drive the engine's own logic where systemd is not
+//! present. That is the right fixture for almost everything and the wrong one for exactly one
+//! question: *does the restart machinery work?* Answering that needs units that really start, a
+//! transient timer that really fires, and an `updaterd` that is really replaced by its successor —
+//! so it needs its own fixture rather than a flag on that one.
+//!
+//! What each release carries:
+//!
+//! ```text
+//!   bin/updaterd  bin/robotctl        the binaries under test, built for the container
+//!   systemd/updaterd.service          so the update can restart the updater — the whole point
+//!   systemd/fake-robotd.service       a stand-in for a daemon in the restart set
+//!   systemd/broken.service            only in a `:broken-unit` release: ExecStart=/bin/false
+//!   hooks/postinstall                 the real one, so it installs and enables units for real
+//! ```
+//!
+//! `fake-robotd` rather than a real `robotd`: what is under test is whether the engine restarts what
+//! a release ships, and a `sleep` proves that as well as motor control does while needing no
+//! hardware, no policy and no socket. Its main PID changing is the observation.
+
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use test_support::Publisher;
+
+#[derive(Parser)]
+#[command(about = "Mint releases carrying systemd units, for scripts/systemd-test.sh")]
+struct Cli {
+    /// Directory to create. Refused if it already holds something.
+    root: PathBuf,
+
+    /// The `updaterd` to place in every release, built for wherever this will run.
+    #[arg(long)]
+    updaterd: PathBuf,
+
+    /// The matching `robotctl`. Same release as `updaterd` or the handshake refuses it.
+    #[arg(long)]
+    robotctl: PathBuf,
+
+    /// The real `hooks/postinstall`, so the harness observes the shipped one rather than a stub.
+    #[arg(long)]
+    postinstall: PathBuf,
+
+    /// Where the tree will be *read* from, when that is not where it is minted — the harness
+    /// mints on the host and mounts it into a container, where every path differs.
+    #[arg(long)]
+    prefix: Option<PathBuf>,
+
+    /// `<version>[:broken-unit]`. `broken-unit` adds a unit that installs and cannot start, which
+    /// must fail the update and roll it back.
+    #[arg(required = true, value_name = "SPEC")]
+    releases: Vec<String>,
+}
+
+/// A unit for the updater itself, pointing through `current` exactly as the shipped one does.
+///
+/// `RuntimeDirectory=` is load-bearing rather than tidy: it is where the daemon publishes what
+/// release it is running, and that file is the only way to see that the deferred restart actually
+/// replaced this process rather than merely being scheduled.
+fn updaterd_unit(prefix: &Path) -> String {
+    format!(
+        "[Unit]\nDescription=Updater under test\n\n\
+         [Service]\nType=exec\n\
+         ExecStart={p}/opt/daemon/current/bin/updaterd --config {p}/updater.toml \
+         --socket /run/updaterd.sock\n\
+         Restart=on-failure\nRestartSec=1s\nRuntimeDirectory=updaterd\n\
+         Environment=RUST_LOG=info\n\n\
+         [Install]\nWantedBy=multi-user.target\n",
+        p = prefix.display()
+    )
+}
+
+/// A daemon in the restart set, whose only job is to be restartable and observable.
+const FAKE_ROBOTD_UNIT: &str = "[Unit]\nDescription=Stand-in for a daemon an update restarts\n\n\
+     [Service]\nType=exec\nExecStart=/bin/sleep infinity\nRestart=always\nRestartSec=1s\n\n\
+     [Install]\nWantedBy=multi-user.target\n";
+
+/// A unit that installs cleanly and cannot start. Bug 1 of `install-path-gap.md` in one file: the
+/// update must fail and name it, rather than reverting with "not healthy: unreachable".
+const BROKEN_UNIT: &str = "[Unit]\nDescription=A unit that will not start\n\n\
+     [Service]\nType=oneshot\nExecStart=/bin/false\n\n\
+     [Install]\nWantedBy=multi-user.target\n";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // Same refusal as `fake-release`, for the same reason: this mints a fresh key, and adding to an
+    // existing tree would leave what is already there unverifiable against it.
+    if cli.root.exists() && std::fs::read_dir(&cli.root)?.next().is_some() {
+        return Err(format!("{} exists and is not empty", cli.root.display()).into());
+    }
+
+    for dir in ["keys", "published", "opt/daemon", "var", "bin"] {
+        std::fs::create_dir_all(cli.root.join(dir))?;
+    }
+
+    let updaterd = std::fs::read(&cli.updaterd)?;
+    let robotctl = std::fs::read(&cli.robotctl)?;
+    let postinstall = std::fs::read_to_string(&cli.postinstall)?;
+    let prefix = match &cli.prefix {
+        Some(prefix) => prefix.clone(),
+        None => cli.root.canonicalize()?,
+    };
+
+    // A copy outside any release, which is how a bare board bootstraps: the first install has to be
+    // run by an `updaterd` that is not yet installed anywhere.
+    let bootstrap = cli.root.join("bin/updaterd");
+    std::fs::write(&bootstrap, &updaterd)?;
+    make_executable(&bootstrap)?;
+
+    let publisher = Publisher::new(cli.root.join("keys"), cli.root.join("published"));
+
+    for spec in &cli.releases {
+        let (version, kind) = spec.split_once(':').unwrap_or((spec.as_str(), ""));
+        let dir = cli.root.join("r").join(version);
+
+        let mut release = publisher
+            .release(version)
+            .dir(dir.clone())
+            .file("bin/updaterd", &updaterd, 0o755)
+            .file("bin/robotctl", &robotctl, 0o755)
+            .file(
+                "systemd/updaterd.service",
+                updaterd_unit(&prefix).as_bytes(),
+                0o644,
+            )
+            .file(
+                "systemd/fake-robotd.service",
+                FAKE_ROBOTD_UNIT.as_bytes(),
+                0o644,
+            )
+            .hook(&postinstall);
+
+        match kind {
+            "" => {}
+            "broken-unit" => {
+                release = release.file("systemd/broken.service", BROKEN_UNIT.as_bytes(), 0o644);
+            }
+            other => return Err(format!("unknown spec `:{other}` in `{spec}`").into()),
+        }
+        release.write();
+        println!(
+            "r/{version}{}",
+            if kind.is_empty() {
+                ""
+            } else {
+                " (broken-unit)"
+            }
+        );
+    }
+
+    // `restart` with an empty list, which is not the same as `none`: the set comes from the units a
+    // release ships, so this says "restart what you carry" and nothing more.
+    //
+    // A command probe rather than a socket one, because there is no `robotd` here — and asking
+    // systemd whether the daemon it just restarted is active is a real gate rather than a formality,
+    // which `/bin/true` would have been.
+    let config = format!(
+        r#"# Generated by `cargo run -p test-support --example systemd-fixture`.
+trusted_keys_dir = "{p}/keys"
+hw_rev = 1
+state_dir = "{p}/var"
+allow_fault_injection = true
+
+[component.daemon]
+install_dir = "{p}/opt/daemon"
+source = {{ type = "local_dir", path = "{p}/published" }}
+keep_previous = 2
+on_apply = {{ action = "restart", units = [] }}
+health = {{ probe = "command", program = "/usr/bin/systemctl", args = ["is-active", "--quiet", "fake-robotd"], timeout = "20s" }}
+"#,
+        p = prefix.display()
+    );
+    std::fs::write(cli.root.join("updater.toml"), config)?;
+
+    println!(
+        "\nminted at {}, paths written for {}",
+        cli.root.display(),
+        prefix.display()
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -14,6 +14,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// The file this was read from, when it was read from one.
+    ///
+    /// Not configuration — it is how the engine hands the *same* config to the release's own
+    /// `updaterd --self-test` before committing to it. That check exists to catch a new binary
+    /// which rejects the board's `updater.toml`, and it can only do that if it is pointed at the
+    /// file in use: `--config` has a default, so a self-test run without one silently validates
+    /// `/etc/robot/updater.toml` however the running daemon was started. It read as the release
+    /// being broken.
+    ///
+    /// `None` when the config came from text rather than a path — every test, and nothing on a
+    /// board.
+    #[serde(skip)]
+    pub loaded_from: Option<PathBuf>,
+
     /// Directory of trusted minisign public keys. A signature is valid if it
     /// verifies against *any* key in here.
     ///
@@ -333,7 +347,11 @@ impl Config {
             path: path.to_path_buf(),
             source: e,
         })?;
-        Self::from_toml(&text)
+        let mut config = Self::from_toml(&text)?;
+        // Absolute, because the self-test runs as a fresh process whose working directory is not
+        // this one's.
+        config.loaded_from = Some(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
+        Ok(config)
     }
 
     /// Bounds applied when extracting an artifact.

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -778,7 +778,7 @@ impl Engine {
         // has none to restart — a model, or the bootstrap install, which forces it precisely
         // because nothing is installed yet and there is no running daemon to make stale.
         if matches!(cfg.on_apply, ApplyAction::Restart { .. }) {
-            self_test_updaterd(release_dir).await?;
+            self_test_updaterd(release_dir, self.config.loaded_from.as_deref()).await?;
         }
 
         emit(Phase::HealthGate, None);
@@ -1797,7 +1797,7 @@ const DEFERRED_RESTART_DELAY: &str = "5s";
 ///
 /// A release with no `updaterd` — a model component, or one predating the flag — passes. The point
 /// is to catch a broken replacement, not to require every artifact to contain one.
-async fn self_test_updaterd(release_dir: &Path) -> Result<(), Error> {
+async fn self_test_updaterd(release_dir: &Path, config: Option<&Path>) -> Result<(), Error> {
     let binary = release_dir.join("bin").join("updaterd");
     if !binary.is_file() {
         return Ok(());
@@ -1805,6 +1805,13 @@ async fn self_test_updaterd(release_dir: &Path) -> Result<(), Error> {
 
     let mut command = tokio::process::Command::new(&binary);
     command.arg("--self-test");
+    // The config *this* engine was loaded from, not the flag's default. Without it the probe reads
+    // `/etc/robot/updater.toml` whatever the running daemon was started with, so on any board using
+    // `--config` it validates a file that is not in use — and reports the release as broken when
+    // that file does not exist. Found by `scripts/systemd-test.sh` on its first run.
+    if let Some(config) = config {
+        command.arg("--config").arg(config);
+    }
 
     // Through the retry, and this is the call that most needs it: the binary being exec'd was
     // written by *this update*, moments ago, while hooks and `systemctl` were spawning around it —
@@ -2210,7 +2217,7 @@ esac
             "#!/bin/sh\necho 'config error: unknown field `nope`' >&2\nexit 1\n",
         );
 
-        let err = self_test_updaterd(release.path()).await.unwrap_err();
+        let err = self_test_updaterd(release.path(), None).await.unwrap_err();
 
         assert!(
             matches!(err, Error::SelfTest(_)),
@@ -2225,7 +2232,7 @@ esac
     #[tokio::test]
     async fn a_replacement_updaterd_that_starts_passes() {
         let release = release_with_updaterd("#!/bin/sh\nexit 0\n");
-        assert!(self_test_updaterd(release.path()).await.is_ok());
+        assert!(self_test_updaterd(release.path(), None).await.is_ok());
     }
 
     /// Model components ship no `updaterd`, and neither do releases predating the flag. Requiring
@@ -2233,7 +2240,7 @@ esac
     #[tokio::test]
     async fn a_release_without_an_updaterd_passes() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(self_test_updaterd(dir.path()).await.is_ok());
+        assert!(self_test_updaterd(dir.path(), None).await.is_ok());
     }
 
     /// The two lists are one decision, and splitting them is how a daemon gets excluded from the


### PR DESCRIPTION
Item 4, the last of the plan in `install-path-gap.md` — and it found a bug in the engine before it had asserted anything.

## What only this can see

Every other check in the tree drives the engine against a **stub `systemctl`**. They cover the decisions well: which units it would restart, in what order, what it does when one is missing. None of them can see whether a restart *happened*.

`scripts/systemd-test.sh` boots systemd as pid 1, mints three signed releases carrying real units and a real `updaterd`, installs one, applies the next through the running daemon, then applies one that ships a unit which cannot start:

```
    [ok] systemd is pid 1 (degraded)
    [ok] postinstall installed, enabled and started units on a board that had none
    [ok] 1.0.0 is live
    [ok] 1.1.0 is live
    [ok] on_apply restarted the daemon the release ships (pid 154 -> 297)
    [ok] the transient timer replaced updaterd after 4s (pid 173 -> 356)
    [ok] the restarted updaterd is running 1.1.0
    [ok] its startup reconciliation restarted nothing, as it should
    [ok] the update rolled back rather than reporting success
    [ok] rolled back to 1.1.0
    [ok] the reason names the unit, not 'unreachable'
    [ok] the daemon is running again after the rollback
```

Four of those are new information:

- **`on_apply` really restarts**, asserted on the unit's main PID changing rather than on a command having been issued.
- **The deferred transient timer really fires and really replaces `updaterd`**, and the successor runs the new release. A child process could not do this — it would sit in the cgroup being killed — which is the entire reason for `systemd-run` and was until now an untested claim in a comment.
- **`hooks/postinstall` really installs, enables and starts** a unit the board has never had. The plan noted no stub can show this.
- **A unit that installs cleanly and cannot start fails the update and names itself**: `restart failed: Job for broken.service failed…` rather than `not healthy within 30s: unreachable`. That is bug 1 of `install-path-gap.md`, and the only class the cheaper items cannot reach.

## The bug it found

The first commit is a fix, not a test. `self_test_updaterd` ran the release's new binary with **no `--config`**, and that flag has a default — so the probe validated `/etc/robot/updater.toml` however the running daemon was started. The rollback reason was:

```
the new updaterd failed its self-test: invalid config
path=/etc/robot/updater.toml error=No such file or directory
```

blaming the release for a file it has nothing to do with. Worse, it defeats the check's stated purpose: catching a new binary that rejects *the board's* `updater.toml`, the operator's file preserved across installs, which it cannot do while pointed elsewhere. `Config` now remembers where it was read from, and the probe is given it.

Harmless on a board today, since the unit passes the default path. Not harmless on a dev box using `--config`, and not harmless as a guarantee.

## Docker rather than `systemd-nspawn`

A deliberate change from what the plan proposed, argued in the script's header. The objection to privileged containers **in CI** stands, and this is not CI. What decided it is the plan's own reason for ranking real systemd last: *a check that can only run on a machine nobody develops on stops being read.* Docker Desktop runs a privileged container with systemd as pid 1 on the laptop this was written on; nspawn does not. The fidelity that matters — real units, real cgroups, real transient timers — is identical.

## Notes

- **Not in CI**, deliberately: it needs `--privileged` and the host's cgroup filesystem, and `board` is already the slowest job. Run it when `on_apply`, the deferred restarts, or the hook change.
- The fixture is a new example rather than a flag on `fake-release`, which deliberately mints releases with **no** units because it exists to drive the engine where systemd is absent.
- `fake-robotd` is a `sleep`: what is under test is whether the engine restarts what a release ships, and a sleep proves that as well as motor control while needing no hardware. It publishes no identity, so the reconciliation sees `Unknown` and leaves it alone — which is why that assertion is written as an absence.
- `-p updater` green (150 lib tests), clippy clean, and the harness lints under the `shellcheck` gate added in #78.
- Two injections remain, both cheap now the harness exists: `systemd-run` failing, and `enable --now` on a unit whose `User=` does not exist.

With this, every item of the plan is done.