### PR TITLE
Find the board over Bluetooth when its address moves

### DIFF
--- a/btd/examples/duck-btctl.rs
+++ b/btd/examples/duck-btctl.rs
@@ -130,6 +130,60 @@ fn answers_to(reported: &str, wanted: &str) -> bool {
     }
 }
 
+/// Which of the candidates to talk to, given what was asked for.
+///
+/// Generic over the payload so the rule can be tested: a `Peripheral` cannot be constructed off a
+/// radio, and this is the one place where getting it wrong means acting on the wrong robot.
+///
+/// **A name that matches more than one candidate is refused, not resolved.** The two are
+/// indistinguishable from here, so there is nothing to prefer and picking either means a write
+/// landing on whichever the scan happened to report first — `net.connect` puts a wifi password on
+/// that robot. `identity.rs` names the way this happens with nobody doing anything wrong: a board
+/// whose bootloader leaves `serial-number` empty falls back to the hostname, so every board flashed
+/// from one image answers to `radxa-zero3`.
+///
+/// Without a name the first candidate still wins. That path is unchanged on purpose — choosing
+/// between robots nobody named is exactly what omitting `--name` asks for, and making it an error
+/// would break the shorthand on any bench with two boards on it.
+fn choose<T>(found: Vec<(T, String)>, wanted: Option<&str>) -> Result<(T, String), String> {
+    let Some(wanted) = wanted else {
+        // `run` returns early on an empty `found`, so there is at least one.
+        return found
+            .into_iter()
+            .next()
+            .ok_or_else(|| "no candidates, which `run` should have reported already".to_owned());
+    };
+
+    // Collected before the filter consumes `found`: robots *were* there, they just call themselves
+    // something else, and naming them beats "not in range" for a robot that has been renamed since
+    // whoever is typing last looked.
+    let others: Vec<String> = found.iter().map(|(_, name)| name.clone()).collect();
+    let mut matching: Vec<(T, String)> = found
+        .into_iter()
+        .filter(|(_, name)| answers_to(name, wanted))
+        .collect();
+
+    if matching.len() > 1 {
+        let names: Vec<String> = matching.iter().map(|(_, name)| name.clone()).collect();
+        return Err(format!(
+            "{} robots answer to {wanted:?}: {}\nRefusing to guess between them — whichever the \
+             scan reported first is not a choice. Rename one from the robot itself (`robotctl \
+             system set-name`) and use the new name here.",
+            names.len(),
+            names.join(", ")
+        ));
+    }
+
+    matching.pop().ok_or_else(|| {
+        format!(
+            "no robot named {wanted:?} in range. These answered to the duck service: {}\nA name of \
+             the form `alias [advertised]` is one robot reported under two names, and either half \
+             works.",
+            others.join(", ")
+        )
+    })
+}
+
 /// Devices as indented lines: what names each one, what it calls itself, what it is doing.
 ///
 /// Shared by `scan` and by the failure message, because identifying a robot in a list of earbuds is
@@ -536,26 +590,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         return Err(nothing_found(&seen, cli.name.as_deref()).await.into());
     }
 
-    let (peripheral, name) = match &cli.name {
-        Some(wanted) => {
-            // Collected before the search consumes `found`: robots *were* there, they just call
-            // themselves something else, and naming them beats "not in range" for a robot that has
-            // been renamed since whoever is typing last looked.
-            let others: Vec<String> = found.iter().map(|(_, name)| name.clone()).collect();
-            found
-                .into_iter()
-                .find(|(_, name)| answers_to(name, wanted))
-                .ok_or_else(|| {
-                    format!(
-                        "no robot named {wanted:?} in range. These answered to the duck service: \
-                         {}\nA name of the form `alias [advertised]` is one robot reported under \
-                         two names, and either half works.",
-                        others.join(", ")
-                    )
-                })?
-        }
-        None => found.into_iter().next().expect("non-empty"),
-    };
+    let (peripheral, name) = choose(found, cli.name.as_deref())?;
     eprintln!("connecting to {name}…");
 
     step(
@@ -872,6 +907,68 @@ mod tests {
         assert!(lists_others(true, 1), "--verbose asks what the radio saw");
         assert!(lists_others(false, 0), "no robot: the list is all there is");
         assert!(lists_others(true, 0));
+    }
+
+    /// Named candidates, as `choose` takes them.
+    fn candidates(names: &[&str]) -> Vec<(usize, String)> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (i, (*name).to_owned()))
+            .collect()
+    }
+
+    /// The ordinary case: one name, one robot, and the composite spelling still resolves.
+    #[test]
+    fn a_name_selects_the_one_robot_that_answers_to_it() {
+        let (which, _) = choose(candidates(&["duck-aaaa", "duck-c51b"]), Some("duck-c51b"))
+            .expect("the named robot");
+        assert_eq!(which, 1);
+
+        let (which, _) = choose(
+            candidates(&["duck-aaaa", "radxa-zero3 [duck-c51b]"]),
+            Some("duck-c51b"),
+        )
+        .expect("either half of a composite");
+        assert_eq!(which, 1);
+    }
+
+    /// **The safety rule.** Two robots answering to one name is not rare or hypothetical: a board
+    /// whose bootloader leaves `serial-number` empty is named from its hostname, so a bench flashed
+    /// from one image is full of `radxa-zero3`. Whichever the scan reported first is not a choice,
+    /// and the command that lands on it may be `net.connect` with someone's wifi password.
+    #[test]
+    fn a_name_matching_two_robots_is_refused_rather_than_guessed() {
+        let error = choose(
+            candidates(&["radxa-zero3", "radxa-zero3", "duck-c51b"]),
+            Some("radxa-zero3"),
+        )
+        .expect_err("a collision is an error");
+
+        assert!(error.contains("2 robots"), "{error}");
+        // Both are named, so the reader can tell which two collided.
+        assert!(error.contains("radxa-zero3, radxa-zero3"), "{error}");
+        assert!(error.contains("set-name"), "the way out: {error}");
+    }
+
+    /// Omitting `--name` is a request to pick one, and it stays one. Making the ambiguity an error
+    /// on this path would break the shorthand on every bench with two boards on it.
+    #[test]
+    fn without_a_name_the_first_candidate_still_wins() {
+        let (which, _) =
+            choose(candidates(&["duck-aaaa", "duck-c51b"]), None).expect("the first one");
+        assert_eq!(which, 0);
+    }
+
+    /// A name nobody answers to lists what was there, because the usual cause is a robot that has
+    /// been renamed since whoever is typing last looked.
+    #[test]
+    fn a_name_nobody_answers_to_lists_the_robots_that_were_there() {
+        let error = choose(candidates(&["duck-aaaa", "duck-bbbb"]), Some("duck-c51b"))
+            .expect_err("not in range");
+
+        assert!(error.contains("no robot named"), "{error}");
+        assert!(error.contains("duck-aaaa, duck-bbbb"), "{error}");
     }
 
     /// `--name` says which robot to talk to and the `name` subcommand's positional says what to

--- a/docs/robot/duck-btctl.md
+++ b/docs/robot/duck-btctl.md
@@ -48,6 +48,21 @@ A robot that has never been renamed calls itself `duck-` plus four characters de
 serial, so `duck-c51b`. macOS often reports one robot under two names at once, as
 `radxa-zero3 [duck-c51b]` — either half works as `--name`.
 
+Without `--name`, the first robot found wins. With it, two robots answering to the same name is an
+error rather than a choice:
+
+```
+2 robots answer to "radxa-zero3": radxa-zero3, radxa-zero3
+```
+
+That happens on a board whose bootloader leaves its serial blank, because it is then named after
+its hostname and every board flashed from one image has the same one. Rename one from the robot
+itself and use the new name:
+
+```bash
+robotctl system set-name ducky
+```
+
 ## Identity
 
 ```bash

--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -100,6 +100,27 @@ is. The raw ssh error for this is a wall of text about a possible attack.
 This matters more than it sounds, because DHCP leases get reused — the address that was one
 board last week is a different board today, with a different key.
 
+## When the board comes back at a different address
+
+The wifi cutover in the middle of provisioning can leave the board on a different lease than the
+one you gave. `provision-board.sh` goes looking: while it waits for ssh it also asks the robot over
+Bluetooth what address it ended up with, and adopts the answer.
+
+```
+  bluetooth: the robot reports 192.168.1.57, and 192.168.1.42 was its old lease.
+```
+
+Nothing to do — the rest of the run is addressed there.
+
+Three things stop it working, and it says which:
+
+- It needs `cargo` and this clone, because `duck-btctl` is an example rather than an installed binary.
+- It can only ask once `btd` is running, which on a board being provisioned for the first time is a
+  few minutes into phase 2.
+- The robot reports its **wifi** address, so a board you reach over ethernet is not covered.
+
+`--no-ble` turns it off. A robot that has been given its own pairing PIN needs it in `DUCK_PIN`.
+
 ## Making an existing board take dev builds
 
 For a board provisioned some other way, or one set up before you had the key. Both halves are

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -27,9 +27,43 @@
 #                     releases. The default is to send this clone's
 #                     deploy/dev-key/team.dev.pub.
 #   --dev-key PATH    somewhere else to find it.
+#   --no-ble          do not use Bluetooth to re-find the board. See below for what that costs.
 #
 # Needs `ssh` and `scp`, an account on the board that can `sudo`, and nothing else. It expects
 # to be able to prompt for the sudo password, so it allocates a terminal for that one command.
+#
+# ## When the board comes back at a different address
+#
+# A DHCP lease moves, and the cutover in the middle of provisioning is exactly when it does: the
+# board leaves on netplan's lease and comes back on NetworkManager's. From out here that is
+# indistinguishable from a board that never booted at all — the address you were given simply
+# stops answering, and every remaining step is addressed to it.
+#
+# So the wait is a race. ssh keeps polling the address you gave, and in parallel a Bluetooth probe
+# asks the robot itself what address it ended up with — `net.status`, the same call the phone app
+# makes. Whichever answers first wins, and an answer over Bluetooth is adopted for everything
+# after it.
+#
+# On the same address ssh wins essentially always: `hci0` takes about seventy seconds to appear on
+# this board and sshd does not, so the probe is still building when the ordinary case is already
+# over. That is the point. It costs nothing in the normal case and it is the only thing that can
+# answer in the abnormal one.
+#
+# **The probe is only trusted when exactly one robot answers to the name this board advertises**,
+# which is read off the board before the reboot while ssh still works. Adopting an address means
+# ssh'ing somewhere new, and doing that to a robot chosen by scan order is worse than waiting.
+#
+# It needs `cargo` and this clone, because `duck-btctl` is an example rather than an installed
+# binary. Without either, the wait is exactly what it was before and says so. Three more things it
+# cannot do:
+#
+#   - A board being provisioned for the first time has no `btd` until the install reaches it, so
+#     Bluetooth cannot answer for the first few minutes.
+#   - A robot with a per-robot pairing PIN needs it in `DUCK_PIN`; the probe otherwise offers the
+#     factory default.
+#   - `net.status` reports the *wifi* interface, so a board you reach over ethernet is not covered.
+#     Which is the right interface to read — the cutover this exists for is wifi's — but it means an
+#     ethernet lease that moves is still a lease nothing here can find.
 set -eu
 
 # Committed, so a new developer needs nothing from anybody to provision a dev board. `--dev-key`
@@ -44,6 +78,35 @@ REF=""
 DEV_KEY="$DEV_KEY_DEFAULT"
 NO_DEV_KEY=""
 USE_LOCAL=""
+NO_BLE=""
+
+# ── the Bluetooth fallback ───────────────────────────────────────────────────
+#
+# `duck-btctl` is an example rather than a binary — deliberately, so `btleplug` never reaches a
+# robot — which means the only way to run it is `cargo` against this clone.
+BLE_MANIFEST="$(dirname "$0")/../Cargo.toml"
+
+# The name the robot advertises, read off the board before the reboot.
+#
+# Empty means the fallback is off: a probe with no name talks to whichever robot the scan reported
+# first, and the whole point of the fallback is to hand ssh a new address to trust.
+BLE_NAME=""
+
+# Whether `btd` was already running before the reboot. Does not gate the probe — it is one line in
+# a message, so a first-time board is told why Bluetooth has nothing to say yet rather than left to
+# wonder whether the probe is broken.
+BLE_LIVE=""
+
+# The PIN the probe offers. The factory default, which is what a board being provisioned has;
+# `DUCK_PIN` is for a robot that has been given its own.
+BLE_PIN="${DUCK_PIN:-000000}"
+
+# Scratch for the probe: its verdict, and its output kept for the diagnosis.
+BLE_DIR=""
+# The running probe, empty when none is.
+BLE_PID=""
+# What the probe last said, printed once rather than every three seconds.
+BLE_SAID=""
 
 # How long to wait for the board to come back after its reboot. Generous on purpose, and sized
 # for the worst legitimate case rather than the normal one: a first boot after an overlay change
@@ -62,8 +125,14 @@ say()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 
+# The header is the help, so print it whole: every comment line from the shebang to the first line
+# that is not one.
+#
+# A line range is what this was, and it had already gone stale — `2,22p` stopped mid-sentence
+# inside `--forget-host-key` and hid the three options after it, because the range does not move
+# when a paragraph is added above it. Nothing to keep in step this way.
 usage() {
-    sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
     exit "${1:-0}"
 }
 
@@ -73,6 +142,7 @@ while [ $# -gt 0 ]; do
         --forget-host-key) FORGET_KEY=1; shift ;;
         --dev-key)    DEV_KEY="${2:?--dev-key needs a path}"; shift 2 ;;
         --no-dev-key) NO_DEV_KEY=1; shift ;;
+        --no-ble)     NO_BLE=1; shift ;;
         --local)      USE_LOCAL=1; shift ;;
         -h|--help)    usage 0 ;;
         -*)           die "unknown option: $1" ;;
@@ -158,11 +228,262 @@ alive() (
     wait "$_probe_pid"
 ) 2>/dev/null
 
-# True while the board still has provisioning left to do. `provision.sh` removes the state file
-# when it finishes, which makes "are we done" a question with a file for an answer rather than
-# a log line to pattern-match.
+# Does the board still have provisioning left to do? `provision.sh` removes the state file when it
+# finishes, which makes "are we done" a question with a file for an answer rather than a log line
+# to pattern-match.
+#
+#   0  still provisioning
+#   1  finished
+#   2  cannot tell, because the board is not answering
+#
+# Three answers rather than two, and the third is a bug this fixes. `rsh` fails when the *board*
+# went away just as surely as when the file is gone, so one test read `finished` for a board that
+# had merely moved to a new lease mid-install — and the watcher announced provisioning complete and
+# then a health check that could not connect. Which of the two it is decides whether to stop or to
+# go looking, so it cannot be collapsed.
 still_provisioning() {
-    rsh "test -f ${STATE}" >/dev/null 2>&1
+    if rsh "test -f ${STATE}" >/dev/null 2>&1; then
+        return 0
+    fi
+    # The file is gone, or the board is. One more question tells them apart, and it is only ever
+    # asked once — at the end, or at the failure.
+    if alive 10; then
+        return 1
+    fi
+    return 2
+}
+
+# Point everything at a new address for the same board.
+#
+# The `[user@]` is carried across rather than rebuilt: a board whose account is not the default
+# would otherwise become unreachable at the moment this was trying to save it.
+adopt_address() {
+    case "$HOST" in
+        *@*) HOST="${HOST%@*}@$1" ;;
+        *)   HOST="$1" ;;
+    esac
+    HOST_ONLY="$1"
+
+    # A recycled lease is the one way an adopted address cannot work: another board held it, so
+    # known_hosts has *its* key on record and ssh refuses this one outright. `alive` discards output,
+    # so without this the wait would simply go quiet until the budget ran out and blame the board.
+    _adopted="$(rsh true 2>&1 || true)"
+    case "$_adopted" in
+        *"REMOTE HOST IDENTIFICATION HAS CHANGED"*|*"Host key verification failed"*)
+            die "the robot says it is at ${1}, and ssh refuses that address: known_hosts has a
+  different board's key on record for it. A DHCP lease that has been round the houses is enough
+  to do this. Drop it and re-run:
+    ssh-keygen -R ${1}" ;;
+    esac
+}
+
+# ── the Bluetooth probe ──────────────────────────────────────────────────────
+
+# Print something in the middle of a line of progress dots, once per distinct message.
+#
+# Repeats are dropped rather than rate-limited: a probe that keeps returning the same answer every
+# twenty seconds has nothing new to say, and the alternative is a screen of one repeated line with
+# the useful message scrolled off the top.
+#
+# Closing the dot line is this function's job rather than every caller's, which it can do because
+# POSIX `sh` has no locals and `_dots` is therefore shared with the loop printing them.
+ble_say() {
+    [ "$BLE_SAID" != "$1" ] || return 0
+    BLE_SAID="$1"
+    [ "${_dots:-0}" = 0 ] || echo
+    _dots=0
+    printf '\033[1m  bluetooth:\033[0m %s\n' "$1"
+}
+
+# Learn the name the robot advertises, while ssh still works. Empty when it cannot be known.
+#
+# Two sources, because a board being provisioned is in one of two states and they have different
+# authorities:
+#
+#   - A board that already runs the daemon is asked. That answer includes a rename someone stored
+#     through `system.setName`, which no derivation can know about.
+#   - A board that does not is derived from, exactly as `configd/src/identity.rs` will when it
+#     starts: `duck-` and the first two bytes of the SHA-256 of the SoC serial. Computed on the
+#     board, so nothing is needed on this machine — macOS has `shasum` and not `sha256sum`, and
+#     that is a silly reason for a fallback not to work.
+#
+# A board with no readable serial is deliberately left empty rather than guessed at. `configd` falls
+# back to the hostname there, and every board flashed from one image has the same one — so the name
+# would match all of them, which is the case the probe must not act on.
+learn_ble_name() {
+    if _name="$(rsh "robotctl system info --json 2>/dev/null" 2>/dev/null)"; then
+        _name="$(printf '%s' "$_name" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')"
+        if [ -n "$_name" ]; then
+            printf '%s' "$_name"
+            return 0
+        fi
+    fi
+
+    # Mirrors `serial_at` clause for clause, because a name that disagrees with the robot's is worse
+    # than no name at all:
+    #
+    #   tr '\0' '\n' | head -n1   a devicetree property holds NUL-terminated strings and may hold
+    #                             several, so the first NUL ends the value — `split('\0').next()`,
+    #                             not "delete the NULs", which would hash two values joined.
+    #   sed            the `.trim()`.
+    #   *[![:graph:]]* `is_ascii_graphic`, which excludes the space: a property that exists but is
+    #                  blank or full of control characters is no identity, and printing nothing here
+    #                  is how this agrees.
+    #
+    # Nothing is printed unless the digest came out, so a board without `sha256sum` yields no name
+    # rather than the name `duck-`, which every such board would then share.
+    rsh "serial=\$(tr '\\0' '\\n' < /proc/device-tree/serial-number 2>/dev/null | head -n1 \
+             | sed 's/^[[:space:]]*//; s/[[:space:]]*\$//'); \
+         case \"\$serial\" in \
+           '' | *[![:graph:]]*) exit 0 ;; \
+         esac; \
+         digest=\$(printf '%s' \"\$serial\" | sha256sum 2>/dev/null | cut -c1-4); \
+         [ \${#digest} -eq 4 ] || exit 0; \
+         printf 'duck-%s' \"\$digest\"" 2>/dev/null || true
+}
+
+# Start a probe in the background, unless one is already running.
+#
+# Backgrounded and polled rather than waited on, because it has to lose gracefully: the whole design
+# is that ssh usually answers first, and a probe still holding a radio open must not delay the run
+# that already succeeded. The verdict is written to a temporary name and renamed, so a poll can
+# never read half a line.
+ble_probe_start() {
+    [ -n "$BLE_NAME" ] || return 0
+    [ -z "$BLE_PID" ] || return 0
+
+    {
+        if cargo run -q --manifest-path "$BLE_MANIFEST" -p btd --example duck-btctl -- \
+            --name "$BLE_NAME" --pin "$BLE_PIN" wifi status \
+            >"${BLE_DIR}/out" 2>"${BLE_DIR}/err"
+        then
+            _found="$(sed -n 's/.*"ip4"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+                "${BLE_DIR}/out" | head -n1)"
+            if [ -n "$_found" ]; then
+                printf 'ip %s\n' "$_found" > "${BLE_DIR}/verdict.tmp"
+            else
+                # The robot answered and reported no IPv4 address, which is not a failed probe —
+                # it is the diagnosis, and a far better one than silence.
+                printf 'no-address\n' > "${BLE_DIR}/verdict.tmp"
+            fi
+        else
+            printf 'failed\n' > "${BLE_DIR}/verdict.tmp"
+        fi
+        mv -f "${BLE_DIR}/verdict.tmp" "${BLE_DIR}/verdict"
+    } >/dev/null 2>&1 &
+
+    BLE_PID=$!
+}
+
+# The probe's verdict if it has one, consumed so each is acted on once. 1 while it is still working.
+#
+# Prints and nothing else. Reaping the job and clearing `BLE_PID` belong to the caller, because this
+# is read through a command substitution — a subshell — and an assignment made in here would be
+# discarded with it. That is not a hypothetical tidiness point: `BLE_PID` would have stayed set for
+# the rest of the run, `ble_probe_start` would have returned early on every call, and the fallback
+# would have had exactly one attempt at a board whose `btd` needs a minute to come up.
+ble_verdict() {
+    [ -n "$BLE_DIR" ] || return 1
+    [ -f "${BLE_DIR}/verdict" ] || return 1
+
+    cat "${BLE_DIR}/verdict"
+    rm -f "${BLE_DIR}/verdict"
+}
+
+# Why the last probe failed, as `duck-btctl` put it.
+#
+# Its own words rather than a paraphrase, and not matched on either: it explains a name nobody
+# answers to, two robots answering to one, a missing adapter and a refused PIN, each differently and
+# better than this script could. Matching on those strings would be one more thing to keep in step.
+ble_failure() {
+    [ -n "$BLE_DIR" ] || return 0
+    [ -f "${BLE_DIR}/err" ] || return 0
+    # Compiler output on a first run is many lines of nothing anyone wants; the last line is the
+    # error itself.
+    grep -v '^ *$' "${BLE_DIR}/err" 2>/dev/null | tail -n1 || true
+}
+
+ble_stop() {
+    if [ -n "$BLE_PID" ]; then
+        kill -TERM "$BLE_PID" 2>/dev/null || true
+        wait "$BLE_PID" 2>/dev/null || true
+        BLE_PID=""
+    fi
+    # A verdict nobody read is about a wait that is over. Left behind, it would be the first thing
+    # the *next* wait saw — an address from before the board rebooted again.
+    [ -z "$BLE_DIR" ] || rm -f "${BLE_DIR}/verdict" "${BLE_DIR}/verdict.tmp"
+}
+
+# How long the last wait took, for whoever has to report it.
+WAITED=0
+
+# Wait until $HOST answers, adopting a new address if the robot reports one over Bluetooth. 0 when
+# the board answers — possibly somewhere new — and 1 when the budget ran out. Sets $WAITED.
+#
+# Wall clock, not a sum of sleeps. A probe that takes longer than expected must eat into the budget
+# rather than extend it: the sum-of-sleeps version could not time out at all while a probe was
+# blocked, which is precisely the failure this loop is here to survive.
+wait_for_board() {
+    _budget="$1"
+    _began="$(date +%s)"
+    _dots=0
+    BLE_SAID=""
+    ble_probe_start
+
+    until alive 10; do
+        _verdict="$(ble_verdict || true)"
+        if [ -n "$_verdict" ]; then
+            # Reaped here rather than in `ble_verdict`, which cannot: see its comment.
+            [ -z "$BLE_PID" ] || wait "$BLE_PID" 2>/dev/null || true
+            BLE_PID=""
+        fi
+
+        case "$_verdict" in
+            "ip "*)
+                _reported="${_verdict#ip }"
+                if [ "$_reported" = "$HOST_ONLY" ]; then
+                    # Nothing to adopt, and still worth saying: the board is up and answering, so
+                    # what this is waiting for is sshd rather than a boot.
+                    ble_say "the robot is up and reports ${_reported}, the address already in use,
+             so this is waiting on sshd rather than on the board"
+                else
+                    ble_say "the robot reports ${_reported}, and ${HOST_ONLY} was its old lease.
+             Everything after this is addressed there."
+                    adopt_address "$_reported"
+                fi
+                ;;
+            no-address)
+                ble_say "the robot is up and has no IPv4 address, so it never got a lease.
+             Phase 2 downloads a release, so it cannot finish in this state — but NetworkManager
+             may still be trying, so this keeps waiting."
+                ;;
+            failed)
+                ble_say "nothing usable yet — $(ble_failure)"
+                ;;
+        esac
+
+        # Re-armed only on a verdict, so there is one probe at a time and one radio in use. A probe
+        # that has just failed is worth repeating: the commonest reason by far is a board whose
+        # `btd` has not finished starting.
+        if [ -n "$_verdict" ]; then
+            ble_probe_start
+        fi
+
+        WAITED="$(( $(date +%s) - _began ))"
+        if [ "$WAITED" -ge "$_budget" ]; then
+            [ "$_dots" = 0 ] || echo
+            ble_stop
+            return 1
+        fi
+        printf '.'
+        _dots=1
+        sleep 3
+    done
+
+    WAITED="$(( $(date +%s) - _began ))"
+    [ "$_dots" = 0 ] || echo
+    ble_stop
+    return 0
 }
 
 # ── checks that are cheaper to fail now than halfway ─────────────────────────
@@ -229,6 +550,53 @@ elif [ ! -f "$DEV_KEY" ]; then
   board that should only take releases."
 fi
 
+# ── arrange the Bluetooth fallback, while ssh still works ────────────────────
+#
+# All of it happens here, before anything has been changed, because every part of it needs a working
+# ssh connection — and after the reboot is precisely when there may not be one. A fallback that has
+# to reach the board to arm itself is no fallback at all.
+if [ -n "$NO_BLE" ]; then
+    say "not using Bluetooth to re-find the board (--no-ble)"
+elif ! command -v cargo >/dev/null 2>&1; then
+    warn "no cargo on this machine, so Bluetooth cannot be used to re-find the board if its
+  address changes across the reboot. Not fatal — the board finishes on its own either way, and
+  the wait below is what it always was. Install Rust to get the fallback."
+elif [ ! -f "$BLE_MANIFEST" ]; then
+    warn "${BLE_MANIFEST} is not there, so this is not being run from a clone and duck-btctl
+  cannot be built — no Bluetooth fallback if the board's address changes across the reboot."
+else
+    BLE_NAME="$(learn_ble_name)"
+    if [ -z "$BLE_NAME" ]; then
+        warn "cannot tell what name this board will advertise over Bluetooth, so there is no
+  fallback if its address changes across the reboot. A board whose bootloader leaves
+  /proc/device-tree/serial-number empty is named after its hostname, which is the same on every
+  board flashed from one image — so a probe could not tell this robot from the next one, and
+  guessing is worse than waiting."
+    else
+        BLE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/provision-ble.XXXXXX")"
+
+        # Both the probe and the scratch go, whichever way this script ends. A radio left held open
+        # by an orphaned `cargo run` is the one piece of litter here that a later run would notice.
+        #
+        # Only EXIT does the cleaning, and the signals just exit — which is what makes Ctrl-C still
+        # *stop* this. A handler on INT that returns rather than exiting resumes the script at the
+        # next line, so the ten-second grace `provision.sh` prints before rebooting would have
+        # become uninterruptible from here: the one place Ctrl-C is documented to work.
+        trap 'ble_stop; [ -z "$BLE_DIR" ] || rm -rf "$BLE_DIR"' EXIT
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
+
+        if rsh "systemctl is-active --quiet btd" >/dev/null 2>&1; then
+            BLE_LIVE=1
+            say "this board advertises as '${BLE_NAME}', and btd is running — so Bluetooth can
+    re-find it if its address changes"
+        else
+            say "this board will advertise as '${BLE_NAME}'. btd is not running on it yet, so
+    Bluetooth can only answer once the install reaches it — a few minutes into phase 2"
+        fi
+    fi
+fi
+
 # ── put what the board needs where the board can reach it ────────────────────
 
 if [ -n "$DEV_KEY" ]; then
@@ -287,27 +655,35 @@ while [ "$(( $(date +%s) - _start ))" -lt 20 ]; do
     sleep 2
 done
 
-# Wall clock, not a sum of sleeps. A probe that takes longer than expected must eat into the
-# budget rather than extend it — the sum-of-sleeps version could not time out at all while a
-# probe was blocked, which is precisely the failure this loop is here to survive.
-_start="$(date +%s)"
-_elapsed=0
-until alive 10; do
-    _elapsed="$(( $(date +%s) - _start ))"
-    if [ "$_elapsed" -ge "$BOOT_TIMEOUT" ]; then
-        die "no answer from ${HOST} after ${_elapsed}s.
+_was="$HOST_ONLY"
+if ! wait_for_board "$BOOT_TIMEOUT"; then
+    # Why the fallback did not save this, which is the part the operator cannot see. Said only when
+    # it explains something: with a live `btd` and a name, the probe already reported its own
+    # failure while the dots were going past.
+    _why=""
+    if [ -z "$BLE_NAME" ]; then
+        _why="
+  Bluetooth was not used here, and a new address is exactly what it would have found."
+    elif [ -z "$BLE_LIVE" ]; then
+        _why="
+  Bluetooth had nothing to report, which is expected on a board being provisioned for the first
+  time: btd is installed by phase 2, so there was nothing to ask until the install reached it."
+    fi
+
+    die "no answer from ${HOST} after ${WAITED}s.
   That does not mean provisioning failed. The board resumes by itself at boot, so this is a
   viewer that lost sight of it — the board may well be finishing right now. Look directly:
     ssh -t ${HOST} 'sudo tail -f ${LOG}'
   If it is genuinely unreachable: a failed wifi cutover makes the backstop restore netplan and
   reboot, which costs a second boot, and NetworkManager may come back on a different DHCP lease
-  than netplan had — so check for a new address before concluding the board is down."
-    fi
-    printf '.'
-    sleep 3
-done
-echo
-say "back after ~$(( $(date +%s) - _start ))s"
+  than netplan had — so check for a new address before concluding the board is down.${_why}"
+fi
+
+if [ "$HOST_ONLY" = "$_was" ]; then
+    say "back after ~${WAITED}s"
+else
+    say "back after ~${WAITED}s, at ${HOST_ONLY}"
+fi
 
 # ── phase 2, which is running unattended on the board ────────────────────────
 
@@ -372,13 +748,46 @@ while :; do
         _quiet=$((_quiet + 3))
     fi
 
-    if ! still_provisioning; then
+    # Captured rather than tested, because `set -e` would take a bare non-zero return as a
+    # failure of this script.
+    _left=0
+    still_provisioning || _left=$?
+    if [ "$_left" = 1 ]; then
         # One more read before leaving. `provision.sh` writes its closing lines and *then*
         # removes the state file, so a loop that breaks the moment the file is gone drops the
         # last thing it said — including which token ended up where, and whether the board came
         # out a dev board. Which is the part worth reading.
         drain_log || true
         break
+    fi
+
+    # The board went away mid-install. Not the end of provisioning — it carries on without this
+    # watcher — and not necessarily a fault either: the wifi backstop reboots the board when a
+    # cutover does not take, and NetworkManager can come back on a lease netplan never had.
+    #
+    # So this is the second place a new address is worth going to look for, and it reuses the same
+    # race the reboot does.
+    if [ "$_left" = 2 ]; then
+        _was="$HOST_ONLY"
+        echo
+        warn "lost contact with ${HOST_ONLY} while it was still provisioning. Looking for it."
+        if ! wait_for_board "$BOOT_TIMEOUT"; then
+            die "${HOST_ONLY} stopped answering after ${WAITED}s of looking, and provisioning had
+  not finished. The board carries on by itself, so this is a lost viewer rather than a failed
+  install — but it does need finding. It is most likely on a new DHCP lease: check your router's
+  leases, and then:
+    ssh -t <new address> 'sudo tail -f ${LOG}'"
+        fi
+        if [ "$HOST_ONLY" = "$_was" ]; then
+            say "back after ~${WAITED}s; resuming the log"
+        else
+            say "back after ~${WAITED}s at ${HOST_ONLY}; resuming the log"
+            # The log is the same file on the same board, so the byte offset still holds. What can
+            # differ is how it is read: the reader was chosen against a connection that has since
+            # been replaced, and the group membership behind it is per-login.
+            choose_log_reader || true
+        fi
+        _quiet=0
     fi
 
     # A board that has stopped writing and still has a state file has either failed or is


### PR DESCRIPTION
`provision-board.sh` waits out the reboot in the middle of provisioning by polling the address it was given. The wifi cutover is exactly when that address stops being right: the board leaves on netplan's lease and comes back on NetworkManager's, and from out here that is indistinguishable from a board that never booted.

## The race

ssh keeps polling the address it has, and in parallel a `duck-btctl wifi status` asks the robot what address it ended up with — `net.status`, the same call the phone app makes. Whichever answers first wins, and an answer over Bluetooth is adopted for the rest of the run, including the log stream and the closing `robotctl health`.

```
==> waiting for radxa@192.168.1.42 to come back (up to 300s)
  (the board finishes on its own — this is only watching)
.........
  bluetooth: the robot reports 192.168.1.57, and 192.168.1.42 was its old lease.
             Everything after this is addressed there.
==> back after ~48s, at 192.168.1.57
```

ssh wins on the same address essentially always — `hci0` takes about seventy seconds to appear on this board and sshd does not — so the probe costs nothing in the normal case and is the only thing that can answer in the abnormal one.

## Which robot answered

The probe is only trusted when exactly one robot answers to the name this board advertises, read off the board before the reboot while ssh still works: `robotctl system info` where the daemon is already installed, and otherwise derived exactly as `configd/src/identity.rs` will. A board with no readable serial yields no name at all rather than a guess — `configd` falls back to the hostname there, and every board flashed from one image shares it.

Enforcing that needed a change on the client side. `duck-btctl --name` matching more than one candidate took whichever the scan reported first; it now refuses, because the two are indistinguishable from the client and the command landing on the wrong one may be `net.connect` with someone's wifi password. Without `--name` the first candidate still wins, so the shorthand keeps working on a bench with two boards on it.

## Also

`still_provisioning` could not tell "the state file is gone" from "ssh failed", so a board that moved mid-install was announced as provisioning complete and then failed its health check. It now separates the two, which is the second place a new address is worth looking for.

`usage` printed a fixed line range that had gone stale — it stopped mid-sentence inside `--forget-host-key` and hid the three options after it.

## What it does not cover

- `cargo` and this clone are needed, since `duck-btctl` is an example rather than an installed binary. Without them the wait is what it was before, and says so.
- A board being provisioned for the first time has no `btd` until phase 2's install reaches it, so Bluetooth cannot answer for the first few minutes. Re-provisioning a board that already has the daemon is covered throughout.
- `net.status` reports the wifi interface, so an ethernet lease that moves is still one nothing here can find.

`--no-ble` turns the whole thing off. `DUCK_PIN` is for a robot with its own pairing PIN.

## Testing

`cargo test -p btd` covers the selection rule, including the collision. The script's race, the tri-state `still_provisioning`, and the name derivation against `configd`'s pinned `duck-c51b` were driven through a throwaway harness with ssh and cargo stubbed — 16 assertions, not committed, since CI only lints these scripts. Not yet run against a board whose lease actually moves.