### PR TITLE
dev-push: sideload from a directory updaterd can actually read

### DIFF
--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -996,6 +996,12 @@ Cheap additions that slot into the same IPC / engine and pay off:
   `--version` — an operator naming a directory is not a mirror that has gone
   backwards, and a local build is a prerelease that sorts below whatever the board is
   running, so guarding it would refuse every push.
+  One constraint on the directory, and it is systemd's rather than the engine's:
+  `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and**
+  its own `/var/tmp`, so a release copied to either from a shell is not the one the
+  daemon reads. That is why the sideload directory lives in the board user's home and
+  why `Check::SideloadDir` exists — without it the failure is a missing manifest in a
+  directory whose `ls` lists it, which is unfalsifiable from the outside.
 - **BLE provisioning security.** Adjacent but important: wifi credentials pass
   over BLE during setup. That characteristic must be paired + encrypted, or it's
   a credential leak. Update artifacts are signed so a spoofed *trigger* is

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -48,14 +48,14 @@ scripts/dev-push.sh
 ```
 
 It cross-compiles the workspace, packages the same artifact a release does, signs it with the dev
-key, copies it to `/var/tmp/duck-sideload` on the board, and applies it there through
+key, copies it to `~/duck-sideload` on the board, and applies it there through
 `robotctl update apply --from`. Then it waits for the five daemons to report the new release:
 
 ```
 ==> building 0.5.1-dev.local.1763400000.g7fc1444 for the board (zigbuild)
 ==> packaging
 ==> signing with /Users/you/.duck-keys/team.dev.key
-==> copying to radxa@192.168.1.42:/var/tmp/duck-sideload
+==> copying to radxa@192.168.1.42:/home/radxa/duck-sideload
 ==> applying on radxa@192.168.1.42
 ==> 0.5.1-dev.local.1763400000.g7fc1444 is live on radxa@192.168.1.42
 ==> checking every daemon is running it
@@ -170,11 +170,11 @@ rebuild. The default is faster day to day and is what CI uses.
 
 ## Re-install what is already on the board
 
-The push leaves the artifact in `/var/tmp/duck-sideload`, so a board can install it again without
+The push leaves the artifact in `~/duck-sideload` on the board, so it can be installed again without
 building anything:
 
 ```bash
-sudo robotctl update apply daemon --from /var/tmp/duck-sideload
+sudo robotctl update apply daemon --from ~/duck-sideload
 ```
 
 The same command takes any directory holding a release — a USB stick, for instance. Each push
@@ -226,6 +226,14 @@ rm -rf ~/.cache/duck-cross/aarch64
 **`apply failed (exit 2)`, with `robotctl` and `updaterd` reporting an API mismatch** — the board's
 installed release predates `apply --from`. Use `--bootstrap` once.
 
+**`preflight check failed: SideloadDir: ... is not there for updaterd`** — the release is under
+`/tmp` or `/var/tmp`, which happens if `DUCK_SIDELOAD_DIR` or a hand-written `--from` points there.
+`updaterd.service` sets `PrivateTmp=yes`, so the daemon has its own `/tmp` and `/var/tmp` and
+neither is the one your shell copied into. Any other path works; the default, `~/duck-sideload`,
+is one. On a board whose release predates that check, the same mistake reads as
+`no manifest for version <version> in <dir>` — for a directory whose `ls` lists exactly that
+manifest.
+
 **`verification failed: signature did not verify against any of N usable trusted key(s)`** — reads
 like a corrupt release, and usually means the board is not a dev board: the dev key never landed, or
 `allow_dev_keys` is off, either of which leaves that key out of the usable set. On the board:
@@ -272,7 +280,7 @@ This should not have been necessary, so it is worth reading the journal for why 
 |---|---|
 | `DUCK_BOARD` | The board, instead of an argument. `radxa@192.168.1.42`. |
 | `DUCK_DEV_SECRET_KEY` | The dev signing key. Default `~/.duck-keys/team.dev.key`. |
-| `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `/var/tmp/duck-sideload`. |
+| `DUCK_SIDELOAD_DIR` | Where the artifact lands on the board. Default `~/duck-sideload` there. Never under `/tmp` or `/var/tmp`: `updaterd` has private copies of both and would read those. |
 | `DUCK_CROSS_SYSROOT` | The cached libudev copy. Default `~/.cache/duck-cross/aarch64`. |
 
 ## What this deliberately does not do

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -416,6 +416,11 @@ enum UpdateCommand {
         /// robot's trusted set and `allow_dev_keys` is on, so a customer robot refuses it
         /// exactly as it refuses `--ref`.
         ///
+        /// **Not under /tmp or /var/tmp.** `updaterd.service` sets `PrivateTmp=yes`, so the
+        /// daemon that reads this directory has its own pair of those and neither is the one
+        /// a shell copied into. Preflight names that case rather than letting it surface as a
+        /// missing manifest in a directory the caller can plainly see.
+        ///
         /// `conflicts_with = "staging"` because a directory has no channels — the source
         /// layer says so too, and being told at parse time is better than after a connection.
         #[arg(long, value_name = "DIR", conflicts_with = "staging")]

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -38,9 +38,9 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-# Where the artifact lands on the board. World-writable parent, so no sudo to copy into it;
-# `updaterd` reads it as root.
-REMOTE_DIR="${DUCK_SIDELOAD_DIR:-/var/tmp/duck-sideload}"
+# Where the artifact lands on the board. Empty here and resolved after the board is known,
+# because the default is a path on *that* machine — see the block below the argument parsing.
+REMOTE_DIR="${DUCK_SIDELOAD_DIR:-}"
 
 # The secret half of `team.dev`, the same key `dev.yml` signs branch builds with. Named apart
 # from `DUCK_DEV_KEY`, which the provisioning scripts use for the *public* half.
@@ -70,6 +70,26 @@ if [ -z "$BOARD" ]; then
     echo "no board: pass one as an argument or set DUCK_BOARD" >&2
     echo "  scripts/dev-push.sh radxa@duck.local" >&2
     exit 2
+fi
+
+# ── where the artifact lands, and why it is not /var/tmp ───────────────────────────────
+#
+# The board user's home, not `/var/tmp/duck-sideload`, which is where this used to put it and
+# which cannot work: `updaterd.service` sets `PrivateTmp=yes`, so the unit gets a `/tmp` and a
+# `/var/tmp` of its own. The files land in the ones the shell sees, `updaterd` reads the ones the
+# namespace gave it, and `apply --from` fails with "no manifest for version ... in
+# /var/tmp/duck-sideload" against a directory whose `ls` lists that exact manifest. It cost an
+# afternoon to see, because every artifact was demonstrably where the error said it was not.
+#
+# The home directory has the property /var/tmp was picked for — writable by the ssh user, so no
+# sudo to copy into it — and is outside that namespace. `updaterd` sets no `ProtectHome=`, and
+# `xtask/tests/sideload.rs` fails if either half of that stops being true.
+#
+# Resolved on the board rather than written literally: `$HOME` here is this laptop's, and the
+# apply needs an absolute path because `updaterd`'s working directory is not the user's.
+if [ -z "$REMOTE_DIR" ]; then
+    REMOTE_DIR="$(ssh "$BOARD" 'echo "$HOME/duck-sideload"')"
+    [ -n "$REMOTE_DIR" ] || { echo "could not resolve a home directory on $BOARD" >&2; exit 1; }
 fi
 
 if [ "$DOCKER" = no ]; then

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1733,6 +1733,7 @@ impl Engine {
             available_bytes: available,
             interrupt_sessions: options.interrupt_sessions,
             robot_query_timeout: ROBOT_QUERY_TIMEOUT,
+            from_dir: options.from_dir.as_deref(),
         }
         .run()
         .await?;

--- a/updater/src/preflight.rs
+++ b/updater/src/preflight.rs
@@ -33,6 +33,20 @@ pub enum Check {
     NoRemoteSession,
     /// Room for download + extract + retained releases.
     DiskSpace,
+    /// The `--from` directory is one *this process* can read.
+    ///
+    /// `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and**
+    /// its own `/var/tmp`. A release copied to either from a shell — the obvious place to put
+    /// one, and where `scripts/dev-push.sh` used to put it — is therefore not the one this
+    /// process sees, and every message downstream is a lie: "no manifest for version X in
+    /// /var/tmp/duck-sideload", against a directory whose `ls` shows that exact manifest, its
+    /// signature and the artifact. Nothing in that output points at the namespace, and the
+    /// caller has done nothing wrong.
+    ///
+    /// So it is a named check rather than a better error message further down: it fails before
+    /// any lookup, it says which mount namespace is responsible, and a board that does not
+    /// privatise `/var/tmp` passes it without noticing it exists.
+    SideloadDir,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +80,9 @@ pub struct Preflight<'a> {
     /// Skip only the remote-session check. Never affects verification.
     pub interrupt_sessions: bool,
     pub robot_query_timeout: Duration,
+    /// The directory `apply --from <dir>` was pointed at, if any. `None` for every other
+    /// target, which reads its manifest from the configured source instead.
+    pub from_dir: Option<&'a std::path::Path>,
 }
 
 /// Clock floor: a system time before this cannot be right, and TLS would fail
@@ -87,6 +104,7 @@ impl Preflight<'_> {
 
         results.push(self.check_clock());
         results.push(self.check_disk());
+        results.push(self.check_sideload_dir());
         results.push(self.check_robot_stopped().await);
         results.push(self.check_no_remote_session().await);
 
@@ -117,6 +135,49 @@ impl Preflight<'_> {
                     "needs {} bytes free, only {} available",
                     self.required_bytes, self.available_bytes
                 )
+            }),
+        }
+    }
+
+    /// Whether `--from <dir>` names a directory this process can see.
+    ///
+    /// Two failures, and they need different sentences. A path under `/tmp` or `/var/tmp` is
+    /// almost certainly there for the caller and hidden from here by `PrivateTmp=yes`
+    /// ([`Check::SideloadDir`]), so the message names the namespace and where to put the
+    /// release instead. Anywhere else, a missing directory is a missing directory.
+    ///
+    /// `exists()` and not a permission check: this runs as root, which reads any path it can
+    /// reach, so what remains is reachability.
+    fn check_sideload_dir(&self) -> CheckResult {
+        let Some(dir) = self.from_dir else {
+            return CheckResult {
+                check: Check::SideloadDir,
+                passed: true,
+                detail: None,
+            };
+        };
+        if dir.exists() {
+            return CheckResult {
+                check: Check::SideloadDir,
+                passed: true,
+                detail: None,
+            };
+        }
+
+        let private = dir.starts_with("/tmp") || dir.starts_with("/var/tmp");
+        CheckResult {
+            check: Check::SideloadDir,
+            passed: false,
+            detail: Some(if private {
+                format!(
+                    "{} is not there for updaterd, whichever shell created it: this unit runs \
+                     with PrivateTmp=yes, so it has a /tmp and a /var/tmp of its own and neither \
+                     is the one you copied into. The release is fine — put it anywhere outside \
+                     those two (a home directory, or /var/lib) and install from there.",
+                    dir.display()
+                )
+            } else {
+                format!("{} does not exist", dir.display())
             }),
         }
     }
@@ -172,6 +233,8 @@ impl Preflight<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
     use crate::robot::{AbsentRobot, Health, RobotClient};
 
@@ -206,6 +269,7 @@ mod tests {
             available_bytes: available,
             interrupt_sessions: false,
             robot_query_timeout: Duration::from_millis(50),
+            from_dir: None,
         }
     }
 
@@ -228,6 +292,65 @@ mod tests {
         let report = preflight(&robot, 5_000, 1_000).run().await.unwrap();
         assert!(!report.passed());
         assert_eq!(report.first_failure().unwrap().check, Check::DiskSpace);
+    }
+
+    /// The failure a `PrivateTmp=yes` unit gives for a directory the caller can see, and the
+    /// reason this check exists at all: without it the first error is "no manifest for version X
+    /// in /var/tmp/duck-sideload", which is unfalsifiable from a shell where `ls` lists the
+    /// manifest. The namespace has to be named, or there is nothing to act on.
+    #[tokio::test]
+    async fn a_sideload_dir_under_var_tmp_names_the_namespace() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let mut pf = preflight(&robot, 0, 1_000);
+        let dir = Path::new("/var/tmp/duck-sideload-does-not-exist");
+        pf.from_dir = Some(dir);
+
+        let report = pf.run().await.unwrap();
+        let failure = report.first_failure().expect("an invisible dir must fail");
+        assert_eq!(failure.check, Check::SideloadDir);
+        let detail = failure.detail.as_deref().unwrap_or_default();
+        assert!(detail.contains("PrivateTmp=yes"), "{detail}");
+        assert!(detail.contains("duck-sideload-does-not-exist"), "{detail}");
+    }
+
+    /// Outside `/tmp`, the same missing directory is just missing — telling someone about mount
+    /// namespaces when they typo'd a path sends them after the wrong thing.
+    #[tokio::test]
+    async fn a_missing_dir_elsewhere_is_reported_plainly() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let mut pf = preflight(&robot, 0, 1_000);
+        pf.from_dir = Some(Path::new("/var/lib/robot/no-such-sideload"));
+
+        let report = pf.run().await.unwrap();
+        let failure = report.first_failure().expect("a missing dir must fail");
+        assert_eq!(failure.check, Check::SideloadDir);
+        let detail = failure.detail.as_deref().unwrap_or_default();
+        assert!(!detail.contains("PrivateTmp"), "{detail}");
+        assert!(detail.contains("does not exist"), "{detail}");
+    }
+
+    /// A directory that is there passes, including one under `/var/tmp`: this check is about
+    /// what the process can read, not about a policy on where a release may live. `updaterd`
+    /// running as a CLI (`updaterd install --from`) is outside the unit's namespace and sees
+    /// `/var/tmp` normally — refusing it there would break the bootstrap path.
+    #[tokio::test]
+    async fn a_visible_dir_passes_wherever_it_is() {
+        let robot = FakeRobot {
+            safe: SafeToRestart::Yes,
+            session: false,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let mut pf = preflight(&robot, 0, 1_000);
+        pf.from_dir = Some(dir.path());
+
+        let report = pf.run().await.unwrap();
+        assert!(report.passed(), "{:?}", report.first_failure());
     }
 
     #[tokio::test]

--- a/xtask/tests/sideload.rs
+++ b/xtask/tests/sideload.rs
@@ -1,0 +1,116 @@
+//! The sideload directory and the unit that has to read it, checked against each other.
+//!
+//! `scripts/dev-push.sh` copies a release onto the board and `updaterd` installs it. Those two
+//! agree about the path by convention, and one of the ways they can disagree is invisible from
+//! either side alone: `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own
+//! `/tmp` **and** its own `/var/tmp`, so a directory under either is not the one the daemon reads.
+//! The push succeeds, every file is demonstrably in place, and the apply fails with "no manifest
+//! for version ... in /var/tmp/duck-sideload" — a sentence that cannot be reconciled with `ls`.
+//!
+//! `updater/src/preflight.rs` makes that failure say so when it happens. This file is the other
+//! half: the default path must not be one the unit hides in the first place. Neither file can
+//! check it — the script does not read the unit, the unit does not know the script — so it is
+//! checked here, where the whole repository is readable.
+
+use std::path::{Path, PathBuf};
+
+const SCRIPT: &str = "scripts/dev-push.sh";
+const UNIT: &str = "updater/systemd/updaterd.service";
+
+/// Paths a `PrivateTmp=yes` unit gets a private copy of, and therefore cannot be sideloaded from.
+const PRIVATE: [&str; 2] = ["/tmp/", "/var/tmp/"];
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask/ has a parent")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    std::fs::read_to_string(root().join(rel)).unwrap_or_else(|e| panic!("{rel}: {e}"))
+}
+
+/// The file with `#` comments removed, so an explanation of why a path is *not* used does not
+/// read as a use of it — the reason for that comment is the bug this file exists to hold shut.
+///
+/// Cuts at the first `#`, which is wrong for a `#` inside quotes. The only such line here is a
+/// `sed` expression with no path in it, and a mangled line can at worst hide a match, which the
+/// assertions below would report as a pass — so the failure mode is a weaker test, never a false
+/// alarm.
+fn code(text: &str) -> String {
+    text.lines()
+        .map(|l| l.split_once('#').map_or(l, |(before, _)| before))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A `KEY=VALUE` directive from a unit file, last assignment winning as systemd does.
+fn directive(unit: &str, key: &str) -> Option<String> {
+    unit.lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#'))
+        .filter_map(|l| l.split_once('='))
+        .filter(|(k, _)| k.trim() == key)
+        .map(|(_, v)| v.trim().to_owned())
+        .next_back()
+}
+
+fn privatises_tmp() -> bool {
+    matches!(
+        directive(&read(UNIT), "PrivateTmp").as_deref(),
+        Some("yes" | "true" | "on" | "1")
+    )
+}
+
+/// The push must not put a release where the daemon cannot see it.
+#[test]
+fn the_sideload_path_is_not_one_private_tmp_hides() {
+    if !privatises_tmp() {
+        return;
+    }
+
+    let script = code(&read(SCRIPT));
+    for hidden in PRIVATE {
+        assert!(
+            !script.contains(hidden),
+            "{SCRIPT} names {hidden} while {UNIT} sets PrivateTmp=yes, so `updaterd` would read \
+             its own copy of that directory and find nothing there. Either put the release \
+             somewhere outside {PRIVATE:?}, or drop PrivateTmp from the unit."
+        );
+    }
+}
+
+/// And the home directory it uses instead has to stay reachable.
+///
+/// `ProtectHome=` would hide it exactly as `PrivateTmp=` hides `/var/tmp` — same failure, same
+/// unreadable error, and adding one line of hardening to the unit is all it would take.
+#[test]
+fn a_home_sideload_path_requires_no_protect_home() {
+    let script = code(&read(SCRIPT));
+    if !script.contains("$HOME/duck-sideload") {
+        return;
+    }
+
+    match directive(&read(UNIT), "ProtectHome").as_deref() {
+        None | Some("no" | "false" | "off" | "0") => {}
+        Some(other) => panic!(
+            "{UNIT} sets ProtectHome={other}, and {SCRIPT} sideloads from a home directory — \
+             `updaterd` cannot read it, and `apply --from` will fail with a path that is \
+             plainly there. Move the sideload directory, or leave ProtectHome unset."
+        ),
+    }
+}
+
+/// The whole reason the path moved: the daemon reads it, so it has to exist for the daemon.
+///
+/// Named here rather than left implicit because both tests above are conditional, and a
+/// conditional test that stops applying is indistinguishable from one that passes.
+#[test]
+fn the_unit_still_privatises_tmp_or_this_file_is_moot() {
+    assert!(
+        privatises_tmp() || code(&read(SCRIPT)).contains("$HOME/duck-sideload"),
+        "{UNIT} no longer sets PrivateTmp=yes and {SCRIPT} no longer sideloads from a home \
+         directory: nothing above is asserting anything. Delete this file, or restore one half."
+    );
+}


### PR DESCRIPTION
`scripts/dev-push.sh` copied the release to `/var/tmp/duck-sideload`. `updaterd.service` sets `PrivateTmp=yes`, which gives the unit its own `/tmp` **and** its own `/var/tmp` — so the files landed in the pair the shell sees, and the daemon read the pair the namespace gave it:

```
==> copying to pierre@192.168.50.63:/var/tmp/duck-sideload
==> applying on pierre@192.168.50.63
  Preflight
error: network error: no manifest for version 0.5.1-dev.local.1786973040.g7fc1444 in /var/tmp/duck-sideload
```

`ls` on that directory lists exactly that manifest, its `.minisig`, the artifact and its `.minisig`. There is nothing in the error to act on, and nothing in the repo's tests to catch it: they point `LocalDir` at a fixture root, where no namespace applies.

### What changed

**The push sideloads from the board user's home**, resolved on the board (`$HOME` on a laptop is the laptop's). It keeps the one property `/var/tmp` was picked for — writable by the ssh user, so no sudo to copy into it — and is outside the unit's namespace. `updaterd` sets no `ProtectHome=`.

**Preflight gains `Check::SideloadDir`.** A `--from` directory this process cannot see now fails before any manifest lookup, and under `/tmp` or `/var/tmp` the message names the cause:

```
error: preflight check failed: SideloadDir: /var/tmp/duck-sideload is not there for updaterd,
whichever shell created it: this unit runs with PrivateTmp=yes, so it has a /tmp and a /var/tmp
of its own and neither is the one you copied into. The release is fine — put it anywhere outside
those two (a home directory, or /var/lib) and install from there.
```

A missing directory anywhere else stays a plain "does not exist" — mount namespaces are the wrong thing to send someone after when they typo'd a path. A board that does not privatise `/var/tmp` passes the check without noticing it exists, and `updaterd install --from` (the `--bootstrap` path, a root CLI process outside the namespace) is unaffected.

**`xtask/tests/sideload.rs`** holds the script and the unit against each other: the script may not name a path the unit hides, and while it sideloads from a home directory the unit may not set `ProtectHome=`. Neither file can check that on its own — the script does not read the unit, the unit does not know the script. A third test fails if both halves stop applying, so the file cannot go quietly vacuous.

### Notes

- No IPC change and no `API_VERSION` bump: `preflight::Check` is internal, reported through the existing `Error::Preflight`.
- Verified: `cargo test -p updater` (283), `-p xtask`, `-p robotctl` green; `shellcheck scripts/dev-push.sh` clean; the guard test confirmed failing when the default is put back under `/var/tmp`. **Not** verified against the board end to end — it dropped off the network mid-session.
- Stacked on #94, which is where the docs page being edited here comes from.