### PR TITLE
The raw pad stream, in the monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1107,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1196,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2344,7 +2374,10 @@ version = "0.5.1"
 dependencies = [
  "clap",
  "duck-ipc-proto",
+ "evdev",
  "gilrs",
+ "libc",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
@@ -2610,6 +2643,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3404,6 +3443,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4408,6 +4453,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ units
 
 The two software blocks answer different questions. `software` is what each daemon that serves a
 socket says about itself, and what is installed on the board; `units` is what systemd says about
-every unit a release manages — including `btd` and `padd`, which serve no socket and can only be
-reported from outside — with the release each process was actually launched from. That second one
+every unit a release manages — including `btd` and `padd`, which answer no version query and can
+only be reported from outside — with the release each process was actually launched from. That second one
 is the question after an update: a daemon still running the old binary shows a release older than
 the installed one, and the report names the restart that fixes it.
 
@@ -163,6 +163,13 @@ gravity and the fall verdict drawn from it, and the achieved loop rate as a trac
 that has already recovered is still visible. The bottom border names the policy that is loaded,
 because `walk` is a mode two releases with different gaits both report — and "which network is
 this?" is the first question when comparing them.
+
+`p` opens the gamepad's raw input: every evdev report from the pad `padd` is driving from, the
+sticks and buttons as the kernel delivered them, and the gaps between reports as a trace. That last
+part is the reason it exists — `padd` resends the last stick value at 50 Hz, so a radio that has
+stopped delivering still looks like a live driver in the `asked` column above it, and the robot walks
+on a command nobody is giving. Reading it is in
+[pair a gamepad](docs/robot/pair-a-gamepad.md#when-it-drops-while-you-are-driving).
 
 `q` quits, `↑`/`↓` scroll the joint list, `u` switches the angles between degrees and radians.
 Angles are degrees on screen — joints, head and the yaw rate. Redirected or piped it prints one

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -171,6 +171,17 @@ pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
         // unpredictably-lagged view it could not reason about. `robot.health` is the question an
         // app actually has.
         RobotSubscribe(_) => None,
+
+        // The same objection as `robot.subscribe`, only more so: this is every evdev event the pad
+        // sends, over a hundred reports a second, and it exists to *measure the cadence of its own
+        // delivery*. Carried over BLE the measurement would be of the phone's link rather than the
+        // pad's, which is worse than refusing — it would be a number that looks like an answer.
+        //
+        // It is also not `btd`'s to forward. Every route here goes to one of three sockets `btd`
+        // holds, and this one is served by `padd`, which is deliberately not among them: `padd` is
+        // the unprivileged client whose whole value is having no special access, and giving the BLE
+        // transport a connection to it would be the first thing to make that untrue.
+        PadInput => None,
     }
 }
 

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -54,7 +54,9 @@ report. A robot with no policy says so, and one whose policy would not load says
 which the stream's `held` cannot distinguish.
 
 `q` quits; `↑`/`↓` scroll the joint list on a window too short for all of it; `u` switches the
-angles between degrees and radians. Angles are degrees on screen — joints, head and the yaw rate.
+angles between degrees and radians; `p` opens the pad's raw input stream — every evdev report from
+the gamepad, with the gaps between them, which is the only place a stalled radio is visible
+([pair a gamepad](pair-a-gamepad.md#when-it-drops-while-you-are-driving)). Angles are degrees on screen — joints, head and the yaw rate.
 Redirected or piped it prints one line per tick instead, so `> run.log` and `| grep FALLEN`
 behave, and those numbers stay radians whatever the screen is set to. The joint vectors are in
 `--json`, which carries the whole state, one object per line:
@@ -136,7 +138,8 @@ sudo systemctl stop padd
 sudo -u padd /opt/robot/daemon/current/bin/padd --max-linear 0.25
 ```
 
-When the link itself is the suspect, copy the measurement over from a clone of this repo:
+When the link itself is the suspect, watch it live — `robotctl monitor`, then `p`. For a verdict
+over a window instead, copy the measurement over from a clone of this repo:
 
 ```
 scp scripts/pad-link-test.sh radxa@<board>:/tmp/

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -100,7 +100,39 @@ the one instrument that distinguishes a board setting from a pad that is not lis
 
 ## When it drops while you are driving
 
-Copy the measurement onto the board, from a clone of this repo:
+Watch the pad's own input stream, which is already on the board:
+
+```bash
+robotctl monitor
+```
+
+Press `p`. The block that opens is the raw evdev stream from the pad `padd` is driving from — every
+report, timestamped by the kernel:
+
+```
+┌ pad Xbox Wireless Controller · /dev/input/event5 · 78:86:2e:bb:13:28 ─────────────┐
+│ cadence  124/s while driving · last 8 ms ago · worst 84 ms · over 100 ms 0 · …    │
+│ gap ms                                       ▁▁▁▁▂▁▁▁▁▃▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │
+│ X     ····│██··   -8734 Y     ····│····       0 Z     ·········       0 …         │
+│ held     BTN_START                                                                │
+└ 4213 reports · gap ≤100 ms ───────────────────────────────── reports intact ──────┘
+```
+
+Move the sticks and the bars follow them. What the trace is for is the row above: a bar per report,
+so a stall is a spike, and one that has already recovered is still on screen. Full height is 100 ms
+— the point a driver starts to feel it — and past 500 ms `robotd` has zeroed the velocity.
+
+**Nothing else on the robot can show this.** `padd` resends the last stick value at 50 Hz, so a
+radio that has stopped delivering still looks like a live driver everywhere downstream: `robot.state`
+carries fresh intents, the deadman never fires, and the robot keeps walking on a command nobody is
+giving. The `asked` column in the block above it will look perfect while this one flatlines.
+
+A pad at rest sends nothing, so silence is only evidence while you are driving. The block says
+`the sticks are still` past five seconds rather than accusing the link, and counts those spells
+separately.
+
+Then, for a verdict over a window rather than a live picture, copy the measurement onto the board
+from a clone of this repo:
 
 ```bash
 scp scripts/pad-link-test.sh radxa@<board>:/tmp/

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -72,7 +72,17 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// v6 `updaterd` would accept `update.apply --from /some/dir` and quietly install from its
 /// *configured* source instead — a mirror of the release the operator meant to sideload, or nothing
 /// at all. Refusing the call outright is what this constant is for.
-pub const API_VERSION: u32 = 7;
+/// # v8 — `pad.input`
+///
+/// A namespace addition of the kind v5 was, and it bumps for the same stated reason: the constant
+/// says "these two peers were not built together", not "nothing you knew has changed".
+///
+/// **What it costs here is smaller than usual, and worth being precise about.** The new method is
+/// served by `padd` on a socket of its own, so no existing client loses anything by not knowing it,
+/// and a `robotctl` that asks an older `padd` for it finds no socket at all rather than a refusal.
+/// The bump still lands on `updaterd`'s exact `!=` check, so every binary on a board must come from
+/// one release — which was already the rule.
+pub const API_VERSION: u32 = 8;
 
 pub const DEFAULT_SOCKET: &str = "/run/updaterd.sock";
 
@@ -87,6 +97,13 @@ pub mod socket {
     pub const UPDATER: &str = super::DEFAULT_SOCKET;
     pub const ROBOT: &str = "/run/robotd.sock";
     pub const CONFIG: &str = "/run/configd.sock";
+    /// `padd`'s raw input tap — [`super::method::PAD_INPUT`], and nothing else.
+    ///
+    /// Under `/run/padd/` because that is `padd`'s `RuntimeDirectory=`, which is the only place a
+    /// process running under `ProtectSystem=strict` may create a file. systemd removes the
+    /// directory when the unit stops, so a socket left behind cannot outlive the daemon that
+    /// would have answered on it.
+    pub const PAD: &str = "/run/padd/pad.sock";
 }
 
 /// Where each daemon publishes what it is running: `/run/<service>/identity.json`.
@@ -281,6 +298,23 @@ pub mod method {
     pub const PAD_PAIR: &str = "pad.pair";
     /// Forget a pad, so it stops reconnecting.
     pub const PAD_FORGET: &str = "pad.forget";
+
+    /// Subscribe to the raw input stream of the pad `padd` is driving from.
+    ///
+    /// **The one method in this namespace `padd` answers itself**, on [`super::socket::PAD`]
+    /// rather than `configd`'s socket. That is not a lapse in the split above: the three calls
+    /// before it are Bluetooth *configuration*, and this is the input device — which only the
+    /// process already reading it can name, since it is the node gilrs picked.
+    ///
+    /// It exists for one question the rest of the system cannot answer. `padd` polls the last
+    /// known stick value and keeps sending it at 50 Hz, so a radio that stops delivering reports
+    /// still produces fresh intents: `robotd` sees a live driver, the deadman never fires, and the
+    /// robot walks on a stale command. Nothing in `robot.state` can show that. The raw event
+    /// stream can, because a report that never arrived leaves a measurable hole in the cadence.
+    pub const PAD_INPUT: &str = "pad.input";
+
+    /// One report from the pad, pushed after [`PAD_INPUT`].
+    pub const PAD_REPORT: &str = "pad.report";
 }
 
 /// JSON-RPC error codes.
@@ -402,6 +436,8 @@ pub enum Call {
     PadStatus,
     PadPair(PadPairParams),
     PadForget(PadForgetParams),
+    /// Subscribe to the raw pad input stream. Answered by `padd`, not `configd`.
+    PadInput,
 }
 
 impl Call {
@@ -444,6 +480,7 @@ impl Call {
             Call::PadStatus => method::PAD_STATUS,
             Call::PadPair(_) => method::PAD_PAIR,
             Call::PadForget(_) => method::PAD_FORGET,
+            Call::PadInput => method::PAD_INPUT,
         }
     }
 
@@ -531,7 +568,8 @@ impl Call {
             | Call::SystemServices
             | Call::SystemReboot
             | Call::SystemPairingPin
-            | Call::PadStatus => Value::Object(serde_json::Map::new()),
+            | Call::PadStatus
+            | Call::PadInput => Value::Object(serde_json::Map::new()),
         }
     }
 
@@ -591,6 +629,7 @@ impl Call {
                 Call::PadPair(decode(params.or(Some(&empty)))?)
             }
             method::PAD_FORGET => Call::PadForget(decode(params)?),
+            method::PAD_INPUT => Call::PadInput,
             other => {
                 return Err(Error::new(
                     code::METHOD_NOT_FOUND,
@@ -658,6 +697,24 @@ impl Request {
     /// Read a robot-state notification back.
     pub fn as_state(&self) -> Option<RobotState> {
         if self.method != method::ROBOT_STATE {
+            return None;
+        }
+        serde_json::from_value(self.params.clone()?).ok()
+    }
+
+    /// A raw-pad notification: no `id`, so no response is expected.
+    pub fn notify_pad_report(report: &PadReport) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_owned(),
+            id: None,
+            method: method::PAD_REPORT.to_owned(),
+            params: Some(serde_json::to_value(report).unwrap_or(Value::Null)),
+        }
+    }
+
+    /// Read a raw-pad notification back.
+    pub fn as_pad_report(&self) -> Option<PadReport> {
+        if self.method != method::PAD_REPORT {
             return None;
         }
         serde_json::from_value(self.params.clone()?).ok()
@@ -1759,8 +1816,10 @@ pub enum UnitState {
 /// **This exists to answer "which version is actually running", which nothing else could.**
 /// `updaterd`, `robotd` and `configd` report their build over their own sockets, so a running
 /// daemon that did not restart into a new release is already visible for those three. `btd` and
-/// `padd` serve no socket, and asking them is not an option — the process that needs interrogating
-/// is by definition the *old* one, which cannot have learned a new way to answer.
+/// `padd` cannot be asked, and the reason is not merely that they have no service socket — `padd`
+/// does serve one, for [`method::PAD_INPUT`] and nothing else. It is that the process which needs
+/// interrogating is by definition the *old* one, which cannot have learned a new way to answer,
+/// whatever socket it is holding.
 ///
 /// So it is read from outside the process: systemd knows the PID, and `/proc/<pid>/exe` resolves to
 /// the real path the binary was executed from. Since a release installs to `…/releases/<version>/`
@@ -1825,6 +1884,232 @@ pub struct PadForgetResult {
     /// False when no such pad was bonded — not an error, and a client should not present it as
     /// one. Same contract as [`ForgetResult`].
     pub removed: bool,
+}
+
+// ── pad input, as the kernel delivers it ─────────────────────────────────────
+
+/// How the cadence of raw pad reports is judged.
+///
+/// Shared so the live view in `robotctl monitor` and `scripts/pad-link-test.sh` reach the same
+/// verdict about the same link: two tools that disagree about what counts as a stall are two tools
+/// nobody can compare. The script keeps its own copies of these numbers deliberately — it is a
+/// `/bin/sh` file that has to run on a board with none of this compiled — and names them there.
+pub mod pad_link {
+    /// Under this, a late report is invisible to whoever is driving. Over it, the robot feels
+    /// sticky.
+    pub const NOTABLE_MS: u64 = 100;
+
+    /// Where `robotd` zeroes the velocity: the default of its `safety.deadman_ms`. A gap past this
+    /// is not a latency complaint, it is the robot stopping.
+    pub const DEADMAN_MS: u64 = 500;
+
+    /// Past this, silence is the operator rather than the radio.
+    ///
+    /// An evdev device sends nothing while nothing moves, so a pad at rest is indistinguishable
+    /// from a link that has stopped delivering — except by duration. A link silent this long would
+    /// have hit its supervision timeout and dropped, and a drop is visible on its own. Counting
+    /// quiet as a stall is how the first real measurement of this robot reported a 75-second
+    /// breach of the deadman on a link that never faltered.
+    pub const IDLE_MS: u64 = 5000;
+}
+
+/// The pad's input device, as the kernel describes it.
+///
+/// Sent when a subscriber attaches and again whenever the device changes, because every number in
+/// a [`PadFrame`] is meaningless without it: `ABS_X = 1583` is a stick position only once you know
+/// the axis runs −32768..32767 on this pad and 0..65535 on the next one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadInputDevice {
+    /// As the pad calls itself: "Xbox Wireless Controller".
+    pub name: String,
+    /// The event node being read, `/dev/input/event5`.
+    ///
+    /// Worth reporting because it *changes*: a pad that drops and comes back is often a different
+    /// number, and one stale path in a log is how two sessions get read as one.
+    pub node: String,
+    /// The pad's address, as the kernel has it. This is what ties a report stream to a `btmon`
+    /// capture of the same link.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique: Option<String>,
+    /// `0x0005` for Bluetooth, `0x0003` for USB — [`Self::over_bluetooth`].
+    pub bus: u16,
+    pub vendor: u16,
+    pub product: u16,
+    /// Every absolute axis the device declares, with the range its values live in.
+    pub axes: Vec<PadAxis>,
+    /// Every button it declares. The whole list, not the ones this build has a use for: a pad
+    /// whose Start does nothing is a pad someone needs to see the raw code of.
+    pub buttons: Vec<PadKey>,
+}
+
+impl PadInputDevice {
+    /// Bus id of a Bluetooth device, from `linux/input.h`.
+    pub const BUS_BLUETOOTH: u16 = 0x0005;
+    /// Bus id of a USB device.
+    pub const BUS_USB: u16 = 0x0003;
+
+    /// Is this pad on the radio at all?
+    ///
+    /// A pad on a cable has no link to measure, and saying so beats reporting a flawless one —
+    /// `pad-link-test.sh` refuses to run in that case for the same reason.
+    pub fn over_bluetooth(&self) -> bool {
+        self.bus == Self::BUS_BLUETOOTH
+    }
+}
+
+/// One absolute axis, with the range and the noise floor the driver claims for it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadAxis {
+    /// The evdev code: `ABS_X` is 0.
+    pub code: u16,
+    /// `ABS_X`, as `linux/input-event-codes.h` spells it.
+    pub name: String,
+    pub min: i32,
+    pub max: i32,
+    /// The driver's own dead zone for this axis, in axis units.
+    ///
+    /// A *hardware* claim about where centre stops being centre, and worth having next to the
+    /// live value: a stick whose rest position sits outside it is a stick that will creep,
+    /// whatever `padd`'s own `--deadzone` then does about it.
+    pub flat: i32,
+    /// Changes smaller than this the driver considers noise.
+    pub fuzz: i32,
+    /// Where the axis was when the device was described, so a subscriber starts with the whole
+    /// picture rather than with whatever moves first.
+    pub value: i32,
+}
+
+/// One button, and whether it was held when the device was described.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadKey {
+    /// The evdev code: `BTN_SOUTH` is 0x130.
+    pub code: u16,
+    pub name: String,
+    pub pressed: bool,
+}
+
+/// What arrives on a [`method::PAD_INPUT`] subscription.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "report", rename_all = "snake_case")]
+pub enum PadReport {
+    /// A pad's event node is open and reports are coming. Sent on subscribing if a pad is already
+    /// connected, and again each time one appears, so a subscriber has one code path for "already
+    /// there" and "turned up later".
+    Attached { device: Box<PadInputDevice> },
+    /// One report, as the kernel framed it.
+    Frame(PadFrame),
+    /// The node closed: the pad dropped, was switched off, or `padd` stopped reading it.
+    Detached {
+        /// Why, in `padd`'s words. Not a code — nothing acts on this, and the honest answer is
+        /// usually an errno the operator wants verbatim.
+        why: String,
+    },
+}
+
+/// One report from the pad: everything the kernel delivered between two `SYN_REPORT`s.
+///
+/// **The report, not the event, is the unit of a radio's cadence.** One flick of a stick is four
+/// events in a single report, and counting events instead turns one late report into four.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadFrame {
+    /// Reports since this device attached, counted by `padd`.
+    ///
+    /// A hole in it means the *socket* fell behind — see [`Self::socket_dropped`]. A report the
+    /// pad never sent leaves no hole at all, which is the whole difficulty of measuring this:
+    /// absence is not an event, and only the clock can find it.
+    pub seq: u64,
+    /// The kernel's timestamp on the report, microseconds since the epoch.
+    ///
+    /// **Not the time `padd` read it.** `input_event.time` is stamped as the kernel takes the
+    /// report off the transport, so a cadence measured from it is the pad's own and survives
+    /// `padd` being scheduled late. It is also what lines this stream up against a `btmon`
+    /// capture of the same seconds.
+    pub at_us: u64,
+    /// Microseconds since the previous report. Absent for the first one after attaching, where
+    /// there is nothing to measure from.
+    ///
+    /// **Signed, because it can genuinely be negative.** `input_event.time` is `CLOCK_REALTIME`,
+    /// which is the price of [`Self::at_us`] lining up with a `btmon` capture: a board with no RTC
+    /// gets its clock stepped once its first NTP reply lands, and that step falls between two
+    /// reports of a link that never faltered. A negative gap is that step, and reading it as a
+    /// 40-year stall — or clamping it to zero and calling it the fastest report ever seen — are
+    /// both worse than saying so.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since_us: Option<i64>,
+    /// Every event in the report, in the order the kernel delivered them.
+    pub events: Vec<PadEvent>,
+    /// `SYN_DROPPED` preceded this report: the kernel discarded events because **this reader**
+    /// fell behind.
+    ///
+    /// It says nothing about the radio, and it makes [`Self::since_us`] here meaningless — the
+    /// events that would have filled the gap were thrown away before anyone saw them.
+    #[serde(default, skip_serializing_if = "not")]
+    pub after_drop: bool,
+    /// Reports this subscriber missed because its own socket was behind, since the last frame it
+    /// did receive.
+    ///
+    /// A slow client and a stalled radio produce the same silence, and a debug view that cannot
+    /// tell them apart is one that invents faults. `padd` never blocks its reader on a subscriber:
+    /// it drops, counts, and says so here.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub socket_dropped: u64,
+}
+
+/// One evdev event, as it came off the device.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadEvent {
+    /// The evdev type, numerically: `EV_SYN` 0, `EV_KEY` 1, `EV_ABS` 3.
+    pub kind: u16,
+    pub code: u16,
+    pub value: i32,
+    /// `ABS_X`, `BTN_SOUTH`, `SYN_REPORT` — the name `linux/input-event-codes.h` gives this
+    /// type/code pair, so a captured line reads without a lookup table beside it. Numeric for a
+    /// code the kernel headers this was built against do not name.
+    pub name: String,
+}
+
+impl PadEvent {
+    /// `EV_SYN` — bookkeeping: the report boundary, and the dropped marker.
+    pub const SYNCHRONIZATION: u16 = 0x00;
+    /// `EV_KEY` — a button changed state.
+    pub const KEY: u16 = 0x01;
+    /// `EV_ABS` — an absolute axis moved.
+    pub const ABSOLUTE: u16 = 0x03;
+
+    /// Did an axis move? The value is then a position in that axis's own range — see
+    /// [`PadAxis::min`] and [`PadAxis::max`], which is why it cannot be read without them.
+    pub fn is_axis(&self) -> bool {
+        self.kind == Self::ABSOLUTE
+    }
+
+    /// Did a button change? `value` is 0 for released and non-zero for held: 1 on a press and 2 on
+    /// an autorepeat, which a pad does not send but a reader must not mistake for a release.
+    pub fn is_button(&self) -> bool {
+        self.kind == Self::KEY
+    }
+}
+
+/// Answer to [`Call::PadInput`].
+///
+/// `accepted` is not "a pad is connected". A subscription with no pad is normal and is half the
+/// point: `padd` runs from boot waiting for one, and watching for it to appear is exactly what
+/// this stream is for. The pad, when there is one, arrives as [`PadReport::Attached`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadInputResult {
+    pub accepted: bool,
+    /// Why not, when it was refused — a platform with no evdev to read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `skip_serializing_if` for a `bool` that is false by default.
+fn not(b: &bool) -> bool {
+    !*b
+}
+
+/// `skip_serializing_if` for a counter that is zero on every healthy frame.
+fn is_zero(n: &u64) -> bool {
+    *n == 0
 }
 
 /// Re-exported so consumers spell version types with the *same* `semver` this crate
@@ -2444,6 +2729,124 @@ mod tests {
         };
         let line = serde_json::to_string(&sick).unwrap();
         assert_eq!(serde_json::from_str::<HealthResult>(&line).unwrap(), sick);
+    }
+
+    /// The three shapes a pad subscriber has to tell apart travel under one tag, and a frame
+    /// keeps every field a cadence is measured from. A `Frame` that deserialised as `Attached`
+    /// would present a dropped link as a fresh device.
+    #[test]
+    fn pad_reports_round_trip_under_their_tag() {
+        let attached = PadReport::Attached {
+            device: Box::new(PadInputDevice {
+                name: "Xbox Wireless Controller".into(),
+                node: "/dev/input/event5".into(),
+                unique: Some("78:86:2e:bb:13:28".into()),
+                bus: PadInputDevice::BUS_BLUETOOTH,
+                vendor: 0x045e,
+                product: 0x0b13,
+                axes: vec![PadAxis {
+                    code: 0,
+                    name: "ABS_X".into(),
+                    min: -32768,
+                    max: 32767,
+                    flat: 128,
+                    fuzz: 16,
+                    value: -3,
+                }],
+                buttons: vec![PadKey {
+                    code: 0x130,
+                    name: "BTN_SOUTH".into(),
+                    pressed: false,
+                }],
+            }),
+        };
+        let frame = PadReport::Frame(PadFrame {
+            seq: 412,
+            at_us: 1_755_500_000_123_456,
+            since_us: Some(7_920),
+            events: vec![
+                PadEvent {
+                    kind: 3,
+                    code: 0,
+                    value: -1583,
+                    name: "ABS_X".into(),
+                },
+                PadEvent {
+                    kind: 0,
+                    code: 0,
+                    value: 0,
+                    name: "SYN_REPORT".into(),
+                },
+            ],
+            after_drop: false,
+            socket_dropped: 0,
+        });
+        let detached = PadReport::Detached {
+            why: "read failed: No such device (os error 19)".into(),
+        };
+
+        for report in [attached, frame, detached] {
+            let line = serde_json::to_string(&Request::notify_pad_report(&report)).unwrap();
+            assert!(line.contains(r#""method":"pad.report""#), "{line}");
+            let back: Request = serde_json::from_str(&line).unwrap();
+            assert!(back.is_notification(), "a report answers nothing");
+            assert_eq!(back.as_pad_report().unwrap(), report, "{line}");
+        }
+    }
+
+    /// The two counters that only ever mean bad news stay off a healthy frame, which is most of
+    /// them at 125 reports a second — and a reader must still see `false` and `0` rather than a
+    /// missing field it has to interpret.
+    #[test]
+    fn a_clean_frame_carries_neither_alarm() {
+        let clean = PadFrame {
+            seq: 1,
+            at_us: 10,
+            since_us: None,
+            events: vec![],
+            after_drop: false,
+            socket_dropped: 0,
+        };
+        let line = serde_json::to_string(&clean).unwrap();
+        assert!(!line.contains("after_drop"), "{line}");
+        assert!(!line.contains("socket_dropped"), "{line}");
+        assert!(!line.contains("since_us"), "{line}");
+        assert_eq!(serde_json::from_str::<PadFrame>(&line).unwrap(), clean);
+
+        let troubled = PadFrame {
+            after_drop: true,
+            socket_dropped: 3,
+            since_us: Some(640_000),
+            ..clean
+        };
+        let line = serde_json::to_string(&troubled).unwrap();
+        assert!(line.contains(r#""after_drop":true"#), "{line}");
+        assert!(line.contains(r#""socket_dropped":3"#), "{line}");
+        assert_eq!(serde_json::from_str::<PadFrame>(&line).unwrap(), troubled);
+    }
+
+    /// A pad on a cable is not a link with nothing wrong with it — it is a link that is not
+    /// there. `pad-link-test.sh` refuses to measure one, and the live view has to say the same.
+    #[test]
+    fn a_usb_pad_is_not_on_the_radio() {
+        let usb = PadInputDevice {
+            name: "Xbox Wireless Controller".into(),
+            node: "/dev/input/event5".into(),
+            unique: None,
+            bus: PadInputDevice::BUS_USB,
+            vendor: 0,
+            product: 0,
+            axes: vec![],
+            buttons: vec![],
+        };
+        assert!(!usb.over_bluetooth());
+        assert!(
+            PadInputDevice {
+                bus: PadInputDevice::BUS_BLUETOOTH,
+                ..usb
+            }
+            .over_bluetooth()
+        );
     }
 
     /// `move` and `loop` are Rust keywords, so the fields are renamed on the wire. A typo

--- a/padd/Cargo.toml
+++ b/padd/Cargo.toml
@@ -14,12 +14,24 @@ description = "Gamepad → robot intents"
 # same Xbox controller reports different codes over USB and Bluetooth.
 #
 # The same expense returns for the next C dependency that has to reach the board, which is
-# an argument for preferring pure-Rust crates anywhere else on that path.
+# an argument for preferring pure-Rust crates anywhere else on that path. `evdev` below is one:
+# it reads the same device node gilrs reads, for `src/tap.rs`, and brings no C with it.
 
 [dependencies]
 duck-ipc-proto = { path = "../duck-ipc-proto" }
 clap = { workspace = true, features = ["derive"] }
 gilrs = "0.11"
+# Only to serialise the tap's own lines; the wire types themselves live in duck-ipc-proto.
+serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+# The raw input tap (`src/tap.rs`) is evdev, and evdev is Linux. Nothing else in `padd` is
+# platform-specific, so a Mac still builds and still drives a pad — it serves no tap.
+[target.'cfg(target_os = "linux")'.dependencies]
+# The raw event stream, unfiltered: `raw_stream::RawDevice` is the one that does *not* resync on
+# SYN_DROPPED, which is the event a link investigation most needs to see.
+evdev = "0.13"
+# `getgrnam`/`chown`, to hand the tap's socket to the `robot` group. Bindings only, no C to build.
+libc = "0.2"

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -24,9 +24,20 @@
 //! device needs root and BlueZ, and a `padd` holding either would stop being the unprivileged client
 //! whose whole value is having no special access. It lives in `configd`, next to wifi.
 //!
+//! ## It also hands out the pad's raw input
+//!
+//! One socket, read-only, for `pad.input` and nothing else — `src/tap.rs`, and it does not make this
+//! a privileged process. It exists because `padd` is the reason a stalled radio is invisible: the
+//! sticks are *polled*, so the last known value keeps being sent at 50 Hz whether or not the pad is
+//! still talking, and every surface downstream then shows a robot with a live driver. The event
+//! stream one layer below has the evidence, so it is passed out unaltered rather than summarised.
+//! `robotctl monitor` draws it; `docs/robot/pair-a-gamepad.md` says how to read it.
+//!
 //! For development against a board: `ssh -L /tmp/robotd.sock:/run/robotd.sock duck`, then
 //! point `--socket` at the forwarded path. Pad on your laptop, robot on the bench, no code.
-//! `systemctl stop padd` first, or two processes fight over the sticks.
+//! `systemctl stop padd` first, or two processes fight over the sticks. Run that way, `--tap-socket`
+//! wants a path you can write — `/run/padd/` belongs to the unit — and on a Mac there is no tap at
+//! all, since it reads evdev.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
@@ -36,6 +47,31 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use duck_ipc_proto as proto;
 use gilrs::{Axis, Button, Gilrs};
+
+#[cfg(target_os = "linux")]
+mod tap;
+
+/// The raw tap, on a platform with no evdev to read.
+///
+/// A `padd` on a Mac still drives a pad — that is the bench setup in the crate docs above, and it
+/// would be a poor trade to lose it over a debug facility. It serves no tap, and `robotctl monitor`
+/// finds no socket and says so, which is the truth rather than an empty stream.
+#[cfg(not(target_os = "linux"))]
+mod tap {
+    pub struct Tap;
+
+    impl Tap {
+        pub fn serve(_socket: &std::path::Path) -> std::io::Result<Self> {
+            Err(std::io::Error::other(
+                "the raw pad tap reads evdev, which only Linux has",
+            ))
+        }
+
+        pub fn watch(&self, _pad: &gilrs::Gamepad<'_>) {}
+
+        pub fn idle(&self) {}
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "padd", about = "Drive the robot from a gamepad", version)]
@@ -66,6 +102,13 @@ struct Args {
     /// Full-deflection head travel, radians.
     #[arg(long, default_value_t = 0.5)]
     max_head: f64,
+
+    /// Where to serve the raw input tap: the pad's own event stream, for `robotctl monitor`.
+    ///
+    /// Read-only, and nothing on the driving path depends on it — if the socket cannot be created
+    /// `padd` says so once and drives anyway.
+    #[arg(long, default_value = proto::socket::PAD)]
+    tap_socket: PathBuf,
 }
 
 /// How long to wait between checks when there is no pad.
@@ -105,6 +148,20 @@ fn main() -> std::process::ExitCode {
         Err(e) => {
             tracing::error!(error = %e, "no gamepad subsystem");
             return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    // Before robotd's socket on purpose: a `padd` that cannot reach `robotd` exits and is retried
+    // by systemd, and the tap is the one thing here that could have told someone why the pad looked
+    // dead. Its own failure is logged and stepped over — see `--tap-socket`.
+    let tap = match tap::Tap::serve(&args.tap_socket) {
+        Ok(tap) => Some(tap),
+        Err(e) => {
+            tracing::warn!(
+                error = %e, socket = %args.tap_socket.display(),
+                "no raw pad tap — `robotctl monitor` cannot show the pad's own event stream"
+            );
+            None
         }
     };
 
@@ -159,6 +216,9 @@ fn main() -> std::process::ExitCode {
                 tracing::warn!("pad gone — sending nothing; robotd's deadman holds the robot");
                 driving = false;
             }
+            if let Some(tap) = tap.as_ref() {
+                tap.idle();
+            }
             std::thread::sleep(IDLE_POLL);
             continue;
         };
@@ -166,6 +226,13 @@ fn main() -> std::process::ExitCode {
         if !driving {
             tracing::warn!(pad = pad.name(), "pad connected — driving");
             driving = true;
+        }
+
+        // Every tick rather than on the transition above: a pad that drops and comes back between
+        // two ticks never clears `driving`, and it comes back as a different event node often
+        // enough that a tap following the old one would report the rest of the session as silence.
+        if let Some(tap) = tap.as_ref() {
+            tap.watch(&pad);
         }
 
         if toggle_mode {

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -1,0 +1,766 @@
+//! The raw input tap: a second reader of the same pad, on a socket of its own.
+//!
+//! ## Why `padd` grew a socket to serve one read-only stream
+//!
+//! One question about a gamepad cannot be answered from anywhere else in this system. `padd` polls
+//! the last known stick value and sends it at a steady 50 Hz, so a radio that has stopped
+//! delivering reports still produces perfectly fresh intents: `robotd` sees a live driver, the
+//! deadman never fires, and the robot keeps walking on a command nobody is still giving. Every
+//! surface downstream — `robot.state`, the monitor's `requested` column, the journal — shows a
+//! healthy robot, because from their side it is one.
+//!
+//! The evidence lives one layer below `padd`: the event stream itself, where a report that never
+//! arrived leaves a hole in the cadence. So this hands that stream out unaltered rather than
+//! summarising it, and lets whoever is investigating do the arithmetic.
+//!
+//! ## Why it reads the device a second time instead of forwarding what gilrs gives it
+//!
+//! `Gilrs::next_event` is not the raw stream and cannot be made into one. It applies three filters
+//! by default — `axis_dpad_to_button`, `Jitter`, `deadzone` — which rewrite values, drop small
+//! movements, and swallow whole events; `gilrs-core` turns `SYN_DROPPED` into an internal resync
+//! flag that never reaches a consumer; and neither `SYN_REPORT` nor `MSC_SCAN` survives the trip.
+//! Every one of those is a thing someone chasing an unreliable link needs to see.
+//!
+//! Opening the node twice costs nothing and takes nothing away: an evdev reader gets its own queue,
+//! so this cannot starve gilrs of an event, and `scripts/pad-link-test.sh` has been reading the same
+//! node alongside `padd` since before this existed. The node comes from gilrs itself
+//! ([`gilrs::LinuxGamepadExt::devpath`]), which is the only way to be sure this is watching the pad
+//! that is actually driving — one Xbox controller registers several input devices, and the first
+//! one in `/proc/bus/input/devices` is a media-key keyboard that never sends anything.
+//!
+//! ## What it costs while nobody is watching
+//!
+//! Nothing. The device is not opened until a subscriber connects, and it is closed again after the
+//! first report following the last one leaving — the same bargain `robotd` strikes by only
+//! assembling a `robot.state` frame when someone is subscribed. A pad at rest is silent, so a
+//! parked reader is not a wakeup either.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use duck_ipc_proto as proto;
+use evdev::raw_stream::RawDevice;
+use evdev::{
+    AbsoluteAxisCode, AttributeSet, EventType, KeyCode, MiscCode, RelativeAxisCode,
+    SynchronizationCode,
+};
+use gilrs::LinuxGamepadExt;
+
+/// Reports a subscriber may fall behind by before frames start being dropped for it.
+///
+/// Two seconds of a busy pad. Generous, because the cost of a queue is memory and the cost of a
+/// drop is a hole in the very measurement this exists to make — but bounded, because the alternative
+/// is a slow client turning into unbounded memory on a robot. A drop is counted and reported rather
+/// than hidden ([`proto::PadFrame::socket_dropped`]).
+const QUEUE: usize = 256;
+
+/// The group that may read the tap, matching `robotd`'s own socket.
+///
+/// Deliberately the same one: whoever may watch `robot.state` may watch the pad driving it, and
+/// nobody else gains anything by this existing.
+const GROUP: &str = "robot";
+
+/// Socket mode. Same reasoning as every other socket here — the group decides who may ask.
+const SOCKET_MODE: u32 = 0o660;
+
+/// How long to wait before opening the node again after a stream ended.
+///
+/// It bounds a spin. Two of the ways a stream ends leave the state that started it unchanged — the
+/// node cannot be opened at all (no `input` group, so every attempt fails identically), and a device
+/// that is already gone when it is opened — and without this the reader would reopen, fail, and
+/// reopen again as fast as the kernel could refuse it. On a robot being driven, by the tool brought
+/// in to find out why driving is unreliable, which is the same trap `pad-link-test.sh` documents
+/// hitting in its watch loop.
+///
+/// A quarter of a second: four attempts a second is nothing, and nobody notices it when a pad that
+/// really has come back takes that long to be picked up.
+const REOPEN_AFTER: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// The tap, as the main loop holds it.
+pub struct Tap {
+    shared: Arc<Shared>,
+}
+
+/// Shared between the accept loop, each subscriber's writer, and the reader.
+struct Shared {
+    state: Mutex<State>,
+    /// Signalled whenever the reader might have work: a pad appeared, or someone subscribed.
+    wake: Condvar,
+}
+
+struct State {
+    /// The node to read, as gilrs named it. `None` when no pad is connected.
+    wanted: Option<PathBuf>,
+    subscribers: Vec<Subscriber>,
+    /// The `Attached` report for the device currently open.
+    ///
+    /// Kept so a subscriber arriving mid-stream is told what it is looking at immediately, rather
+    /// than having to wait for the pad to be unplugged and put back to find out.
+    attached: Option<Arc<proto::PadReport>>,
+}
+
+struct Subscriber {
+    reports: SyncSender<Arc<proto::PadReport>>,
+    /// Frames dropped because this subscriber's queue was full. Its writer stamps them into the
+    /// next frame it does send, so a slow client cannot read as a stalled radio.
+    dropped: Arc<AtomicU64>,
+}
+
+impl Tap {
+    /// Bind the socket and start serving.
+    ///
+    /// Fails only where the socket cannot be created. The caller is expected to carry on driving
+    /// without a tap in that case: `padd`'s job is to make the robot drivable, and a debug facility
+    /// that refuses to be optional would be a way for this file to stop a robot.
+    pub fn serve(socket: &Path) -> std::io::Result<Self> {
+        // The directory is `RuntimeDirectory=padd`, which systemd has already made on a board. Tried
+        // anyway for `padd` run by hand, and its failure left to `bind` to report against the full
+        // path — which is the message that actually helps.
+        if let Some(parent) = socket.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        // systemd removes the runtime directory when the unit stops, so a stale socket only happens
+        // to a `padd` killed outside its unit. Removing it is still right: the alternative is a
+        // daemon that refuses to start because of a file whose owner is gone.
+        let _ = std::fs::remove_file(socket);
+
+        let listener = UnixListener::bind(socket)?;
+        std::fs::set_permissions(socket, std::fs::Permissions::from_mode(SOCKET_MODE))?;
+        if let Err(e) = give_to_group(socket, GROUP) {
+            // Not fatal, and said out loud with what it means: the socket still exists, and only
+            // `padd` itself and root can read it. On a board this is a broken install; on a laptop
+            // it is a machine with no `robot` group, which is ordinary.
+            tracing::warn!(
+                error = %e, group = GROUP, socket = %socket.display(),
+                "the tap's socket stays private to padd — nothing else can read the pad stream"
+            );
+        }
+
+        let shared = Arc::new(Shared {
+            state: Mutex::new(State {
+                wanted: None,
+                subscribers: Vec::new(),
+                attached: None,
+            }),
+            wake: Condvar::new(),
+        });
+
+        let accepting = Arc::clone(&shared);
+        thread::Builder::new()
+            .name("pad-tap-accept".to_owned())
+            .spawn(move || accept(listener, &accepting))?;
+
+        let reading = Arc::clone(&shared);
+        thread::Builder::new()
+            .name("pad-tap-read".to_owned())
+            .spawn(move || read(&reading))?;
+
+        Ok(Self { shared })
+    }
+
+    /// Read this pad from now on.
+    ///
+    /// Safe to call every tick: it compares before it disturbs anything, because the alternative is
+    /// tearing the reader down and rebuilding it 50 times a second.
+    ///
+    /// It takes the gamepad rather than a path so the node can only come from gilrs — the one place
+    /// that knows which of a pad's several input devices is the one being driven from.
+    pub fn watch(&self, pad: &gilrs::Gamepad<'_>) {
+        self.want(Some(pad.devpath().to_path_buf()));
+    }
+
+    /// No pad. The reader closes the device and says so to whoever is watching.
+    pub fn idle(&self) {
+        self.want(None);
+    }
+
+    fn want(&self, node: Option<PathBuf>) {
+        let mut state = self.shared.lock();
+        if state.wanted == node {
+            return;
+        }
+        state.wanted = node;
+        drop(state);
+        self.shared.wake.notify_all();
+    }
+}
+
+impl Shared {
+    /// The state, whether or not a thread panicked while holding it.
+    ///
+    /// A poisoned lock must not take the tap down with it: the data behind it is a subscriber list
+    /// and a path, neither of which a panic can leave half-written into an invalid shape.
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Wait until there is both a pad to read and somebody to read it for.
+    fn wait_for_work(&self) -> PathBuf {
+        let mut state = self.lock();
+        loop {
+            if let Some(node) = state.wanted.clone()
+                && !state.subscribers.is_empty()
+            {
+                return node;
+            }
+            state = self
+                .wake
+                .wait(state)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+
+    /// Should the reader let go of the node it has open?
+    fn done_with(&self, node: &Path) -> Option<&'static str> {
+        let state = self.lock();
+        if state.subscribers.is_empty() {
+            // Said as a reason rather than dropped silently: a client that reconnects wants to know
+            // why the previous stream ended, and "nobody was watching" is not a fault.
+            return Some("nobody is watching any more");
+        }
+        if state.wanted.as_deref() != Some(node) {
+            return Some("the pad changed");
+        }
+        None
+    }
+
+    fn attach(&self, device: proto::PadInputDevice) {
+        let report = Arc::new(proto::PadReport::Attached {
+            device: Box::new(device),
+        });
+        let mut state = self.lock();
+        state.attached = Some(Arc::clone(&report));
+        state.send(&report);
+    }
+
+    fn detach(&self, why: String) {
+        let mut state = self.lock();
+        state.attached = None;
+        state.send(&Arc::new(proto::PadReport::Detached { why }));
+    }
+
+    fn frame(&self, frame: proto::PadFrame) {
+        self.frame_report(&Arc::new(proto::PadReport::Frame(frame)));
+    }
+
+    /// Hand out one already-built report. Split from [`Self::frame`] so a test can send the same
+    /// report many times without rebuilding it.
+    fn frame_report(&self, report: &Arc<proto::PadReport>) {
+        self.lock().send(report);
+    }
+
+    /// Add a subscriber, seeded with the device it is about to see frames from.
+    ///
+    /// Hands back the counter of what gets dropped for it, which only its own writer may clear.
+    fn subscribe(&self) -> (Receiver<Arc<proto::PadReport>>, Arc<AtomicU64>) {
+        let (reports, rx) = sync_channel(QUEUE);
+        let mut state = self.lock();
+        if let Some(attached) = state.attached.clone() {
+            // Cannot fail: the queue is empty and this is the first thing in it.
+            let _ = reports.try_send(attached);
+        }
+        let dropped = Arc::new(AtomicU64::new(0));
+        state.subscribers.push(Subscriber {
+            reports,
+            dropped: Arc::clone(&dropped),
+        });
+        drop(state);
+        // A subscriber is the reader's other precondition, so it may have work now.
+        self.wake.notify_all();
+        (rx, dropped)
+    }
+}
+
+impl State {
+    /// Hand one report to every subscriber, dropping it for any that has fallen behind.
+    ///
+    /// **Never blocks.** The reader thread is the only thing that can measure the pad's cadence, and
+    /// a subscriber that stalled it would corrupt the measurement it asked for — every frame after
+    /// the stall would carry a gap the radio had nothing to do with.
+    fn send(&mut self, report: &Arc<proto::PadReport>) {
+        self.subscribers.retain(|subscriber| {
+            match subscriber.reports.try_send(Arc::clone(report)) {
+                Ok(()) => true,
+                Err(TrySendError::Full(_)) => {
+                    subscriber.dropped.fetch_add(1, Ordering::Relaxed);
+                    true
+                }
+                // The writer is gone: the client disconnected.
+                Err(TrySendError::Disconnected(_)) => false,
+            }
+        });
+    }
+}
+
+/// Accept subscribers forever. One thread each: a subscriber does nothing but be written to, and
+/// the write must not be able to block the reader.
+fn accept(listener: UnixListener, shared: &Arc<Shared>) {
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let shared = Arc::clone(shared);
+                if let Err(e) = thread::Builder::new()
+                    .name("pad-tap-client".to_owned())
+                    .spawn(move || subscriber(stream, &shared))
+                {
+                    tracing::warn!(error = %e, "cannot serve a pad tap subscriber");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "pad tap accept failed"),
+        }
+    }
+}
+
+/// One subscriber, from its request to its socket closing.
+fn subscriber(stream: UnixStream, shared: &Arc<Shared>) {
+    let mut writer = match stream.try_clone() {
+        Ok(writer) => writer,
+        Err(e) => {
+            tracing::warn!(error = %e, "cannot split a pad tap connection");
+            return;
+        }
+    };
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
+        return;
+    }
+
+    let request = match serde_json::from_str::<proto::Request>(&line) {
+        Ok(request) => request,
+        Err(e) => {
+            let error = proto::Error::new(proto::code::PARSE_ERROR, e.to_string());
+            let _ = write_line(&mut writer, &proto::Response::err(None, error));
+            return;
+        }
+    };
+    let id = request.id.clone();
+    match request.as_call() {
+        Ok(proto::Call::PadInput) => {}
+        Ok(other) => {
+            // Served by this socket and nothing else. A client that meant to reach `robotd` or
+            // `configd` gets told which door it is knocking on rather than a silent hang.
+            let error = proto::Error::new(
+                proto::code::METHOD_NOT_FOUND,
+                format!(
+                    "padd's socket serves {} only, not {}",
+                    proto::method::PAD_INPUT,
+                    other.method()
+                ),
+            );
+            let _ = write_line(&mut writer, &proto::Response::err(id, error));
+            return;
+        }
+        Err(e) => {
+            let _ = write_line(&mut writer, &proto::Response::err(id, e));
+            return;
+        }
+    }
+
+    // Answered before subscribing, so the reply cannot arrive after a notification it precedes.
+    if let Some(id) = id {
+        let accepted = proto::PadInputResult {
+            accepted: true,
+            reason: None,
+        };
+        if write_line(&mut writer, &proto::Response::ok(Some(id), &accepted)).is_err() {
+            return;
+        }
+    }
+
+    let (reports, dropped) = shared.subscribe();
+    tracing::info!("pad tap subscriber attached");
+
+    for report in reports {
+        // Whatever this subscriber missed goes on the next frame it does get, where it belongs:
+        // beside the gap it explains. Left on the counter until then, so it cannot be lost to an
+        // `Attached` or a `Detached` that carries nowhere to put it.
+        let stamped = match (&*report, dropped.load(Ordering::Relaxed)) {
+            (proto::PadReport::Frame(frame), missed) if missed > 0 => {
+                dropped.store(0, Ordering::Relaxed);
+                Some(proto::PadReport::Frame(proto::PadFrame {
+                    socket_dropped: missed,
+                    ..frame.clone()
+                }))
+            }
+            _ => None,
+        };
+        let note = proto::Request::notify_pad_report(stamped.as_ref().unwrap_or(&report));
+        if write_line(&mut writer, &note).is_err() {
+            break;
+        }
+    }
+    tracing::info!("pad tap subscriber gone");
+}
+
+fn write_line(writer: &mut impl Write, message: &impl serde::Serialize) -> std::io::Result<()> {
+    let mut line = serde_json::to_vec(message)?;
+    line.push(b'\n');
+    writer.write_all(&line)?;
+    writer.flush()
+}
+
+/// Open the wanted node, stream it, and go back to waiting when it ends. Forever.
+fn read(shared: &Arc<Shared>) {
+    loop {
+        let node = shared.wait_for_work();
+        let why = stream(shared, &node);
+        tracing::info!(node = %node.display(), why, "pad tap stopped reading");
+        shared.detach(why);
+        thread::sleep(REOPEN_AFTER);
+    }
+}
+
+/// Read one device until it ends, describing how it ended.
+fn stream(shared: &Arc<Shared>, node: &Path) -> String {
+    let mut device = match RawDevice::open(node) {
+        Ok(device) => device,
+        // The everyday cause is permissions: reading an input device needs the `input` group, which
+        // `padd`'s unit grants and a hand-run `padd` usually has not been given.
+        Err(e) => return format!("cannot open {}: {e}", node.display()),
+    };
+    shared.attach(describe(&device, node));
+    tracing::info!(node = %node.display(), "pad tap reading");
+
+    let mut seq = 0u64;
+    let mut previous_us: Option<u64> = None;
+    let mut events: Vec<proto::PadEvent> = Vec::new();
+    // The kernel's contract after `SYN_DROPPED`: everything up to the next `SYN_REPORT` is a
+    // half-report and must be thrown away, because the events that completed it are already gone.
+    let mut resyncing = false;
+    let mut after_drop = false;
+
+    loop {
+        let batch = match device.fetch_events() {
+            Ok(batch) => batch,
+            // ENODEV, every time, and it is the measurement rather than an error: this is what a
+            // pad switching off or leaving range looks like from here.
+            Err(e) => return format!("{} ended: {e}", node.display()),
+        };
+
+        for event in batch {
+            let kind = event.event_type().0;
+            let code = event.code();
+            let syn = (EventType(kind) == EventType::SYNCHRONIZATION)
+                .then_some(SynchronizationCode(code));
+
+            if syn == Some(SynchronizationCode::SYN_DROPPED) {
+                // Not the radio. This reader fell behind and the kernel emptied its queue, which
+                // makes the gap around it unmeasurable — so the next complete report says so.
+                events.clear();
+                resyncing = true;
+                after_drop = true;
+                continue;
+            }
+
+            events.push(proto::PadEvent {
+                kind,
+                code,
+                value: event.value(),
+                name: event_name(kind, code),
+            });
+
+            if syn != Some(SynchronizationCode::SYN_REPORT) {
+                continue;
+            }
+            // A report ends at its `SYN_REPORT`, which is kept: this is a copy of the stream, and
+            // an event removed for being bookkeeping is an event someone has to take on trust.
+            let report = std::mem::take(&mut events);
+            if resyncing {
+                resyncing = false;
+                continue;
+            }
+
+            let at_us = micros(event.timestamp());
+            seq += 1;
+            shared.frame(proto::PadFrame {
+                seq,
+                at_us,
+                since_us: previous_us.map(|previous| at_us as i64 - previous as i64),
+                events: report,
+                after_drop,
+                socket_dropped: 0,
+            });
+            previous_us = Some(at_us);
+            after_drop = false;
+        }
+
+        // Checked between reads rather than per event: the state cannot change usefully inside one
+        // batch, and this is a lock per report at most.
+        if let Some(why) = shared.done_with(node) {
+            return why.to_owned();
+        }
+    }
+}
+
+/// Everything about the device that a number in a frame has to be read against.
+fn describe(device: &RawDevice, node: &Path) -> proto::PadInputDevice {
+    let id = device.input_id();
+    let axes = device
+        .get_absinfo()
+        .map(|axes| {
+            axes.map(|(code, info)| proto::PadAxis {
+                code: code.0,
+                name: event_name(EventType::ABSOLUTE.0, code.0),
+                min: info.minimum(),
+                max: info.maximum(),
+                flat: info.flat(),
+                fuzz: info.fuzz(),
+                value: info.value(),
+            })
+            .collect()
+        })
+        .unwrap_or_default();
+    // Which buttons are already held. Asked of the kernel rather than assumed clear, so a
+    // subscriber that attaches while a trigger is down is not told the pad is at rest.
+    let held = device
+        .get_key_state()
+        .unwrap_or_else(|_| AttributeSet::new());
+    let buttons = device
+        .supported_keys()
+        .map(|keys| {
+            keys.iter()
+                .map(|code| proto::PadKey {
+                    code: code.0,
+                    name: event_name(EventType::KEY.0, code.0),
+                    pressed: held.contains(code),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    proto::PadInputDevice {
+        name: device.name().unwrap_or("unnamed input device").to_owned(),
+        node: node.display().to_string(),
+        unique: device.unique_name().map(str::to_owned),
+        bus: id.bus_type().0,
+        vendor: id.vendor(),
+        product: id.product(),
+        axes,
+        buttons,
+    }
+}
+
+/// The name `linux/input-event-codes.h` gives one type/code pair — `ABS_X`, `BTN_SOUTH`,
+/// `SYN_REPORT`.
+///
+/// evdev's `Debug` prints the constant, and `unknown key: 42` for a code it has no constant for.
+/// That prose must not reach the wire: a pad with an axis nobody has mapped is exactly the pad
+/// someone is reading this stream to understand, and `3:42` they can look up beats a sentence they
+/// cannot grep for. Anything with a space in it is the unknown form.
+fn event_name(kind: u16, code: u16) -> String {
+    let named = match EventType(kind) {
+        EventType::SYNCHRONIZATION => format!("{:?}", SynchronizationCode(code)),
+        EventType::KEY => format!("{:?}", KeyCode(code)),
+        EventType::ABSOLUTE => format!("{:?}", AbsoluteAxisCode(code)),
+        EventType::RELATIVE => format!("{:?}", RelativeAxisCode(code)),
+        EventType::MISC => format!("{:?}", MiscCode(code)),
+        _ => String::new(),
+    };
+    if named.is_empty() || named.contains(' ') {
+        format!("{kind}:{code}")
+    } else {
+        named
+    }
+}
+
+/// A kernel timestamp as microseconds since the epoch.
+///
+/// A time before the epoch reads as zero, which cannot happen on a running kernel and is not worth
+/// a second failure path in a debug stream: the frame's `since_us` would carry the absurdity into
+/// view anyway.
+fn micros(at: SystemTime) -> u64 {
+    at.duration_since(UNIX_EPOCH)
+        .map(|since| since.as_micros() as u64)
+        .unwrap_or(0)
+}
+
+/// Hand the socket to a group, leaving its owner alone.
+///
+/// `robotd` gets the same effect from `Group=robot` in its unit, because a socket inherits its
+/// creator's primary group. `padd` cannot copy that: its primary group is its own, and it reaches
+/// the robot group as a supplementary one — which is enough for this, since POSIX lets the owner of
+/// a file give it to any group the owner belongs to.
+fn give_to_group(socket: &Path, group: &str) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(group).map_err(std::io::Error::other)?;
+    // SAFETY: `getgrnam` reads the group database and returns a pointer into storage it owns. The
+    // name is a valid C string for the length of the call, and the result is only read here — no
+    // other thread of `padd` calls into the group database.
+    let entry = unsafe { libc::getgrnam(name.as_ptr()) };
+    if entry.is_null() {
+        return Err(std::io::Error::other(format!(
+            "no {group} group on this system"
+        )));
+    }
+    // SAFETY: checked non-null immediately above, and `struct group` is fully initialised by
+    // `getgrnam` when it returns a pointer at all.
+    let gid = unsafe { (*entry).gr_gid };
+
+    let path = CString::new(socket.as_os_str().as_bytes()).map_err(std::io::Error::other)?;
+    // SAFETY: a valid C string path; `-1` for the owner is the documented "leave it alone".
+    if unsafe { libc::chown(path.as_ptr(), u32::MAX, gid) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn a_device() -> proto::PadInputDevice {
+        proto::PadInputDevice {
+            name: "Xbox Wireless Controller".to_owned(),
+            node: "/dev/input/event5".to_owned(),
+            unique: Some("78:86:2e:bb:13:28".to_owned()),
+            bus: proto::PadInputDevice::BUS_BLUETOOTH,
+            vendor: 0x045e,
+            product: 0x0b13,
+            axes: vec![],
+            buttons: vec![],
+        }
+    }
+
+    fn a_frame(seq: u64) -> Arc<proto::PadReport> {
+        Arc::new(proto::PadReport::Frame(proto::PadFrame {
+            seq,
+            at_us: 1_000_000 + seq * 8_000,
+            since_us: Some(8_000),
+            events: vec![],
+            after_drop: false,
+            socket_dropped: 0,
+        }))
+    }
+
+    fn a_shared() -> Arc<Shared> {
+        Arc::new(Shared {
+            state: Mutex::new(State {
+                wanted: None,
+                subscribers: Vec::new(),
+                attached: None,
+            }),
+            wake: Condvar::new(),
+        })
+    }
+
+    /// A subscriber that connects while a pad is already being read is told what it is watching.
+    ///
+    /// Without this it would see values with no ranges to read them against and no device name,
+    /// until the pad was unplugged and put back — which is the one thing nobody debugging a link
+    /// wants to be told to do.
+    #[test]
+    fn a_subscriber_arriving_mid_stream_is_told_the_device() {
+        let shared = a_shared();
+        shared.attach(a_device());
+
+        let (reports, _dropped) = shared.subscribe();
+        let first = reports.try_recv().expect("seeded with the device");
+        assert!(matches!(&*first, proto::PadReport::Attached { .. }));
+    }
+
+    /// A subscriber that falls behind loses reports and is *told how many*, on the next frame it
+    /// does get. The reader is never blocked: a client that could stall it would corrupt the very
+    /// cadence it asked for, since every gap after the stall would be its own fault.
+    #[test]
+    fn a_slow_subscriber_is_dropped_from_rather_than_blocking_the_reader() {
+        let shared = a_shared();
+        let (reports, dropped) = shared.subscribe();
+
+        for seq in 0..(QUEUE as u64 + 10) {
+            shared.frame_report(&a_frame(seq));
+        }
+
+        assert_eq!(
+            dropped.load(Ordering::Relaxed),
+            10,
+            "the overflow is counted"
+        );
+        assert_eq!(
+            shared.lock().subscribers.len(),
+            1,
+            "and the subscriber is kept — it is behind, not gone"
+        );
+        drop(reports);
+    }
+
+    /// A subscriber whose socket closed is forgotten, so a monitor opened and shut fifty times does
+    /// not leave fifty senders behind for the reader to serialise into.
+    #[test]
+    fn a_departed_subscriber_is_forgotten() {
+        let shared = a_shared();
+        let (reports, _dropped) = shared.subscribe();
+        assert_eq!(shared.lock().subscribers.len(), 1);
+
+        drop(reports);
+        shared.frame_report(&a_frame(1));
+        assert!(shared.lock().subscribers.is_empty());
+    }
+
+    /// The reader opens nothing until there is both a pad and somebody watching, and lets go as soon
+    /// as either goes away. On a robot nobody is usually watching, and a per-report wakeup for an
+    /// audience of none is the cost `robotd` refuses to pay for `robot.state` either.
+    #[test]
+    fn the_device_is_only_held_while_a_pad_and_a_watcher_both_exist() {
+        let shared = a_shared();
+        let node = Path::new("/dev/input/event5");
+
+        let (reports, _dropped) = shared.subscribe();
+        assert_eq!(
+            shared.done_with(node),
+            Some("the pad changed"),
+            "nothing is wanted yet, so this node is not it"
+        );
+
+        shared.lock().wanted = Some(node.to_path_buf());
+        assert_eq!(shared.done_with(node), None, "a pad and a watcher");
+
+        shared.lock().wanted = Some(PathBuf::from("/dev/input/event7"));
+        assert_eq!(
+            shared.done_with(node),
+            Some("the pad changed"),
+            "a pad that came back as a different node"
+        );
+
+        shared.lock().wanted = Some(node.to_path_buf());
+        drop(reports);
+        shared.frame_report(&a_frame(1)); // the send that notices the departure
+        assert_eq!(shared.done_with(node), Some("nobody is watching any more"));
+    }
+
+    /// Names come from the kernel's own tables, and a code with no name there becomes numbers rather
+    /// than evdev's `unknown key: 42` prose — which nobody can grep for and which would land in the
+    /// middle of a JSON line.
+    #[test]
+    fn every_code_gets_a_name_or_a_number() {
+        assert_eq!(event_name(EventType::ABSOLUTE.0, 0), "ABS_X");
+        assert_eq!(event_name(EventType::KEY.0, 0x130), "BTN_SOUTH");
+        assert_eq!(event_name(EventType::SYNCHRONIZATION.0, 0), "SYN_REPORT");
+        assert_eq!(event_name(EventType::SYNCHRONIZATION.0, 3), "SYN_DROPPED");
+        assert_eq!(event_name(EventType::MISC.0, 4), "MSC_SCAN");
+
+        // A type this build has no table for, and a code inside one it has.
+        assert_eq!(event_name(0x15, 1), "21:1");
+        let unnamed = event_name(EventType::ABSOLUTE.0, 0x3e);
+        assert!(!unnamed.contains(' '), "no prose on the wire: {unnamed}");
+    }
+
+    /// The tap's wire types are the protocol's, so a frame it builds is a frame `robotctl` parses.
+    /// Cheap to assert here, and the alternative is finding out on a board.
+    #[test]
+    fn a_frame_survives_the_wire() {
+        let report = a_frame(7);
+        let line = serde_json::to_string(&proto::Request::notify_pad_report(&report)).unwrap();
+        let back: proto::Request = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.as_pad_report().as_ref(), Some(&*report));
+    }
+}

--- a/padd/systemd/padd.service
+++ b/padd/systemd/padd.service
@@ -85,13 +85,20 @@ Environment=RUST_LOG=info
 StandardOutput=journal
 StandardError=journal
 
-# Where this daemon publishes what it is running: /run/padd/identity.json, read by
-# `robotctl health` and by updaterd's startup check.
+# /run/padd/, which holds two things: identity.json — what this daemon is running, read by
+# `robotctl health` and by updaterd's startup check — and pad.sock, the read-only raw input tap
+# `robotctl monitor` shows the pad's own event stream from (`src/tap.rs`).
 #
 # `RuntimeDirectory=` rather than a path this unit is granted: it is the only mechanism that both
 # creates the directory owned by this unit's User= *and* survives ProtectSystem=strict, which
 # otherwise leaves the whole filesystem read-only. systemd also removes it when the unit stops, so a
-# stopped daemon cannot leave behind an identity claiming to be running.
+# stopped daemon cannot leave behind an identity claiming to be running — nor a socket nothing is
+# listening on, which is the difference between "padd is not running" and a client hanging.
+#
+# The tap's socket is 0660 and handed to the `robot` group by `padd` itself, so it reaches exactly
+# who may already drive the robot. That is done in code rather than with `Group=robot` here, the way
+# robotd does it: this process keeps its own primary group, and reaches the robot group as a
+# supplementary one.
 RuntimeDirectory=padd
 
 [Install]

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -82,6 +82,13 @@ struct Cli {
     #[arg(long, global = true, default_value = proto::socket::CONFIG)]
     config_socket: PathBuf,
 
+    /// Path to `padd`'s raw input tap, which `monitor` reads the pad's own event stream from.
+    ///
+    /// Optional in the only sense that matters: nothing fails when it is absent. `monitor` says the
+    /// tap is not there and carries on showing the robot.
+    #[arg(long, global = true, default_value = proto::socket::PAD)]
+    pad_socket: PathBuf,
+
     #[command(subcommand)]
     namespace: Namespace,
 }
@@ -2105,7 +2112,7 @@ fn run(cli: Cli) -> Result<(), Failure> {
             return run_version(&cli.socket, &cli.robot_socket, &cli.config_socket, json);
         }
         Namespace::Monitor { hz, json } => {
-            return monitor::run(&cli.robot_socket, hz, json);
+            return monitor::run(&cli.robot_socket, &cli.pad_socket, hz, json);
         }
         // Pure codegen: no socket, no daemon, no root. It must keep working on a robot
         // where nothing is running, since that is where an operator most wants to type

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -14,7 +14,7 @@
 //! arrive on the socket, and a UI that can only notice a keystroke when the robot happens
 //! to send a frame stops responding the moment the robot does.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::BufRead;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
@@ -63,6 +63,51 @@ const HEADER_HEIGHT: u16 = 8;
 /// Request id for the subscribe call, so its answer can be told apart from the stream that
 /// follows it on the same connection.
 const SUBSCRIBE_ID: u64 = 1;
+
+/// Rows the pad block occupies while it is open: two borders, the cadence, the gap trace, three
+/// rows of axes and the buttons.
+///
+/// Fixed, like the header and for the same reason — but *only while open*. Toggling it is a
+/// deliberate act, and everything below moving then is what the reader asked for.
+const PAD_HEIGHT: u16 = 8;
+
+/// Rows of axis cells the pad block draws.
+///
+/// Three fits every axis of an Xbox pad from 80 columns up, and the caption says how many were left
+/// out when they do not fit — a grid that stops where the room ran out, with nothing saying so, is
+/// a pad drawn as though it had fewer axes than it has.
+const AXIS_ROWS: usize = 3;
+
+/// Columns one axis cell needs: six for the name, nine of bar, eight for the raw value, and the
+/// space that separates it from the cell before it.
+const AXIS_CELL: u16 = 24;
+
+/// Full height of the gap trace, milliseconds.
+///
+/// The point where a late report starts to be felt, **not** the deadman. Drawn to the deadman a
+/// healthy link is a blank row — an 8 ms gap is 1.6% of 500 and rounds away — and a trace that is
+/// empty while everything works cannot be told from one that is not being fed. At this scale an
+/// ordinary report is a low bar, sticky is full height, and a stall past the deadman saturates: its
+/// size is on the cadence line, where a number can say 620 without needing 620 rows.
+const GAP_FULL_SCALE_MS: u64 = proto::pad_link::NOTABLE_MS;
+
+/// How many report gaps the pad trace keeps. As with the loop trace, more than any terminal is
+/// wide, so the window is bounded by the display.
+const GAP_SAMPLES: usize = 600;
+
+/// How long to wait before reaching for `padd`'s tap again.
+///
+/// Longer than the socket's own restart delay would be pointless precision — `padd.service` waits
+/// five seconds between attempts, so this will usually catch it on the second or third try — and
+/// short enough that a pad tap started after the monitor turns up while somebody is still watching.
+const PAD_RETRY: Duration = Duration::from_secs(2);
+
+/// Gaps the cadence figure is averaged over.
+///
+/// A rate from the whole history answers "how has this link been", which the trace already shows.
+/// The number beside it should answer "how is it now", and a second of reports is what a hand on a
+/// stick can feel.
+const CADENCE_WINDOW: usize = 100;
 
 /// Which unit the angles on screen are drawn in.
 ///
@@ -132,13 +177,21 @@ impl Units {
     }
 }
 
-/// What the reader thread has to say.
+/// What a reader thread has to say.
 enum Update {
     State(Box<proto::RobotState>),
     /// The subscribe acknowledgement, which names the policy this `robotd` is running.
     Policy(Box<proto::SubscribeResult>),
     /// The stream ended. Carries the sentence to exit with.
     Ended(String),
+    /// One report from `padd`'s raw pad tap.
+    Pad(Box<proto::PadReport>),
+    /// The tap is not there, or stopped.
+    ///
+    /// **Not fatal, unlike [`Self::Ended`].** The pad tap is a second connection to a second
+    /// daemon, and a monitor that quit because `padd` was stopped would be a monitor that stops
+    /// working on every robot nobody has paired a pad to.
+    PadLost(String),
 }
 
 /// Subscribe to `robot.state` and render it until interrupted.
@@ -146,7 +199,7 @@ enum Update {
 /// Never returns `Ok` on its own: `q`/`Ctrl-C` is the exit in the live view, Ctrl-C alone in
 /// the piped one. A closed socket is an error either way — that is what `robotd` restarting
 /// mid-update looks like, and it is worth seeing rather than hanging through.
-pub fn run(robot_socket: &Path, hz: u32, json: bool) -> Result<(), Failure> {
+pub fn run(robot_socket: &Path, pad_socket: &Path, hz: u32, json: bool) -> Result<(), Failure> {
     let mut client = Client::connect_to("robotd", robot_socket)?;
     let call = proto::Call::RobotSubscribe(proto::SubscribeParams {
         hz: (hz > 0).then_some(hz),
@@ -166,7 +219,13 @@ pub fn run(robot_socket: &Path, hz: u32, json: bool) -> Result<(), Failure> {
     let _writer = writer;
 
     let (tx, rx) = mpsc::channel();
+    let pad_tx = tx.clone();
+    let pad_socket = pad_socket.to_path_buf();
     thread::spawn(move || read_states(reader, &tx));
+    // Its own thread and its own connection, for the same reason the robot's stream has one: a
+    // blocking read on either socket must not be able to hold up the other, and `padd`'s tap goes
+    // quiet for minutes at a time whenever nobody is touching the sticks.
+    thread::spawn(move || read_pad(&pad_socket, &pad_tx));
 
     let mut terminal = ratatui::init();
     let outcome = live(&mut terminal, &rx, hz);
@@ -287,6 +346,84 @@ fn decode(line: &str) -> Option<Update> {
         .map(|r| Update::Policy(Box::new(r)))
 }
 
+/// Read `padd`'s raw pad tap on a thread of its own, reconnecting for as long as the view lives.
+///
+/// Every way this ends is a sentence for the pad block rather than an error for the process. The tap
+/// is a debug facility on a second daemon: it is absent on a robot with no pad paired, absent while
+/// `padd` is stopped, and absent on a release older than the one that added it — and none of those is
+/// a reason for `robotctl monitor` to stop showing the robot.
+///
+/// **It retries, because `padd` restarting is routine rather than exceptional.** Its unit is
+/// `Restart=always`, and it exits deliberately whenever `robotd`'s socket is not there — during
+/// every update, for one. A reader that gave up on the first refusal would leave a monitor session
+/// that outlived one restart permanently blind to the pad, with a stale sentence explaining why.
+fn read_pad(socket: &Path, tx: &mpsc::Sender<Update>) {
+    loop {
+        // The reason is reported on every attempt rather than only when it changes: the block is
+        // where it is read, and it is read whenever someone presses `p`, which may be long after.
+        if let Err(why) = subscribe_to_pad(socket, tx)
+            && tx.send(Update::PadLost(why)).is_err()
+        {
+            return; // the UI is gone
+        }
+        thread::sleep(PAD_RETRY);
+    }
+}
+
+/// One connection to the tap, from its subscribe to whatever ended it.
+fn subscribe_to_pad(socket: &Path, tx: &mpsc::Sender<Update>) -> Result<(), String> {
+    let mut client = Client::connect_to("padd", socket).map_err(|e| e.message)?;
+    client
+        .send(&proto::Request::call(
+            proto::Id::Number(SUBSCRIBE_ID),
+            &proto::Call::PadInput,
+        ))
+        .map_err(|e| e.message)?;
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        return Err(match client.reader.read_line(&mut line) {
+            Err(e) => format!("the pad tap stopped: {e}"),
+            Ok(0) => "padd closed the pad tap".to_owned(),
+            Ok(_) => match decode_pad(&line) {
+                // A refusal, which `padd` gives only where it cannot read input devices at all.
+                Some(Err(refused)) => refused,
+                Some(Ok(report)) => {
+                    if tx.send(Update::Pad(Box::new(report))).is_err() {
+                        return Ok(()); // the UI is gone
+                    }
+                    continue;
+                }
+                None => continue,
+            },
+        });
+    }
+}
+
+/// One line of the tap: a report, a refusal, or something this build has no use for.
+fn decode_pad(line: &str) -> Option<Result<proto::PadReport, String>> {
+    if let Ok(request) = serde_json::from_str::<proto::Request>(line)
+        && let Some(report) = request.as_pad_report()
+    {
+        return Some(Ok(report));
+    }
+    let response = serde_json::from_str::<proto::Response>(line).ok()?;
+    if response.id != Some(proto::Id::Number(SUBSCRIBE_ID)) {
+        return None;
+    }
+    if let Some(error) = response.error {
+        return Some(Err(error.message));
+    }
+    match response.result_as::<proto::PadInputResult>() {
+        Ok(result) if !result.accepted => Some(Err(result
+            .reason
+            .unwrap_or_else(|| "padd refused the subscription".to_owned()))),
+        // Accepted. The pad itself arrives as `PadReport::Attached`, so there is nothing to say.
+        _ => None,
+    }
+}
+
 /// The live view's loop: absorb whatever has arrived, honour the keyboard, repaint.
 fn live(terminal: &mut DefaultTerminal, rx: &Receiver<Update>, hz: u32) -> Result<(), Failure> {
     // A frame every `1/hz`, so waiting a fifth of a period keeps the keyboard responsive
@@ -334,6 +471,12 @@ fn live(terminal: &mut DefaultTerminal, rx: &Receiver<Update>, hz: u32) -> Resul
                         view.toggle_units();
                         fresh = true;
                     }
+                    // The pad's own event stream. Off by default: it is worth eight rows only to
+                    // someone asking about the pad, and those rows come out of the joints table.
+                    KeyCode::Char('p') => {
+                        view.toggle_pad();
+                        fresh = true;
+                    }
                     _ => {}
                 },
                 // A resize changes what fits, and the next frame may be a whole period away.
@@ -376,6 +519,189 @@ fn terminal_failure(e: std::io::Error) -> Failure {
     Failure::new(exit::FAILED, format!("terminal error: {e}"))
 }
 
+/// The pad's own event stream, as the monitor accumulates it.
+///
+/// **Everything here is derived from raw reports, and nothing here is `padd`'s opinion.** That is
+/// the point of the tap: `padd` is the process whose view of the pad is already known to be
+/// misleading — it resends the last stick value at 50 Hz, so a link that has stopped delivering
+/// still looks like a driver with a hand on the stick from everywhere downstream.
+#[derive(Default)]
+struct PadView {
+    /// Why there is nothing to show, when there is nothing: no tap on this robot, `padd` stopped,
+    /// or a pad that has gone away. Never left blank — a pad block that is simply empty is the one
+    /// failure mode a debug view must not have.
+    trouble: Option<String>,
+    /// The device the reports are coming from. Every number below is read against it.
+    device: Option<proto::PadInputDevice>,
+    /// Where each axis is now, by evdev code. Seeded from the device so an untouched stick has a
+    /// position rather than a blank.
+    axes: HashMap<u16, i32>,
+    held: HashSet<u16>,
+    /// When the last report arrived *here*.
+    ///
+    /// The monitor's own clock, deliberately: [`proto::PadFrame::at_us`] is the robot's, and this
+    /// view is often running on a laptop whose clock has no relationship to it. Sub-millisecond
+    /// socket latency is noise against a gap that matters.
+    arrived: Option<Instant>,
+    reports: u64,
+    /// Gaps between reports while the sticks were moving, newest first, milliseconds.
+    gaps: VecDeque<u64>,
+    worst_ms: u64,
+    over_notable: u64,
+    over_deadman: u64,
+    /// Spells of silence past [`proto::pad_link::IDLE_MS`]: a pad at rest, not a link that stopped.
+    quiet: u64,
+    /// Reports the kernel discarded because `padd` fell behind — `SYN_DROPPED`. Says nothing about
+    /// the radio, and makes the gap around it meaningless.
+    after_drops: u64,
+    /// Reports dropped between `padd` and here, because this monitor fell behind.
+    socket_dropped: u64,
+    /// Times the robot's realtime clock stepped backwards between two reports. Expected exactly
+    /// once on a board with no RTC, when its first NTP reply lands.
+    clock_steps: u64,
+}
+
+impl PadView {
+    /// Take one report.
+    fn absorb(&mut self, report: proto::PadReport) {
+        match report {
+            proto::PadReport::Attached { device } => {
+                // A new device is a new measurement: the counters and the trace describe *a link*,
+                // and carrying the old ones over would blame this pad for the last one's stalls.
+                let device = *device;
+                self.axes = device.axes.iter().map(|a| (a.code, a.value)).collect();
+                self.held = device
+                    .buttons
+                    .iter()
+                    .filter(|b| b.pressed)
+                    .map(|b| b.code)
+                    .collect();
+                self.device = Some(device);
+                self.trouble = None;
+                self.arrived = None;
+                self.reports = 0;
+                self.gaps.clear();
+                self.worst_ms = 0;
+                self.over_notable = 0;
+                self.over_deadman = 0;
+                self.quiet = 0;
+                self.after_drops = 0;
+                self.socket_dropped = 0;
+                self.clock_steps = 0;
+            }
+            proto::PadReport::Detached { why } => {
+                // The device goes, the counters stay: they are what someone reads *after* the pad
+                // dropped, and clearing them here would erase the evidence at the moment it
+                // became interesting.
+                self.device = None;
+                self.trouble = Some(why);
+            }
+            proto::PadReport::Frame(frame) => self.frame(frame),
+        }
+    }
+
+    fn frame(&mut self, frame: proto::PadFrame) {
+        self.reports += 1;
+        self.arrived = Some(Instant::now());
+        self.socket_dropped += frame.socket_dropped;
+        if frame.after_drop {
+            self.after_drops += 1;
+        }
+
+        for event in &frame.events {
+            if event.is_axis() {
+                self.axes.insert(event.code, event.value);
+            } else if event.is_button() {
+                // Non-zero, not `== 1`: a repeat arrives as 2, and treating it as a release would
+                // show a held button letting go while it is being held down.
+                if event.value != 0 {
+                    self.held.insert(event.code);
+                } else {
+                    self.held.remove(&event.code);
+                }
+            }
+        }
+
+        let Some(since_us) = frame.since_us else {
+            return; // the first report after attaching: nothing to measure from
+        };
+        if since_us < 0 {
+            self.clock_steps += 1;
+            return;
+        }
+        // The gap after a `SYN_DROPPED` spans events the kernel threw away, so it measures this
+        // reader falling behind rather than the link. Counted as neither a stall nor a quiet spell.
+        if frame.after_drop {
+            return;
+        }
+
+        let ms = (since_us / 1_000) as u64;
+        if ms > proto::pad_link::IDLE_MS {
+            self.quiet += 1;
+            return;
+        }
+        if self.gaps.len() == GAP_SAMPLES {
+            self.gaps.pop_back();
+        }
+        self.gaps.push_front(ms);
+        self.worst_ms = self.worst_ms.max(ms);
+        if ms > proto::pad_link::NOTABLE_MS {
+            self.over_notable += 1;
+        }
+        if ms > proto::pad_link::DEADMAN_MS {
+            self.over_deadman += 1;
+        }
+    }
+
+    /// Reports per second while the sticks are moving, over the last [`CADENCE_WINDOW`] gaps.
+    ///
+    /// Against elapsed time this would read as a catastrophically slow pad the moment anyone pauses,
+    /// which is every real session — the same trap `scripts/pad-link-test.sh` rates against driving
+    /// time to avoid.
+    fn cadence(&self) -> Option<f64> {
+        let window: Vec<u64> = self.gaps.iter().copied().take(CADENCE_WINDOW).collect();
+        if window.is_empty() {
+            return None;
+        }
+        let mean = window.iter().sum::<u64>() as f64 / window.len() as f64;
+        (mean > 0.0).then(|| 1_000.0 / mean)
+    }
+
+    /// How long since a report, and what that silence means.
+    fn silence(&self) -> Option<(Duration, Silence)> {
+        let age = self.arrived?.elapsed();
+        let ms = age.as_millis() as u64;
+        let verdict = if ms > proto::pad_link::IDLE_MS {
+            Silence::Idle
+        } else if ms > proto::pad_link::DEADMAN_MS {
+            Silence::PastTheDeadman
+        } else if ms > proto::pad_link::NOTABLE_MS {
+            Silence::Notable
+        } else {
+            Silence::Arriving
+        };
+        Some((age, verdict))
+    }
+}
+
+/// What the time since the last report means.
+///
+/// The distinction between the last two is the whole difficulty of measuring a pad link, and
+/// getting it wrong is not hypothetical: counting quiet as a stall is how the first measurement on
+/// this robot reported three breaches of the deadman — the longest 75 seconds — on a link that
+/// never faltered. A pad on a table sends nothing, and nothing is what a dead radio sends too.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Silence {
+    /// Reports are arriving.
+    Arriving,
+    /// Late enough to feel sticky.
+    Notable,
+    /// Late enough that `robotd` has zeroed the velocity — if the sticks were moving.
+    PastTheDeadman,
+    /// Longer than any link stays up while silent, so it is the sticks at rest.
+    Idle,
+}
+
 /// Everything on screen, plus the little history the trace needs.
 struct View {
     /// Requested rate, for judging whether the stream has stalled.
@@ -404,6 +730,11 @@ struct View {
     /// What every angle on screen is drawn in. Degrees to start with: this view is read while
     /// looking at the robot, and a leg is a picture in degrees and arithmetic in radians.
     units: Units,
+    /// The pad's raw event stream. Accumulated whether or not it is on screen, so opening the block
+    /// shows a link's history rather than starting a measurement from the keypress.
+    pad: PadView,
+    /// Is the pad block open? Closed to begin with — see [`PAD_HEIGHT`].
+    show_pad: bool,
 }
 
 impl View {
@@ -419,11 +750,17 @@ impl View {
             scroll: 0,
             visible: 0,
             units: Units::Degrees,
+            pad: PadView::default(),
+            show_pad: false,
         }
     }
 
     fn toggle_units(&mut self) {
         self.units = self.units.toggled();
+    }
+
+    fn toggle_pad(&mut self) {
+        self.show_pad = !self.show_pad;
     }
 
     /// Move the joint window. Clamped on render, where the number of rows that fit is known.
@@ -448,6 +785,17 @@ impl View {
             Update::Policy(policy) => {
                 self.policy = Some(*policy);
                 Ok(true)
+            }
+            Update::Pad(report) => {
+                self.pad.absorb(*report);
+                // A repaint even while the block is closed would be a redraw per report, at up to
+                // 125 a second, for something nobody is looking at.
+                Ok(self.show_pad)
+            }
+            Update::PadLost(why) => {
+                self.pad.device = None;
+                self.pad.trouble = Some(why);
+                Ok(self.show_pad)
             }
             Update::State(state) => {
                 if self.trace.len() == TRACE_SAMPLES {
@@ -491,12 +839,18 @@ impl View {
         // scrolled off the bottom is still reachable, whereas a missing loop rate is the one
         // number that says whether the others can be trusted at all. Capped at six because a
         // mostly-flat rate drawn twenty rows tall is a wall of ink, not more information.
+        //
+        // The pad block, when open, sits directly under the header rather than at the bottom: it is
+        // the *source* of the command the header reports, and the frame then reads top to bottom in
+        // the order the robot does — sticks, command, joints, loop rate.
+        let pad_height = if self.show_pad { PAD_HEIGHT } else { 0 };
         let trace_height = area
             .height
-            .saturating_sub(HEADER_HEIGHT + rows as u16 + 3)
+            .saturating_sub(HEADER_HEIGHT + pad_height + rows as u16 + 3)
             .clamp(3, 6);
-        let [header, joints, trace] = Layout::vertical([
+        let [header, pad, joints, trace] = Layout::vertical([
             Constraint::Length(HEADER_HEIGHT),
+            Constraint::Length(pad_height),
             Constraint::Min(4),
             Constraint::Length(trace_height),
         ])
@@ -510,6 +864,9 @@ impl View {
         let state = self.latest.as_ref().expect("a state, checked above");
 
         self.render_header(frame, header, state);
+        if self.show_pad {
+            self.render_pad(frame, pad);
+        }
         frame.render_stateful_widget(
             self.joints(state, rows, visible),
             joints,
@@ -540,8 +897,13 @@ impl View {
                 // The units key is named next to the others because a reader who does not know
                 // it exists has no way to discover that the numbers could be radians instead.
                 Line::from(format!(
-                    " q quits · ↑↓ scrolls · u {} ",
-                    self.units.toggled().name()
+                    " q quits · ↑↓ scrolls · u {} · p {} ",
+                    self.units.toggled().name(),
+                    if self.show_pad {
+                        "hides the pad"
+                    } else {
+                        "the raw pad"
+                    }
                 ))
                 .dim()
                 .right_aligned(),
@@ -841,6 +1203,325 @@ impl View {
         )
     }
 
+    /// The pad's own event stream: what the sticks are doing, and whether the reports carrying
+    /// that are arriving.
+    ///
+    /// The second half is the reason this exists. A stick position is also visible in the header's
+    /// `asked` column, one layer of interpretation later; the *cadence* of the reports behind it is
+    /// visible nowhere else, and it is what fails when a robot walks on a command nobody is giving.
+    fn render_pad(&self, frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+        // Before the block, because the caption has to say how many axes fit and the block is built
+        // once. Two columns of border come off the width the cells get.
+        let columns = usize::from(area.width.saturating_sub(2) / AXIS_CELL).max(1);
+        let axis_count = self.pad.device.as_ref().map_or(0, |d| d.axes.len());
+
+        let block = Block::bordered()
+            .title(Line::from(self.pad_title()))
+            .title_bottom(Line::from(self.pad_caption(columns, axis_count)).dim())
+            .title_bottom(Line::from(self.pad_alarms()).right_aligned());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let Some(device) = self.pad.device.as_ref() else {
+            frame.render_widget(Paragraph::new(self.pad_absence()), inner);
+            return;
+        };
+
+        // Fixed rows, in the order the questions arrive: is it arriving, has it been arriving, and
+        // what is it saying.
+        let [cadence, gaps, axes, held] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(AXIS_ROWS as u16),
+            Constraint::Length(1),
+        ])
+        .areas::<4>(inner);
+
+        frame.render_widget(self.pad_cadence(), cadence);
+        // A label beside the trace rather than a title above it: a bordered block for one row of
+        // sparkline would cost three rows to draw one.
+        let [label, trace] =
+            Layout::horizontal([Constraint::Length(10), Constraint::Min(8)]).areas::<2>(gaps);
+        frame.render_widget(Paragraph::new(Line::from(" gap ms").dim()), label);
+        frame.render_widget(self.pad_gaps(), trace);
+        frame.render_widget(Paragraph::new(self.pad_axes(device, columns)), axes);
+        frame.render_widget(Paragraph::new(self.pad_held(device)), held);
+    }
+
+    /// Which pad, on which node, over what.
+    fn pad_title(&self) -> Vec<Span<'static>> {
+        let Some(device) = self.pad.device.as_ref() else {
+            return vec![Span::raw(" pad · raw input ")];
+        };
+        let mut title = vec![
+            Span::raw(" pad "),
+            Span::styled(
+                device.name.clone(),
+                Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" · {} ", device.node)).dim(),
+        ];
+        if let Some(unique) = device.unique.as_deref() {
+            // The address, because it is the join key: a `btmon` capture of the same minutes is
+            // keyed on it, and this stream's timestamps are the kernel's, on the same clock.
+            title.push(Span::raw(format!("· {unique} ")).dim());
+        }
+        if !device.over_bluetooth() {
+            // A pad on a cable has no link to measure. Saying so beats reporting a flawless one —
+            // `pad-link-test.sh` refuses to run at all in this case.
+            title.push(Span::styled(
+                "· on USB, so there is no radio here ",
+                Style::new().fg(Color::Yellow),
+            ));
+        }
+        title
+    }
+
+    /// What the trace is drawn to, and how much of a link is behind it.
+    ///
+    /// On the border rather than in a row of its own, and always present: a sparkline with no stated
+    /// scale is a shape, not a measurement, and the reader cannot tell a low bar from a short one.
+    fn pad_caption(&self, columns: usize, axes: usize) -> Vec<Span<'static>> {
+        // Terse on purpose. A bottom border is clipped from the right, and the count of what is
+        // hidden sits at the end — so every word spent on the scale is a word that can push the
+        // notice off a narrow screen. "Newest right" is not repeated here: the loop-rate trace
+        // directly below says it, and both are drawn the same way.
+        let mut caption = vec![Span::raw(format!(
+            " {} reports · gap ≤{} ms ",
+            self.pad.reports, GAP_FULL_SCALE_MS
+        ))];
+        // Never silently short: a grid that stops at the last cell that happened to fit is a pad
+        // presented as having fewer axes than it has. The same rule the joints table follows.
+        let room = columns * AXIS_ROWS;
+        if axes > room {
+            caption.push(Span::raw(format!("· {room} of {axes} axes ")));
+        }
+        caption
+    }
+
+    /// The counters that only ever mean something went wrong, on the block's bottom border.
+    ///
+    /// Kept out of the rows above because they are almost always zero and each one invalidates a
+    /// different part of what is above it — a caption is where a qualification belongs.
+    fn pad_alarms(&self) -> Vec<Span<'static>> {
+        let pad = &self.pad;
+        let mut alarms = Vec::new();
+        if pad.after_drops > 0 {
+            alarms.push(Span::styled(
+                format!(
+                    " syn_dropped {} — padd fell behind, not the radio ",
+                    pad.after_drops
+                ),
+                Style::new().fg(Color::Magenta),
+            ));
+        }
+        if pad.socket_dropped > 0 {
+            alarms.push(Span::styled(
+                format!(
+                    " {} reports dropped reaching this view ",
+                    pad.socket_dropped
+                ),
+                Style::new().fg(Color::Magenta),
+            ));
+        }
+        if pad.clock_steps > 0 {
+            alarms.push(Span::styled(
+                format!(" the robot's clock stepped {}× ", pad.clock_steps),
+                Style::new().fg(Color::Yellow),
+            ));
+        }
+        if alarms.is_empty() {
+            // Not blank: "nothing has invalidated any of this" is a thing the reader needs told,
+            // and an empty border is indistinguishable from a view that does not check.
+            alarms.push(Span::raw(" reports intact ").dim());
+        }
+        alarms
+    }
+
+    /// Why there is nothing to show. Always says what to do next.
+    fn pad_absence(&self) -> Vec<Line<'static>> {
+        let mut lines = vec![match self.pad.trouble.as_deref() {
+            Some(trouble) => Line::from(vec![
+                Span::raw(" no raw pad stream · "),
+                Span::styled(trouble.to_owned(), Style::new().fg(Color::Yellow)),
+            ]),
+            None => Line::from(" waiting for padd to open a pad…").dim(),
+        }];
+        lines.push(
+            Line::from(
+                " `robotctl pad status` says whether a pad is connected and whether padd is running.",
+            )
+            .dim(),
+        );
+        // The counters outlive the device on purpose, so a pad that has just dropped still has its
+        // measurement on screen — that is the moment someone looks.
+        if self.pad.reports > 0 {
+            lines.push(Line::from(vec![
+                Span::raw(format!(
+                    " last link · {} reports · worst gap {} ms · over {} ms {} · over {} ms ",
+                    self.pad.reports,
+                    self.pad.worst_ms,
+                    proto::pad_link::NOTABLE_MS,
+                    self.pad.over_notable,
+                    proto::pad_link::DEADMAN_MS,
+                )),
+                Span::styled(
+                    self.pad.over_deadman.to_string(),
+                    if self.pad.over_deadman > 0 {
+                        Style::new().fg(Color::Red)
+                    } else {
+                        Style::new().dim()
+                    },
+                ),
+            ]));
+        }
+        lines
+    }
+
+    /// Is it arriving, and how fast.
+    fn pad_cadence(&self) -> Paragraph<'static> {
+        let pad = &self.pad;
+        // Before any report there is no rate, no age and no worst gap, and a row of dashes and
+        // zeroes would read as a link delivering nothing rather than as a pad nobody has touched.
+        // An evdev device is silent until something moves, so this is the ordinary opening state.
+        if pad.reports == 0 {
+            return Paragraph::new(
+                Line::from(" cadence  nothing yet — an evdev pad sends nothing until it moves")
+                    .dim(),
+            );
+        }
+
+        let mut line = vec![Span::raw(" cadence  ")];
+        match pad.cadence() {
+            Some(rate) => line.push(Span::styled(
+                format!("{rate:.0}/s"),
+                Style::new().fg(Color::Cyan),
+            )),
+            // Not "0/s": reports have arrived but no gap has been measurable yet — one report, or
+            // nothing but quiet spells — and a zero rate reads as a dead link.
+            None => line.push(Span::raw("—").dim()),
+        }
+        line.push(Span::raw(" while driving · last ").dim());
+
+        match pad.silence() {
+            Some((age, verdict)) => {
+                let (word, style) = match verdict {
+                    Silence::Arriving => (String::new(), Style::new().fg(Color::Green)),
+                    Silence::Notable => (" — sticky".to_owned(), Style::new().fg(Color::Yellow)),
+                    Silence::PastTheDeadman => (
+                        format!(" — past the {} ms deadman", proto::pad_link::DEADMAN_MS),
+                        Style::new().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    ),
+                    // The distinction that matters: this is a pad on a table, not a dead radio.
+                    Silence::Idle => (
+                        " — the sticks are still".to_owned(),
+                        Style::new().add_modifier(Modifier::DIM),
+                    ),
+                };
+                line.push(Span::styled(format!("{} ms ago", age.as_millis()), style));
+                if !word.is_empty() {
+                    line.push(Span::styled(word, style));
+                }
+            }
+            None => line.push(Span::raw("nothing yet").dim()),
+        }
+
+        line.push(Span::raw(format!(
+            " · worst {} ms · over {} ms {} · over {} ms ",
+            self.pad.worst_ms,
+            proto::pad_link::NOTABLE_MS,
+            self.pad.over_notable,
+            proto::pad_link::DEADMAN_MS,
+        )));
+        line.push(Span::styled(
+            self.pad.over_deadman.to_string(),
+            if self.pad.over_deadman > 0 {
+                Style::new().fg(Color::Red).add_modifier(Modifier::BOLD)
+            } else {
+                Style::new().dim()
+            },
+        ));
+        if self.pad.quiet > 0 {
+            line.push(Span::raw(format!(" · {} quiet spells", self.pad.quiet)).dim());
+        }
+
+        Paragraph::new(Line::from(line))
+    }
+
+    /// Every gap between reports while driving, newest right.
+    ///
+    /// Drawn to a fixed [`GAP_FULL_SCALE_MS`] rather than to the tallest gap on screen: an
+    /// auto-scaled trace moves its own baseline as the window slides, so a link stalling every
+    /// second draws exactly like a healthy one. Quiet spells are left out entirely — they are the
+    /// operator's hand, and a full-height bar for every pause would bury the stalls this is
+    /// looking for.
+    fn pad_gaps(&self) -> Sparkline<'static> {
+        // Floored at one level, which is the smallest mark a sparkline can make. An 8 ms gap is 8%
+        // of the scale and rounds to a blank cell, so a link behaving perfectly drew an empty row —
+        // indistinguishable from a trace nobody is feeding, which is the one thing it must not be.
+        // A bar at the floor claims only "a report arrived here, below the first step the row can
+        // resolve"; the cadence line carries the precision.
+        // `div_ceil`, not `/`: a sparkline row is eight ticks and the widget scales with integer
+        // arithmetic, so `max / 8` lands a tick *below* the first one that draws anything.
+        let floor = GAP_FULL_SCALE_MS.div_ceil(8);
+        let gaps: Vec<u64> = self.pad.gaps.iter().map(|ms| (*ms).max(floor)).collect();
+        Sparkline::default()
+            .data(gaps)
+            .direction(RenderDirection::RightToLeft)
+            .max(GAP_FULL_SCALE_MS)
+            .style(Style::new().fg(Color::Cyan))
+    }
+
+    /// Where every axis is, against the range the device declares for it.
+    fn pad_axes(&self, device: &proto::PadInputDevice, columns: usize) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        let mut axes = device.axes.iter();
+        for _ in 0..AXIS_ROWS {
+            let row: Vec<&proto::PadAxis> = axes.by_ref().take(columns).collect();
+            if row.is_empty() {
+                break;
+            }
+            let mut spans = Vec::new();
+            for axis in row {
+                spans.extend(axis_cell(axis, self.pad.axes.get(&axis.code).copied()));
+            }
+            lines.push(Line::from(spans));
+        }
+        lines
+    }
+
+    /// Which buttons are down, by the name the kernel gives them.
+    ///
+    /// Raw names rather than `padd`'s vocabulary — `BTN_START`, not "Start". The mapping from one to
+    /// the other is gilrs's SDL database, and a pad whose Start does nothing is a pad someone needs
+    /// the raw code of.
+    fn pad_held(&self, device: &proto::PadInputDevice) -> Line<'static> {
+        let mut names: Vec<String> = device
+            .buttons
+            .iter()
+            .filter(|button| self.pad.held.contains(&button.code))
+            .map(|button| button.name.clone())
+            .collect();
+        // A code the device never declared but is sending anyway. Worth showing rather than
+        // dropping: it is either a pad this build has not seen or a stream nobody understands yet.
+        names.extend(
+            self.pad
+                .held
+                .iter()
+                .filter(|code| !device.buttons.iter().any(|b| b.code == **code))
+                .map(|code| format!("{}:{code}", proto::PadEvent::KEY)),
+        );
+        names.sort();
+
+        if names.is_empty() {
+            return Line::from(" held     none").dim();
+        }
+        Line::from(vec![
+            Span::raw(" held     "),
+            Span::styled(names.join(" "), Style::new().fg(Color::Green)),
+        ])
+    }
+
     /// Achieved loop rate over time.
     ///
     /// The instantaneous number in the header cannot show a *dropout*: a loop that fell to
@@ -868,6 +1549,70 @@ impl View {
             .max(self.peak.max(1))
             .style(Style::new().fg(Color::Cyan))
             .block(Block::bordered().title(Line::from(title).alignment(Alignment::Left)))
+    }
+}
+
+/// One axis: its name, where it is in its own range, and the raw value.
+///
+/// The name is the kernel's with `ABS_` taken off: `ABS_HAT0X` does not fit a cell that also has to
+/// hold a bar and a five-digit value, and every axis here carries the same prefix, so dropping it
+/// costs nothing a reader needs. Everything else is the raw code's own — no remapping, no gilrs
+/// vocabulary.
+///
+/// The bar is centred for an axis whose range crosses zero and left-anchored for one that starts
+/// there, because those are two different controls. A stick rests at the middle of −32768..32767 and
+/// a trigger rests at the bottom of 0..1023 — drawing the trigger centred would show it half pulled
+/// at rest, which is exactly the kind of quiet lie this view exists to avoid.
+fn axis_cell(axis: &proto::PadAxis, value: Option<i32>) -> Vec<Span<'static>> {
+    /// Cells of bar, leaving room in [`AXIS_CELL`] for the name and the value.
+    const WIDTH: usize = 9;
+
+    let name = axis.name.trim_start_matches("ABS_").to_owned();
+    let Some(value) = value else {
+        return vec![Span::raw(format!(" {name:<6}{:WIDTH$}{:>8}", "", "-")).dim()];
+    };
+
+    let span = f64::from(axis.max) - f64::from(axis.min);
+    let fraction = if span > 0.0 {
+        ((f64::from(value) - f64::from(axis.min)) / span).clamp(0.0, 1.0)
+    } else {
+        // A degenerate range the driver reported: draw nothing rather than divide by it.
+        0.0
+    };
+
+    let bar = if axis.min < 0 {
+        centred_bar(fraction, WIDTH)
+    } else {
+        let filled = (fraction * WIDTH as f64).round() as usize;
+        format!("{}{}", "█".repeat(filled), "·".repeat(WIDTH - filled))
+    };
+
+    vec![
+        Span::raw(format!(" {name:<6}")),
+        Span::styled(bar, Style::new().fg(Color::Cyan)),
+        Span::raw(format!("{value:>8}")),
+    ]
+}
+
+/// A bar growing from the middle of `width` cells, for an axis that rests at centre.
+fn centred_bar(fraction: f64, width: usize) -> String {
+    let half = width / 2;
+    let offset = ((fraction - 0.5) * 2.0 * half as f64).round();
+    let cells = (offset.abs() as usize).min(half);
+    if offset < 0.0 {
+        format!(
+            "{}{}│{}",
+            "·".repeat(half - cells),
+            "█".repeat(cells),
+            "·".repeat(width - half - 1)
+        )
+    } else {
+        format!(
+            "{}│{}{}",
+            "·".repeat(half),
+            "█".repeat(cells),
+            "·".repeat(width - half - 1 - cells)
+        )
     }
 }
 
@@ -1387,6 +2132,550 @@ mod tests {
         state.movement.requested[2] = 1.0;
         state.movement.applied[2] = 1.0;
         state
+    }
+
+    /// Feed the view one update.
+    ///
+    /// [`Failure`] carries no `Debug`, so `expect` is not available on an absorb — every test here
+    /// asserts on `is_ok` for the same reason the older ones do.
+    fn feed(view: &mut View, update: Update) {
+        assert!(view.absorb(update).is_ok(), "an update is not a failure");
+    }
+
+    /// A stick axis: signed, resting at centre, with the driver's own dead zone.
+    fn stick(code: u16, name: &str) -> proto::PadAxis {
+        proto::PadAxis {
+            code,
+            name: name.to_owned(),
+            min: -32768,
+            max: 32767,
+            flat: 128,
+            fuzz: 16,
+            value: 0,
+        }
+    }
+
+    /// A trigger: it rests at the bottom of its range, not the middle.
+    fn trigger(code: u16, name: &str) -> proto::PadAxis {
+        proto::PadAxis {
+            code,
+            name: name.to_owned(),
+            min: 0,
+            max: 1023,
+            flat: 0,
+            fuzz: 0,
+            value: 0,
+        }
+    }
+
+    fn hat(code: u16, name: &str) -> proto::PadAxis {
+        proto::PadAxis {
+            code,
+            name: name.to_owned(),
+            min: -1,
+            max: 1,
+            flat: 0,
+            fuzz: 0,
+            value: 0,
+        }
+    }
+
+    fn a_device() -> proto::PadInputDevice {
+        proto::PadInputDevice {
+            name: "Xbox Wireless Controller".to_owned(),
+            node: "/dev/input/event5".to_owned(),
+            unique: Some("78:86:2e:bb:13:28".to_owned()),
+            bus: proto::PadInputDevice::BUS_BLUETOOTH,
+            vendor: 0x045e,
+            product: 0x0b13,
+            // The eight an Xbox pad declares: two sticks, two triggers, and the hat. Sticks rest
+            // centred, triggers and the hat do not, which is the distinction the cells have to draw.
+            axes: vec![
+                stick(0, "ABS_X"),
+                stick(1, "ABS_Y"),
+                trigger(2, "ABS_Z"),
+                stick(3, "ABS_RX"),
+                stick(4, "ABS_RY"),
+                trigger(5, "ABS_RZ"),
+                hat(16, "ABS_HAT0X"),
+                hat(17, "ABS_HAT0Y"),
+            ],
+            buttons: vec![proto::PadKey {
+                code: 0x13b,
+                name: "BTN_START".to_owned(),
+                pressed: false,
+            }],
+        }
+    }
+
+    /// A report `since_us` microseconds after the one before it, moving `ABS_X`.
+    fn a_frame(seq: u64, since_us: Option<i64>) -> proto::PadReport {
+        proto::PadReport::Frame(proto::PadFrame {
+            seq,
+            at_us: 1_000_000 + seq * 8_000,
+            since_us,
+            events: vec![
+                proto::PadEvent {
+                    kind: proto::PadEvent::ABSOLUTE,
+                    code: 0,
+                    value: -1583,
+                    name: "ABS_X".to_owned(),
+                },
+                proto::PadEvent {
+                    kind: proto::PadEvent::SYNCHRONIZATION,
+                    code: 0,
+                    value: 0,
+                    name: "SYN_REPORT".to_owned(),
+                },
+            ],
+            after_drop: false,
+            socket_dropped: 0,
+        })
+    }
+
+    /// A view with a pad attached and the block open.
+    fn watching_a_pad() -> View {
+        let mut view = View::new(20);
+        assert!(view.absorb(Update::State(Box::new(a_state()))).is_ok());
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Attached {
+                device: Box::new(a_device()),
+            })),
+        );
+        view.toggle_pad();
+        view
+    }
+
+    /// The block costs eight rows on a terminal that is already short of them, so it stays shut
+    /// until someone asks — and the key that opens it is named on screen, since a reader who does
+    /// not know it exists has no way to discover the pad stream is there at all.
+    #[test]
+    fn the_pad_block_is_closed_until_it_is_asked_for() {
+        let mut view = View::new(20);
+        feed(&mut view, Update::State(Box::new(a_state())));
+
+        let shut = render_to(&mut view, 100, 32);
+        assert!(shut.contains("p the raw pad"), "{shut}");
+        assert!(
+            !shut.contains(" pad · "),
+            "nothing of the pad block:\n{shut}"
+        );
+
+        view.toggle_pad();
+        let open = render_to(&mut view, 100, 32);
+        assert!(open.contains("pad · raw input"), "{open}");
+        assert!(open.contains("p hides the pad"), "{open}");
+
+        // With a pad on the other end it is the measurement, not an explanation of its absence.
+        let mut watching = watching_a_pad();
+        let live = render_to(&mut watching, 100, 32);
+        assert!(live.contains("cadence"), "{live}");
+        assert!(live.contains("Xbox Wireless Controller"), "{live}");
+        assert!(
+            live.contains("78:86:2e:bb:13:28"),
+            "the join key for a btmon capture:\n{live}"
+        );
+    }
+
+    /// **A pad on a table is not a stalled link.** An evdev device sends nothing while nothing
+    /// moves, so silence is only evidence while someone is driving — and counting quiet as a stall
+    /// is how the first measurement on this robot reported a 75-second breach of the deadman on a
+    /// link that never faltered.
+    #[test]
+    fn a_pad_at_rest_is_not_a_stalled_link() {
+        let mut view = watching_a_pad();
+        let quiet_us = (proto::pad_link::IDLE_MS as i64 + 1_000) * 1_000;
+        feed(&mut view, Update::Pad(Box::new(a_frame(2, Some(quiet_us)))));
+
+        assert_eq!(view.pad.quiet, 1, "a quiet spell");
+        assert_eq!(view.pad.over_deadman, 0, "and not a stall");
+        assert_eq!(view.pad.worst_ms, 0, "which is not the worst gap either");
+        assert!(
+            view.pad.gaps.is_empty(),
+            "nor a bar on the trace, where it would dwarf every real stall"
+        );
+    }
+
+    /// A gap the sticks *were* moving through is the fault this exists to find, and it is named
+    /// with what it does rather than as a number: past the deadman, `robotd` has already zeroed the
+    /// velocity, and the robot stopped.
+    #[test]
+    fn a_stall_past_the_deadman_is_counted_and_named() {
+        let mut view = watching_a_pad();
+        for (seq, ms) in [(2u64, 8i64), (3, 150), (4, 620)] {
+            feed(
+                &mut view,
+                Update::Pad(Box::new(a_frame(seq, Some(ms * 1_000)))),
+            );
+        }
+
+        assert_eq!(
+            view.pad.over_notable, 2,
+            "150 ms and 620 ms both feel sticky"
+        );
+        assert_eq!(view.pad.over_deadman, 1, "only 620 ms stops the robot");
+        assert_eq!(view.pad.worst_ms, 620);
+        assert_eq!(view.pad.gaps.len(), 3);
+
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("worst 620 ms"), "{screen}");
+        assert!(screen.contains("over 500 ms 1"), "{screen}");
+    }
+
+    /// `SYN_DROPPED` is this reader falling behind, not the radio. Blaming the link for it would
+    /// invent a fault, and the gap around it measures nothing at all.
+    #[test]
+    fn a_dropped_report_is_blamed_on_the_reader_not_the_radio() {
+        let mut view = watching_a_pad();
+        feed(&mut view, Update::Pad(Box::new(a_frame(2, Some(8_000)))));
+        let proto::PadReport::Frame(mut frame) = a_frame(3, Some(900_000)) else {
+            unreachable!("a_frame builds a frame")
+        };
+        frame.after_drop = true;
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Frame(frame))),
+        );
+
+        assert_eq!(view.pad.after_drops, 1);
+        assert_eq!(
+            view.pad.over_deadman, 0,
+            "the 900 ms spans discarded events"
+        );
+        assert_eq!(view.pad.gaps.len(), 1, "and is not on the trace");
+
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("syn_dropped 1"), "{screen}");
+        assert!(screen.contains("not the radio"), "{screen}");
+    }
+
+    /// Reports dropped between `padd` and this view are this view's own slowness. They look exactly
+    /// like a stalled radio in the cadence, so they are counted apart and said out loud.
+    #[test]
+    fn reports_lost_reaching_the_view_are_not_the_links_fault() {
+        let mut view = watching_a_pad();
+        let proto::PadReport::Frame(mut frame) = a_frame(9, Some(8_000)) else {
+            unreachable!("a_frame builds a frame")
+        };
+        frame.socket_dropped = 4;
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Frame(frame))),
+        );
+
+        assert_eq!(view.pad.socket_dropped, 4);
+        assert_eq!(view.pad.over_deadman, 0);
+        let screen = render_to(&mut view, 110, 32);
+        assert!(
+            screen.contains("4 reports dropped reaching this view"),
+            "{screen}"
+        );
+    }
+
+    /// The robot's clock stepping is not a report arriving before the one in front of it. A board
+    /// with no RTC does this once, when its first NTP reply lands, and reading it as a 40-year gap
+    /// would put a stall in the record that never happened.
+    #[test]
+    fn a_clock_step_is_not_a_gap() {
+        let mut view = watching_a_pad();
+        feed(
+            &mut view,
+            Update::Pad(Box::new(a_frame(2, Some(-4_000_000)))),
+        );
+
+        assert_eq!(view.pad.clock_steps, 1);
+        assert!(view.pad.gaps.is_empty());
+        assert_eq!(view.pad.worst_ms, 0);
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("clock stepped 1"), "{screen}");
+    }
+
+    /// A stick rests in the middle of its range and a trigger at the bottom of its. Drawing both
+    /// the same way would show every trigger half pulled on an untouched pad.
+    #[test]
+    fn a_trigger_is_not_drawn_like_a_stick() {
+        let device = a_device();
+        let text = |axis: &proto::PadAxis, value: i32| -> String {
+            axis_cell(axis, Some(value))
+                .iter()
+                .map(|s| s.content.to_string())
+                .collect()
+        };
+
+        let axis = |name: &str| {
+            device
+                .axes
+                .iter()
+                .find(|a| a.name == name)
+                .expect("a_device declares it")
+                .clone()
+        };
+        let stick = &axis("ABS_X");
+        assert!(text(stick, 0).contains('│'), "a stick has a centre column");
+        assert!(
+            !text(stick, 0).contains('█'),
+            "and nothing filled at rest: {}",
+            text(stick, 0)
+        );
+        assert!(text(stick, -32768).contains('█'), "{}", text(stick, -32768));
+
+        let trigger = &axis("ABS_Z");
+        assert!(
+            !text(trigger, 0).contains('█'),
+            "a trigger at rest is empty: {}",
+            text(trigger, 0)
+        );
+        assert!(text(trigger, 1023).contains('█'), "{}", text(trigger, 1023));
+        assert!(
+            !text(trigger, 0).contains('│'),
+            "and has no centre to speak of: {}",
+            text(trigger, 0)
+        );
+    }
+
+    /// Every cell is the same width whatever the value, or the grid dances from report to report at
+    /// 125 a second. The same rule the deviation bars follow, and for the same reason.
+    #[test]
+    fn axis_cells_are_all_one_width() {
+        let device = a_device();
+        let width = |axis: &proto::PadAxis, value: Option<i32>| {
+            axis_cell(axis, value)
+                .iter()
+                .map(|s| s.content.chars().count())
+                .sum::<usize>()
+        };
+        for axis in &device.axes {
+            for value in [None, Some(axis.min), Some(0), Some(axis.max)] {
+                assert_eq!(
+                    width(axis, value),
+                    AXIS_CELL as usize,
+                    "{} at {value:?}",
+                    axis.name
+                );
+            }
+        }
+    }
+
+    /// The measurement outlives the pad. A link that just dropped is exactly when someone looks at
+    /// this block, and clearing the counters on the way out would erase the evidence at that moment.
+    #[test]
+    fn a_pad_that_dropped_keeps_its_measurement_on_screen() {
+        let mut view = watching_a_pad();
+        for (seq, ms) in [(2u64, 8i64), (3, 640)] {
+            feed(
+                &mut view,
+                Update::Pad(Box::new(a_frame(seq, Some(ms * 1_000)))),
+            );
+        }
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Detached {
+                why: "/dev/input/event5 ended: No such device (os error 19)".to_owned(),
+            })),
+        );
+
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("No such device"), "{screen}");
+        assert!(screen.contains("last link"), "{screen}");
+        assert!(screen.contains("worst gap 640 ms"), "{screen}");
+        assert!(screen.contains("robotctl pad status"), "{screen}");
+    }
+
+    /// No tap at all — an older release, or `padd` stopped — is a sentence and a next step, not an
+    /// empty box and not a dead monitor.
+    #[test]
+    fn no_tap_says_so_and_says_what_to_run() {
+        let mut view = View::new(20);
+        feed(&mut view, Update::State(Box::new(a_state())));
+        view.toggle_pad();
+        // Losing the tap must not end the monitor, which `feed` asserts for every update.
+        feed(
+            &mut view,
+            Update::PadLost(
+                "padd is not running or has no socket at /run/padd/pad.sock".to_owned(),
+            ),
+        );
+
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("no raw pad stream"), "{screen}");
+        assert!(screen.contains("/run/padd/pad.sock"), "{screen}");
+        assert!(screen.contains("robotctl pad status"), "{screen}");
+    }
+
+    /// The rate is per second of *driving*. Rated against elapsed time it would read as a broken
+    /// pad the moment anyone pauses, which is every real session.
+    #[test]
+    fn the_cadence_is_rated_against_driving_not_the_clock() {
+        let mut view = watching_a_pad();
+        for seq in 2..12 {
+            feed(&mut view, Update::Pad(Box::new(a_frame(seq, Some(8_000)))));
+        }
+        let quiet_us = (proto::pad_link::IDLE_MS as i64 + 30_000) * 1_000;
+        feed(
+            &mut view,
+            Update::Pad(Box::new(a_frame(12, Some(quiet_us)))),
+        );
+
+        let cadence = view.pad.cadence().expect("ten gaps of 8 ms");
+        assert!(
+            (cadence - 125.0).abs() < 1.0,
+            "half a minute of stillness must not slow the pad down: {cadence}"
+        );
+    }
+
+    /// **A link behaving perfectly must still draw something.** An ordinary 8 ms gap is 8% of the
+    /// trace's scale, and the widget's integer arithmetic rounds that to a blank cell — so a healthy
+    /// pad drew an empty row, which cannot be told from a trace nobody is feeding.
+    #[test]
+    fn a_healthy_cadence_still_marks_the_trace() {
+        let mut view = watching_a_pad();
+        for seq in 2..30 {
+            feed(&mut view, Update::Pad(Box::new(a_frame(seq, Some(8_000)))));
+        }
+
+        let screen = render_to(&mut view, 110, 32);
+        let trace = screen
+            .lines()
+            .find(|line| line.contains("gap ms"))
+            .expect("the gap row");
+        assert!(
+            trace.contains('▁'),
+            "every report leaves a mark at the floor:\n{trace}"
+        );
+        assert!(
+            !trace.contains('█'),
+            "and nothing claims a stall on a link with none:\n{trace}"
+        );
+    }
+
+    /// A grid that stops at the last cell that fitted is a pad drawn with fewer axes than it has.
+    /// The joints table has said what it hides since it was written; so does this.
+    #[test]
+    fn a_narrow_terminal_says_which_axes_it_left_out() {
+        let mut view = watching_a_pad();
+        // Two columns of cells, so six of the eight axes fit into three rows.
+        let narrow = render_to(&mut view, 70, 32);
+        assert!(narrow.contains("6 of 8 axes"), "{narrow}");
+
+        let wide = render_to(&mut view, 130, 32);
+        assert!(
+            !wide.contains("of 8 axes"),
+            "nothing is hidden, so nothing is counted:\n{wide}"
+        );
+        for axis in ["HAT0X", "HAT0Y", "RX", "RZ"] {
+            assert!(wide.contains(axis), "{axis} is missing:\n{wide}");
+        }
+    }
+
+    /// Not an assertion — a look at the block with a link under load, printed by
+    /// `cargo test -p robotctl show_the_pad_block -- --nocapture --ignored`.
+    #[test]
+    #[ignore = "prints the pad block for a human to read"]
+    fn show_the_pad_block() {
+        let mut view = watching_a_pad();
+        let gaps = [
+            8i64, 8, 9, 8, 40, 8, 8, 120, 8, 8, 8, 9, 8, 8, 260, 8, 8, 8, 620, 8, 8, 8,
+        ];
+        for (i, ms) in gaps.iter().enumerate() {
+            feed(
+                &mut view,
+                Update::Pad(Box::new(a_frame(i as u64 + 2, Some(ms * 1_000)))),
+            );
+        }
+        let proto::PadReport::Frame(mut frame) = a_frame(99, Some(8_000)) else {
+            unreachable!("a_frame builds a frame")
+        };
+        frame.events.insert(
+            0,
+            proto::PadEvent {
+                kind: proto::PadEvent::KEY,
+                code: 0x13b,
+                value: 1,
+                name: "BTN_START".to_owned(),
+            },
+        );
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Frame(frame))),
+        );
+        println!("{}", render_to(&mut view, 100, 30));
+    }
+
+    /// A pad on a cable has no radio to measure, and a flawless report about one is worse than no
+    /// report — `pad-link-test.sh` refuses to run in that case for the same reason.
+    #[test]
+    fn a_pad_on_usb_is_told_it_has_no_radio() {
+        let mut view = View::new(20);
+        feed(&mut view, Update::State(Box::new(a_state())));
+        view.toggle_pad();
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Attached {
+                device: Box::new(proto::PadInputDevice {
+                    bus: proto::PadInputDevice::BUS_USB,
+                    ..a_device()
+                }),
+            })),
+        );
+
+        let screen = render_to(&mut view, 110, 32);
+        assert!(screen.contains("no radio here"), "{screen}");
+    }
+
+    /// The buttons are named as the kernel names them, and an untouched pad says "none" rather than
+    /// leaving the row blank — a blank row cannot be told apart from a row that never updates.
+    #[test]
+    fn held_buttons_are_named_in_the_kernels_words() {
+        let mut view = watching_a_pad();
+        let shut = render_to(&mut view, 110, 32);
+        assert!(shut.contains("held     none"), "{shut}");
+
+        let proto::PadReport::Frame(mut frame) = a_frame(2, Some(8_000)) else {
+            unreachable!("a_frame builds a frame")
+        };
+        frame.events.insert(
+            0,
+            proto::PadEvent {
+                kind: proto::PadEvent::KEY,
+                code: 0x13b,
+                value: 1,
+                name: "BTN_START".to_owned(),
+            },
+        );
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::Frame(frame))),
+        );
+
+        let held = render_to(&mut view, 110, 32);
+        assert!(held.contains("BTN_START"), "{held}");
+    }
+
+    /// An autorepeat arrives as 2, not 1. Treating anything but zero as a release would show a
+    /// button letting go while it is being held down.
+    #[test]
+    fn a_repeat_is_not_a_release() {
+        let mut view = watching_a_pad();
+        for value in [1, 2] {
+            let proto::PadReport::Frame(mut frame) = a_frame(2, Some(8_000)) else {
+                unreachable!("a_frame builds a frame")
+            };
+            frame.events.insert(
+                0,
+                proto::PadEvent {
+                    kind: proto::PadEvent::KEY,
+                    code: 0x13b,
+                    value,
+                    name: "BTN_START".to_owned(),
+                },
+            );
+            feed(
+                &mut view,
+                Update::Pad(Box::new(proto::PadReport::Frame(frame))),
+            );
+            assert!(view.pad.held.contains(&0x13b), "value {value}");
+        }
     }
 
     fn a_state() -> proto::RobotState {

--- a/scripts/pad-link-test.sh
+++ b/scripts/pad-link-test.sh
@@ -35,6 +35,11 @@ MAC=
 MODE=watch
 SINCE=-7d
 
+# The three thresholds below have a compiled twin in `duck_ipc_proto::pad_link`, which
+# `robotctl monitor`'s live pad block reads them from. Deliberately two copies: this file has to run
+# on a board with none of that compiled, and it is `scp`-ed there on its own. They must agree — two
+# tools that disagree about what counts as a stall are two tools nobody can compare — so change both.
+#
 # Where the deadman zeroes the velocity, from robotd's default `safety.deadman_ms`. A stall longer
 # than this is not a latency complaint, it is the robot stopping.
 DEADMAN_MS=500

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -639,6 +639,18 @@ impl Server {
                 ),
             ),
 
+            // `pad.input` is the one call in that namespace `configd` does *not* answer, so it
+            // cannot share the arm above: sending someone to `configd` for it would cost them the
+            // same wrong-socket round trip this arm exists to save.
+            Call::PadInput => Response::err(
+                Some(id),
+                proto::Error::new(
+                    proto::code::METHOD_NOT_FOUND,
+                    "pad.input is served by padd itself, on /run/padd/pad.sock — unlike the rest \
+                     of pad.*, which configd answers",
+                ),
+            ),
+
             // Answered by the transport that received it — `btd` checks the PIN itself and never
             // forwards this. Reaching updaterd means a client sent it to the wrong socket, or over
             // a transport that has no PIN gate: on a unix socket, `SO_PEERCRED` already decided who


### PR DESCRIPTION
`robotctl monitor`, then `p`: the gamepad's own evdev stream, live.

```
┌ pad Xbox Wireless Controller · /dev/input/event5 · 78:86:2e:bb:13:28 ─────────────┐
│ cadence  124/s while driving · last 8 ms ago · worst 84 ms · over 100 ms 0 · …    │
│ gap ms                                       ▁▁▁▁▂▁▁▁▁▃▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │
│ X     ····│██··   -8734 Y     ····│····       0 Z     ·········       0 …         │
│ held     BTN_START                                                                │
└ 4213 reports · gap ≤100 ms ───────────────────────────────── reports intact ──────┘
```

## Why the monitor could not already show this

`padd` polls the sticks and sends the last known value at 50 Hz. A radio that stops
delivering reports therefore keeps producing perfectly fresh intents: `robotd` sees a live
driver, the deadman never fires, and the robot walks on a command nobody is still giving.
The `asked` column in the block above this one looks right the whole time, because from
robotd's side it is right.

The evidence is one layer below, in the event stream, where a report that never arrived
leaves a hole in the cadence. `scripts/pad-link-test.sh` already reads that stream to reach
a verdict over a two-minute window; this is the same evidence while you are driving, and it
keeps the window's history so the order works out — the robot feels sticky, and *then* you
press `p`.

## Where the data comes from

`padd` serves one read-only socket, `pad.input` on `/run/padd/pad.sock`, and hands out
reports rather than a summary: the kernel's own timestamp per report — which lines the
stream up against a `btmon` capture of the same seconds — the events in it, and counters
for when a gap measures something other than the radio.

It reads the device a second time rather than forwarding what gilrs gives it.
`Gilrs::next_event` applies three filters by default that rewrite values and drop small
movements, and `gilrs-core` turns `SYN_DROPPED` into an internal resync flag no consumer
ever sees; `SYN_REPORT` and `MSC_SCAN` do not survive the trip either. Opening the node
twice takes nothing away — an evdev reader gets its own queue — and the node comes from
gilrs, which is the only way to be sure this watches the pad that is actually driving: one
Xbox controller registers several input devices, and the first one in
`/proc/bus/input/devices` is a media-key keyboard that never sends anything.

Nothing is opened until somebody subscribes. The reader is never blocked on a subscriber:
frames are dropped, counted, and the count travels with the next frame that gets through.

## Three distinctions the numbers are worthless without

- **A pad at rest sends nothing.** Silence past five seconds is the operator's hand, not a
  dead radio. Counting it as a stall is how the first measurement of this robot reported a
  75-second breach of the deadman on a link that never faltered.
- **`SYN_DROPPED` is `padd` falling behind**, and reports lost on the way to the view are
  the view falling behind. Both look exactly like a stalled radio in a gap.
- **A report arriving before the one in front of it is the clock stepping**, which a board
  with no RTC does once, when its first NTP reply lands.

Thresholds are shared with `pad-link-test.sh` — 100 ms is felt, 500 ms is `robotd` zeroing
the velocity — so the live view and the script cannot disagree about what a stall is.

## Consequences worth knowing

- **`API_VERSION` 7 → 8.** Additive, and it still lands on `updaterd`'s exact `!=`: every
  binary on a board must come from one release, which was already the rule. A `robotctl`
  asking an older `padd` for the tap finds no socket rather than a refusal.
- `btd` refuses to route `pad.input`: over BLE the measurement would be of the phone's link
  rather than the pad's, which is worse than refusing.
- One new dependency, `evdev`, Linux-only and pure Rust — no second libudev.
- Losing the tap is a sentence in the block, never the end of the command.

## Testing

`cargo test --workspace` is green, coverage 77.4% against the floor of 72, `clippy` and
`fmt` clean, and `padd` cross-builds for the board.

**Not run against hardware.** No board, pad or Linux host was available here, so the
reader loop — `RawDevice::open`, the frame assembly, the socket's permissions — has only
been compiled for aarch64, never executed. Its logic tests are Linux-only and will first
run on CI's runner. The frame handling, every threshold decision and the whole block are
covered by tests on this side.

Worth doing on a board before merging: pair a pad, `robotctl monitor`, `p`, and walk away
from the robot until the link breaks.