### PR TITLE
btctl: `scan` answers first, and diagnoses on request

### DIFF
--- a/btd/examples/btctl.rs
+++ b/btd/examples/btctl.rs
@@ -174,15 +174,32 @@ async fn device_list(mut devices: Vec<&Seen>) -> String {
     lines.join("\n")
 }
 
-/// What `scan` prints: the robots, and then everything else, because a robot can be in either half.
+/// Whether the devices that are not robots are listed, or only counted.
 ///
 /// The duck service UUID in the advertisement is the only evidence available to a listing —
 /// everything stronger needs a connection, and connecting to 43 devices to ask each whether it is a
-/// robot would be minutes of pairing prompts. So the second block is not padding: a robot already
-/// bonded with this Mac frequently advertises no services at all, and it is the reason `--name`
-/// exists. Naming that here is what turns "my robot is missing" into a next move.
-async fn listing(seen: &[Seen]) -> String {
+/// robot would be minutes of pairing prompts. So that block is not padding: a robot already bonded
+/// with this Mac frequently advertises no services at all, and it is the reason `--name` exists.
+///
+/// But `scan` is read to answer "which robots can I talk to", and a dozen lines of earbuds above
+/// the answer buries it. So the block is the diagnosis rather than the output, and it appears when
+/// it is one:
+///
+/// - `--verbose`, which is the flag for asking what the radio actually saw.
+/// - **No robot advertised the service**, verbose or not. That is precisely the case where the robot
+///   is plausibly in the other list and hiding the evidence would leave nothing to act on.
+///
+/// Otherwise it is a count and how to expand it, because "that was every device" and "that was the
+/// robots" want different next moves.
+fn lists_others(verbose: bool, robots: usize) -> bool {
+    verbose || robots == 0
+}
+
+/// What `scan` prints: the robots, and — per [`lists_others`] — everything else.
+async fn listing(seen: &[Seen], verbose: bool) -> String {
     let (robots, others): (Vec<&Seen>, Vec<&Seen>) = seen.iter().partition(|d| d.duck);
+    // Kept before `device_list` consumes the vector, since it decides the second block below.
+    let found = robots.len();
 
     let mut out = if robots.is_empty() {
         "no robot advertised the duck service.".to_owned()
@@ -195,14 +212,22 @@ async fn listing(seen: &[Seen]) -> String {
     };
 
     if !others.is_empty() {
-        let anonymous = others.iter().filter(|d| d.local_name.is_none()).count();
-        out.push_str(&format!(
-            "\n\n{} other device(s) in {SCAN_TIME:?}, {anonymous} with no name. A robot bonded with \
-             this Mac often stops advertising the service to it, so it can be one of these — \
-             `--name <its name>` connects to it anyway:\n{}",
-            others.len(),
-            device_list(others).await,
-        ));
+        if lists_others(verbose, found) {
+            let anonymous = others.iter().filter(|d| d.local_name.is_none()).count();
+            out.push_str(&format!(
+                "\n\n{} other device(s) in {SCAN_TIME:?}, {anonymous} with no name. A robot bonded \
+                 with this Mac often stops advertising the service to it, so it can be one of \
+                 these — `--name <its name>` connects to it anyway:\n{}",
+                others.len(),
+                device_list(others).await,
+            ));
+        } else {
+            out.push_str(&format!(
+                "\n\n{} other device(s) in range, not listed. A robot bonded with this Mac can be \
+                 among them, advertising no service — `--verbose` lists them.",
+                others.len(),
+            ));
+        }
     }
     out
 }
@@ -288,7 +313,7 @@ struct Cli {
     #[arg(long = "name", id = "robot", value_name = "ROBOT_NAME", global = true)]
     name: Option<String>,
 
-    /// Print every line sent and received.
+    /// Print every line sent and received, and have `scan` list every device rather than the robots.
     #[arg(long, global = true)]
     verbose: bool,
 
@@ -479,7 +504,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         if seen.is_empty() {
             return Err(nothing_found(&seen, None).await.into());
         }
-        println!("{}", listing(&seen).await);
+        println!("{}", listing(&seen, cli.verbose).await);
         return Ok(());
     }
 
@@ -831,6 +856,19 @@ mod tests {
         assert!(answers_to(reported, "radxa-zero3"), "the cached GAP name");
         assert!(answers_to(reported, reported), "copied from the failure");
         assert!(!answers_to(reported, "duck-ffff"));
+    }
+
+    /// `scan` is read to learn which robots are reachable, and a dozen lines of earbuds above the
+    /// answer bury it. The clause worth pinning is the second one: with nothing advertising the
+    /// service, the other devices *are* the answer — the robot is plausibly among them — so they are
+    /// listed whether or not `--verbose` was given, and gating them purely on the flag would leave
+    /// that failure with nothing to act on.
+    #[test]
+    fn other_devices_are_listed_when_they_are_the_diagnosis() {
+        assert!(!lists_others(false, 1), "the robot is the answer");
+        assert!(lists_others(true, 1), "--verbose asks what the radio saw");
+        assert!(lists_others(false, 0), "no robot: the list is all there is");
+        assert!(lists_others(true, 0));
     }
 
     /// `--name` says which robot to talk to and the `name` subcommand's positional says what to

--- a/docs/robot/cheatsheet-dev.md
+++ b/docs/robot/cheatsheet-dev.md
@@ -209,6 +209,9 @@ btctl --name <robot-name> info
 btctl scan
 ```
 
+Robots only, with everything else in radio range counted rather than listed. Add `--verbose` to see
+that list, and read it when the robot you want is not in the first one.
+
 ```
 btctl --name <robot-name> info
 ```
@@ -251,7 +254,10 @@ btctl --name <robot-name> reboot
   giving always: it skips a slow fallback tier that tries every already-connected peripheral on the
   Mac, earbuds included.
 - `--pin <six-digits>` — defaults to `000000`. `robotctl system pin` on the robot shows the real one.
-- `--verbose` — print every line sent and received. The first thing to add when something hangs.
+- `--verbose` — print every line sent and received. The first thing to add when something hangs. It
+  also makes `scan` list every device the radio saw rather than only the robots, which is worth
+  having when a robot is missing from the list — a robot bonded with this Mac often stops
+  advertising the service to it, so it shows up as one of the other devices.
 
 ### Anything not wrapped above
 


### PR DESCRIPTION
Stacked on #91 — both touch `btctl`, so this branches off it rather than off `main`. GitHub retargets this to `main` once #91 merges.

`btctl scan` printed the robots and then every other device the radio saw. In a room with a laptop, some earbuds and a handful of unnamed peripherals, the two lines being looked for sat above a dozen that were not.

Now the other devices are counted, not listed:

```
1 robot(s) advertising the duck service:
  duck-c51b duck-c51b — 1 service(s)

43 other device(s) in range, not listed. A robot bonded with this Mac can be among them,
advertising no service — `--verbose` lists them.
```

`--verbose` expands it to the block that used to print unconditionally.

That block earns its keep, which is why it stays reachable rather than being deleted: a robot bonded with this Mac frequently advertises no service at all and shows up among the others, which is the reason `--name` exists in the first place.

It is also still printed **unasked when no robot advertised the service**, verbose or not. That is precisely the case where one of the other devices is plausibly the robot, and gating it on the flag alone would answer `no robot advertised the duck service` with nothing to act on. `lists_others` is that rule, and a test pins it — the flag half is obvious, the no-robot half is the one a later change would quietly drop.

The `--verbose` help line and the dev cheatsheet both say what the flag now does to `scan`.