### PR TITLE
duck-btctl: a version mismatch is a warning, not a locked door

### DIFF
--- a/btd/examples/duck-btctl.rs
+++ b/btd/examples/duck-btctl.rs
@@ -784,8 +784,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // on macOS sees neither a prompt nor an error. A read is acknowledged, so an unpaired link
     // fails here instead, which is what makes CoreBluetooth start pairing.
     //
-    // The value is the robot's API version. Worth checking before sending anything: a client one
-    // version ahead can say so rather than have every call refused.
+    // The value is the robot's API version, and it is reported rather than enforced. See the
+    // mismatch warning below for why this tool refuses nothing on it.
     let read = step(
         "reading the API version",
         "This read requires an encrypted link, so it is what triggers pairing. A hang here usually \
@@ -803,12 +803,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!("robot speaks API v{theirs}");
             }
             if u32::from(theirs) != duck_ipc_proto::API_VERSION {
-                return Err(format!(
-                    "the robot speaks API v{theirs} and this client speaks v{}; \
-                     install matching versions",
-                    duck_ipc_proto::API_VERSION
-                )
-                .into());
+                warn_about_skew(theirs);
             }
         }
         Err(e) => return Err(e),
@@ -989,6 +984,35 @@ fn characteristics(
 }
 
 /// One command becomes one JSON-RPC line, plus how long to wait for it.
+/// Say that the two ends were not built together, and carry on.
+///
+/// **This used to be a refusal, and the refusal was wrong twice over.**
+///
+/// It was wrong about what it was reading. `API_VERSION` is an agreement between the binaries on
+/// one board — `robotctl` and `updaterd` come from one release, and `updaterd`'s exact `!=` on
+/// `Hello` is what enforces it. A laptop is not a binary on the board, and will routinely be a
+/// release ahead of a robot it is talking to precisely because it is the machine that builds
+/// releases. Nothing on the far side of this link agrees with the refusal either: this tool never
+/// sends `Hello`, `configd` checks no version on `net.*` or `system.*`, and `updaterd` requires no
+/// handshake before `update.status`. So every call the refusal blocked would have been answered.
+///
+/// And it was wrong about when to be strict. BLE is the transport for a robot that has no network,
+/// and `wifi connect` is how that robot gets one — so refusing on version skew took away the
+/// command that fixes the skew, at the one moment it was needed. A robot with a stale release and
+/// no wifi could not be given wifi by the tool whose reason for existing is that case.
+///
+/// What a genuine mismatch costs without the gate is a method whose params changed shape, which
+/// comes back as a JSON-RPC error naming the method — printed, and reported through the exit
+/// status. That is a worse message than this one and a much better outcome than a locked door.
+fn warn_about_skew(theirs: u8) {
+    eprintln!(
+        "warning: the robot speaks API v{theirs} and this client speaks v{}, so they were not \
+         built together. Carrying on: most calls do not care, and a call that does will say so. \
+         Install matching versions before believing anything surprising.",
+        duck_ipc_proto::API_VERSION
+    );
+}
+
 fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::error::Error>> {
     let (method, params, timeout) = match command {
         // `scan` returns from `run` as soon as the discovery loop ends, so it never reaches a

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -138,6 +138,16 @@ One service, **one characteristic**. A client reads it once for the robot's API 
 NDJSON request bytes to it, and subscribes to it for answers — the same JSON-RPC lines every other
 transport carries. The read is not optional; see §5 for why it exists.
 
+**The version it returns is for saying so, not for refusing.** `API_VERSION` is an agreement between
+the binaries on one board, enforced by `updaterd`'s exact `!=` on `hello`; a client on a laptop or a
+phone is not one of those binaries and will routinely be a release either side of a robot. Nothing
+across this link checks it: `configd` gates no `net.*` or `system.*` call on a version, and
+`updaterd` requires no handshake before `update.status`. So a client that refuses on skew refuses
+calls the robot would have answered — and it refuses them on the transport that exists for a robot
+with no network, where `net.connect` is the way out of the skew. `duck-btctl` warns and proceeds,
+and an app should do the same: surface the mismatch, let the call go, and report the JSON-RPC error
+if a method whose shape changed is actually reached.
+
 **No framing header.** The newline that already separates NDJSON messages is the frame delimiter in
 both directions. That is safe rather than lucky: `serde_json` escapes a newline inside a string as
 `\n`, so a raw `0x0A` never appears inside a serialised object — the same property that makes NDJSON


### PR DESCRIPTION
`duck-btctl` reads the robot's API version off the RPC characteristic and refused to send anything if it differed from its own. From a v8 laptop against a v7 robot, that is every command:

```
$ duck-btctl --name duck-5b21 wifi status
the robot speaks API v7 and this client speaks v8; install matching versions
```

## Every one of those calls would have worked

Nothing across the link agrees with the refusal:

- `duck-btctl` never sends `hello` — `request_line` maps each command straight to `net.status`, `system.info`, `robot.health`, `update.status`;
- `configd` checks no version on `net.*` or `system.*`; it only reports `api_version` when asked for `hello`;
- `updaterd` checks `!=` inside its `hello` arm and requires no handshake before `update.status`.

And v7 → v8 is `pad.input`, a namespace `padd` serves on a socket of its own that never crosses BLE.

## It was also the wrong moment to be strict

BLE is the transport for a robot that has no network, and `wifi connect` is how that robot gets one. Refusing on version skew took away the command that resolves the skew, at the one moment it was needed: a board on a stale release with no wifi could not be given wifi by the tool whose reason for existing is that case.

`API_VERSION` is an agreement between the binaries on one board — its own doc comment scopes it that way, and `updaterd`'s exact `!=` is what enforces it. A laptop is not a binary on the board, and is routinely a release ahead of the robot precisely because it is the machine that builds releases.

## The change

The read now reports instead of gating:

```
warning: the robot speaks API v7 and this client speaks v8, so they were not built together.
Carrying on: most calls do not care, and a call that does will say so. Install matching
versions before believing anything surprising.
```

The read itself stays exactly as load-bearing as it was — it is what makes a central bond before it writes. Only the verdict changed.

What the gate genuinely protected against is a method whose params changed shape. That comes back as a JSON-RPC error naming the method, which the tool already prints and carries into its exit status — a better outcome than a door that will not open.

`app-path-design.md` §3 now says the same thing to the app, which would otherwise inherit the refusal: surface the mismatch, let the call go, report the error if a changed method is actually reached.

## Checks

`cargo fmt --check`, `cargo clippy -p btd --all-targets` clean, `cargo test -p btd` passes (52 tests). The warning path itself is untested here — it needs a robot on a different release than the laptop, which is the case that reported it.

Independent of #101 — different file region, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
