### PR TITLE
updater: say a release is still building, rather than broken

### DIFF
--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -122,6 +122,24 @@ pub enum Error {
     #[error("network error: {0}")]
     Network(String),
 
+    /// The release exists but carries no assets, which is what every release looks like until
+    /// its build finishes uploading them.
+    ///
+    /// Distinct from [`Self::Network`] because the old answer — "has no asset named
+    /// \"manifest.json\" (has: )" under a "network error" prefix — describes a malformed
+    /// release and a broken link, and it is neither. The release is fine and the board is
+    /// online; the artifacts are minutes away. Both people who hit it went looking for the
+    /// wrong thing.
+    #[error(
+        "release {tag} has no assets yet, so there is nothing here to install. Its build has \
+         not finished uploading them — publishing a release creates it before that build \
+         starts, so the first few minutes of every release look like this and nothing is wrong \
+         with it. The release page lists the assets as they land:\n  \
+         https://github.com/{repo}/releases/tag/{tag}\nRun the same command again once they \
+         are there."
+    )]
+    ReleaseNotReady { repo: String, tag: String },
+
     /// Signature or hash mismatch. Never retried automatically — a failure here
     /// means the bytes are not ours.
     #[error("verification failed: {0}")]
@@ -180,6 +198,13 @@ impl Error {
             Error::StagingBehind { .. } => code::WOULD_DOWNGRADE,
             Error::Busy => code::BUSY,
             Error::Network(_) => code::NETWORK,
+            // Shares the network code rather than adding one, for the reason `StagingBehind`
+            // shares the downgrade code above — with a second reason here. To a client this is
+            // the same answer as any other fetch that came up empty, and the one behaviour a
+            // client should have is the one `NETWORK` already asks for: retry later. That is
+            // exactly right for a release whose upload is still in flight, so a new code would
+            // be an `API_VERSION` bump that changed no client's mind about what to do.
+            Error::ReleaseNotReady { .. } => code::NETWORK,
             Error::Verification(_) => code::VERIFICATION_FAILED,
             Error::Incompatible(_) => code::INCOMPATIBLE,
             // Shares the incompatible code rather than adding one, for the reason `SelfTest`

--- a/updater/src/source/github.rs
+++ b/updater/src/source/github.rs
@@ -189,7 +189,20 @@ impl GithubReleases {
     }
 
     /// The API download URL for a named asset. Pair it with [`OCTET_STREAM`].
-    fn asset_url(release: &Release, name: &str) -> Result<String, Error> {
+    ///
+    /// A release with *no* assets at all is reported separately, because it is not the same
+    /// situation as a missing one. Assets are uploaded at the end of a release build, so an
+    /// empty release is every release for the few minutes before that finishes — a state to
+    /// wait out, not a fault to investigate. A release that has assets but not this one is the
+    /// fault case, and there the list of what *is* there is the whole diagnostic.
+    fn asset_url(&self, release: &Release, name: &str) -> Result<String, Error> {
+        if release.assets.is_empty() {
+            return Err(Error::ReleaseNotReady {
+                repo: self.repo.clone(),
+                tag: release.tag_name.clone(),
+            });
+        }
+
         release
             .assets
             .iter()
@@ -228,7 +241,7 @@ impl GithubReleases {
         };
 
         let release = self.release_for_tag(&tag).await?;
-        let api_url = Self::asset_url(&release, &name)?;
+        let api_url = self.asset_url(&release, &name)?;
         tracing::debug!(%tag, %name, "resolved asset through the release API");
         Ok((api_url, Some(OCTET_STREAM)))
     }
@@ -236,9 +249,9 @@ impl GithubReleases {
     async fn signed_manifest(&self, tag: &str) -> Result<SignedBytes<Manifest>, Error> {
         let release = self.release_for_tag(tag).await?;
 
-        let manifest_url = Self::asset_url(&release, &self.manifest_asset)?;
+        let manifest_url = self.asset_url(&release, &self.manifest_asset)?;
         let sig_name = format!("{}{SIG_SUFFIX}", self.manifest_asset);
-        let sig_url = Self::asset_url(&release, &sig_name)?;
+        let sig_url = self.asset_url(&release, &sig_name)?;
 
         let bytes = http::get_bytes(&self.client, &manifest_url, Some(OCTET_STREAM)).await?;
         let signature = http::get_bytes(&self.client, &sig_url, Some(OCTET_STREAM)).await?;
@@ -463,9 +476,41 @@ mod tests {
                 url: "https://api.github.com/repos/ORG/robot-daemon/releases/assets/1".into(),
             }],
         };
-        let err = GithubReleases::asset_url(&release, "manifest.json").unwrap_err();
+        let err = source().asset_url(&release, "manifest.json").unwrap_err();
         // A support ticket needs to see what *was* there.
         assert!(err.to_string().contains("other.txt"), "{err}");
+    }
+
+    /// A release whose build has not uploaded yet must not read as a broken release.
+    ///
+    /// This is what an operator hits by running `update apply --staging` in the minutes after
+    /// publishing, and the old answer — `network error: ... has no asset named "manifest.json"
+    /// (has: )` — pointed at the two things that were not wrong: the release, and the network.
+    #[test]
+    fn an_empty_release_says_its_build_has_not_finished() {
+        let release = Release {
+            tag_name: "daemon-staging-v0.5.1".into(),
+            draft: false,
+            prerelease: true,
+            assets: vec![],
+        };
+
+        let err = source().asset_url(&release, "manifest.json").unwrap_err();
+        assert!(
+            matches!(err, Error::ReleaseNotReady { .. }),
+            "an empty release is a wait, not a fetch failure, got {err:?}"
+        );
+
+        let msg = err.to_string();
+        // The tag, so it is clear *which* release, and where to watch it land.
+        assert!(msg.contains("daemon-staging-v0.5.1"), "{msg}");
+        assert!(
+            msg.contains("https://github.com/ORG/robot-daemon/releases/tag/daemon-staging-v0.5.1"),
+            "{msg}"
+        );
+        // And none of the vocabulary that sent people debugging the wrong thing.
+        assert!(!msg.contains("network"), "{msg}");
+        assert!(!msg.contains("no asset named"), "{msg}");
     }
 
     /// **A manifest must not redirect the asset lookup at another repository.**


### PR DESCRIPTION
Running `update apply` in the minutes after publishing a release answers:

```
$ sudo robotctl update apply daemon --staging
Preflight
Checking
error: network error: release daemon-staging-v0.5.1 has no asset named "manifest.json" (has: )
```

Nothing is wrong with that release. A release object is created and published *before* its build starts, and the artifacts are uploaded when that build finishes (`_build-release.yml:404`), so an empty release is what every release looks like for the first few minutes. The board is online, the release is fine, and the answer is to wait — but the message describes a malformed release under a prefix that says the network failed, so the reader goes off to check both.

Now:

```
error: release daemon-staging-v0.5.1 has no assets yet, so there is nothing here to install. Its
build has not finished uploading them — publishing a release creates it before that build starts,
so the first few minutes of every release look like this and nothing is wrong with it. The release
page lists the assets as they land:
  https://github.com/pollen-robotics/microduck_daemon/releases/tag/daemon-staging-v0.5.1
Run the same command again once they are there.
```

## What is and isn't in scope

An **empty** asset list becomes its own refusal. A release that has assets but not the one asked for keeps the old message — that one is a real fault, and the list of what *is* there is the whole diagnostic.

It shares `code::NETWORK` rather than adding a code, for the reason `StagingBehind` shares the downgrade code: to a client this is the same answer as any other fetch that came up empty, and the one behaviour it should have is the one `NETWORK` already asks for — retry later, which is exactly right for an upload still in flight. No `API_VERSION` bump.

## Stable has the same window

Asked while writing this, and yes. Both stable shapes upload at the end too — promote at `_promote-release.yml:212`, direct-stable through the same `_build-release.yml` path. Stable is arguably worse, because `newest_under` picks the highest version without looking at whether it has assets, so a fleet-wide `update apply daemon` during that window fails on every board at once. This message is what makes that legible; two follow-ups are deliberately **not** here:

- **Close the window in CI** — draft the release while building, publish after upload. Robots already skip drafts. The catch is that the promote check `gh release view "daemon-staging-v${version}"` sees drafts too, so it would promote a half-built candidate unless guarded with `--jq .isDraft`.
- **Skip asset-less releases in `newest_under`** — `latest` would resolve to the previous good release and the fleet would never see the window. Tempting, but it also silently hides a release whose upload genuinely failed, which is a real behaviour change rather than a feedback fix.

## Testing

`cargo test -p updater` — 280 pass. New test asserts the empty case is `ReleaseNotReady`, carries the tag and the release URL, and contains neither "network" nor "no asset named"; the existing missing-asset test still asserts the available list.
