### PR TITLE
btd: the robot's name goes on the adapter too, not just the advertisement

### DIFF
--- a/btd/examples/duck-btctl.rs
+++ b/btd/examples/duck-btctl.rs
@@ -112,12 +112,18 @@ fn identity(peripheral: &Peripheral, address: btleplug::api::BDAddr) -> String {
 /// from the local name in the advertisement, and btleplug reports them joined when they differ:
 /// `radxa-zero3 [duck-c51b]` (`corebluetooth/internal.rs`, `on_discovered_peripheral`).
 ///
-/// They differ on every robot, because the two names come from different places. The GAP name is
-/// BlueZ's adapter alias, which is hostname-derived and therefore `radxa-zero3` on every board
-/// flashed from one image; the advertisement carries the name `configd` owns, `duck-c51b` or
-/// whatever `system.setName` last stored. Matching the joined string exactly meant **both**
-/// spellings a person would type were rejected — and the failure then listed the robot as evidence
-/// it was not in range.
+/// They used to differ on every robot, because the two names came from different places: the GAP
+/// name is BlueZ's adapter alias, hostname-derived and therefore `radxa-zero3` on every board
+/// flashed from one image, while the advertisement carried the name `configd` owns. `btd` now sets
+/// the alias to the advertised name (`btd/src/bluez.rs`, `advertise`), so a robot on a current
+/// release reports one name however it is asked.
+///
+/// **This still has to accept both**, and will for as long as a bench has robots on it. A board on
+/// an older release has the old alias; so does a client that cached the old GAP name before the
+/// robot was updated, until `bluetoothctl remove <mac>` or forgetting it in macOS Bluetooth
+/// settings clears that. Matching the joined string exactly meant **both** spellings a person
+/// would type were rejected — and the failure then listed the robot as evidence it was not in
+/// range.
 ///
 /// So either half is accepted. The advertised half is the robot's real name, and the one the phone
 /// app has to match on; the GAP half is accepted because it is what macOS Bluetooth settings shows.

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -456,14 +456,41 @@ async fn serve_on_an_adapter(
     Ok(())
 }
 
-/// Advertise the service under `name`.
+/// Advertise the service under `name`, and make that the adapter's name too.
 ///
 /// The handle deregisters on drop, so the caller holds it for as long as the robot should be
 /// visible.
+///
+/// **Both names, because a robot has two and only one of them used to be set.** The advertisement
+/// carries a Local Name; the adapter separately serves a GAP Device Name (`0x2A00`), which BlueZ
+/// takes from `Adapter.Alias` and which defaults to the hostname. So a renamed robot advertised
+/// `duck-5b21` while answering `radxa-zero3` to anyone who read the characteristic — and a client
+/// that read it kept the answer:
+///
+/// - **BlueZ caches it over the advertised name.** `Device1.Name` is what `btleplug` reports, so
+///   on Linux a robot is `duck-5b21` until the first connection and `radxa-zero3` after it, and
+///   `duck-btctl --name duck-5b21` then finds nothing. Two scans a minute apart disagreed;
+/// - **CoreBluetooth keeps both**, and `btleplug` joins them as `radxa-zero3 [duck-5b21]`;
+/// - **a phone's Bluetooth settings shows the GAP name**, which is the case that matters most and
+///   the one nothing in this repo could see.
+///
+/// Setting the alias is therefore part of naming the robot rather than a nicety, and it belongs
+/// here so that no path can publish a name without it: [`reconcile_name`] re-advertises on every
+/// rename and comes through this function to do it. The alias persists in BlueZ's own state, so
+/// the write is skipped when it already says the right thing.
+///
+/// A failure to set it is logged and not propagated. The alias is worth less than being visible at
+/// all, and returning an error here would take the advertisement down with it.
 async fn advertise(
     adapter: &bluer::Adapter,
     name: &str,
 ) -> bluer::Result<bluer::adv::AdvertisementHandle> {
+    if adapter.alias().await.ok().as_deref() != Some(name)
+        && let Err(e) = adapter.set_alias(name.to_owned()).await
+    {
+        tracing::warn!(error = %e, name, "cannot set the adapter alias; the GAP name stays stale");
+    }
+
     adapter
         .advertise(Advertisement {
             service_uuids: [SERVICE_UUID].into_iter().collect(),

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -603,6 +603,18 @@ three comments in the tree described the intended behaviour as though it existed
 The reconcile runs alongside the adapter watch inside one bring-up, so losing the radio ends both —
 and the next bring-up asks again, which is what picks up a rename made while Bluetooth was down.
 
+**A robot has two names, and both are set.** The advertisement carries a Local Name; the adapter
+separately serves a GAP Device Name (`0x2A00`) that BlueZ takes from `Adapter.Alias` and defaults to
+the hostname. Setting only the first meant a renamed robot advertised `duck-c51b` and answered
+`radxa-zero3` to anyone who read the characteristic — and reading it is what a central does on
+connecting. BlueZ then caches the answer over the advertised name, so on Linux a robot was
+`duck-c51b` until first contact and `radxa-zero3` after it, and `--name duck-c51b` stopped finding
+it; CoreBluetooth keeps both and reports `radxa-zero3 [duck-c51b]`. A phone's own Bluetooth settings
+shows the GAP name, which is the case that matters most here and the one no tool in this tree could
+see. `advertise` sets the alias alongside the advertisement, so every path that publishes a name
+publishes both. A client that cached the old name keeps it until it is forgotten, which is a client
+problem with a client fix.
+
 Reconciled rather than event-driven, deliberately. `btd` forwards `system.setName` without reading
 the reply — interpreting replies is what this daemon avoids — and re-asking the moment it forwards
 one races the write it just forwarded. Polling is fewer moving parts and covers renames made through

--- a/docs/robot/duck-btctl.md
+++ b/docs/robot/duck-btctl.md
@@ -45,8 +45,13 @@ Robots only, with everything else in radio range counted rather than listed. `--
 that list, and it is worth reading when the robot you want is not in the first one.
 
 A robot that has never been renamed calls itself `duck-` plus four characters derived from its
-serial, so `duck-c51b`. macOS often reports one robot under two names at once, as
-`radxa-zero3 [duck-c51b]` — either half works as `--name`.
+serial, so `duck-c51b`. Either half of a robot reported under two names at once — macOS shows
+`radxa-zero3 [duck-c51b]` — works as `--name`.
+
+A robot that scanned as `duck-c51b` and then, after one connection, only as `radxa-zero3` is on a
+release that gave its name to the advertisement but not to the adapter, and the client cached the
+adapter's. Update the robot. That does not clear what the client already cached, so clear it too:
+`bluetoothctl remove <mac>` on Linux, or forget the robot in macOS Bluetooth settings.
 
 With no name at all — no `--name`, no `DUCK_ROBOT` — the first robot found wins. With a name, two
 robots answering to it is an error rather than a choice:


### PR DESCRIPTION
A robot has two names, and `btd` only ever set one of them.

The advertisement carries a Local Name, which `btd` reconciles against `configd` every few seconds. The adapter *separately* serves a GAP Device Name (`0x2A00`), which BlueZ takes from `Adapter.Alias` and which defaults to the hostname. Nothing in the tree ever set that, so a renamed board advertised `duck-5b21` while answering `radxa-zero3` to anyone who read the characteristic — and reading it is exactly what a central does on connecting.

## What that looked like

```
$ duck-btctl scan
  50:37:CD:16:2C:51 duck-5b21 — 1 service(s)

$ duck-btctl --name duck-5b21 status      # connects; BlueZ reads 0x2A00

$ duck-btctl --name duck-5b21 wifi status
no robot named "duck-5b21" in range. These answered to the duck service: radxa-zero3
```

BlueZ caches the GAP name over the advertised one in `Device1.Name`, which is what `btleplug` reports. So on Linux a robot is `duck-5b21` until first contact and `radxa-zero3` after it, and the name a person was told to type stops finding a robot sitting right there. CoreBluetooth keeps both and reports them joined, which is why `answers_to` already accepted either half — it was papering over this.

The case that matters most is the one no tool here could see: **a phone's own Bluetooth settings shows the GAP name.** Every robot appeared to iOS and Android as `radxa-zero3`, renamed or not.

## The change

`advertise` sets the alias alongside the advertisement. It goes there rather than at the call sites so that no path can publish a name without it — `reconcile_name` re-advertises on every rename and comes through this function to do it.

- The write is skipped when the alias already says the right thing, so the reconcile loop does not rewrite BlueZ's state every few seconds.
- A failure is logged and not propagated: being visible is worth more than being correctly named, and returning an error would take the advertisement down with it.
- The alias persists in BlueZ's own state, so it survives a reboot even before `btd` sets it again.

## After installing this

A client that already cached the old name keeps it — updating the robot does not clear a cache on a laptop. `bluetoothctl remove <mac>` on Linux, or forget the robot in macOS Bluetooth settings. `docs/robot/duck-btctl.md` now says so next to the symptom.

`answers_to` in `duck-btctl` keeps accepting both halves, and its doc comment now says why: a bench holds robots on more than one release.

## Checks

`cargo fmt --check`, `cargo clippy -p btd --all-targets --target aarch64-unknown-linux-gnu` clean, `cargo test -p btd` passes. The changed code is `cfg(target_os = "linux")` and needs a board to exercise: on one, `bluetoothctl info <mac>` should report `Name: duck-xxxx` rather than `radxa-zero3`, and a scan should keep saying the same thing after a connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)