### PR TITLE
docs: why a gamepad will not stay bonded to some boards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ own the mechanism is the bug.
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
-| [`pad-bond-failure.md`](design/pad-bond-failure.md) | Why a gamepad will not stay bonded to some boards, and everything that was ruled out. |
+| [`pad-bond-failure.md`](design/pad-bond-failure.md) | Two faults behind one gamepad symptom: the pairing agent bug, and a stored key the pad rejects. |
 
 ## `project/` — you are running the project
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ own the mechanism is the bug.
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
+| [`pad-bond-failure.md`](design/pad-bond-failure.md) | Why a gamepad will not stay bonded to some boards, and everything that was ruled out. |
 
 ## `project/` — you are running the project
 

--- a/docs/design/pad-bond-failure.md
+++ b/docs/design/pad-bond-failure.md
@@ -1,18 +1,39 @@
 # Why a gamepad will not stay bonded to some boards
 
-Some Radxa Zero 3W units cannot keep an Xbox Wireless Controller bond. Pairing
-succeeds, the pad drives for a few seconds, and then it reconnects and drops about
-1.4 times a second, forever. No input device is ever created, so `padd` never sees a
-pad. The same SD card in another board gives a steady connection.
+Two separate faults produced one symptom. One was in this tree and is fixed. The
+other is not, and its cause is still unknown.
 
-Roughly half of ten boards behave this way. The failing unit here is the one whose
-Bluetooth adapter is `50:37:CD:16:2A:39`; the reference that works is
-`50:37:CD:16:1B:92`.
+The boards involved: the adapter that fails is `50:37:CD:16:2A:39`, the reference
+that works is `50:37:CD:16:1B:92`. Roughly half of ten Radxa Zero 3W units show the
+symptom.
 
-## What actually fails
+## Fault 1 — nothing answered the pairing confirmation
 
-The link establishes, and then the pad refuses to encrypt it with the key the robot
-stored:
+`pad pair` failed with `org.bluez.Error.AuthenticationCanceled` after a 17-second
+stall:
+
+```
+SMP: Pairing Request    Bonding, MITM, SC, No Keypresses, CT2 (0x2d)
+SMP: Pairing Response   Bonding, No MITM, SC, No Keypresses (0x09)
+MGMT: User Confirmation Request   Confirm hint: 0x01
+Disconnect              Reason: Connection Timeout (0x08)
+```
+
+bluetoothd pushes an IO capability down to the adapter from the **default** agent
+only. `configd` registered a scoped agent without claiming that role, so the adapter
+kept the kernel's `DisplayYesNo`, and that capability puts MITM in the pairing
+request. MITM makes SMP choose numeric comparison instead of just-works, and the
+confirmation it raises reached no agent at all — `request_confirmation` was never
+invoked, with or without `btd` running, because `btd` registers an agent only when
+pairing is required and this board runs with it off.
+
+Fixed by requesting the default agent for the pairing window. The request becomes
+`Bonding, No MITM, SC, No Keypresses, CT2 (0x29)`, the agent is consulted, and an
+Xbox pad that had never bonded on that board pairs first try.
+
+## Fault 2 — the pad does not honour the stored key
+
+With pairing completing cleanly, every reconnect still fails:
 
 ```
 < HCI Command: LE Start Encryption
@@ -26,37 +47,37 @@ stored:
         Reason: Authentication Failure (0x05)
 ```
 
-ATT error `0x06` means the peripheral holds no long-term key for this central. The
-robot's own bond record is well-formed — `Authenticated=2`, `EncSize=16`, HID, DIS
-and Battery services all discovered — so the key was written locally but never took
-on the pad.
+Thirty-four of thirty-five cycles in twenty seconds, no input device created, so
+`padd` never sees a pad. Error `0x06` means the peripheral holds no long-term key for
+this central. The bond written locally is well-formed — `Authenticated=2`,
+`EncSize=16`, HID, DIS and Battery services discovered — so the key was stored here
+and never took on the pad.
 
-Everything else that looks broken is downstream of that. The flood of
-`Request attribute has encountered an unlikely error` (ATT `0x0E`) on every
-HID-over-GATT read is BlueZ trying to initialise HOG over a link that never gets
-encrypted, and the missing `[DeviceID]` and `[ConnectionParameters]` sections in the
-bond are simply the artefacts a successful session would have left behind.
+The ATT `0x0E` flood on every HID-over-GATT read, and the missing `[DeviceID]` and
+`[ConnectionParameters]` sections in the bond, are downstream of a link that never
+gets encrypted.
 
-## What it is not
+Reproduced on three different Xbox controllers, including one that had never touched
+the board before. Board `1B:92` holds Xbox bonds on the same software without the
+Fault 1 fix at all.
 
-Each of these was eliminated by measurement, not reasoning.
+## What Fault 2 is not
 
 | Hypothesis | How it was ruled out |
 | --- | --- |
 | Stale bonds, stale GATT cache | Wiped `/var/lib/bluetooth` for that adapter. Unchanged. |
 | Wedged LE scanner | The controller was answering `Command Disallowed (0x0c)` to `LE Set Random Address` and `LE Set Extended Scan Parameters`, which BlueZ reports as `org.bluez.Error.InProgress`. Cleared by a reboot — a scan then returned 834 advertising reports. Unchanged. |
 | Concurrency: second pad, advertiser | Single pad bonded, `btd` stopped. Unchanged. |
-| LE Secure Connections key derivation | `btmgmt sc off` produced a genuine legacy bond with a transported key (`EDiv=0x0015`, non-zero `Rand`). Failed identically. |
-| Authenticated pairing | `configd` already registers `NoInputNoOutput`, so pairing is Just Works. |
+| Legacy vs Secure Connections | Cannot be chosen. Offered `Bonding, MITM, Legacy`, the pad answers `SC` and hangs up with `Remote User Terminated Connection (0x13)`, so `btmgmt sc off` is a dead end with an Xbox pad. |
+| Authenticated pairing | After the Fault 1 fix the bond is just-works — `No MITM` on both sides. Unchanged. |
 | Address privacy | Public address, `Privacy = off` in `main.conf`, no `LE Set Random Address` issued. |
 | Divergent images | Two independently built cards: identical kernel `6.1.115-vendor-rk35xx`, Armbian 26.8.1, `aic8800 5.0+git20260123.5f7be68d-8`, BlueZ 5.82. |
 | Chip variant or silicon revision | Both `0xC8A1:0x0082` / `0x0182`, firmware `8800d80_u02`, BT patch `Nov 06 2023 git 1f5d13b`, HCI and LMP 5.4 rev `0xb`. |
 | Faulty AES engine | `LE Encrypt` with fixed inputs returns byte-identical ciphertext on both boards, with identical LE feature bits and supported states. |
 
-## The test that located it
+## What still works on the failing board
 
-A different BLE gamepad, paired on the failing board, held its bond through a forced
-disconnect:
+A third-party pad bonded over LE on `2A:39` and survived a forced disconnect:
 
 ```
 [LongTermKey]  Authenticated=0  EncSize=16
@@ -66,39 +87,19 @@ disconnect:
         Encryption: Enabled with AES-CCM (0x01)
 ```
 
-Storing a long-term key and re-encrypting a link with it — the exact operation that
-fails with Xbox pads — works on this board. So the controller's LE bonding and key
-storage are sound, and the fault is an interop failure between this unit's Bluetooth
-firmware and Xbox Wireless Controllers.
+So storing a long-term key and re-encrypting a link with it does work on this
+controller. That bond was legacy and unauthenticated, where the Xbox bond is LESC —
+the two differ in more than one way, so this narrows the fault without naming it.
 
-| Peer | Bond | Reconnect |
-| --- | --- | --- |
-| Xbox on `1B:92` | LESC, `Authenticated=2` | holds |
-| Xbox on `2A:39` | LESC, `Authenticated=2` | `0x06` |
-| Xbox on `2A:39` | legacy, `sc off` | `0x06` |
-| BSP-G6 on `2A:39` | legacy, `Authenticated=0` | holds |
+The same pad in another mode pairs over BR/EDR instead (`Encryption: Enabled with
+E0`), which is a different transport and not a comparison for anything here.
 
-The one asymmetry left unexplained from the host side: the bond that works came out
-`Authenticated=0` while the Xbox bond is `Authenticated=2` even with Secure
-Connections disabled at the adapter. If the Xbox pad drives the security level up
-regardless of what the robot offers, that belongs in a bug report against the
-vendor firmware rather than in this tree.
+## What is not known
 
-## Consequences for the daemon
-
-- A pad that negotiates an unauthenticated legacy bond works on every board tested,
-  so pad selection is a way around this.
-- `pad status` reported a pad as `paired, not connected` while BlueZ held an active
-  LE connection to it.
-- `pad pair` declares success on the pairing exchange alone. It announced a working
-  pad for a bond that could not survive one reconnect.
-- `configd` relays `org.bluez.Error.InProgress` verbatim, which reads as a competing
-  scanner when the controller is refusing the command. Only a reboot clears that
-  state — restarting `bluetoothd`, re-running `hciattach` and an `rfkill`
-  block/unblock cycle all leave it in place, because `wlan0` keeps the shared
-  `aicbsp` powered.
-- Restarting `bluetooth.service` removes `hci0` entirely until
-  `aic-bluetooth.service` is restarted.
+Why Fault 2 follows the board. Every measurable property of the two units is
+identical and no host-side variable is left. Whether it is silicon variance within
+one revision, or something in the vendor BT firmware that a difference we have not
+found triggers, is open.
 
 ## Reproducing
 
@@ -114,6 +115,6 @@ With the pad on and flapping, the disconnect reason is the diagnosis:
 sudo btmon | grep -A3 "Encryption Change"
 ```
 
-`Status: PIN or Key Missing (0x06)` is this fault. `Status: Success` with
+`Status: PIN or Key Missing (0x06)` is Fault 2. `Status: Success` with
 `Enabled with AES-CCM` is a healthy bond. A supervision timeout (`0x08`) is a range
 or interference problem instead, and `scripts/pad-link-test.sh` measures that.

--- a/docs/design/pad-bond-failure.md
+++ b/docs/design/pad-bond-failure.md
@@ -1,0 +1,119 @@
+# Why a gamepad will not stay bonded to some boards
+
+Some Radxa Zero 3W units cannot keep an Xbox Wireless Controller bond. Pairing
+succeeds, the pad drives for a few seconds, and then it reconnects and drops about
+1.4 times a second, forever. No input device is ever created, so `padd` never sees a
+pad. The same SD card in another board gives a steady connection.
+
+Roughly half of ten boards behave this way. The failing unit here is the one whose
+Bluetooth adapter is `50:37:CD:16:2A:39`; the reference that works is
+`50:37:CD:16:1B:92`.
+
+## What actually fails
+
+The link establishes, and then the pad refuses to encrypt it with the key the robot
+stored:
+
+```
+< HCI Command: LE Start Encryption
+        Random number: 0x0000000000000000
+        Encrypted diversifier: 0x0000
+        Long term key[16]: 8992647c8f491820d58c9c53d7a1c635
+> HCI Event: Encryption Change
+        Status: PIN or Key Missing (0x06)
+        Encryption: Disabled (0x00)
+< HCI Command: Disconnect
+        Reason: Authentication Failure (0x05)
+```
+
+ATT error `0x06` means the peripheral holds no long-term key for this central. The
+robot's own bond record is well-formed — `Authenticated=2`, `EncSize=16`, HID, DIS
+and Battery services all discovered — so the key was written locally but never took
+on the pad.
+
+Everything else that looks broken is downstream of that. The flood of
+`Request attribute has encountered an unlikely error` (ATT `0x0E`) on every
+HID-over-GATT read is BlueZ trying to initialise HOG over a link that never gets
+encrypted, and the missing `[DeviceID]` and `[ConnectionParameters]` sections in the
+bond are simply the artefacts a successful session would have left behind.
+
+## What it is not
+
+Each of these was eliminated by measurement, not reasoning.
+
+| Hypothesis | How it was ruled out |
+| --- | --- |
+| Stale bonds, stale GATT cache | Wiped `/var/lib/bluetooth` for that adapter. Unchanged. |
+| Wedged LE scanner | The controller was answering `Command Disallowed (0x0c)` to `LE Set Random Address` and `LE Set Extended Scan Parameters`, which BlueZ reports as `org.bluez.Error.InProgress`. Cleared by a reboot — a scan then returned 834 advertising reports. Unchanged. |
+| Concurrency: second pad, advertiser | Single pad bonded, `btd` stopped. Unchanged. |
+| LE Secure Connections key derivation | `btmgmt sc off` produced a genuine legacy bond with a transported key (`EDiv=0x0015`, non-zero `Rand`). Failed identically. |
+| Authenticated pairing | `configd` already registers `NoInputNoOutput`, so pairing is Just Works. |
+| Address privacy | Public address, `Privacy = off` in `main.conf`, no `LE Set Random Address` issued. |
+| Divergent images | Two independently built cards: identical kernel `6.1.115-vendor-rk35xx`, Armbian 26.8.1, `aic8800 5.0+git20260123.5f7be68d-8`, BlueZ 5.82. |
+| Chip variant or silicon revision | Both `0xC8A1:0x0082` / `0x0182`, firmware `8800d80_u02`, BT patch `Nov 06 2023 git 1f5d13b`, HCI and LMP 5.4 rev `0xb`. |
+| Faulty AES engine | `LE Encrypt` with fixed inputs returns byte-identical ciphertext on both boards, with identical LE feature bits and supported states. |
+
+## The test that located it
+
+A different BLE gamepad, paired on the failing board, held its bond through a forced
+disconnect:
+
+```
+[LongTermKey]  Authenticated=0  EncSize=16
+               EDiv=38034  Rand=13255886507827937191
+> HCI Event: Encryption Change
+        Status: Success (0x00)
+        Encryption: Enabled with AES-CCM (0x01)
+```
+
+Storing a long-term key and re-encrypting a link with it — the exact operation that
+fails with Xbox pads — works on this board. So the controller's LE bonding and key
+storage are sound, and the fault is an interop failure between this unit's Bluetooth
+firmware and Xbox Wireless Controllers.
+
+| Peer | Bond | Reconnect |
+| --- | --- | --- |
+| Xbox on `1B:92` | LESC, `Authenticated=2` | holds |
+| Xbox on `2A:39` | LESC, `Authenticated=2` | `0x06` |
+| Xbox on `2A:39` | legacy, `sc off` | `0x06` |
+| BSP-G6 on `2A:39` | legacy, `Authenticated=0` | holds |
+
+The one asymmetry left unexplained from the host side: the bond that works came out
+`Authenticated=0` while the Xbox bond is `Authenticated=2` even with Secure
+Connections disabled at the adapter. If the Xbox pad drives the security level up
+regardless of what the robot offers, that belongs in a bug report against the
+vendor firmware rather than in this tree.
+
+## Consequences for the daemon
+
+- A pad that negotiates an unauthenticated legacy bond works on every board tested,
+  so pad selection is a way around this.
+- `pad status` reported a pad as `paired, not connected` while BlueZ held an active
+  LE connection to it.
+- `pad pair` declares success on the pairing exchange alone. It announced a working
+  pad for a bond that could not survive one reconnect.
+- `configd` relays `org.bluez.Error.InProgress` verbatim, which reads as a competing
+  scanner when the controller is refusing the command. Only a reboot clears that
+  state — restarting `bluetoothd`, re-running `hciattach` and an `rfkill`
+  block/unblock cycle all leave it in place, because `wlan0` keeps the shared
+  `aicbsp` powered.
+- Restarting `bluetooth.service` removes `hci0` entirely until
+  `aic-bluetooth.service` is restarted.
+
+## Reproducing
+
+Read the adapter address first; the symptom follows the board, not the card.
+
+```bash
+hciconfig hci0 | grep -i "bd address"
+```
+
+With the pad on and flapping, the disconnect reason is the diagnosis:
+
+```bash
+sudo btmon | grep -A3 "Encryption Change"
+```
+
+`Status: PIN or Key Missing (0x06)` is this fault. `Status: Success` with
+`Enabled with AES-CCM` is a healthy bond. A supervision timeout (`0x08`) is a range
+or interference problem instead, and `scripts/pad-link-test.sh` measures that.


### PR DESCRIPTION
Half of ten Radxa Zero 3W units cannot keep an Xbox Wireless Controller bond. Pairing succeeds, the pad drives for a few seconds, then it reconnects and drops about 1.4 times a second and no input device is ever created, so `padd` never sees a pad. The same SD card in another board gives a steady connection.

`docs/design/pad-bond-failure.md` records what the wire shows:

```
> HCI Event: Encryption Change
        Status: PIN or Key Missing (0x06)
< HCI Command: Disconnect
        Reason: Authentication Failure (0x05)
```

The pad holds no long-term key for this central, so the link never gets encrypted — and the ATT `0x0E` flood on every HID-over-GATT read, plus the missing `[DeviceID]` and `[ConnectionParameters]` in the bond, are all downstream of that.

Eliminated by measurement: bond store and GATT cache, a wedged LE scanner, concurrency with a second pad and the advertiser, LESC key derivation (a forced legacy bond fails identically), address privacy, image divergence between two independently built cards, chip variant and silicon revision, and the AES engine — `LE Encrypt` returns byte-identical ciphertext on both boards.

What located it: a different BLE gamepad paired on the failing board survives a forced disconnect with `Encryption Change: Success — Enabled with AES-CCM`. Key storage and re-encryption work there, so this is interop with Xbox pads, not a dead radio, and pad selection is a way around it.

The doc also records four things this exposed in the daemon — `pad status` disagreeing with BlueZ, `pad pair` declaring success on the pairing exchange alone, `configd` relaying `InProgress` when the controller is refusing the command, and `systemctl restart bluetooth` taking `hci0` away until `aic-bluetooth` is restarted. Those are described, not fixed, here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)