### PR TITLE
0.5.1, and how to cut it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "btd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bluer",
  "btleplug",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "configd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "duck-control"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "duck-ipc-proto",
  "libloading 0.8.9",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "duck-ipc-proto"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "semver",
  "serde",
@@ -2340,7 +2340,7 @@ checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "padd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "duck-ipc-proto",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "robotctl"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "robotd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arc-swap",
  "clap",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "minisign",
@@ -3862,7 +3862,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4427,7 +4427,7 @@ checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xtask"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "minisign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ floor  = "1.23"
 target = "1.28.0"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 # 1.89 for `std::fs::File::try_lock`, which is how the single-flight update lock works
 # without a dependency (updater/src/journal.rs). Edition 2024 needs 1.85, so this covers

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ sudo robotctl update apply --staging daemon
 To pick a candidate rather than the newest one:
 
 ```bash
-sudo robotctl update apply --staging --version 0.5.0 daemon
+sudo robotctl update apply --staging --version 0.5.1 daemon
 ```
 
 The flag applies to that one command and leaves nothing switched on, so the next `apply` is back
@@ -274,6 +274,54 @@ It builds here, signs with the dev key, copies the release to the board and appl
 verification, same health gate, same auto-rollback, about a minute instead of a push and a CI run.
 Setup and the one-time first push are in the
 [dev board cheat sheet](docs/robot/cheatsheet-dev.md).
+
+## Cut a release
+
+Releases are built and signed in CI, never on a laptop. Two tags: the pre-release goes to a canary
+robot, and the release promotes exactly those bytes.
+
+Bump `version` under `[workspace.package]` in `Cargo.toml` first — 0.5.0 to 0.5.1 here. `xtask
+package` refuses a tag that disagrees with it, which is what stops a robot reporting a version it
+is not running. Then refresh the lockfile:
+
+```bash
+cargo update --workspace
+```
+
+Merge that, then from `main`:
+
+```bash
+git tag daemon-staging-v0.5.1 && git push --tags
+```
+
+CI builds it, signs it, verifies it through the real update engine and publishes it as a
+prerelease. Watch it:
+
+```bash
+gh run list --workflow release
+```
+
+Once it is green, on the canary robot:
+
+```bash
+sudo robotctl update apply --staging daemon
+```
+
+Drive it. When it holds up, from `main` again:
+
+```bash
+git tag daemon-v0.5.1 && git push --tags
+```
+
+That promotes the staging build rather than rebuilding it — the same bytes, re-signed with the key
+customer robots trust. Creating the release in the GitHub UI instead of pushing the tag does the
+same thing.
+
+A `daemon-v` tag with no staging build behind it is allowed and builds directly. Both are signed
+the same way, so the difference is validation rather than authenticity, and the release notes say
+which one happened. Key custody and the `promote` workflow — including `min_supported`, for forcing
+robots off a bad release — are in [CONTRIBUTING.md](CONTRIBUTING.md#releasing) and
+[`docs/project/ci-setup.md`](docs/project/ci-setup.md).
 
 ## Where next
 


### PR DESCRIPTION
`[workspace.package] version` moves to 0.5.1, with `cargo update --workspace` carrying the ten workspace crates in the lockfile. No dependency moved. The bump has to land before a tag: `xtask package` refuses one that disagrees with `Cargo.toml`.

The release procedure was only in CONTRIBUTING.md, as a table of what each tag makes CI do. That answers what a tag means, not how to ship — and the tags read in the wrong order for someone doing it the first time, since the pre-release is pushed first and the release promotes its bytes rather than building new ones.

The README now carries the steps, beside the other ways software reaches a robot: bump, tag `daemon-staging-v0.5.1`, install it on a canary with `--staging`, tag `daemon-v0.5.1`. The CONTRIBUTING table stays for what the tags mean; key custody stays in `docs/project/ci-setup.md`.

The `--staging --version` example moves to 0.5.1 with it.