### PR TITLE
Say so when the staging channel has nothing newer than the board

### DIFF
--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -1144,6 +1144,16 @@ that doesn't match the staging manifest.
   The first attempt at this was a board pointed at staging by editing `tag_prefix`, which
   reported `no releases in … with tag prefix "daemon-staging-v"` against a candidate sitting
   right there — the prefix said where to look, and the prerelease filter refused to look.
+
+  **`--staging` refuses when the channel is behind the board.** A release promoted straight to
+  stable publishes no candidate — a supported path, and the one `release.yml` labels "NOT
+  canaried" — so the staging scan keeps answering with the last version that did publish one.
+  On a board already past that version, `--staging` used to install it: verified, swapped, and
+  then reverted when a daemon the older release does not contain failed to start. The rollback
+  was right and said nothing about the cause, so the resolved candidate is now compared against
+  what is installed and the refusal names both versions. `--staging --version X` is unguarded and
+  is the way past — an operator naming a candidate is stating intent, which is also how the one
+  a board just rolled back from gets reinstalled.
 - On green, **promote**: repoint `stable` at the *same bytes* already validated —
   re-sign the `stable` manifest to reference the identical tarball + hash. No
   rebuild, no re-flash, no hand-copying files. Promotion is one command / one

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -457,11 +457,11 @@ impl Engine {
         // would reject every branch install. Rollback and reset-to-golden move backwards on
         // purpose without passing through here.
         //
-        // The two `Staging` targets are unguarded for the `Exact` reason and not the `Ref`
-        // one: a candidate carries a plain version that normally sorts *above* the installed
-        // release, so the guard would rarely fire — but when it did, it would be refusing a
-        // reinstall of the candidate a board had just rolled back from, which is exactly the
-        // move someone reaches for while investigating that rollback.
+        // `StagingExact` is unguarded for the `Exact` reason: naming a candidate is how someone
+        // reinstalls the one a board just rolled back from, which is exactly the move they reach
+        // for while investigating that rollback. Bare `Staging` *is* guarded, but by
+        // [`staging_has_nothing_newer`] below rather than by this — the refusals are not the same
+        // claim, and this one's message would be actively misleading there.
         //
         // `from_dir` is exempt for the `Exact` reason. The guard defends against a *mirror*
         // that has gone backwards, and a directory named on the command line by somebody with
@@ -475,6 +475,27 @@ impl Engine {
             && manifest.version < *installed
         {
             return Err(Error::WouldDowngrade {
+                installed: installed.clone(),
+                candidate: manifest.version,
+            });
+        }
+
+        // `--staging` on a board that is ahead of the candidate channel. Reachable the moment a
+        // release is promoted straight to stable — which is a supported path, `release.yml` calls
+        // it "build → STABLE directly (no staging release exists; NOT canaried)" — because the
+        // staging scan then keeps answering with the last version that did publish a candidate.
+        //
+        // Refused rather than installed. Every layer below here behaved correctly when it was
+        // not: the artifact verified, the swap happened, a unit that the older release does not
+        // contain failed to start, and the update reverted. But the operator asked for "the one
+        // being tested" and there is no such thing, so the answer is a sentence rather than a
+        // rollback — and `orphan` cannot be that sentence, since it only sees a stale unit, not a
+        // stale channel.
+        if let Some(installed) =
+            staging_has_nothing_newer(&target, installed.as_ref(), &manifest.version)
+        {
+            return Err(Error::StagingBehind {
+                component: component.to_owned(),
                 installed: installed.clone(),
                 candidate: manifest.version,
             });
@@ -1806,6 +1827,31 @@ impl Reverted {
     }
 }
 
+/// Is this a bare `--staging` whose newest candidate is *older* than what the board runs?
+///
+/// Returns the installed version when so, purely so the caller can build the refusal without
+/// unwrapping the option a second time.
+///
+/// A predicate rather than a let-chain at the call site because the interesting content is which
+/// targets it answers for, and that is worth a test. `Target::Staging` only:
+///
+/// - `StagingExact` names an older candidate on purpose — see the call site.
+/// - `Latest` has its own guard, which makes a different claim.
+/// - `Ref` and `Exact` are exempt from both, for reasons the call site states.
+///
+/// Equality is not "behind": that a candidate has been promoted to exactly what is installed is
+/// what `AlreadyCurrent` reports, above this and more usefully.
+fn staging_has_nothing_newer<'a>(
+    target: &crate::proto::Target,
+    installed: Option<&'a semver::Version>,
+    candidate: &semver::Version,
+) -> Option<&'a semver::Version> {
+    if !matches!(target, crate::proto::Target::Staging) {
+        return None;
+    }
+    installed.filter(|installed| candidate < *installed)
+}
+
 /// The program that drives units. A constant so tests can substitute a stub for it.
 const SYSTEMCTL: &str = "systemctl";
 
@@ -2246,6 +2292,124 @@ async fn run_systemctl(mut command: tokio::process::Command, what: &str) -> Resu
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod staging_channel_tests {
+    use super::*;
+    use crate::proto::Target;
+
+    fn v(s: &str) -> semver::Version {
+        semver::Version::parse(s).expect("a version")
+    }
+
+    /// The incident, in one assertion. A board on stable `0.4.0` asking for the newest candidate
+    /// when the last candidate published was `0.2.0`: 0.3.0 and 0.4.0 were promoted straight to
+    /// stable, so the staging scan still answers `0.2.0`.
+    #[test]
+    fn a_candidate_older_than_the_board_is_reported() {
+        assert_eq!(
+            staging_has_nothing_newer(&Target::Staging, Some(&v("0.4.0")), &v("0.2.0")),
+            Some(&v("0.4.0"))
+        );
+    }
+
+    /// The ordinary case, which must stay silent: a candidate ahead of the board is the entire
+    /// point of the channel.
+    #[test]
+    fn a_candidate_ahead_of_the_board_is_not() {
+        assert_eq!(
+            staging_has_nothing_newer(&Target::Staging, Some(&v("0.4.0")), &v("0.5.0")),
+            None
+        );
+    }
+
+    /// A candidate equal to what is installed is `AlreadyCurrent`, which the caller answers
+    /// before reaching here. Reporting it as a stale channel would be both wrong and worse.
+    #[test]
+    fn a_candidate_equal_to_the_board_is_not_behind() {
+        assert_eq!(
+            staging_has_nothing_newer(&Target::Staging, Some(&v("0.4.0")), &v("0.4.0")),
+            None
+        );
+    }
+
+    /// A first install has nothing to be behind. Guarding it would make `--staging` unusable on a
+    /// freshly flashed board, which is one of the two boards that ever uses the flag.
+    #[test]
+    fn a_board_with_nothing_installed_is_never_behind() {
+        assert_eq!(
+            staging_has_nothing_newer(&Target::Staging, None, &v("0.2.0")),
+            None
+        );
+    }
+
+    /// Every other target, at a version that *would* trip this if the variant were not checked.
+    ///
+    /// The load-bearing one is `StagingExact`: it is the way past the refusal this function
+    /// produces, so guarding it too would leave a board that can neither install the candidate
+    /// nor be told why. The rest have their own guards or their own exemptions.
+    #[test]
+    fn no_other_target_is_this_functions_business() {
+        for target in [
+            Target::StagingExact(v("0.2.0")),
+            Target::Latest,
+            Target::Exact(v("0.2.0")),
+            Target::Ref("my-branch".into()),
+        ] {
+            assert_eq!(
+                staging_has_nothing_newer(&target, Some(&v("0.4.0")), &v("0.2.0")),
+                None,
+                "{target:?} must not be refused as a stale staging channel"
+            );
+        }
+    }
+
+    /// The message is the deliverable — the rollback it replaces was already correct, and what
+    /// was missing was a sentence saying the channel had nothing newer. So: the two versions, the
+    /// reason there is nothing there, and a command that can be pasted.
+    #[test]
+    fn the_refusal_says_the_channel_is_behind_and_what_to_type() {
+        let text = Error::StagingBehind {
+            component: "daemon".into(),
+            installed: v("0.4.0"),
+            candidate: v("0.2.0"),
+        }
+        .to_string();
+
+        assert!(text.contains("newest release candidate is 0.2.0"), "{text}");
+        assert!(text.contains("already on 0.4.0"), "{text}");
+        assert!(
+            text.contains("nothing more recent is available on the staging channel"),
+            "{text}"
+        );
+        assert!(
+            text.contains("robotctl update apply daemon --staging --version 0.2.0"),
+            "{text}"
+        );
+        // Not the other refusal's words. Someone told "refusing to downgrade" goes looking for a
+        // mirror that has gone backwards, and there isn't one.
+        assert!(!text.contains("downgrade"), "{text}");
+    }
+
+    /// Both refusals answer the same JSON-RPC code, so a client that already handles one handles
+    /// this. Pinned because the reasoning is a choice — see [`Error::code`].
+    #[test]
+    fn it_answers_the_downgrade_code() {
+        assert_eq!(
+            Error::StagingBehind {
+                component: "daemon".into(),
+                installed: v("0.4.0"),
+                candidate: v("0.2.0"),
+            }
+            .code(),
+            Error::WouldDowngrade {
+                installed: v("0.4.0"),
+                candidate: v("0.2.0"),
+            }
+            .code()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -74,6 +74,31 @@ pub enum Error {
         candidate: semver::Version,
     },
 
+    /// `--staging` resolved to a candidate older than what the board is running, which means
+    /// the staging channel has nothing newer to offer.
+    ///
+    /// Distinct from [`Self::WouldDowngrade`] because the operator's next move is different.
+    /// That one is a rollback-attack guard: it says a *mirror* may have gone backwards, and
+    /// the right response is to distrust the source. This one says the source is fine and the
+    /// channel is simply behind — usually because the last releases were promoted straight to
+    /// stable and published no candidate. Answering "refusing to downgrade" sent the one
+    /// person who hit it looking for a broken mirror.
+    ///
+    /// Only [`crate::proto::Target::Staging`] reaches it. `StagingExact` is how someone names
+    /// an older candidate deliberately, so the message names that command as the way past.
+    #[error(
+        "the newest release candidate is {candidate}, and this board is already on \
+         {installed} — nothing more recent is available on the staging channel. A release \
+         promoted straight to stable publishes no candidate, so staging stays at the last \
+         version that had one. There is nothing here to test. To install this older candidate \
+         anyway, name it:\n  robotctl update apply {component} --staging --version {candidate}"
+    )]
+    StagingBehind {
+        component: String,
+        installed: semver::Version,
+        candidate: semver::Version,
+    },
+
     /// The candidate does not contain a binary an installed unit execs.
     ///
     /// Carries a preformatted message rather than its parts, because the useful half is the
@@ -148,6 +173,11 @@ impl Error {
             Error::UnknownComponent(_) => code::UNKNOWN_COMPONENT,
             Error::NotInstalled { .. } => code::NOT_INSTALLED,
             Error::WouldDowngrade { .. } => code::WOULD_DOWNGRADE,
+            // Shares the downgrade code rather than adding one, for the reason `WouldOrphanUnit`
+            // shares `INCOMPATIBLE` below: to a client this is the same answer — "refused, the
+            // target is older than what is installed" — and what a person needs is the message.
+            // A new code would be an `API_VERSION` bump for a refusal no client branches on.
+            Error::StagingBehind { .. } => code::WOULD_DOWNGRADE,
             Error::Busy => code::BUSY,
             Error::Network(_) => code::NETWORK,
             Error::Verification(_) => code::VERIFICATION_FAILED,


### PR DESCRIPTION
Reported from a board: `sudo robotctl update apply daemon --staging` on stable
`0.4.0` attempted `0.2.0`, failed to restart `configd`, and rolled back.

`0.2.0` is the newest `daemon-staging-v*` release that exists. `0.3.0` and
`0.4.0` were promoted straight to stable, and a straight-to-stable release
publishes no candidate — `release.yml` labels that path "build → STABLE
directly (no staging release exists; NOT canaried)". So the staging scan keeps
answering with the last version that did publish one, and on a board past that
version `--staging` walks backwards.

Everything after resolution behaved correctly: verified, swapped, `configd`
(which `0.2.0` predates) failed `203/EXEC`, the failed restart failed the
update, and the engine reverted to `0.4.0` with no `apply_error`. The operator
got a systemd error code.

## What this adds

`Target::Staging` now compares the resolved candidate against what is installed
and refuses when the channel is behind:

```
the newest release candidate is 0.2.0, and this board is already on 0.4.0 —
nothing more recent is available on the staging channel. A release promoted
straight to stable publishes no candidate, so staging stays at the last version
that had one. There is nothing here to test. To install this older candidate
anyway, name it:
  robotctl update apply daemon --staging --version 0.2.0
```

`StagingExact` stays unguarded. It is the way past this refusal, and it is how
the candidate a board just rolled back from gets reinstalled — guarding it would
leave a board that can neither install the candidate nor be told why.

It is not `WouldDowngrade`. That variant claims a mirror may have gone backwards
and invites distrusting the source; here the source is fine and the channel is
behind. It shares the JSON-RPC code, so no `API_VERSION` bump.

## Relationship to the orphan check

c7cd15c already refuses a release that would leave an installed unit with
nothing to exec, and its module doc documents this same incident. That check is
on `main` and not in `0.4.0`, which is why the board saw neither refusal. The
two are not redundant: the orphan check names a stale *unit* and is the right
answer for a downgrade someone means, and it cannot name a stale *channel*.

**Both want releasing** — a board on `0.4.0` has neither.

## Tests

Seven in `engine::staging_channel_tests`: the incident itself, a candidate ahead
of the board, equality (which is `AlreadyCurrent`, above this), a first install,
every other `Target` variant at a version that would otherwise trip it, the
message, and the shared error code.

Cannot be driven end-to-end in `updater/tests/apply.rs` — its fixture is
`LocalDir`, which has no staging channel by design and has a test asserting
that. Hence a pure predicate with the decision under test.

`cargo test -p updater` green: 159 + 12 + 67 + 7 + 12 + 22.