### PR TITLE
A revert that happened is not a failed rollback

### DIFF
--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -367,24 +367,38 @@ Both injections named here are in it too, and both landed assertions nothing els
   account exists and its unit runs. The other half — the same unit with nothing creating the user —
   fails the update and names the unit rather than the account.
 
-### The gap the harness found on the way
+### The gap the harness found on the way — fixed
 
-**A failed update can fail its own rollback**, and `RollbackFailed` is the outcome the design calls the
-most serious one. Reproduced by the missing-user release above, and asserted as current behaviour so
-that changing it is deliberate:
+**A failed update reported a failed rollback for a robot it had successfully put back.** Reproduced by
+the missing-user release above, and `RollbackFailed` is the outcome the design calls the most serious
+one — so it was worth more than a note.
 
-`hooks/postinstall` overwrites unit files and, by design, does not put them back on a rollback — the
-hook argues that a release which did not take leaves one service failing until the next one does, which
-is the same situation either way. That holds while the failing unit is only *failing*. It stops holding
-when the unit is in the restart set of the release being reverted **to**, because the revert re-runs
-the same restart and inherits the same failure.
+The cause is not the rollback. `hooks/postinstall` overwrites unit files and, by design, does not put
+them back: the hook argues that a release which did not take leaves one service failing until the next
+one does, which is the same situation either way. That reasoning holds and is unchanged. What it did
+not anticipate is the unit being in the restart set of the release being reverted **to** — then the
+revert re-runs the same restart and inherits the same failure. Reachable by an ordinary bad release
+rather than only by the downgrade case above: two consecutive releases ship the same unit name and the
+newer one is broken.
 
-Reachable by an ordinary bad release rather than only by the downgrade case this document already
-records: two consecutive releases ship the same unit name and the newer one is broken. The revert
-itself does happen — `current` goes back — so what is lost is the apply action, not the tree. Worth a
-decision rather than a patch, and the options are not symmetric: making `postinstall` reversible is the
-change the hook explicitly declined, while tolerating a failed restart *during a rollback* weakens the
-distinction `restart_one` draws on purpose.
+**The fix separates the swap from the apply action, because only one of them is the recovery.** Past
+`swap_to` and the trial being cleared, the robot *is* back on the release it came from; a unit that
+then fails to restart is a second fact, not a contradiction of the first. So `Error::RollbackFailed`
+keeps its meaning — the robot could not be put back at all — and a failed apply action during a revert
+is carried into the reported outcome and logged at `error`:
+
+```text
+not healthy within 30s: …; the release was reverted but a unit did not restart (…), so
+something on this robot is down
+```
+
+Both facts, in the order someone needs them: why the update failed first, then what is still down.
+
+The two rejected alternatives, since neither is obviously wrong. Making `postinstall` reversible is the
+change the hook explicitly declined; it needs state outside the release and adds a failure mode to the
+recovery path, which is the one place that has to stay boring. Tolerating a failed restart *everywhere*
+would weaken the distinction `restart_one` draws on purpose — a unit that exists and will not start is
+how a broken release is caught, and that is still fatal on the way *in*.
 
 ### Not doing
 

--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -355,9 +355,36 @@ binary with no `--config`, so it validated `/etc/robot/updater.toml` however the
 started — defeating the check's whole purpose, which is to catch a new binary that rejects *the
 board's* config file.
 
-Two injections named here are still worth adding now that the harness exists, and neither needs new
-machinery: `systemd-run` failing (the update must still succeed, and the successor must reconcile the
-stale unit), and `enable --now` on a unit whose `User=` does not exist.
+Both injections named here are in it too, and both landed assertions nothing else could make:
+
+- **`systemd-run` cannot be run.** The update still succeeds — scheduling is best-effort by design,
+  because the update is committed by then — the journal says so, and `btd` and `updaterd` are left on
+  the old release exactly as a missed timer leaves them. Then the next `updaterd` start reconciles the
+  stale `btd` onto the active release and does **not** restart itself, which in that process would be a
+  loop with no way out. That is `reconcile.rs` closing the loop for the first time outside a unit test.
+- **A unit whose `User=` the release brings with it.** `postinstall` installs `sysusers.d` files and
+  runs `systemd-sysusers` before the units, and its comment calls that ordering load-bearing. The
+  account exists and its unit runs. The other half — the same unit with nothing creating the user —
+  fails the update and names the unit rather than the account.
+
+### The gap the harness found on the way
+
+**A failed update can fail its own rollback**, and `RollbackFailed` is the outcome the design calls the
+most serious one. Reproduced by the missing-user release above, and asserted as current behaviour so
+that changing it is deliberate:
+
+`hooks/postinstall` overwrites unit files and, by design, does not put them back on a rollback — the
+hook argues that a release which did not take leaves one service failing until the next one does, which
+is the same situation either way. That holds while the failing unit is only *failing*. It stops holding
+when the unit is in the restart set of the release being reverted **to**, because the revert re-runs
+the same restart and inherits the same failure.
+
+Reachable by an ordinary bad release rather than only by the downgrade case this document already
+records: two consecutive releases ship the same unit name and the newer one is broken. The revert
+itself does happen — `current` goes back — so what is lost is the apply action, not the tree. Worth a
+decision rather than a patch, and the options are not symmetric: making `postinstall` reversible is the
+change the hook explicitly declined, while tolerating a failed restart *during a rollback* weakens the
+distinction `restart_one` draws on purpose.
 
 ### Not doing
 

--- a/scripts/systemd-test.sh
+++ b/scripts/systemd-test.sh
@@ -71,8 +71,8 @@ BIN=target/docker/release
 
 # ── the fixture ──
 #
-# Three releases: one to start on, one to move to, and one that installs a unit which cannot start.
-echo "==> minting three signed releases"
+# One to start on, one to move to, then one per injection.
+echo "==> minting the signed releases"
 rm -rf "$FIXTURE"
 mkdir -p "$WORK"
 cargo run -q -p test-support --example systemd-fixture -- "$FIXTURE" \
@@ -80,7 +80,7 @@ cargo run -q -p test-support --example systemd-fixture -- "$FIXTURE" \
     --robotctl "$BIN/robotctl" \
     --postinstall hooks/postinstall \
     --prefix "$MOUNT" \
-    1.0.0 1.1.0 1.2.0:broken-unit | sed 's/^/    /'
+    1.0.0 1.1.0 1.2.0 1.3.0:sysusers 1.4.0:missing-user 1.5.0:broken-unit | sed 's/^/    /'
 
 # `local_dir` serves the newest version it can see, so what is offered is decided by what has been
 # copied in. One at a time, and the harness controls when.
@@ -125,6 +125,8 @@ in_container "systemctl is-active --quiet fake-robotd" \
     || fail "postinstall installed fake-robotd but it is not running"
 in_container "systemctl is-active --quiet updaterd" \
     || fail "postinstall installed updaterd.service but it is not running"
+in_container "test -f /run/btd/identity.json" \
+    || fail "the btd stand-in did not publish an identity, so nothing here can be observed"
 pass "postinstall installed, enabled and started units on a board that had none"
 
 live() { docker exec "$NAME" readlink "$MOUNT/opt/daemon/current" | sed 's|releases/||'; }
@@ -133,14 +135,21 @@ main_pid() { docker exec "$NAME" systemctl show -p MainPID --value "$1" | tr -d 
 [ "$(live)" = 1.0.0 ] || fail "current is $(live), expected 1.0.0"
 pass "1.0.0 is live"
 
+# `robotctl` from the live release, so the client and the daemon are always the same build — an
+# `API_VERSION` bump would otherwise refuse the call, which is the contract and not the subject here.
+apply() {
+    in_container "$MOUNT/opt/daemon/current/bin/robotctl update apply daemon" > "$1" 2>&1 || true
+}
+
 # ── the update, through the daemon ──
 robotd_before="$(main_pid fake-robotd)"
 updaterd_before="$(main_pid updaterd)"
 
 cp "$FIXTURE"/r/1.1.0/* "$FIXTURE/published/"
 echo "==> applying 1.1.0 through the running updaterd"
-in_container "$MOUNT/opt/daemon/current/bin/robotctl update apply daemon" \
-    > "$WORK/apply.log" 2>&1 || { sed 's/^/    /' "$WORK/apply.log"; fail "apply failed"; }
+apply "$WORK/apply.log"
+grep -q '"outcome": "applied"' "$WORK/apply.log" \
+    || { sed 's/^/    /' "$WORK/apply.log"; fail "apply did not report success"; }
 
 [ "$(live)" = 1.1.0 ] || fail "current is $(live) after applying 1.1.0"
 pass "1.1.0 is live"
@@ -183,26 +192,148 @@ then
 fi
 pass "its startup reconciliation restarted nothing, as it should"
 
+# ── injection: `systemd-run` cannot be run ──
+#
+# Scheduling the deferred restarts is best-effort by design: the update is committed and journalled by
+# then, so an update that worked must not be reported as failed because a timer could not be created.
+# That is only affordable because it is not the last word — the next `updaterd` start compares each
+# unit against the active release and restarts what is stale (`updater/src/reconcile.rs`). Both halves
+# of that are asserted here, and neither is observable without systemd.
+#
+# Shadowed in `/usr/local/sbin`, which comes first in the PATH systemd gives a unit, so the engine
+# resolves this one instead of the real `systemd-run`.
+echo "==> applying 1.2.0 with systemd-run broken"
+in_container "printf '#!/bin/sh\nexit 1\n' > /usr/local/sbin/systemd-run && chmod 755 /usr/local/sbin/systemd-run"
+btd_before="$(main_pid btd)"
+updaterd_before="$(main_pid updaterd)"
+
+cp "$FIXTURE"/r/1.2.0/* "$FIXTURE/published/"
+apply "$WORK/no-timer.log"
+grep -q '"outcome": "applied"' "$WORK/no-timer.log" \
+    || { sed 's/^/    /' "$WORK/no-timer.log"; fail "a restart that could not be scheduled failed the update"; }
+pass "the update still succeeded — an unschedulable restart is not an update failure"
+
+# Matched on the half both arms share: a `systemd-run` that cannot be *executed* and one that exits
+# non-zero are different log lines, and which of them a shadow produces is not the point.
+in_container "journalctl -u updaterd -b --no-pager | grep -q 'until the next updaterd start notices'" \
+    || fail "nothing in the journal says the restart could not be scheduled"
+pass "the journal says the restart could not be scheduled"
+
+# Nothing restarted them, so both are still on 1.1.0 — which is the silent state this exists to end.
+sleep 8
+[ "$(main_pid btd)" = "$btd_before" ] \
+    || fail "btd restarted anyway, so this is not testing what it claims"
+[ "$(main_pid updaterd)" = "$updaterd_before" ] \
+    || fail "updaterd restarted anyway, so this is not testing what it claims"
+in_container "grep -q 'releases/1.1.0/bin/fake-btd' /run/btd/identity.json" \
+    || fail "btd is not on the old release, so there is nothing for the successor to fix"
+pass "btd and updaterd are left on 1.1.0, as a missed timer leaves them"
+
+# The successor's job. Restarted by hand here; on a board this is the next boot, or the next update.
+in_container "rm -f /usr/local/sbin/systemd-run"
+echo "==> restarting updaterd, whose successor should notice"
+in_container "systemctl restart updaterd"
+waited=0
+until in_container "grep -q 'releases/1.2.0/bin/fake-btd' /run/btd/identity.json 2>/dev/null"; do
+    waited=$((waited + 1))
+    [ "$waited" -lt 30 ] || fail "the successor did not restart the stale btd"
+    sleep 1
+done
+pass "its reconciliation restarted the stale btd onto 1.2.0 after ${waited}s"
+
+# And it did not restart *itself*. There is nothing for it to fix here — a restarted `updaterd`
+# re-execs through `current`, so the successor is the active release by construction — but the
+# reconciliation runs over a list that includes its own unit, and a self-restart there would be a loop
+# in the one process that owns recovery. The absence of a second restart is the assertion.
+self_pid="$(main_pid updaterd)"
+sleep 3
+[ "$(main_pid updaterd)" = "$self_pid" ] \
+    || fail "updaterd restarted itself from its own startup path, which is a loop"
+pass "and did not restart itself, which in that process would be a loop with no way out"
+
+# ── injection: a unit whose `User=` the release brings with it ──
+#
+# `hooks/postinstall` installs `sysusers.d` files and runs `systemd-sysusers` *before* the units, and
+# its comment calls that ordering load-bearing: a unit naming a `User=` that does not exist fails to
+# start, and the failure reads as a broken daemon rather than a missing account. Nothing observed it.
+cp "$FIXTURE"/r/1.3.0/* "$FIXTURE/published/"
+echo "==> applying 1.3.0, which ships a unit and the account it needs"
+apply "$WORK/sysusers.log"
+grep -q '"outcome": "applied"' "$WORK/sysusers.log" \
+    || { sed 's/^/    /' "$WORK/sysusers.log"; fail "a release bringing its own user did not apply"; }
+in_container "id duck-test >/dev/null 2>&1" \
+    || fail "postinstall did not create the account the release ships"
+in_container "systemctl is-active --quiet needs-a-user" \
+    || fail "the unit is not running, so accounts did not come before units"
+pass "accounts before units: the shipped user exists and its unit is running"
+
+# ── injection: the same unit with nothing creating its user ──
+#
+# The other half of the ordering claim. `enable --now` failing in the hook is only a warning — a
+# service that cannot start must not fail an otherwise good update — but the restart in `on_apply`
+# right afterwards is not, and that is the distinction `restart_one` draws deliberately.
+cp "$FIXTURE"/r/1.4.0/* "$FIXTURE/published/"
+echo "==> applying 1.4.0, whose unit names a user nothing creates"
+apply "$WORK/ghost.log"
+grep -q '"outcome": "applied"' "$WORK/ghost.log" \
+    && fail "a unit that cannot start reported success"
+grep -q "needs-a-user" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the reason does not name the unit"; }
+pass "the update failed and named the unit rather than the account"
+
+# The release did revert: `rollback_to` swaps `current` before it re-runs the apply action, so the
+# tree is right even when what follows is not.
+[ "$(live)" = 1.3.0 ] || fail "current is $(live) after the failed update, expected 1.3.0"
+pass "current went back to 1.3.0"
+
+# **A gap this harness found, pinned here rather than papered over.** The rollback *also* failed:
+#
+#     rollback failed after a failed update: restart failed:
+#     Job for needs-a-user.service failed
+#
+# `hooks/postinstall` overwrote 1.3.0's good unit file with 1.4.0's broken one, and by design does not
+# put it back — the hook argues that a release which did not take leaves one service failing until the
+# next one does, which is the same situation either way. That reasoning holds while the failing unit is
+# only *failing*. It stops holding when the unit is in the restart set of the release being reverted
+# *to*, because then the revert re-runs the same restart and inherits the same failure — and
+# `RollbackFailed` is the outcome the design calls the most serious one.
+#
+# Reachable by an ordinary bad release, not only by the downgrade case `install-path-gap.md` records:
+# two consecutive releases ship the same unit name and the newer one is broken. Asserted as-is, so
+# that whatever is decided about it is a deliberate change rather than a surprise.
+grep -q "rollback failed" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the known rollback gap did not reproduce — if it is fixed, this check should be too"; }
+pass "the rollback failed too, which is the known gap: the bad unit file outlived the release"
+
+# The rest of the robot is still up, which is what keeps this a gap rather than an outage.
+in_container "systemctl is-active --quiet fake-robotd" \
+    || fail "fake-robotd is down as well"
+pass "the daemons that could restart did, so only the broken unit is down"
+
+# Cleared by hand, so the next case starts from a board whose units match its release. On a real board
+# this is what the next good release does on its own.
+in_container "rm -f /etc/systemd/system/needs-a-user.service && systemctl daemon-reload"
+
 # ── the injection: a unit that installs and cannot start ──
 #
 # Bug 1's class. The unit arrives with the release, postinstall installs and enables it, `enable
 # --now` fails and is only a warning — and then `on_apply` restarts it, which is not. The update must
 # fail, roll back, and say which unit.
-cp "$FIXTURE"/r/1.2.0/* "$FIXTURE/published/"
-echo "==> applying 1.2.0, which ships a unit that cannot start"
+cp "$FIXTURE"/r/1.5.0/* "$FIXTURE/published/"
+echo "==> applying 1.5.0, which ships a unit that cannot start"
 # Exit status is deliberately not the check. A rollback is a *successful* call that reports an
 # unsuccessful outcome — `robotctl` exits 0 having told you what happened, and reading the status
 # instead would assert a different contract than the one that matters here.
-in_container "$MOUNT/opt/daemon/current/bin/robotctl update apply daemon" \
-    > "$WORK/broken.log" 2>&1 || true
+apply "$WORK/broken.log"
 grep -q rolled_back "$WORK/broken.log" \
     || { sed 's/^/    /' "$WORK/broken.log"; fail "the update did not roll back"; }
 grep -q '"outcome": "applied"' "$WORK/broken.log" \
     && fail "the update reported success despite a unit that cannot start"
 pass "the update rolled back rather than reporting success"
 
-[ "$(live)" = 1.1.0 ] || fail "rolled back to $(live), expected 1.1.0"
-pass "rolled back to 1.1.0"
+# 1.3.0, not 1.4.0: that one never became live, so it was never what this rolled back from.
+[ "$(live)" = 1.3.0 ] || fail "rolled back to $(live), expected 1.3.0"
+pass "rolled back to 1.3.0"
 
 grep -qi "broken" "$WORK/broken.log" \
     || { sed 's/^/    /' "$WORK/broken.log"; fail "the reason does not name the unit that failed"; }

--- a/scripts/systemd-test.sh
+++ b/scripts/systemd-test.sh
@@ -286,24 +286,21 @@ pass "the update failed and named the unit rather than the account"
 [ "$(live)" = 1.3.0 ] || fail "current is $(live) after the failed update, expected 1.3.0"
 pass "current went back to 1.3.0"
 
-# **A gap this harness found, pinned here rather than papered over.** The rollback *also* failed:
+# The revert happened *and* one unit did not come back with it. Two facts, reported as two — this was
+# a single `rollback failed after a failed update`, which asserted the one thing that was false (the
+# robot had not been put back) and buried the one thing that was true (a daemon is down).
 #
-#     rollback failed after a failed update: restart failed:
-#     Job for needs-a-user.service failed
-#
-# `hooks/postinstall` overwrote 1.3.0's good unit file with 1.4.0's broken one, and by design does not
-# put it back — the hook argues that a release which did not take leaves one service failing until the
-# next one does, which is the same situation either way. That reasoning holds while the failing unit is
-# only *failing*. It stops holding when the unit is in the restart set of the release being reverted
-# *to*, because then the revert re-runs the same restart and inherits the same failure — and
-# `RollbackFailed` is the outcome the design calls the most serious one.
-#
-# Reachable by an ordinary bad release, not only by the downgrade case `install-path-gap.md` records:
-# two consecutive releases ship the same unit name and the newer one is broken. Asserted as-is, so
-# that whatever is decided about it is a deliberate change rather than a surprise.
+# `hooks/postinstall` overwrote 1.3.0's good unit file with 1.4.0's broken one and by design does not
+# put it back, so the revert's own restart of a unit with that name inherits the same failure. The
+# hook's reasoning is unchanged and still holds: one service is failing until the next release fixes
+# it. What changed is that this no longer reads as the recovery having failed.
 grep -q "rollback failed" "$WORK/ghost.log" \
-    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the known rollback gap did not reproduce — if it is fixed, this check should be too"; }
-pass "the rollback failed too, which is the known gap: the bad unit file outlived the release"
+    && { sed 's/^/    /' "$WORK/ghost.log"; fail "a revert that happened is still reported as a failed rollback"; }
+grep -q "did not restart" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not name the unit that did not come back"; }
+grep -q "is down" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not say something is down"; }
+pass "reported as reverted and as having left something down, not as a failed rollback"
 
 # The rest of the robot is still up, which is what keeps this a gap rather than an outage.
 in_container "systemctl is-active --quiet fake-robotd" \

--- a/test-support/examples/systemd-fixture.rs
+++ b/test-support/examples/systemd-fixture.rs
@@ -14,13 +14,23 @@
 //!   bin/updaterd  bin/robotctl        the binaries under test, built for the container
 //!   systemd/updaterd.service          so the update can restart the updater — the whole point
 //!   systemd/fake-robotd.service       a stand-in for a daemon in the restart set
-//!   systemd/broken.service            only in a `:broken-unit` release: ExecStart=/bin/false
+//!   systemd/btd.service               a stand-in for the one daemon held back from that restart
+//!   bin/fake-btd                      what it runs: publishes an identity, then sleeps
+//!   systemd/broken.service            only in `:broken-unit`: ExecStart=/bin/false
+//!   systemd/needs-a-user.service      only in `:sysusers` and `:missing-user`, with `User=`
+//!   systemd/sysusers.d/duck-test.conf only in `:sysusers`, and what creates that user
 //!   hooks/postinstall                 the real one, so it installs and enables units for real
 //! ```
 //!
 //! `fake-robotd` rather than a real `robotd`: what is under test is whether the engine restarts what
 //! a release ships, and a `sleep` proves that as well as motor control does while needing no
 //! hardware, no policy and no socket. Its main PID changing is the observation.
+//!
+//! **The stand-in named `btd` is named that on purpose.** `NEVER_RESTART` is a list of unit names in
+//! code, so only a unit actually called `btd` is excluded from the in-flight restart and picked up by
+//! the deferred one — which makes it the only way to observe the case the startup reconciliation
+//! exists for: a deferred restart that never happened. Unlike `fake-robotd` it publishes an identity,
+//! because that is what the reconciliation reads.
 
 use std::path::{Path, PathBuf};
 
@@ -50,8 +60,10 @@ struct Cli {
     #[arg(long)]
     prefix: Option<PathBuf>,
 
-    /// `<version>[:broken-unit]`. `broken-unit` adds a unit that installs and cannot start, which
-    /// must fail the update and roll it back.
+    /// `<version>[:broken-unit|:sysusers|:missing-user]`.
+    ///
+    /// `broken-unit` adds a unit that installs and cannot start; `sysusers` a unit whose `User=` the
+    /// release also brings the account for; `missing-user` the same unit with nothing creating it.
     #[arg(required = true, value_name = "SPEC")]
     releases: Vec<String>,
 }
@@ -77,6 +89,44 @@ fn updaterd_unit(prefix: &Path) -> String {
 /// A daemon in the restart set, whose only job is to be restartable and observable.
 const FAKE_ROBOTD_UNIT: &str = "[Unit]\nDescription=Stand-in for a daemon an update restarts\n\n\
      [Service]\nType=exec\nExecStart=/bin/sleep infinity\nRestart=always\nRestartSec=1s\n\n\
+     [Install]\nWantedBy=multi-user.target\n";
+
+/// What the `btd` stand-in runs.
+///
+/// `readlink -f`, not `$0`: the unit points through `current`, and an identity naming a symlink says
+/// nothing about which release is running. The real daemons read `/proc/self/exe`, which resolves for
+/// the same reason.
+const FAKE_BTD: &str = "#!/bin/sh\n\
+     exe=\"$(readlink -f \"$0\")\"\n\
+     mkdir -p /run/btd\n\
+     printf '{\"service\":\"btd\",\"version\":\"0.0.0\",\"exe\":\"%s\",\"pid\":%s}\\n' \\\n\
+         \"$exe\" \"$$\" > /run/btd/identity.json\n\
+     exec sleep infinity\n";
+
+/// The unit for it, named `btd` so `NEVER_RESTART` applies to it.
+fn fake_btd_unit(prefix: &Path) -> String {
+    format!(
+        "[Unit]\nDescription=Stand-in for the daemon an update must not restart\n\n\
+         [Service]\nType=exec\nExecStart={p}/opt/daemon/current/bin/fake-btd\n\
+         Restart=always\nRestartSec=1s\nRuntimeDirectory=btd\n\n\
+         [Install]\nWantedBy=multi-user.target\n",
+        p = prefix.display()
+    )
+}
+
+/// A unit whose `User=` is created by the release's own `sysusers.d` file, which is the ordering
+/// `hooks/postinstall` calls load-bearing: accounts before units, or the unit fails to start and the
+/// failure reads as a broken daemon rather than a missing account.
+const NEEDS_A_USER_UNIT: &str = "[Unit]\nDescription=A unit that runs as a shipped user\n\n\
+     [Service]\nType=exec\nExecStart=/bin/sleep infinity\nUser=duck-test\nRestart=always\n\
+     RestartSec=1s\n\n[Install]\nWantedBy=multi-user.target\n";
+
+const SYSUSERS_CONF: &str = "u duck-test - \"a user a release brings with it\" /nonexistent\n";
+
+/// The same unit with nothing creating its user — `enable --now` cannot start it, and neither can the
+/// restart that follows.
+const GHOST_USER_UNIT: &str = "[Unit]\nDescription=A unit whose user does not exist\n\n\
+     [Service]\nType=exec\nExecStart=/bin/sleep infinity\nUser=nosuchuser-duck\n\n\
      [Install]\nWantedBy=multi-user.target\n";
 
 /// A unit that installs cleanly and cannot start. Bug 1 of `install-path-gap.md` in one file: the
@@ -133,6 +183,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 FAKE_ROBOTD_UNIT.as_bytes(),
                 0o644,
             )
+            .file("bin/fake-btd", FAKE_BTD.as_bytes(), 0o755)
+            .file(
+                "systemd/btd.service",
+                fake_btd_unit(&prefix).as_bytes(),
+                0o644,
+            )
             .hook(&postinstall);
 
         match kind {
@@ -140,15 +196,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "broken-unit" => {
                 release = release.file("systemd/broken.service", BROKEN_UNIT.as_bytes(), 0o644);
             }
+            "sysusers" => {
+                release = release
+                    .file(
+                        "systemd/sysusers.d/duck-test.conf",
+                        SYSUSERS_CONF.as_bytes(),
+                        0o644,
+                    )
+                    .file(
+                        "systemd/needs-a-user.service",
+                        NEEDS_A_USER_UNIT.as_bytes(),
+                        0o644,
+                    );
+            }
+            "missing-user" => {
+                release = release.file(
+                    "systemd/needs-a-user.service",
+                    GHOST_USER_UNIT.as_bytes(),
+                    0o644,
+                );
+            }
             other => return Err(format!("unknown spec `:{other}` in `{spec}`").into()),
         }
         release.write();
         println!(
             "r/{version}{}",
             if kind.is_empty() {
-                ""
+                String::new()
             } else {
-                " (broken-unit)"
+                format!(" ({kind})")
             }
         );
     }

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -735,8 +735,8 @@ impl Engine {
                 {
                     Some(reverted) => Ok(ApplyResult::RolledBack {
                         attempted: manifest.version.clone(),
-                        reverted_to: Some(reverted),
-                        reason: reason.to_string(),
+                        reason: reverted.describe(&reason.to_string()),
+                        reverted_to: Some(reverted.version),
                     }),
                     // Nothing was reverted, so saying "rolled back" would be a lie.
                     None => Ok(ApplyResult::Stuck {
@@ -832,13 +832,18 @@ impl Engine {
         })
     }
 
+    /// What a revert achieved: the release now live, and whatever went wrong after it was.
+    ///
+    /// Two facts rather than one, because they have different urgencies and used to be collapsed into
+    /// a single `RollbackFailed`. The version is the recovery; `apply_error` is a daemon that is down
+    /// on a robot which is otherwise back where it was.
     async fn rollback_to(
         &self,
         component: &str,
         cfg: &ComponentConfig,
         store: &Store,
         previous: Option<&semver::Version>,
-    ) -> Result<Option<semver::Version>, Error> {
+    ) -> Result<Option<Reverted>, Error> {
         if self.faults.fail_rollback {
             return Err(Error::RollbackFailed("injected rollback failure".into()));
         }
@@ -857,17 +862,53 @@ impl Engine {
             return Ok(None);
         };
 
+        // The swap and the trial are the recovery: past here the robot *is* back on the release it
+        // came from, and only these two failing mean it could not be put back.
         store
             .swap_to(previous)
             .map_err(|e| Error::RollbackFailed(e.to_string()))?;
         self.boot_counter
             .confirm(component)
             .map_err(|e| Error::RollbackFailed(e.to_string()))?;
-        self.run_apply_action(&cfg.on_apply, &store.release_dir(previous))
-            .await
-            .map_err(|e| Error::RollbackFailed(e.to_string()))?;
 
-        Ok(Some(previous.clone()))
+        // The apply action is not, and this used to be `RollbackFailed` too.
+        //
+        // It is reachable by an ordinary bad release: `hooks/postinstall` overwrites unit files and
+        // deliberately does not put them back, so a release that fails *because* one of its units
+        // cannot start leaves that file behind — and if the release being reverted to ships a unit of
+        // the same name, this restart inherits the same failure. `scripts/systemd-test.sh` reproduces
+        // exactly that.
+        //
+        // Reporting it as a failed rollback asserted the one thing that was not true — the swap had
+        // already happened — and buried the one thing that was: a daemon is down. So it is carried
+        // into the outcome instead, which says both. `RollbackFailed` keeps its meaning: the robot
+        // could not be put back at all.
+        let apply_error = if self.faults.fail_rollback_apply {
+            Some("injected apply-action failure during rollback".to_owned())
+        } else {
+            match self
+                .run_apply_action(&cfg.on_apply, &store.release_dir(previous))
+                .await
+            {
+                Ok(()) => None,
+                Err(e) => Some(e.to_string()),
+            }
+        };
+        if let Some(detail) = &apply_error {
+            // At error, because a reverted robot with a dead daemon needs someone to look at it even
+            // though the operation it belongs to reports an outcome rather than a failure.
+            tracing::error!(
+                component,
+                reverted_to = %previous,
+                error = %detail,
+                "reverted, but a unit did not restart — the release is back and something is down"
+            );
+        }
+
+        Ok(Some(Reverted {
+            version: previous.clone(),
+            apply_error,
+        }))
     }
 
     // ── explicit transitions ─────────────────────────────────────────────────
@@ -1018,8 +1059,8 @@ impl Engine {
                 {
                     Some(reverted) => Ok(ApplyResult::RolledBack {
                         attempted: to.clone(),
-                        reverted_to: Some(reverted),
-                        reason: reason.to_string(),
+                        reason: reverted.describe(&reason.to_string()),
+                        reverted_to: Some(reverted.version),
                     }),
                     None => Ok(ApplyResult::Stuck {
                         version: to.clone(),
@@ -1295,8 +1336,8 @@ impl Engine {
             let outcome = match reverted {
                 Some(reverted) => ApplyResult::RolledBack {
                     attempted: pending.version.clone(),
-                    reverted_to: Some(reverted),
-                    reason: reason.clone(),
+                    reason: reverted.describe(&reason),
+                    reverted_to: Some(reverted.version),
                 },
                 // Nothing to revert to. `rollback_to` has cleared the trial, so this
                 // is reported exactly once rather than on every subsequent boot.
@@ -1738,6 +1779,29 @@ impl Engine {
                 "manifest is for channel {:?}, expected {expected:?}",
                 manifest.channel
             )))
+        }
+    }
+}
+
+/// The outcome of a revert: where the robot ended up, and what did not come back with it.
+struct Reverted {
+    version: semver::Version,
+    /// The apply action's failure, when the swap succeeded and it did not.
+    apply_error: Option<String>,
+}
+
+impl Reverted {
+    /// The reason to report, which must carry both facts when there are two.
+    ///
+    /// Appended rather than replacing: why the update failed is what someone is looking for, and a
+    /// unit that then failed to restart is a second thing to act on, not a correction of the first.
+    fn describe(&self, why: &str) -> String {
+        match &self.apply_error {
+            None => why.to_owned(),
+            Some(detail) => format!(
+                "{why}; the release was reverted but a unit did not restart ({detail}), so \
+                 something on this robot is down"
+            ),
         }
     }
 }

--- a/updater/src/faults.rs
+++ b/updater/src/faults.rs
@@ -30,6 +30,13 @@ pub struct Faults {
     /// Make rollback itself fail, exercising the worst path: failed update *and*
     /// failed recovery, which must be reported loudly rather than silently.
     pub fail_rollback: bool,
+    /// Make the *apply action* fail while rolling back, with the swap succeeding.
+    ///
+    /// A different outcome from [`Self::fail_rollback`], and the distinction is the point: the
+    /// robot is back on the known-good release and one unit did not restart. Reachable without a
+    /// fault — a unit file left behind by the failed release does it — but only on a machine with
+    /// systemd, which is why there is a seam for it here.
+    pub fail_rollback_apply: bool,
 }
 
 impl Faults {
@@ -67,11 +74,12 @@ impl Faults {
                 "abort_after_swap" => faults.abort_after_swap = true,
                 "simulate_disk_full" => faults.simulate_disk_full = true,
                 "fail_rollback" => faults.fail_rollback = true,
+                "fail_rollback_apply" => faults.fail_rollback_apply = true,
                 other => {
                     return Err(crate::Error::Config(format!(
                         "unknown fault {other:?}; valid: corrupt_artifact, fail_post_hook, \
                          fail_health, hang_health, abort_after_swap, simulate_disk_full, \
-                         fail_rollback"
+                         fail_rollback, fail_rollback_apply"
                     )));
                 }
             }

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -832,6 +832,64 @@ async fn failed_rollback_is_reported_distinctly() {
     );
 }
 
+/// The case the one above used to swallow: the swap succeeded and the *restart* did not.
+///
+/// Reachable without a fault, and `scripts/systemd-test.sh` reaches it — `hooks/postinstall`
+/// overwrites unit files and by design does not put them back, so a release that fails *because* one
+/// of its units cannot start leaves that file behind, and the revert's own restart of a unit with the
+/// same name inherits the same failure.
+///
+/// Reporting that as `RollbackFailed` asserted the one thing that was false — the robot had been put
+/// back — and buried the one thing that was true, which is that a daemon is down. Both facts, in the
+/// outcome.
+#[tokio::test]
+async fn a_revert_whose_restart_fails_is_still_a_revert() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    let mut engine = fx.engine_healthy();
+    apply_latest(&mut engine).await.unwrap();
+
+    fx.publish("1.1.0", None);
+    let mut engine = fx.engine(
+        Box::new(FakeRobot::unhealthy()),
+        Faults {
+            fail_rollback_apply: true,
+            ..Faults::none()
+        },
+        "",
+    );
+
+    let outcome = apply_latest(&mut engine)
+        .await
+        .expect("a revert that happened is not an error");
+
+    match outcome {
+        updater::proto::ApplyResult::RolledBack {
+            reverted_to,
+            reason,
+            ..
+        } => {
+            assert_eq!(
+                reverted_to.as_ref().map(ToString::to_string).as_deref(),
+                Some("1.0.0"),
+                "the release must be reported as reverted, because it was"
+            );
+            // Why the update failed comes first — that is what someone is looking for — and the
+            // daemon that did not come back is a second thing to act on rather than a correction.
+            assert!(reason.contains("not healthy"), "{reason}");
+            assert!(reason.contains("did not restart"), "{reason}");
+            assert!(reason.contains("is down"), "{reason}");
+        }
+        other => panic!("expected RolledBack, got {other:?}"),
+    }
+
+    assert_eq!(
+        fx.live_version().as_deref(),
+        Some("1.0.0"),
+        "and the tree must actually be back, which is the claim the outcome makes"
+    );
+}
+
 // ── crash recovery ───────────────────────────────────────────────────────────
 
 /// Simulates `kill -9` right after the symlink swap: the new release is live and


### PR DESCRIPTION
Fixes the gap `scripts/systemd-test.sh` found, and carries the two injections that found it — **`804560c` did not make it into #83**, which merged one commit earlier, so the harness on `main` is currently missing them.

## The bug

`rollback_to` mapped every step to `Error::RollbackFailed`, the apply action included. So a failed update whose failure was a bad unit file reported:

```
rollback failed after a failed update: restart failed:
Job for needs-a-user.service failed because the control process exited with error code.
```

That asserts the one thing that was false — the robot had not been put back — and buries the one thing that was true, which is that a daemon is down. `current` had already gone back; the harness asserts it. `RollbackFailed` is the outcome the design calls the most serious one, so saying it wrongly costs more than the words do.

**The cause is not the rollback.** `hooks/postinstall` overwrites unit files and, by design, does not put them back — the hook argues that a release which did not take leaves one service failing until the next one does, the same situation either way. That reasoning holds and is untouched. What it did not anticipate is the unit being in the restart set of the release being reverted **to**: then the revert re-runs the same restart and inherits the same failure. An ordinary bad release reaches it — two consecutive releases ship the same unit name and the newer one is broken — not only the downgrade case `install-path-gap.md` already records.

## The fix

**Separate the swap from the apply action, because only one of them is the recovery.** Past `swap_to` and the trial being cleared, the robot *is* back on the release it came from. A unit that then fails to restart is a second fact, not a contradiction of the first.

- `Error::RollbackFailed` keeps its meaning: the robot could not be put back at all.
- A failed apply action during a revert goes into the reported outcome and is logged at `error`:

```
not healthy within 30s: …; the release was reverted but a unit did not restart (…), so
something on this robot is down
```

Why the update failed comes first, because that is what someone is looking for; the daemon that did not come back is a second thing to act on rather than a correction of the first.

## The two alternatives, since neither is obviously wrong

- **Make `postinstall` reversible** — record what was overwritten so a revert can restore it. This is the change the hook explicitly declined. It needs state outside the release, and it adds a failure mode to the recovery path, which is the one place that has to stay boring. It also would not help the general case: a unit can fail for reasons that have nothing to do with its file.
- **Tolerate a failed restart everywhere** — this would weaken the distinction `restart_one` draws on purpose. A unit that exists and will not start is *how a broken release is caught*, and that stays fatal on the way in. Only the way out changes.

## Verification

`fail_rollback_apply` is a new fault, distinct from `fail_rollback`, because the two outcomes are now different and both need pinning. `a_revert_whose_restart_fails_is_still_a_revert` asserts the outcome, both halves of the reason, and that the tree really is back — the claim the outcome makes.

And the harness that found it now asserts the new behaviour, against real systemd:

```
==> applying 1.4.0, whose unit names a user nothing creates
    [ok] the update failed and named the unit rather than the account
    [ok] current went back to 1.3.0
    [ok] reported as reverted and as having left something down, not as a failed rollback
    [ok] the daemons that could restart did, so only the broken unit is down
```

Full harness green (18 checks). Workspace suite green, clippy clean, fmt clean.

## Note on the injections commit

`cf9c1df` here is `804560c` from #83, cherry-picked because that PR merged without it. It is unchanged apart from the assertion this fix inverts — it pinned the old behaviour deliberately, so that changing it would be a visible decision. This is that decision.