### PR TITLE
An update must not restart the recovery net's oneshot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 |---|---|
 | [`roadmap.md`](project/roadmap.md) | Milestones, and what works today versus what is designed. |
 | [`ci-setup.md`](project/ci-setup.md) | One-time setup for the release pipeline: keys, secrets, rotation. |
-| [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what would close it. Open. |
+| [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what closed it. Closed. |
 | [`slice-2-bringup.md`](project/slice-2-bringup.md) | What a real Radxa Zero 3W did with slice 2. |
 
 ## Elsewhere

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -7,11 +7,16 @@ three different documents, and the answer decides how a skew is diagnosed.
 Everything here is read from the code, and each step names the function that owns it. Where a
 narrative comment elsewhere disagrees with this page, the comment is the bug.
 
-## 1. The five units
+## 1. The five daemons, and the unit that is not one
 
-A release ships five `systemd/*.service` files: `robotd`, `configd`, `btd`, `padd`, `updaterd`. All
-five `ExecStart` a path under `/opt/robot/daemon/current/bin/`, so all five are stale the instant the
-symlink moves, and each one is either restarted by the update or restarted after it.
+A release ships five daemons — `robotd`, `configd`, `btd`, `padd`, `updaterd` — each `ExecStart`ing a
+path under `/opt/robot/daemon/current/bin/`, so each is stale the instant the symlink moves, and each
+is either restarted by the update or restarted after it.
+
+It also ships `robot-boot-check.service`, which is **not** one of them and which an update must never
+restart: it asks whether the release that booted came up and hands over to `robot-rescue` if not, so
+running it mid-update points a rollback check at daemons that are legitimately mid-restart. It carries
+no `[Install]` section, and that is what keeps it out — see §1.1.
 
 | unit | restarted mid-update | restarted ~5 s after the reply |
 |---|---|---|
@@ -29,6 +34,22 @@ single most common stale claim about this system.
 
 And because scheduling a restart is not evidence that one happened, the next `updaterd` start checks
 each unit against the active release and restarts anything stale — §5.
+
+### 1.1 What counts as a unit an update starts
+
+A `systemd/*.service` file with an `[Install]` section. One without is triggered by something else — a
+timer, or another unit pulling it in — so its lifecycle is not the update's to drive, and
+`engine.rs::has_install_section` is where that is decided.
+
+The rule rather than a list of names, because there were already two places applying it and they
+disagreed: `hooks/postinstall` declines to `enable --now` a unit with no `[Install]`, saying so in as
+many words — *"`enable --now` on it would run a rollback check in the middle of the update that
+installed it, with daemons legitimately mid-restart"* — while the engine read every `*.service` and
+restarted it a moment later anyway. Keyed on the section, the two agree by construction and the next
+unit like it needs nobody to remember.
+
+An unreadable unit file counts as one to restart. That is more likely a permissions problem than a
+deliberately triggerless unit, and a restart failing loudly beats one skipped quietly.
 
 ### How the set is computed
 
@@ -214,7 +235,8 @@ restart fails the transition (`../project/install-path-gap.md`).
 
 ## 4. At boot
 
-systemd starts all five units from `multi-user.target`. There is **no ordering between the daemons**
+systemd starts the five daemons from `multi-user.target`, and `robot-boot-check.timer` arms the
+recovery check for 180 seconds in. There is **no ordering between the daemons**
 beyond `padd` after `robotd` (advisory — `padd` exits and retries every 5 s if the socket is absent)
 and `btd` after `dbus`/`bluetooth`. Nothing waits on `updaterd`, and `updaterd` waits on nothing but
 `network-online.target`, which is `Wants` rather than `Requires`.

--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -1,10 +1,11 @@
-# The install path has no test
+# The install path had no test
 
-Status: open · Date: 2026-08-05, revised 2026-08-07 and 2026-08-11 · Owner: pierre
+Status: closed · Date: 2026-08-05, revised 2026-08-07 and 2026-08-11 · Owner: pierre
 
 Four bugs in a row reached a board, all in the install path, none caught by 418 tests or by
-`board-test.sh`. This records why, and what would actually close it. Written the same day, while
-the reasons are still concrete.
+`board-test.sh`. This records why, and what closed it. Written the same day, while the reasons were
+still concrete, and kept in the past tense it has earned rather than rewritten as reference — what it
+is useful for now is the shape of the mistake, not the state of the tree.
 
 A second section covers two findings that *look* like the same thing and are not: version skew
 between a daemon that is already running and a release that has just been installed. Neither would
@@ -14,9 +15,13 @@ their own document because anyone investigating one will arrive believing it is 
 **Revision note.** All four bugs are fixed, and so is the version-skew section that follows them:
 case 1's `serde(default)` discipline landed, case 2's handshake proposal was decided *against* with
 its reasoning written down, and the "units outlive the release that installed them" consequence is
-now a refusal rather than emergent behaviour. What is still open is the *testing* gap the title
-names — no test installs a real artifact — plus the two smaller items marked below, both of which
-are that same gap in a specific form.
+now a refusal rather than emergent behaviour.
+
+**And the gap the title named is closed.** A test installs a real artifact — `board-test.sh` unpacks
+one and runs `install.sh` and `hooks/postinstall` against it — every unit's `ExecStart` binary is
+checked against the tarball that shipped it, a board check runs on every `dev-push.sh`, and
+`scripts/systemd-test.sh` drives a real update against real systemd. The plan those came from is
+below, with what each one turned up; two engine bugs were found by the last of them.
 
 One change since the first draft moves enough of this document to call out here: `updaterd` and
 `btd` are now restarted a few seconds *after* the update replies (`RESTART_AFTER_REPLYING`), and the

--- a/scripts/systemd-test.sh
+++ b/scripts/systemd-test.sh
@@ -161,6 +161,17 @@ robotd_after="$(main_pid fake-robotd)"
     || fail "fake-robotd was not restarted (pid $robotd_before throughout)"
 pass "on_apply restarted the daemon the release ships (pid $robotd_before -> $robotd_after)"
 
+# …and did not restart the one nothing but a timer may start.
+#
+# `recovery-check.service` is shaped like the boot recovery net's oneshot: no `[Install]`, triggered by
+# a timer, and it asks whether the release that booted came up. An update restarting it points a
+# rollback check at daemons that are legitimately mid-restart, and `robot-rescue` can act on that by
+# swapping to golden and rebooting. `hooks/postinstall` already declines to `enable --now` it; the
+# engine used to read every `*.service` and restart it a moment later regardless.
+in_container "test -f /run/recovery-check.ran" \
+    && { in_container "cat /run/recovery-check.ran"; fail "the update ran a unit only a timer may start"; }
+pass "and left the recovery check alone, which only a timer may start"
+
 # 2. The deferred restart. Scheduled five seconds after the reply, through a transient unit, so this
 #    is the one observation a child process could not make: `updaterd` is replaced *by systemd*
 #    after the operation it was performing has finished.

--- a/test-support/examples/systemd-fixture.rs
+++ b/test-support/examples/systemd-fixture.rs
@@ -16,6 +16,7 @@
 //!   systemd/fake-robotd.service       a stand-in for a daemon in the restart set
 //!   systemd/btd.service               a stand-in for the one daemon held back from that restart
 //!   bin/fake-btd                      what it runs: publishes an identity, then sleeps
+//!   systemd/recovery-check.service    a oneshot with no `[Install]`, which nothing may restart
 //!   systemd/broken.service            only in `:broken-unit`: ExecStart=/bin/false
 //!   systemd/needs-a-user.service      only in `:sysusers` and `:missing-user`, with `User=`
 //!   systemd/sysusers.d/duck-test.conf only in `:sysusers`, and what creates that user
@@ -129,6 +130,16 @@ const GHOST_USER_UNIT: &str = "[Unit]\nDescription=A unit whose user does not ex
      [Service]\nType=exec\nExecStart=/bin/sleep infinity\nUser=nosuchuser-duck\n\n\
      [Install]\nWantedBy=multi-user.target\n";
 
+/// A unit shaped like the recovery net's oneshot: triggered by a timer, never by an update.
+///
+/// **No `[Install]` section, which is the whole point.** The real one asks whether the release that
+/// booted came up and hands over to `robot-rescue` if not, so an update that restarts it points a
+/// rollback check at daemons that are legitimately mid-restart. It records each run, so the harness
+/// can assert it did not happen rather than assume.
+const RECOVERY_CHECK_UNIT: &str = "[Unit]\nDescription=Shaped like the boot recovery check\n\n\
+     [Service]\nType=oneshot\n\
+     ExecStart=/bin/sh -c 'echo ran >> /run/recovery-check.ran'\n";
+
 /// A unit that installs cleanly and cannot start. Bug 1 of `install-path-gap.md` in one file: the
 /// update must fail and name it, rather than reverting with "not healthy: unreachable".
 const BROKEN_UNIT: &str = "[Unit]\nDescription=A unit that will not start\n\n\
@@ -181,6 +192,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .file(
                 "systemd/fake-robotd.service",
                 FAKE_ROBOTD_UNIT.as_bytes(),
+                0o644,
+            )
+            .file(
+                "systemd/recovery-check.service",
+                RECOVERY_CHECK_UNIT.as_bytes(),
                 0o644,
             )
             .file("bin/fake-btd", FAKE_BTD.as_bytes(), 0o755)

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -2099,6 +2099,26 @@ fn units_shipped(release_dir: &Path, configured: &[String]) -> Vec<String> {
                 if path.extension().and_then(|e| e.to_str()) != Some("service") {
                     continue;
                 }
+                // A unit with no `[Install]` section is started by something else — a timer, or
+                // another unit pulling it in — so its lifecycle is not this engine's to drive.
+                //
+                // The recovery net's oneshot is exactly that, and deliberately: it asks whether the
+                // release that booted came up, and hands over to `robot-rescue` if not.
+                // `hooks/postinstall` already skips `enable --now` on it for that reason, in as many
+                // words — "`enable --now` on it would run a rollback check in the middle of the
+                // update that installed it, with daemons legitimately mid-restart". Reading every
+                // `*.service` then restarted it a moment later anyway, which is the same mistake
+                // one function further on.
+                //
+                // The rule rather than a name in `NEVER_RESTART`: `postinstall` and this now agree
+                // by construction, and the next unit like it needs nobody to remember.
+                if !has_install_section(&path) {
+                    tracing::debug!(
+                        unit = %path.display(),
+                        "no [Install] section, so something other than this update starts it"
+                    );
+                    continue;
+                }
                 if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
                     units.push(name.to_owned());
                 }
@@ -2122,6 +2142,21 @@ fn units_shipped(release_dir: &Path, configured: &[String]) -> Vec<String> {
     units.sort();
     units.dedup();
     units
+}
+
+/// Is this unit one systemd is asked to enable, or one something else triggers?
+///
+/// An unreadable file answers "yes", which errs towards restarting: a unit whose contents cannot be
+/// read is more likely a permissions or IO problem than a deliberately triggerless unit, and the
+/// restart failing loudly beats it being skipped quietly.
+fn has_install_section(path: &Path) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(text) => text.lines().any(|line| line.trim() == "[Install]"),
+        Err(e) => {
+            tracing::warn!(unit = %path.display(), error = %e, "cannot read this unit; treating it as one to restart");
+            true
+        }
+    }
 }
 
 /// The subset an update restarts in flight: everything shipped, less the two it cannot touch while
@@ -2323,9 +2358,11 @@ esac
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("systemd")).unwrap();
         for unit in units {
+            // With an `[Install]` section, because that is what makes a unit one an update starts.
+            // The unit without one has its own test.
             std::fs::write(
                 dir.path().join("systemd").join(format!("{unit}.service")),
-                "[Unit]\n",
+                "[Unit]\n\n[Install]\nWantedBy=multi-user.target\n",
             )
             .unwrap();
         }
@@ -2386,6 +2423,57 @@ esac
         assert_eq!(
             units_to_restart(release.path(), &overlapping),
             vec!["configd".to_owned(), "robotd".to_owned()]
+        );
+    }
+
+    /// **The recovery net's oneshot must not be restarted by an update.** It asks whether the release
+    /// that booted came up and hands over to `robot-rescue` if not, so running it mid-update points a
+    /// rollback check at daemons that are legitimately mid-restart — and `robot-rescue` can swap to
+    /// golden and reboot.
+    ///
+    /// `hooks/postinstall` already declines to `enable --now` it, for that reason and in those words.
+    /// Reading every `*.service` then restarted it a moment later anyway: two places applying one rule
+    /// to one unit and disagreeing. Keyed on `[Install]` rather than on the name, so the next unit
+    /// like it needs nobody to remember.
+    #[test]
+    fn a_unit_something_else_triggers_is_not_restarted_by_an_update() {
+        let release = release_shipping(&["robotd", "configd"]);
+        // As the real one is: a oneshot with no `[Install]`, armed by a timer.
+        std::fs::write(
+            release
+                .path()
+                .join("systemd")
+                .join("robot-boot-check.service"),
+            "[Unit]\nDescription=Did the release that booted come up?\n\n\
+             [Service]\nType=oneshot\nExecStart=/usr/local/sbin/robot-boot-check\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            units_to_restart(release.path(), &[]),
+            vec!["configd".to_owned(), "robotd".to_owned()],
+            "a unit with no [Install] is triggered by something else and is left to it"
+        );
+    }
+
+    /// The other half, so the rule cannot be satisfied by skipping everything: a unit that *is*
+    /// enabled stays in the set, and the timer beside the oneshot changes nothing — only `.service`
+    /// files were ever read.
+    #[test]
+    fn a_unit_with_an_install_section_is_still_restarted() {
+        let release = release_shipping(&["robotd"]);
+        std::fs::write(
+            release
+                .path()
+                .join("systemd")
+                .join("robot-boot-check.timer"),
+            "[Timer]\nOnBootSec=180\n\n[Install]\nWantedBy=timers.target\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            units_to_restart(release.path(), &[]),
+            vec!["robotd".to_owned()]
         );
     }
 


### PR DESCRIPTION
This was the third commit of #84 and arrived after it merged, so it was stranded. Same change, rebased onto `main` and re-verified there. It is the only one of the three not yet in.

## The bug

```
units_to_restart = ["configd", "padd", "robot-boot-check", "robotd"]
```

`robot-boot-check.service` asks whether the release that booted came up, and hands over to `robot-rescue` if not. An update restarting it points a rollback check at daemons that are legitimately mid-restart — and `robot-rescue` can answer that by swapping to golden and rebooting. During an update. It sorts *before* `robotd`, so it fires mid-sequence, right after `configd` has been restarted.

`hooks/postinstall` already declines to `enable --now` it, and says why in as many words:

> `enable --now` on it would run a rollback check in the middle of the update that installed it, with daemons legitimately mid-restart

The engine then read every `*.service` and restarted it a moment later anyway. Two places, one rule, one unit, and they disagreed.

## What was keeping it harmless

A guard written for a different caller. `robot-boot-check` declines when uptime is over ten minutes, and its comment names `postinstall` as the reason that guard exists. Inside the first ten minutes of a boot — a dev board, or `auto_apply` polling sixty seconds after `updaterd` starts — it does not apply, and the check evaluates its members mid-restart. It still needs `failed` or three restarts to act, so it would usually decline.

"Usually" is not the property to want from the thing that reboots the robot, and nothing about the arrangement was intended.

## The fix

Keyed on `[Install]` rather than a name in `NEVER_RESTART`. A unit with no `[Install]` is triggered by something else — a timer, or another unit pulling it in — so its lifecycle is not the update's to drive. As a rule, `postinstall` and the engine agree by construction rather than by both being remembered, and the next unit like this one needs nobody to notice.

An unreadable unit file counts as one to restart: more likely a permissions problem than a triggerless unit, and a restart failing loudly beats one skipped quietly.

## Demonstrated, and the demonstration is not vacuous

The fixture ships a unit shaped like the real one — no `[Install]`, appends to `/run/recovery-check.ran` on each run — and the harness asserts it did not run. Re-run on this branch, on top of `main`:

```
    [ok] on_apply restarted the daemon the release ships (pid 180 -> 359)
    [ok] and left the recovery check alone, which only a timer may start
```

With the rule disabled it fails, printing the `ran` the unit left behind:

```
ran
    [FAIL] the update ran a unit only a timer may start
```

Two unit tests either side of the rule as well, so `cargo test` catches it without Docker: a release shipping the oneshot restarts only `configd` and `robotd`, and a unit that *does* carry `[Install]` stays in the set. `-p updater` 152 lib tests, clippy and fmt clean.

## Docs

`install-path-gap.md` is retitled and closed — its body has said the gap is shut since the artifact-install test landed, while its title and revision note still said otherwise. `restart-order.md` gains §1.1 for the rule and stops calling five units the whole set, now that a release ships a sixth that is not a daemon.