### PR TITLE
fix(configd): claim the default agent so pad pairing is just-works

### DIFF
--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -189,6 +189,7 @@ trait Device {
 trait AgentManager {
     fn register_agent(&self, agent: &ObjectPath<'_>, capability: &str) -> zbus::Result<()>;
     fn unregister_agent(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
+    fn request_default_agent(&self, agent: &ObjectPath<'_>) -> zbus::Result<()>;
 }
 
 /// An agent that says yes to exactly one device.
@@ -789,13 +790,33 @@ impl Pads for BlueZ {
         let manager = AgentManagerProxy::new(&self.bus)
             .await
             .map_err(|e| e.to_string())?;
-        // Not `RequestDefaultAgent`: `btd` holds the default agent for the phone path, and
-        // bluetoothd prefers the agent belonging to whoever called `Pair()` anyway.
         let registered = manager.register_agent(&agent_path, AGENT_CAPABILITY).await;
         if let Err(e) = &registered {
             // Not fatal. A pad is just-works, so bluetoothd may never need to ask anyone — and if
             // it does, `btd`'s default agent is still there to answer.
             tracing::warn!(error = %e, "could not register a pairing agent; relying on the default");
+        }
+
+        // Becoming the *default* agent is what makes `NoInputNoOutput` reach the controller.
+        // bluetoothd pushes an IO capability down to the adapter from the default agent only;
+        // registering an agent without claiming that role leaves the adapter on the kernel's
+        // default, `DisplayYesNo`. That capability puts MITM in the pairing request, which makes
+        // SMP choose numeric comparison over just-works — so bluetoothd raises a
+        // `RequestConfirmation` that arrives at no agent at all, and the pad waits until the link
+        // supervision times out. Observed as `AuthenticationCanceled` after ~17s, with an
+        // unanswered `User Confirmation Request` in `btmon` and nothing in this daemon's log.
+        //
+        // Claiming it for the pairing window is safe even while `btd` serves phones: this agent
+        // answers a phone's bond the same just-works way `btd`'s own does, `unregister_agent`
+        // below hands the role back, and `btd` only holds it when pairing is required at all.
+        if registered.is_ok()
+            && let Err(e) = manager.request_default_agent(&agent_path).await
+        {
+            tracing::warn!(
+                error = %e,
+                "could not become the default pairing agent; a pad that needs confirmation will \
+                 stall"
+            );
         }
 
         let outcome = self.bond(&device).await;


### PR DESCRIPTION
`robotctl pad pair` failed with `org.bluez.Error.AuthenticationCanceled` on a board where nothing held the default pairing agent.

bluetoothd pushes an IO capability down to the adapter from the **default** agent only. `configd` registered a scoped agent but deliberately skipped `RequestDefaultAgent`, so the adapter kept the kernel's `DisplayYesNo`, and that capability puts MITM in the pairing request:

```
SMP: Pairing Request    Bonding, MITM, SC, No Keypresses, CT2 (0x2d)
SMP: Pairing Response   Bonding, No MITM, SC, No Keypresses (0x09)
MGMT: User Confirmation Request   Confirm hint: 0x01
Disconnect              Reason: Connection Timeout (0x08)      [17s later]
```

MITM makes SMP choose numeric comparison instead of just-works, and the confirmation it raises reached no agent at all — `request_confirmation` was never invoked, with or without `btd` running. `btd` only registers an agent when pairing is required (`btd/src/bluez.rs:186`), and this board runs with pairing off, so there was no default agent to fall back to either.

Claiming the default agent for the pairing window is enough.

## Verified on hardware

Board `50:37:CD:16:2A:39`, via `scripts/dev-push.sh`:

- pairing request becomes `Bonding, No MITM, SC, No Keypresses, CT2 (0x29)`, matching the pad
- the agent is consulted — `configd::bluez: authorising, as asked device="…dev_78_86_2E_92_47_67" what="bond"`
- an Xbox pad that had never paired on that board pairs first try

## Known gap

On a board where `btd` *does* hold the default agent, `unregister_agent` hands the role back but `btd` does not re-assert it. Safe on a board running with pairing off, and safe during the window either way since this agent answers a phone's bond the same just-works way `btd`'s does — but it wants a follow-up, either `btd` re-requesting on release or moving the IO capability out of the agent dance.

## Not fixed here

This does not make an Xbox pad usable on that board. With pairing now completing cleanly, every reconnect still dies at `Encryption Change: Status: PIN or Key Missing (0x06)` — a separate fault, documented in #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)