### PR TITLE
dev-push: sideload where updaterd can read it, a page for the loop, and a board found by name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ another.
 To run a change on a real robot without publishing it, `scripts/dev-push.sh <user@board>` builds
 here and installs there as an ordinary gated update. It cross-compiles with `cargo zigbuild` by
 default, or with `--docker` builds inside the board's userland instead, which needs no toolchain
-set up at all. Setup and the one-time first push:
-[`docs/robot/cheatsheet-dev.md`](docs/robot/cheatsheet-dev.md).
+set up at all. Setup, the flags and the failure modes:
+[`docs/robot/dev-push.md`](docs/robot/dev-push.md).
 
 ## The layout
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,7 @@ scripts/dev-push.sh radxa@<board>
 
 It builds here, signs with the dev key, copies the release to the board and applies it — same
 verification, same health gate, same auto-rollback, about a minute instead of a push and a CI run.
-Setup and the one-time first push are in the
-[dev board cheat sheet](docs/robot/cheatsheet-dev.md).
+Setup and the one-time first push are in [`dev-push.md`](docs/robot/dev-push.md).
 
 ## Cut a release
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Start at the [README](../README.md) if you have a robot and want to use it.
 | [`cheatsheet.md`](robot/cheatsheet.md) | Every `robotctl` command. |
 | [`pair-a-gamepad.md`](robot/pair-a-gamepad.md) | Once per pad: pairing mode, `pad pair`, and what to do when it will not bond. |
 | [`cheatsheet-dev.md`](robot/cheatsheet-dev.md) | The commands that need a dev board: branch builds, candidates, dev pushes. |
+| [`dev-push.md`](robot/dev-push.md) | Build on your machine and install on the board over ssh, with no CI run. |
 | [`duck-btctl.md`](robot/duck-btctl.md) | Every `duck-btctl` command — the robot over Bluetooth, from a laptop. |
 | [`install-dev.md`](robot/install-dev.md) | Setting up a board for development, from nothing. |
 

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -996,6 +996,12 @@ Cheap additions that slot into the same IPC / engine and pay off:
   `--version` — an operator naming a directory is not a mirror that has gone
   backwards, and a local build is a prerelease that sorts below whatever the board is
   running, so guarding it would refuse every push.
+  One constraint on the directory, and it is systemd's rather than the engine's:
+  `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and**
+  its own `/var/tmp`, so a release copied to either from a shell is not the one the
+  daemon reads. That is why the sideload directory lives in the board user's home and
+  why `Check::SideloadDir` exists — without it the failure is a missing manifest in a
+  directory whose `ls` lists it, which is unfalsifiable from the outside.
 - **BLE provisioning security.** Adjacent but important: wifi credentials pass
   over BLE during setup. That characteristic must be paired + encrypted, or it's
   a credential leak. Update artifacts are signed so a spoofed *trigger* is

--- a/docs/robot/cheatsheet-dev.md
+++ b/docs/robot/cheatsheet-dev.md
@@ -101,87 +101,15 @@ ships. `../design/restart-order.md` is the full sequence, step by step.
 
 ## From a laptop — build here, install on the board
 
-No push, no CI run, no tag. One command from a clone of this repo:
+Skipping CI entirely: build on your machine and install over ssh, in about a minute.
 
 ```bash
 scripts/dev-push.sh radxa@<board>
 ```
 
-```bash
-export DUCK_BOARD=radxa@<board>
-```
-
-```bash
-scripts/dev-push.sh
-```
-
-It cross-compiles for the board, packages the same artifact a release does, signs it with the dev
-key, copies it to `/var/tmp/duck-sideload` on the board and applies it there. Roughly a minute on
-an incremental build, against several for a push plus a CI run.
-
-Needs, once:
-
-```bash
-cargo install cargo-zigbuild --locked
-```
-
-```bash
-brew install zig
-```
-
-and `team.dev.key` at `~/.duck-keys/team.dev.key` — the secret half of the key CI signs branch
-builds with. Set `DUCK_DEV_SECRET_KEY` if yours lives elsewhere. The board must be a
-[dev board](install-dev.md); the artifact is signed with a dev key, so a customer robot refuses
-it exactly as it refuses `--ref`.
-
-### Or build in a container, with no toolchain to set up
-
-```bash
-scripts/dev-push.sh --docker radxa@<board>
-```
-
-Needs Docker running and nothing else — no zig, no `cargo-zigbuild`, and no board to copy
-libudev from, which is what makes it the answer before you have a board at all. It builds inside
-Debian Bookworm on arm64, so on an Apple Silicon Mac the target is the host: nothing is
-cross-compiled and libudev is just installed. Same artifact, same `--dry-run` and `--bootstrap`.
-
-Slower to start — a first build compiles the workspace inside the container, and the two modes
-keep separate `target/` directories, so switching costs one full rebuild. Reach for it when the
-zig path is not set up or has broken; the default is faster day to day and is what CI uses.
-
-Verify without installing:
-
-```bash
-scripts/dev-push.sh --dry-run radxa@<board>
-```
-
-**This is an ordinary update.** It goes through `robotctl update apply --from <dir>`, so the
-signature, the artifact hash, compatibility, the health gate and auto-rollback all run — a build
-that does not come up is reverted and the board is back on what it was running. The restart traps
-above still apply: `btd` and `updaterd` keep running the old binary until they are restarted.
-
-The version is `<crate>-dev.local.<epoch>.g<sha7>`, so `robotctl version` on the board says which
-push it is running and two pushes of the same dirty tree never collide.
-
-To install what is already in that directory, or to point at one you filled yourself:
-
-```bash
-sudo robotctl update apply daemon --from /var/tmp/duck-sideload
-```
-
-### The first push to a board below 0.5.0
-
-`apply --from` is part of the release being pushed: it needs API version 7, which first ships in
-0.5.0. A board running anything earlier has an `updaterd` that cannot be asked to use it, and says
-so — `robotctl` and `updaterd` report an API mismatch and refuse the call rather than quietly
-installing from the configured source instead. Deliver it once the ungated way, which stops
-`robotd` and gives up the health gate for that one install:
-
-```bash
-scripts/dev-push.sh --bootstrap radxa@<board>
-```
-
-Every push after that is the ordinary command.
+The result is an ordinary gated update, so the restart traps above still apply.
+[`dev-push.md`](dev-push.md) has the setup, the container build, `--dry-run`, the first push to a
+board below 0.5.0, and what to do when it fails.
 
 ## From a laptop — `duck-btctl`
 

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -33,18 +33,42 @@ see [build in a container](#build-in-a-container-instead).
 
 ## The loop
 
+Name the robot, and let the push find it:
+
 ```bash
-scripts/dev-push.sh radxa@192.168.1.42
+scripts/dev-push.sh --name duck-c51b
 ```
 
-Or name the board once per shell:
+Or once per shell:
 
 ```bash
-export DUCK_BOARD=radxa@192.168.1.42
+export DUCK_ROBOT=duck-c51b
 ```
 
 ```bash
 scripts/dev-push.sh
+```
+
+The name is the one `duck-btctl scan` lists and `robotctl system set-name` sets — the same
+`DUCK_ROBOT` that tool reads ([`duck-btctl.md`](duck-btctl.md)). Its address is
+asked for over Bluetooth — the robot's own `net.status` answers with it — and then cached, so only
+a push that cannot reach the cached address goes back to the radio. That is what makes a new DHCP
+lease, a reflash or a different network cost nothing to follow.
+
+The ssh user is `radxa`. If yours is not:
+
+```bash
+export DUCK_BOARD_USER=pierre
+```
+
+An address still works, and skips the radio entirely:
+
+```bash
+scripts/dev-push.sh radxa@192.168.1.42
+```
+
+```bash
+export DUCK_BOARD=radxa@192.168.1.42
 ```
 
 It cross-compiles the workspace, packages the same artifact a release does, signs it with the dev
@@ -244,6 +268,30 @@ grep -c 'DEV BOARD' /var/lib/robot/provision.log
 
 `0` means the key is missing; [`install-dev.md`](install-dev.md) has both halves of the fix.
 
+**`could not reach <name> over Bluetooth`** — the robot has to be advertising and in range for
+the name path to resolve an address.
+
+```bash
+duck-btctl scan
+```
+
+Nothing listed is a robot that is off, out of range, or already connected to a phone. Give the
+address instead and the radio is not involved:
+
+```bash
+scripts/dev-push.sh radxa@192.168.1.42
+```
+
+**`<name> answered over Bluetooth but has no wifi address`** — it is up but not on a network, so
+there is nothing to ssh to. Join one over the same radio:
+
+```bash
+duck-btctl --name duck-c51b wifi connect <ssid> --psk <passphrase>
+```
+
+**`still <address>, which ssh could not reach`** — the address never moved, so whatever ssh is
+unhappy about is something else. A reflashed board is the usual one; see the host keys below.
+
 **ssh refuses to connect after a reflash** — the board regenerated its host keys.
 
 ```bash
@@ -278,7 +326,11 @@ This should not have been necessary, so it is worth reading the journal for why 
 
 | | |
 |---|---|
-| `DUCK_BOARD` | The board, instead of an argument. `radxa@192.168.1.42`. |
+| `DUCK_ROBOT` | The robot, by name. Its address is found over Bluetooth and cached. |
+| `DUCK_BOARD_USER` | The ssh user on the board, for the name path. Default `radxa`. |
+| `DUCK_PIN` | The robot's pairing PIN, if it is not the factory `000000`. Read by `duck-btctl`. |
+| `DUCK_BOARD_CACHE` | Where resolved addresses are cached. Default `~/.cache/duck/boards`. |
+| `DUCK_BOARD` | The board, by address, instead of an argument. `radxa@192.168.1.42`. |
 | `DUCK_DEV_SECRET_KEY` | The dev signing key. Default `~/.duck-keys/team.dev.key`. |
 | `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `~/duck-sideload` there. Never under `/tmp` or `/var/tmp`: `updaterd` has private copies of both and would read those. |
 | `DUCK_CROSS_SYSROOT` | The cached libudev copy. Default `~/.cache/duck-cross/aarch64`. |

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -1,0 +1,283 @@
+# Build here, install on the board
+
+The loop between changing a line and watching the robot run it, with no push, no CI run and no
+tag. One command from a clone of this repo builds for the board, signs the result and installs it
+over ssh — about a minute on an incremental build, against several for a push plus a CI run.
+
+`scripts/dev-push.sh` is that command. Everything below is a flag on it.
+
+## Once, before the first push
+
+Three things, and then never again.
+
+**The board has to be a dev board.** The artifact is signed with the team dev key, so a customer
+robot refuses it exactly as it refuses `--ref`. [`install-dev.md`](install-dev.md) is how a board
+becomes one.
+
+**The dev signing key** goes at `~/.duck-keys/team.dev.key` — the secret half of the key CI signs
+branch builds with, which a team member has. Set `DUCK_DEV_SECRET_KEY` if yours lives elsewhere.
+
+**A toolchain that can build for the board.** Either install the cross-compiler:
+
+```bash
+cargo install cargo-zigbuild --locked
+```
+
+```bash
+brew install zig
+```
+
+Or install nothing and pass `--docker` to every `dev-push.sh` below, which needs only a running
+Docker daemon. That path is slower to start and is the one to reach for before you have a board at all —
+see [build in a container](#build-in-a-container-instead).
+
+## The loop
+
+```bash
+scripts/dev-push.sh radxa@192.168.1.42
+```
+
+Or name the board once per shell:
+
+```bash
+export DUCK_BOARD=radxa@192.168.1.42
+```
+
+```bash
+scripts/dev-push.sh
+```
+
+It cross-compiles the workspace, packages the same artifact a release does, signs it with the dev
+key, copies it to `/var/tmp/duck-sideload` on the board, and applies it there through
+`robotctl update apply --from`. Then it waits for the five daemons to report the new release:
+
+```
+==> building 0.5.1-dev.local.1763400000.g7fc1444 for the board (zigbuild)
+==> packaging
+==> signing with /Users/you/.duck-keys/team.dev.key
+==> copying to radxa@192.168.1.42:/var/tmp/duck-sideload
+==> applying on radxa@192.168.1.42
+==> 0.5.1-dev.local.1763400000.g7fc1444 is live on radxa@192.168.1.42
+==> checking every daemon is running it
+    current -> 0.5.1-dev.local.1763400000.g7fc1444
+    [ok] robotd
+    [ok] configd
+    [ok] padd
+    [ok] updaterd
+    [ok] btd
+==> every daemon on radxa@192.168.1.42 is running 0.5.1-dev.local.1763400000.g7fc1444
+```
+
+`updaterd` and `btd` restart five seconds after the apply replies, so those two lines take a moment
+to arrive. A `[--] padd published nothing` is not a failure — it is also what a stopped or
+deliberately disabled daemon looks like.
+
+On the board, that version is what `robotctl version` reports:
+
+```bash
+robotctl version
+```
+
+Two pushes of the same dirty tree never collide — the version carries the push's timestamp, not
+just the commit. The tree is expected to be dirty here.
+
+**This is an ordinary update.** The signature, the artifact hash, compatibility, the health gate
+and auto-rollback all run: a build that does not come up is reverted and the board is back on what
+it was running. Going back on purpose is the ordinary command too:
+
+```bash
+sudo robotctl update rollback daemon
+```
+
+## Watching what you just pushed
+
+From a second terminal, before the push, so the restart shows up in it:
+
+```bash
+ssh radxa@192.168.1.42 'journalctl -f -u robotd -u configd -u btd -u padd'
+```
+
+`-u updaterd` on its own is the update itself — each phase, the health gate, and the restarts it
+schedules:
+
+```bash
+ssh radxa@192.168.1.42 'journalctl -f -u updaterd'
+```
+
+A panic in a daemon lands there with a full backtrace: nothing is stripped from these binaries, so
+the frames have names.
+
+```bash
+ssh radxa@192.168.1.42 robotctl health
+```
+
+Whether the control loop is up, and which release each daemon is running.
+[`cheatsheet.md`](cheatsheet.md) has the rest of what to ask a robot.
+
+### More than `info`
+
+Each unit sets `RUST_LOG=info`. To see a daemon's `debug!` lines, override it with a drop-in — on
+the board, `robotd` here:
+
+```bash
+sudo mkdir -p /etc/systemd/system/robotd.service.d
+```
+
+```bash
+sudo tee /etc/systemd/system/robotd.service.d/log.conf > /dev/null <<'EOF'
+[Service]
+Environment=RUST_LOG=debug
+EOF
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart robotd
+```
+
+The drop-in lives in `/etc`, so it outlives every later push. Take it back off when you are done:
+
+```bash
+sudo rm /etc/systemd/system/robotd.service.d/log.conf
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart robotd
+```
+
+## Verify without installing
+
+```bash
+scripts/dev-push.sh --dry-run radxa@192.168.1.42
+```
+
+Builds, signs, copies, and then does everything the real apply does except the swap: signature,
+hash, compatibility, the extraction, and the check that no installed unit is left pointing at a
+binary this build does not contain. It stops before `current` moves, so the board keeps running what
+it was running and no daemon restarts.
+
+## Build in a container instead
+
+```bash
+scripts/dev-push.sh --docker radxa@192.168.1.42
+```
+
+No zig, no `cargo-zigbuild`, and no board to copy libudev from. On an Apple Silicon Mac the
+container's target is the host, so nothing is cross-compiled; on an x86 laptop it runs under
+emulation and the script says so. Same artifact, and `--dry-run` and `--bootstrap` work the same.
+
+The two modes keep separate `target/` directories, so switching between them costs one full
+rebuild. The default is faster day to day and is what CI uses.
+
+## Re-install what is already on the board
+
+The push leaves the artifact in `/var/tmp/duck-sideload`, so a board can install it again without
+building anything:
+
+```bash
+sudo robotctl update apply daemon --from /var/tmp/duck-sideload
+```
+
+The same command takes any directory holding a release — a USB stick, for instance. Each push
+replaces that directory rather than adding to it.
+
+## Compile for the board without a robot
+
+To check that a change builds for the target — the C-linked crates, the Linux-only paths — without
+a board in reach:
+
+```bash
+cargo board --bins
+```
+
+`cargo board` is `cargo zigbuild` with the board's target and glibc floor, defined in
+`.cargo/config.toml`. It needs the same zig toolchain as the default push, and `padd` needs the
+libudev copy that the first push fetches from a board. `--docker` needs neither.
+
+## The first push to a board below 0.5.0
+
+`apply --from` needs API version 7, which first ships in 0.5.0. A board running anything earlier
+has an `updaterd` that cannot be asked to use it, and refuses the call rather than quietly
+installing from its configured source instead. Deliver that release once the ungated way:
+
+```bash
+scripts/dev-push.sh --bootstrap radxa@192.168.1.42
+```
+
+That stops `robotd` and gives up the health gate for that one install. Every push after it is the
+ordinary command.
+
+## When it does not work
+
+**`no dev signing key at ...`** — the board verifies this artifact like any release, so it has to
+be signed. Get `team.dev.key` from a team member, or point `DUCK_DEV_SECRET_KEY` at it.
+
+**`cargo-zigbuild is not installed`** — install it and zig, or use `--docker`.
+
+**`no libudev.so.1 on <board>`** — the first push copies that library off the board to link `padd`
+against. A board that is not up yet cannot provide it; `--docker` does not need it.
+
+**Linker errors about libudev, after reflashing the board** — the copy is cached. Drop it and the
+next push fetches a fresh one:
+
+```bash
+rm -rf ~/.cache/duck-cross/aarch64
+```
+
+**`apply failed (exit 2)`, with `robotctl` and `updaterd` reporting an API mismatch** — the board's
+installed release predates `apply --from`. Use `--bootstrap` once.
+
+**`verification failed: signature did not verify against any of N usable trusted key(s)`** — reads
+like a corrupt release, and usually means the board is not a dev board: the dev key never landed, or
+`allow_dev_keys` is off, either of which leaves that key out of the usable set. On the board:
+
+```bash
+grep -c 'DEV BOARD' /var/lib/robot/provision.log
+```
+
+`0` means the key is missing; [`install-dev.md`](install-dev.md) has both halves of the fix.
+
+**ssh refuses to connect after a reflash** — the board regenerated its host keys.
+
+```bash
+./scripts/provision-board.sh radxa@192.168.1.42 --forget-host-key
+```
+
+**`the release is live but not everything is running it`** — the swap happened and the health gate
+passed, but a daemon is still on the old binary, which reads as a fix that did not work. The script
+names which ones. On the board:
+
+```bash
+robotctl health
+```
+
+The `units` block names the release each daemon is running.
+
+```bash
+journalctl -u updaterd -b | tail
+```
+
+Look for `restart scheduled`, or the reason there was none.
+
+```bash
+sudo systemctl restart updaterd
+```
+
+This should not have been necessary, so it is worth reading the journal for why it was.
+[`cheatsheet-dev.md`](cheatsheet-dev.md) has the restart traps in full, and
+[`../design/restart-order.md`](../design/restart-order.md) is the sequence step by step.
+
+## Settings
+
+| | |
+|---|---|
+| `DUCK_BOARD` | The board, instead of an argument. `radxa@192.168.1.42`. |
+| `DUCK_DEV_SECRET_KEY` | The dev signing key. Default `~/.duck-keys/team.dev.key`. |
+| `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `/var/tmp/duck-sideload`. |
+| `DUCK_CROSS_SYSROOT` | The cached libudev copy. Default `~/.cache/duck-cross/aarch64`. |
+
+## What this deliberately does not do
+
+Nothing a release does for provenance. The version carries a timestamp rather than a tag, the
+artifact is signed with a key customer robots refuse, and nothing is published — so nobody else can
+install what you just ran. Cutting a release is still a tag and `release.yml`
+([`../../README.md`](../../README.md)).

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -48,14 +48,14 @@ scripts/dev-push.sh
 ```
 
 It cross-compiles the workspace, packages the same artifact a release does, signs it with the dev
-key, copies it to `/var/tmp/duck-sideload` on the board, and applies it there through
+key, copies it to `~/duck-sideload` on the board, and applies it there through
 `robotctl update apply --from`. Then it waits for the five daemons to report the new release:
 
 ```
 ==> building 0.5.1-dev.local.1763400000.g7fc1444 for the board (zigbuild)
 ==> packaging
 ==> signing with /Users/you/.duck-keys/team.dev.key
-==> copying to radxa@192.168.1.42:/var/tmp/duck-sideload
+==> copying to radxa@192.168.1.42:/home/radxa/duck-sideload
 ==> applying on radxa@192.168.1.42
 ==> 0.5.1-dev.local.1763400000.g7fc1444 is live on radxa@192.168.1.42
 ==> checking every daemon is running it
@@ -170,11 +170,11 @@ rebuild. The default is faster day to day and is what CI uses.
 
 ## Re-install what is already on the board
 
-The push leaves the artifact in `/var/tmp/duck-sideload`, so a board can install it again without
+The push leaves the artifact in `~/duck-sideload` on the board, so it can be installed again without
 building anything:
 
 ```bash
-sudo robotctl update apply daemon --from /var/tmp/duck-sideload
+sudo robotctl update apply daemon --from ~/duck-sideload
 ```
 
 The same command takes any directory holding a release — a USB stick, for instance. Each push
@@ -226,6 +226,14 @@ rm -rf ~/.cache/duck-cross/aarch64
 **`apply failed (exit 2)`, with `robotctl` and `updaterd` reporting an API mismatch** — the board's
 installed release predates `apply --from`. Use `--bootstrap` once.
 
+**`preflight check failed: SideloadDir: ... is not there for updaterd`** — the release is under
+`/tmp` or `/var/tmp`, which happens if `DUCK_SIDELOAD_DIR` or a hand-written `--from` points there.
+`updaterd.service` sets `PrivateTmp=yes`, so the daemon has its own `/tmp` and `/var/tmp` and
+neither is the one your shell copied into. Any other path works; the default, `~/duck-sideload`,
+is one. On a board whose release predates that check, the same mistake reads as
+`no manifest for version <version> in <dir>` — for a directory whose `ls` lists exactly that
+manifest.
+
 **`verification failed: signature did not verify against any of N usable trusted key(s)`** — reads
 like a corrupt release, and usually means the board is not a dev board: the dev key never landed, or
 `allow_dev_keys` is off, either of which leaves that key out of the usable set. On the board:
@@ -272,7 +280,7 @@ This should not have been necessary, so it is worth reading the journal for why 
 |---|---|
 | `DUCK_BOARD` | The board, instead of an argument. `radxa@192.168.1.42`. |
 | `DUCK_DEV_SECRET_KEY` | The dev signing key. Default `~/.duck-keys/team.dev.key`. |
-| `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `/var/tmp/duck-sideload`. |
+| `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `~/duck-sideload` there. Never under `/tmp` or `/var/tmp`: `updaterd` has private copies of both and would read those. |
 | `DUCK_CROSS_SYSROOT` | The cached libudev copy. Default `~/.cache/duck-cross/aarch64`. |
 
 ## What this deliberately does not do

--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -177,8 +177,8 @@ daemon, with the health gate and auto-rollback:
 sudo robotctl update apply daemon --from /media/usb/release
 ```
 
-That is also what `scripts/dev-push.sh` ends with; the
-[dev board cheat sheet](cheatsheet-dev.md) has the laptop-to-board path.
+That is also what `scripts/dev-push.sh` ends with; [`dev-push.md`](dev-push.md) is the
+laptop-to-board path.
 
 The rest of this section is the **bare-board** case: a factory or offline install, before there is
 a daemon to ask. It is `updaterd` rather than `robotctl` for that reason, and `updaterd` is

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -416,6 +416,11 @@ enum UpdateCommand {
         /// robot's trusted set and `allow_dev_keys` is on, so a customer robot refuses it
         /// exactly as it refuses `--ref`.
         ///
+        /// **Not under /tmp or /var/tmp.** `updaterd.service` sets `PrivateTmp=yes`, so the
+        /// daemon that reads this directory has its own pair of those and neither is the one
+        /// a shell copied into. Preflight names that case rather than letting it surface as a
+        /// missing manifest in a directory the caller can plainly see.
+        ///
         /// `conflicts_with = "staging"` because a directory has no channels — the source
         /// layer says so too, and being told at parse time is better than after a connection.
         #[arg(long, value_name = "DIR", conflicts_with = "staging")]

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -38,9 +38,9 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-# Where the artifact lands on the board. World-writable parent, so no sudo to copy into it;
-# `updaterd` reads it as root.
-REMOTE_DIR="${DUCK_SIDELOAD_DIR:-/var/tmp/duck-sideload}"
+# Where the artifact lands on the board. Empty here and resolved after the board is known,
+# because the default is a path on *that* machine — see the block below the argument parsing.
+REMOTE_DIR="${DUCK_SIDELOAD_DIR:-}"
 
 # The secret half of `team.dev`, the same key `dev.yml` signs branch builds with. Named apart
 # from `DUCK_DEV_KEY`, which the provisioning scripts use for the *public* half.
@@ -70,6 +70,26 @@ if [ -z "$BOARD" ]; then
     echo "no board: pass one as an argument or set DUCK_BOARD" >&2
     echo "  scripts/dev-push.sh radxa@duck.local" >&2
     exit 2
+fi
+
+# ── where the artifact lands, and why it is not /var/tmp ───────────────────────────────
+#
+# The board user's home, not `/var/tmp/duck-sideload`, which is where this used to put it and
+# which cannot work: `updaterd.service` sets `PrivateTmp=yes`, so the unit gets a `/tmp` and a
+# `/var/tmp` of its own. The files land in the ones the shell sees, `updaterd` reads the ones the
+# namespace gave it, and `apply --from` fails with "no manifest for version ... in
+# /var/tmp/duck-sideload" against a directory whose `ls` lists that exact manifest. It cost an
+# afternoon to see, because every artifact was demonstrably where the error said it was not.
+#
+# The home directory has the property /var/tmp was picked for — writable by the ssh user, so no
+# sudo to copy into it — and is outside that namespace. `updaterd` sets no `ProtectHome=`, and
+# `xtask/tests/sideload.rs` fails if either half of that stops being true.
+#
+# Resolved on the board rather than written literally: `$HOME` here is this laptop's, and the
+# apply needs an absolute path because `updaterd`'s working directory is not the user's.
+if [ -z "$REMOTE_DIR" ]; then
+    REMOTE_DIR="$(ssh "$BOARD" 'echo "$HOME/duck-sideload"')"
+    [ -n "$REMOTE_DIR" ] || { echo "could not resolve a home directory on $BOARD" >&2; exit 1; }
 fi
 
 if [ "$DOCKER" = no ]; then

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -2,7 +2,8 @@
 # Build the daemon on this laptop and install it on a board, without CI.
 #
 # Usage:  scripts/dev-push.sh [--docker] [--dry-run] [--bootstrap] [user@host]
-#         DUCK_BOARD=radxa@duck.local scripts/dev-push.sh
+#         scripts/dev-push.sh --name duck-c51b       # find the board over Bluetooth
+#         DUCK_ROBOT=duck-c51b scripts/dev-push.sh
 #
 # Requires the team dev secret key, and one of two build toolchains — `cargo-zigbuild` plus
 # `zig`, or `--docker`. The board must be a dev board (`allow_dev_keys = true` and
@@ -49,15 +50,22 @@ KEY="${DUCK_DEV_SECRET_KEY:-$HOME/.duck-keys/team.dev.key}"
 BOOTSTRAP=no
 DRY_RUN=no
 DOCKER=no
-BOARD="${DUCK_BOARD:-}"
+# Both empty here and filled from the environment below, after the arguments have had their say.
+BOARD=""
+ROBOT=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --bootstrap) BOOTSTRAP=yes ;;
         --dry-run) DRY_RUN=yes ;;
         --docker) DOCKER=yes ;;
+        --name)
+            shift
+            [ $# -gt 0 ] || { echo "--name needs a robot name" >&2; exit 2; }
+            ROBOT="$1"
+            ;;
         -h|--help)
-            sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         -*) echo "unknown option: $1" >&2; exit 2 ;;
@@ -66,9 +74,127 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+# ── which board, and why a name beats an address ───────────────────────────────────────
+#
+# An address moves. A reflash, a router reboot or a different network hands the board a new
+# lease, and mDNS on this image is unreliable enough that a `.local` name is not the answer
+# either (`provision-board.sh` says the same). So the address is the one thing about a board
+# nobody can keep in a shell profile: `DUCK_BOARD=radxa@192.168.1.42` goes stale, and the way
+# that reads is a push that hangs until ssh times out.
+#
+# A robot's *name* does not move. `duck-btctl` finds it over BLE by that name and `net.status`
+# answers with the address it currently has — which makes the radio the way out of exactly the
+# situation the network cannot help with, and needs nothing on the LAN to be known or guessed.
+#
+# Cached, and re-resolved only when ssh cannot reach the cached address, because BLE discovery
+# costs ten to twenty seconds and this script exists to be quick. The steady state is one ssh
+# probe; the reflashed-board case pays one scan and is quick again after it.
+BOARD_USER="${DUCK_BOARD_USER:-radxa}"
+CACHE_DIR="${DUCK_BOARD_CACHE:-$HOME/.cache/duck/boards}"
+
+# The installed client if there is one, the example in this clone otherwise. `duck-btctl` is an
+# example rather than a binary, so it reaches a PATH only via `cargo install --path btd --example
+# duck-btctl`, and plenty of clones have never run that.
+btctl() {
+    if command -v duck-btctl >/dev/null 2>&1; then
+        duck-btctl "$@"
+    else
+        cargo run -q -p btd --example duck-btctl -- "$@"
+    fi
+}
+
+# `net.status` for one robot, JSON on stdout.
+#
+# Only `--name` is passed. A robot with a PIN of its own needs `DUCK_PIN`, which `duck-btctl`
+# reads for itself (`docs/robot/duck-btctl.md`) — repeating it here would be a second place to
+# keep in step, and passing its factory default unconditionally would override the real one.
+ble_status() {
+    btctl --name "$1" wifi status
+}
+
+# A robot name in, `user@address` out. Everything else goes to stderr, so the substitution that
+# calls this captures the address and nothing else.
+resolve_board() {
+    robot_name="$1"
+    # One file per robot, named after it, so two boards do not fight over one cache. Anything a
+    # filesystem would rather not see becomes `_`: a robot can be called `Ducky the Second`.
+    cache="$CACHE_DIR/$(printf '%s' "$robot_name" | tr -c 'A-Za-z0-9._-' '_')"
+    cached=""
+    if [ -f "$cache" ]; then
+        cached="$(cat "$cache")"
+        # `BatchMode=yes` so an unreachable board fails instead of prompting for a password, and
+        # a short timeout because this runs on the happy path of every push.
+        if [ -n "$cached" ] && ssh -o ConnectTimeout=4 -o BatchMode=yes \
+            "$BOARD_USER@$cached" true >/dev/null 2>&1; then
+            echo "$BOARD_USER@$cached"
+            return 0
+        fi
+    fi
+
+    echo "==> asking $robot_name over Bluetooth where it is" >&2
+    reply="$(ble_status "$robot_name")" || {
+        echo "could not reach $robot_name over Bluetooth" >&2
+        echo "  duck-btctl scan                                  # is it advertising?" >&2
+        echo "  scripts/dev-push.sh $BOARD_USER@<address>        # or say where it is" >&2
+        return 1
+    }
+    # An `error` reply is a robot that answered and refused — a wrong PIN, most often — which is a
+    # different problem from a robot with no address, and says so rather than being reported as one.
+    address="$(printf '%s' "$reply" | python3 -c 'import json, sys
+r = json.load(sys.stdin)
+e = r.get("error")
+if e: sys.exit("the robot refused net.status: %s" % (e.get("message") if isinstance(e, dict) else e))
+print((r.get("result") or {}).get("ip4") or "")')" || return 1
+
+    if [ -z "$address" ]; then
+        echo "$robot_name answered over Bluetooth but has no wifi address" >&2
+        echo "Join it to a network first — over the same radio, so this needs no ssh:" >&2
+        echo "  duck-btctl --name '$robot_name' wifi connect <ssid> --psk <passphrase>" >&2
+        return 1
+    fi
+
+    mkdir -p "$CACHE_DIR"
+    # The bare address, without the user: `DUCK_BOARD_USER` is this laptop's setting and may
+    # change between pushes, and a cache holding it would answer with yesterday's.
+    printf '%s\n' "$address" > "$cache"
+
+    if [ "$address" = "$cached" ]; then
+        # Worth saying rather than resolving silently: the address never moved, so whatever ssh
+        # is unhappy about is not the address. A reflashed board is the usual one — new host keys,
+        # same lease — and it looks identical to an unreachable board until someone says this.
+        echo "    still $address, which ssh could not reach — so the address is not the problem" >&2
+        echo "    a reflashed board has new host keys:" >&2
+        echo "      ./scripts/provision-board.sh $BOARD_USER@$address --forget-host-key" >&2
+    else
+        echo "    $robot_name is at $address" >&2
+    fi
+    echo "$BOARD_USER@$address"
+}
+
+# The command line beats the environment, and an address beats a name: an address needs no radio.
+# `DUCK_ROBOT` is the same variable `duck-btctl` defaults `--name` to, so one exported name serves
+# both tools — and empty means unset in both, so `DUCK_ROBOT= scripts/dev-push.sh radxa@…` works.
+# Not `DUCK_NAME`, which `provision.sh` reads and means the opposite way round: the name to *give*
+# a board, not which board to talk to.
+if [ -z "$BOARD" ] && [ -z "$ROBOT" ]; then
+    BOARD="${DUCK_BOARD:-}"
+    [ -n "$BOARD" ] || ROBOT="${DUCK_ROBOT:-}"
+fi
+
+if [ -n "$BOARD" ] && [ -n "$ROBOT" ]; then
+    echo "pass an address or --name, not both: they name the board two different ways" >&2
+    exit 2
+fi
+
+if [ -n "$ROBOT" ]; then
+    BOARD="$(resolve_board "$ROBOT")" || exit 1
+fi
+
 if [ -z "$BOARD" ]; then
-    echo "no board: pass one as an argument or set DUCK_BOARD" >&2
-    echo "  scripts/dev-push.sh radxa@duck.local" >&2
+    echo "no board: name one, or give its address" >&2
+    echo "  scripts/dev-push.sh --name duck-c51b        # found over Bluetooth" >&2
+    echo "  scripts/dev-push.sh radxa@192.168.1.42" >&2
+    echo "or set DUCK_ROBOT or DUCK_BOARD once per shell" >&2
     exit 2
 fi
 

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1733,6 +1733,7 @@ impl Engine {
             available_bytes: available,
             interrupt_sessions: options.interrupt_sessions,
             robot_query_timeout: ROBOT_QUERY_TIMEOUT,
+            from_dir: options.from_dir.as_deref(),
         }
         .run()
         .await?;

--- a/updater/src/preflight.rs
+++ b/updater/src/preflight.rs
@@ -33,6 +33,20 @@ pub enum Check {
     NoRemoteSession,
     /// Room for download + extract + retained releases.
     DiskSpace,
+    /// The `--from` directory is one *this process* can read.
+    ///
+    /// `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and**
+    /// its own `/var/tmp`. A release copied to either from a shell — the obvious place to put
+    /// one, and where `scripts/dev-push.sh` used to put it — is therefore not the one this
+    /// process sees, and every message downstream is a lie: "no manifest for version X in
+    /// /var/tmp/duck-sideload", against a directory whose `ls` shows that exact manifest, its
+    /// signature and the artifact. Nothing in that output points at the namespace, and the
+    /// caller has done nothing wrong.
+    ///
+    /// So it is a named check rather than a better error message further down: it fails before
+    /// any lookup, it says which mount namespace is responsible, and a board that does not
+    /// privatise `/var/tmp` passes it without noticing it exists.
+    SideloadDir,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +80,9 @@ pub struct Preflight<'a> {
     /// Skip only the remote-session check. Never affects verification.
     pub interrupt_sessions: bool,
     pub robot_query_timeout: Duration,
+    /// The directory `apply --from <dir>` was pointed at, if any. `None` for every other
+    /// target, which reads its manifest from the configured source instead.
+    pub from_dir: Option<&'a std::path::Path>,
 }
 
 /// Clock floor: a system time before this cannot be right, and TLS would fail
@@ -87,6 +104,7 @@ impl Preflight<'_> {
 
         results.push(self.check_clock());
         results.push(self.check_disk());
+        results.push(self.check_sideload_dir());
         results.push(self.check_robot_stopped().await);
         results.push(self.check_no_remote_session().await);
 
@@ -117,6 +135,49 @@ impl Preflight<'_> {
                     "needs {} bytes free, only {} available",
                     self.required_bytes, self.available_bytes
                 )
+            }),
+        }
+    }
+
+    /// Whether `--from <dir>` names a directory this process can see.
+    ///
+    /// Two failures, and they need different sentences. A path under `/tmp` or `/var/tmp` is
+    /// almost certainly there for the caller and hidden from here by `PrivateTmp=yes`
+    /// ([`Check::SideloadDir`]), so the message names the namespace and where to put the
+    /// release instead. Anywhere else, a missing directory is a missing directory.
+    ///
+    /// `exists()` and not a permission check: this runs as root, which reads any path it can
+    /// reach, so what remains is reachability.
+    fn check_sideload_dir(&self) -> CheckResult {
+        let Some(dir) = self.from_dir else {
+            return CheckResult {
+                check: Check::SideloadDir,
+                passed: true,
+                detail: None,
+            };
+        };
+        if dir.exists() {
+            return CheckResult {
+                check: Check::SideloadDir,
+                passed: true,
+                detail: None,
+            };
+        }
+
+        let private = dir.starts_with("/tmp") || dir.starts_with("/var/tmp");
+        CheckResult {
+            check: Check::SideloadDir,
+            passed: false,
+            detail: Some(if private {
+                format!(
+                    "{} is not there for updaterd, whichever shell created it: this unit runs \
+                     with PrivateTmp=yes, so it has a /tmp and a /var/tmp of its own and neither \
+                     is the one you copied into. The release is fine — put it anywhere outside \
+                     those two (a home directory, or /var/lib) and install from there.",
+                    dir.display()
+                )
+            } else {
+                format!("{} does not exist", dir.display())
             }),
         }
     }
@@ -172,6 +233,8 @@ impl Preflight<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
     use crate::robot::{AbsentRobot, Health, RobotClient};
 
@@ -206,6 +269,7 @@ mod tests {
             available_bytes: available,
             interrupt_sessions: false,
             robot_query_timeout: Duration::from_millis(50),
+            from_dir: None,
         }
     }
 
@@ -228,6 +292,65 @@ mod tests {
         let report = preflight(&robot, 5_000, 1_000).run().await.unwrap();
         assert!(!report.passed());
         assert_eq!(report.first_failure().unwrap().check, Check::DiskSpace);
+    }
+
+    /// The failure a `PrivateTmp=yes` unit gives for a directory the caller can see, and the
+    /// reason this check exists at all: without it the first error is "no manifest for version X
+    /// in /var/tmp/duck-sideload", which is unfalsifiable from a shell where `ls` lists the
+    /// manifest. The namespace has to be named, or there is nothing to act on.
+    #[tokio::test]
+    async fn a_sideload_dir_under_var_tmp_names_the_namespace() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let mut pf = preflight(&robot, 0, 1_000);
+        let dir = Path::new("/var/tmp/duck-sideload-does-not-exist");
+        pf.from_dir = Some(dir);
+
+        let report = pf.run().await.unwrap();
+        let failure = report.first_failure().expect("an invisible dir must fail");
+        assert_eq!(failure.check, Check::SideloadDir);
+        let detail = failure.detail.as_deref().unwrap_or_default();
+        assert!(detail.contains("PrivateTmp=yes"), "{detail}");
+        assert!(detail.contains("duck-sideload-does-not-exist"), "{detail}");
+    }
+
+    /// Outside `/tmp`, the same missing directory is just missing — telling someone about mount
+    /// namespaces when they typo'd a path sends them after the wrong thing.
+    #[tokio::test]
+    async fn a_missing_dir_elsewhere_is_reported_plainly() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let mut pf = preflight(&robot, 0, 1_000);
+        pf.from_dir = Some(Path::new("/var/lib/robot/no-such-sideload"));
+
+        let report = pf.run().await.unwrap();
+        let failure = report.first_failure().expect("a missing dir must fail");
+        assert_eq!(failure.check, Check::SideloadDir);
+        let detail = failure.detail.as_deref().unwrap_or_default();
+        assert!(!detail.contains("PrivateTmp"), "{detail}");
+        assert!(detail.contains("does not exist"), "{detail}");
+    }
+
+    /// A directory that is there passes, including one under `/var/tmp`: this check is about
+    /// what the process can read, not about a policy on where a release may live. `updaterd`
+    /// running as a CLI (`updaterd install --from`) is outside the unit's namespace and sees
+    /// `/var/tmp` normally — refusing it there would break the bootstrap path.
+    #[tokio::test]
+    async fn a_visible_dir_passes_wherever_it_is() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let mut pf = preflight(&robot, 0, 1_000);
+        pf.from_dir = Some(dir.path());
+
+        let report = pf.run().await.unwrap();
+        assert!(report.passed(), "{:?}", report.first_failure());
     }
 
     #[tokio::test]

--- a/xtask/tests/sideload.rs
+++ b/xtask/tests/sideload.rs
@@ -1,0 +1,116 @@
+//! The sideload directory and the unit that has to read it, checked against each other.
+//!
+//! `scripts/dev-push.sh` copies a release onto the board and `updaterd` installs it. Those two
+//! agree about the path by convention, and one of the ways they can disagree is invisible from
+//! either side alone: `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own
+//! `/tmp` **and** its own `/var/tmp`, so a directory under either is not the one the daemon reads.
+//! The push succeeds, every file is demonstrably in place, and the apply fails with "no manifest
+//! for version ... in /var/tmp/duck-sideload" — a sentence that cannot be reconciled with `ls`.
+//!
+//! `updater/src/preflight.rs` makes that failure say so when it happens. This file is the other
+//! half: the default path must not be one the unit hides in the first place. Neither file can
+//! check it — the script does not read the unit, the unit does not know the script — so it is
+//! checked here, where the whole repository is readable.
+
+use std::path::{Path, PathBuf};
+
+const SCRIPT: &str = "scripts/dev-push.sh";
+const UNIT: &str = "updater/systemd/updaterd.service";
+
+/// Paths a `PrivateTmp=yes` unit gets a private copy of, and therefore cannot be sideloaded from.
+const PRIVATE: [&str; 2] = ["/tmp/", "/var/tmp/"];
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask/ has a parent")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    std::fs::read_to_string(root().join(rel)).unwrap_or_else(|e| panic!("{rel}: {e}"))
+}
+
+/// The file with `#` comments removed, so an explanation of why a path is *not* used does not
+/// read as a use of it — the reason for that comment is the bug this file exists to hold shut.
+///
+/// Cuts at the first `#`, which is wrong for a `#` inside quotes. The only such line here is a
+/// `sed` expression with no path in it, and a mangled line can at worst hide a match, which the
+/// assertions below would report as a pass — so the failure mode is a weaker test, never a false
+/// alarm.
+fn code(text: &str) -> String {
+    text.lines()
+        .map(|l| l.split_once('#').map_or(l, |(before, _)| before))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A `KEY=VALUE` directive from a unit file, last assignment winning as systemd does.
+fn directive(unit: &str, key: &str) -> Option<String> {
+    unit.lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#'))
+        .filter_map(|l| l.split_once('='))
+        .filter(|(k, _)| k.trim() == key)
+        .map(|(_, v)| v.trim().to_owned())
+        .next_back()
+}
+
+fn privatises_tmp() -> bool {
+    matches!(
+        directive(&read(UNIT), "PrivateTmp").as_deref(),
+        Some("yes" | "true" | "on" | "1")
+    )
+}
+
+/// The push must not put a release where the daemon cannot see it.
+#[test]
+fn the_sideload_path_is_not_one_private_tmp_hides() {
+    if !privatises_tmp() {
+        return;
+    }
+
+    let script = code(&read(SCRIPT));
+    for hidden in PRIVATE {
+        assert!(
+            !script.contains(hidden),
+            "{SCRIPT} names {hidden} while {UNIT} sets PrivateTmp=yes, so `updaterd` would read \
+             its own copy of that directory and find nothing there. Either put the release \
+             somewhere outside {PRIVATE:?}, or drop PrivateTmp from the unit."
+        );
+    }
+}
+
+/// And the home directory it uses instead has to stay reachable.
+///
+/// `ProtectHome=` would hide it exactly as `PrivateTmp=` hides `/var/tmp` — same failure, same
+/// unreadable error, and adding one line of hardening to the unit is all it would take.
+#[test]
+fn a_home_sideload_path_requires_no_protect_home() {
+    let script = code(&read(SCRIPT));
+    if !script.contains("$HOME/duck-sideload") {
+        return;
+    }
+
+    match directive(&read(UNIT), "ProtectHome").as_deref() {
+        None | Some("no" | "false" | "off" | "0") => {}
+        Some(other) => panic!(
+            "{UNIT} sets ProtectHome={other}, and {SCRIPT} sideloads from a home directory — \
+             `updaterd` cannot read it, and `apply --from` will fail with a path that is \
+             plainly there. Move the sideload directory, or leave ProtectHome unset."
+        ),
+    }
+}
+
+/// The whole reason the path moved: the daemon reads it, so it has to exist for the daemon.
+///
+/// Named here rather than left implicit because both tests above are conditional, and a
+/// conditional test that stops applying is indistinguishable from one that passes.
+#[test]
+fn the_unit_still_privatises_tmp_or_this_file_is_moot() {
+    assert!(
+        privatises_tmp() || code(&read(SCRIPT)).contains("$HOME/duck-sideload"),
+        "{UNIT} no longer sets PrivateTmp=yes and {SCRIPT} no longer sideloads from a home \
+         directory: nothing above is asserting anything. Delete this file, or restore one half."
+    );
+}


### PR DESCRIPTION
Building on your own machine and installing directly on the board is the loop a developer runs dozens of times a day. It did not work, and where it was documented made that hard to see.

## The push sideloads where `updaterd` can read it

`scripts/dev-push.sh` copied the release to `/var/tmp/duck-sideload`. `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and** its own `/var/tmp` — so the files landed in the pair the shell sees, and the daemon read the pair the namespace gave it:

```
==> copying to pierre@192.168.50.63:/var/tmp/duck-sideload
==> applying on pierre@192.168.50.63
  Preflight
error: network error: no manifest for version 0.5.1-dev.local.1786973040.g7fc1444 in /var/tmp/duck-sideload
```

`ls` on that directory lists exactly that manifest, its `.minisig`, the artifact and its `.minisig`. There is nothing in the error to act on, and nothing in the repo's tests to catch it: they point `LocalDir` at a fixture root, where no namespace applies.

**The push now sideloads from the board user's home**, resolved on the board (`$HOME` on a laptop is the laptop's). It keeps the one property `/var/tmp` was picked for — writable by the ssh user, so no sudo to copy into it — and is outside the unit's namespace. `updaterd` sets no `ProtectHome=`.

**Preflight gains `Check::SideloadDir`.** A `--from` directory this process cannot see now fails before any manifest lookup, and under `/tmp` or `/var/tmp` the message names the cause:

```
error: preflight check failed: SideloadDir: /var/tmp/duck-sideload is not there for updaterd,
whichever shell created it: this unit runs with PrivateTmp=yes, so it has a /tmp and a /var/tmp
of its own and neither is the one you copied into. The release is fine — put it anywhere outside
those two (a home directory, or /var/lib) and install from there.
```

A missing directory anywhere else stays a plain "does not exist" — mount namespaces are the wrong thing to send someone after when they typo'd a path. A board that does not privatise `/var/tmp` passes the check without noticing it exists, and `updaterd install --from` (the `--bootstrap` path, a root CLI process outside the namespace) is unaffected.

**`xtask/tests/sideload.rs`** holds the script and the unit against each other: the script may not name a path the unit hides, and while it sideloads from a home directory the unit may not set `ProtectHome=`. Neither file can check that on its own — the script does not read the unit, the unit does not know the script. A third test fails if both halves stop applying, so the file cannot go quietly vacuous.

## The loop has its own page

It lived as a section inside `cheatsheet-dev.md`, between the `--ref` commands and the restart traps. `docs/robot/dev-push.md` is now its own page, covering, in the order you hit it:

- the three one-time things — dev board, dev key, a toolchain (or `--docker` and none)
- the loop itself, with the output it actually prints and what each `[ok]` line means
- **watching what you just pushed** — the journal for the daemons and for the update, and the drop-in that raises one daemon to `RUST_LOG=debug`
- `--dry-run`, the container build, re-installing from the sideload directory, `cargo board --bins` with no robot in reach
- `--bootstrap`, for the first push to a board below 0.5.0
- one section per failure, keyed on the message you see: missing key, missing zigbuild, missing libudev, a stale libudev cache after a reflash, exit 2 on an API mismatch, a sideload directory `updaterd` cannot see, `signature did not verify against any of N usable trusted key(s)`, a changed ssh host key, and a daemon that did not restart
- the env vars it reads, and what it deliberately does not do that a release does

`cheatsheet-dev.md` keeps one command and a link. `README.md`, `CONTRIBUTING.md`, `install-dev.md` and the docs index now point at the new page instead of at the cheat sheet.

## The board is named, not addressed

`DUCK_BOARD=radxa@192.168.1.42` is the one setting about a board nobody can keep in a shell profile. A reflash, a router reboot or a different network hands it a new lease, and mDNS on this image is unreliable enough that a `.local` name is not the answer either. It reads as a push that hangs until ssh gives up.

A name does not move:

```bash
export DUCK_ROBOT=leduckpierre
scripts/dev-push.sh
```

```
==> asking leduckpierre over Bluetooth where it is
    leduckpierre is at 192.168.50.63
==> building 0.5.1-dev.local.1787044616.g8c16186 for the board (zigbuild)
```

`DUCK_ROBOT` is the variable `duck-btctl` already defaults `--name` to (#98), so one exported name serves both tools, and `DUCK_PIN` reaches the probe through that tool rather than being read twice. The address comes from the robot's own `net.status` over BLE — the channel that works precisely when the network does not, and the same fallback `provision-board.sh` races against ssh (#97).

Cached in `~/.cache/duck/boards`, and re-resolved only when ssh cannot reach the cached address: the steady state is one 4-second-budget ssh probe, and a board that moved pays one scan before being quick again.

Each failure is a different next move, so each says which one it was — a robot that is not advertising, one that answered but is on no network (joinable over the same radio, no ssh needed), one that refused `net.status`, which is a PIN and not an address. Re-resolving to the address ssh just failed on says that too, since the address is then not the problem and a reflashed board with new host keys looks identical until somebody says so.

An address still wins over a name and skips the radio entirely, so nothing that worked before changes. `DUCK_BOARD_USER` covers a board whose ssh user is not `radxa`.

## Notes

- No IPC change and no `API_VERSION` bump: `preflight::Check` is internal, reported through the existing `Error::Preflight`.
- Verified: `cargo test -p updater` (283), `-p xtask`, `-p robotctl` green; `shellcheck scripts/dev-push.sh` clean; the guard test confirmed failing when the default is put back under `/var/tmp`.
- Verified on the board: a push applied, and `robotctl health` reported the pushed release under `daemon` and under all five units.
- The name path was exercised against stubbed `ssh` and `duck-btctl` — cold cache, warm cache, an address ssh cannot reach, a robot on no network, a refused `net.status`, neither name nor address, and both at once — not yet against a robot whose address moved for real.

