### PR TITLE
health: the installed release is not a systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ sudo robotctl update rollback daemon
 `daemon` covers every binary. On a dev board this installs the latest *stable* release, which is
 usually a downgrade — use `--ref` below instead.
 
+A release candidate — published, not yet promoted — is flagged as a prerelease, and a plain `apply`
+skips those so no robot drifts onto a build nobody has validated. Ask for one by name:
+
+```bash
+sudo robotctl update apply --staging daemon
+```
+
+To pick a candidate rather than the newest one:
+
+```bash
+sudo robotctl update apply --staging --version 0.5.0 daemon
+```
+
+The flag applies to that one command and leaves nothing switched on, so the next `apply` is back
+on stable. This is what a canary robot runs before a promotion.
+
 ## Put your branch on the robot
 
 Make sure the board has been through the [dev install](docs/robot/install-dev.md) first — a board that

--- a/README.md
+++ b/README.md
@@ -37,11 +37,26 @@ robot     healthy
   cpu       52 °C
 
 software
-  updaterd  0.1.4 (rev abc1234)
-  robotd    0.1.5 (rev def5678)
-  daemon    0.1.5 installed
-            last update 0.1.4 → 0.1.5: applied
+  updaterd  0.5.0 (rev abc1234)
+  robotd    0.5.0 (rev abc1234)
+  configd   0.5.0 (rev abc1234)
+  daemon    0.5.0 installed
+            last update 0.4.1 → 0.5.0: applied
+
+units
+  updaterd  active · 0.5.0 (rev abc1234)
+  robotd    active · 0.5.0 (rev abc1234)
+  configd   active · 0.5.0 (rev abc1234)
+  btd       active · 0.5.0 (rev abc1234)
+  padd      active · 0.5.0 (rev abc1234)
 ```
+
+The two software blocks answer different questions. `software` is what each daemon that serves a
+socket says about itself, and what is installed on the board; `units` is what systemd says about
+every unit a release manages — including `btd` and `padd`, which serve no socket and can only be
+reported from outside — with the release each process was actually launched from. That second one
+is the question after an update: a daemon still running the old binary shows a release older than
+the installed one, and the report names the restart that fixes it.
 
 ## Drive it
 

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -933,11 +933,6 @@ fn render_health(report: &HealthReport) -> String {
             }
         }
     }
-    if !report.software.units.is_empty() {
-        let _ = writeln!(out, "\nunits");
-        out.push_str(&render_units(&report.software.units, 2));
-    }
-
     for component in &report.software.components {
         let _ = writeln!(
             out,
@@ -952,6 +947,14 @@ fn render_health(report: &HealthReport) -> String {
         if let Some(attempt) = &component.last_attempt {
             let _ = writeln!(out, "  {:<9} last update {attempt}", "");
         }
+    }
+
+    // After the installed lines rather than between them and the daemons above, because it has a
+    // heading and they do not: a block inserted there ends the `software` block early and adopts
+    // `daemon 0.5.0 installed` as one more unit — which reads as a systemd unit named `daemon`.
+    if !report.software.units.is_empty() {
+        let _ = writeln!(out, "\nunits");
+        out.push_str(&render_units(&report.software.units, 2));
     }
 
     // Same shape `robotctl version` uses, blank line and all: these are often multi-line —
@@ -2948,6 +2951,26 @@ mod tests {
         let out = render_health(&report);
         assert!(out.contains("pinned to 0.1.9"), "{out}");
         assert!(out.contains("ROLLED BACK"), "{out}");
+    }
+
+    /// The installed release stays in the `software` block, below the daemons and above `units`.
+    ///
+    /// The component lines carry no heading of their own, so whatever block is printed before them
+    /// takes them: with `units` in between, `daemon    0.2.0 installed` renders under it and reads
+    /// as a sixth systemd unit called `daemon`. Ordering is the whole of the fix, which is exactly
+    /// the kind of thing a later edit undoes without noticing.
+    #[test]
+    fn the_installed_release_is_not_rendered_as_a_unit() {
+        let mut report = health_report(Some(proto::HealthResult::default()), None);
+        report.software.units = vec![
+            unit("robotd", proto::UnitState::Active, Some("0.2.0")),
+            unit("padd", proto::UnitState::Inactive, None),
+        ];
+
+        let out = render_health(&report);
+        let installed = out.find("daemon    0.2.0 installed").expect(&out);
+        let units = out.find("\nunits\n").expect(&out);
+        assert!(installed < units, "{out}");
     }
 
     /// The summary line for one update attempt, including the reason a revert happened —


### PR DESCRIPTION
`robotctl health` printed the `units` block between the daemons and the installed-release lines. Those lines carry no heading of their own — they close the `software` block by sitting under it — so a block inserted above them takes them, and the report ended:

```
units
  ...
  padd      active · 0.5.0 (rev abc1234)
  daemon    0.5.0 installed
            last update 0.4.1 → 0.5.0: applied
```

which reads as a sixth systemd unit called `daemon`, on the one block whose whole job is to say what systemd is running.

`units` now prints after the installed lines, so `software` keeps the shape it had before that block existed and `units` stands alone above the warnings that refer to it. Ordering being the entire fix is what makes it fragile, so a test pins it.

The README sample was from before `configd`, before `units`, and several releases stale in its versions. It is now what the renderer actually produces — checked against its output — plus a line on what separates the two blocks.

The second commit is README-only: `--staging` and `--staging --version`, in the update section beside `apply`, `rollback` and `--ref`. It was reachable only from the dev cheat sheet, which is a page you read once you already know the flag exists.

`cargo test -p robotctl`: 66 passed. `cargo fmt --check` and `cargo clippy --all-targets` clean.