### PR TITLE
docs: Fault 2 is the radio driver, and the pad was never at fault

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ own the mechanism is the bug.
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
-| [`pad-bond-failure.md`](design/pad-bond-failure.md) | Two faults behind one gamepad symptom: the pairing agent bug, and a stored key the pad rejects. |
+| [`pad-bond-failure.md`](design/pad-bond-failure.md) | Two faults behind one gamepad symptom: the pairing agent bug, and the radio driver Armbian's kernel package carries. |
 
 ## `project/` — you are running the project
 

--- a/docs/design/pad-bond-failure.md
+++ b/docs/design/pad-bond-failure.md
@@ -1,16 +1,20 @@
 # Why a gamepad will not stay bonded to some boards
 
-Two separate faults produced one symptom. One was in this tree and is fixed. The
-other is not, and its cause is still unknown.
+Two separate faults produced one symptom. Both are now understood. One was in this tree and is
+fixed. The other is not ours at all: it is the aic8800 driver bundled in Armbian's kernel package,
+and the only fix is to change which kernel package the card carries.
 
-The boards involved: the adapter that fails is `50:37:CD:16:2A:39`, the reference
-that works is `50:37:CD:16:1B:92`. Roughly half of ten Radxa Zero 3W units show the
-symptom.
+The boards involved: `50:37:CD:16:2A:39` fails, `50:37:CD:16:1B:92` is the reference that works,
+and `50:37:CD:16:1D:90` is where Fault 2 was finally cornered — it reproduced the symptom, and it
+is the one board that has been run with two different SD cards and nothing else changed.
+
+Roughly half of ten Radxa Zero 3W units show the symptom. That split is **not** silicon variance.
+It tracks which kernel package the card happens to carry, and §"Fault 2" is the measurement that
+shows it.
 
 ## Fault 1 — nothing answered the pairing confirmation
 
-`pad pair` failed with `org.bluez.Error.AuthenticationCanceled` after a 17-second
-stall:
+`pad pair` failed with `org.bluez.Error.AuthenticationCanceled` after a 17-second stall:
 
 ```
 SMP: Pairing Request    Bonding, MITM, SC, No Keypresses, CT2 (0x2d)
@@ -19,26 +23,39 @@ MGMT: User Confirmation Request   Confirm hint: 0x01
 Disconnect              Reason: Connection Timeout (0x08)
 ```
 
-bluetoothd pushes an IO capability down to the adapter from the **default** agent
-only. `configd` registered a scoped agent without claiming that role, so the adapter
-kept the kernel's `DisplayYesNo`, and that capability puts MITM in the pairing
-request. MITM makes SMP choose numeric comparison instead of just-works, and the
-confirmation it raises reached no agent at all — `request_confirmation` was never
-invoked, with or without `btd` running, because `btd` registers an agent only when
-pairing is required and this board runs with it off.
+bluetoothd pushes an IO capability down to the adapter from the **default** agent only. `configd`
+registered a scoped agent without claiming that role, so the adapter kept an IO capability that
+declares input and display — and that capability is what puts MITM in the pairing request. MITM
+makes SMP choose numeric comparison instead of just-works, and the confirmation it raises reached
+no agent at all: `request_confirmation` was never invoked, with or without `btd` running, because
+`btd` registers an agent only when pairing is required and this board runs with it off.
 
 Fixed by requesting the default agent for the pairing window. The request becomes
-`Bonding, No MITM, SC, No Keypresses, CT2 (0x29)`, the agent is consulted, and an
-Xbox pad that had never bonded on that board pairs first try.
+`Bonding, No MITM, SC, No Keypresses, CT2 (0x29)`, the agent is consulted, and an Xbox pad that had
+never bonded on that board pairs first try.
 
-## Fault 2 — the pad does not honour the stored key
+> **Correction to an earlier draft.** That draft said the adapter "kept the kernel's
+> `DisplayYesNo`". The capability is not merely inherited — **bluetoothd issues it itself**, and it
+> can be watched doing so. Restarting `bluetooth` with `btmon -w` running shows, in the same
+> adapter-init burst as `Set Bondable` and before any of our daemons are up:
+>
+> ```
+> @ MGMT Command: Set IO Capability (0x0018) plen 1   {0x0001} [hci0] 2.949573
+>         Capability: KeyboardDisplay (0x04)
+> ```
+>
+> On `1D:90` the value is `KeyboardDisplay (0x04)`, not `DisplayYesNo`, and registering a
+> `NoInputNoOutput` agent afterwards does not change it. Both capabilities declare input and
+> display and so both set MITM, which is why the mechanism above still holds and the fix still
+> works — but anyone chasing the value should read `MGMT Set IO Capability` in a capture rather
+> than reason about what the adapter "kept".
 
-With pairing completing cleanly, every reconnect still fails:
+## Fault 2 — the radio driver, not the pad
+
+With pairing completing cleanly, every reconnect still failed:
 
 ```
 < HCI Command: LE Start Encryption
-        Random number: 0x0000000000000000
-        Encrypted diversifier: 0x0000
         Long term key[16]: 8992647c8f491820d58c9c53d7a1c635
 > HCI Event: Encryption Change
         Status: PIN or Key Missing (0x06)
@@ -47,19 +64,64 @@ With pairing completing cleanly, every reconnect still fails:
         Reason: Authentication Failure (0x05)
 ```
 
-Thirty-four of thirty-five cycles in twenty seconds, no input device created, so
-`padd` never sees a pad. Error `0x06` means the peripheral holds no long-term key for
-this central. The bond written locally is well-formed — `Authenticated=2`,
-`EncSize=16`, HID, DIS and Battery services discovered — so the key was stored here
-and never took on the pad.
+On `1D:90` the same fault appears one step earlier, on the *first* bond rather than on reconnect —
+the pairing runs to completion, encryption comes up, and the pad hangs up before it has distributed
+its keys:
 
-The ATT `0x0E` flood on every HID-over-GATT read, and the missing `[DeviceID]` and
-`[ConnectionParameters]` sections in the bond, are downstream of a link that never
-gets encrypted.
+```
+> HCI Event: Encryption Change (0x08)      #116  12.849550
+        Status: Success (0x00)
+        Encryption: Enabled with AES-CCM (0x01)
+> HCI Event: Disconnect Complete (0x05)    #118  12.850376
+        Reason: Remote User Terminated Connection (0x13)
+```
 
-Reproduced on three different Xbox controllers, including one that had never touched
-the board before. Board `1B:92` holds Xbox bonds on the same software without the
-Fault 1 fix at all.
+**826 microseconds.** The connection interval is 50 ms, so nothing can have gone over the air in
+between: the pad is not reacting to anything the host does after encryption, it quits at the same
+connection event. No `SMP: Identity Information` ever arrives, so no `[LongTermKey]` is written and
+BlueZ reports `AuthenticationCanceled`. Both shapes are the same fault — a bond that never commits —
+seen from either side of a key that was never stored.
+
+### What actually changes it
+
+One board, one pad, two SD cards, nothing else touched:
+
+| | old card — **works** | new card — **fails** |
+|---|---|---|
+| Armbian | 26.2.1 trixie | 26.8.1 trixie |
+| `linux-image-vendor-rk35xx` | **26.5.1** | **26.8.1** |
+| kernel | 6.1.115-vendor-rk35xx | 6.1.115-vendor-rk35xx |
+| BlueZ | 5.82 | 5.82 |
+| `aic8800_bsp` srcversion | `7ECB260741E5BC9FC904B92` | `738316A2E9D9825966BDB6B` |
+| `aic8800_bsp` size in `lsmod` | 77824 | 86016 |
+| result | bonds; `hid-generic … BLUETOOTH HID v5.09 Gamepad`, `/dev/input/js0` | quits 826 µs after `Encryption Change` |
+
+The kernel **version string is identical**, which is most of why this hid for weeks: `uname -r`,
+`bluetoothctl --version` and every fingerprint built from them match across a working and a broken
+board. What differs is the aic8800 driver *build* bundled inside the kernel package.
+
+Putting the 26.5.1 driver on the failing card fixes it outright. `sudo robotctl pad pair` then
+succeeds first try with the full stack running:
+
+```
+paired  Xbox Wireless Controller 78:86:2E:90:93:3E
+padd is driving from it now.
+
+> HCI Event: Encryption Change (0x08)   Enabled with AES-CCM (0x01)
+      SMP: Identity Information (0x08) len 16
+      SMP: Identity Address Information (0x09) len 7
+disconnect count: 0
+```
+
+`[PeripheralLongTermKey] Authenticated=2 EncSize=16`, `Trusted=true`, `/dev/input/js0`. The two SMP
+packets in the middle are the ones that never arrived before.
+
+**The firmware is not involved.** All five blobs under `/lib/firmware/aic8800/SDIO/aic8800D80/` are
+byte-identical between the two images — `fmacfw` `2aa840eaea976e7fb87e33fd9e82a653`, `fw_adid`
+`f546881a81b960d89a672578eb45a809`, `fw_patch` `9e3808a312cc19925259a6c5163753d5`,
+`fw_patch_table` `0e6fd98c0a89c62ebd4c1a430fafa59f`, `lmacfw_rf` `501c4af180d187c0c5bf52b57cb27560`
+— and the fix was re-verified with the newer firmware in place. Note that directory belongs to
+`armbian-firmware`, not to the `aic8800-firmware` package, which owns `/lib/firmware/aic8800_fw/`.
 
 ## What Fault 2 is not
 
@@ -68,46 +130,78 @@ Fault 1 fix at all.
 | Stale bonds, stale GATT cache | Wiped `/var/lib/bluetooth` for that adapter. Unchanged. |
 | Wedged LE scanner | The controller was answering `Command Disallowed (0x0c)` to `LE Set Random Address` and `LE Set Extended Scan Parameters`, which BlueZ reports as `org.bluez.Error.InProgress`. Cleared by a reboot — a scan then returned 834 advertising reports. Unchanged. |
 | Concurrency: second pad, advertiser | Single pad bonded, `btd` stopped. Unchanged. |
+| `btd` advertising while a peer is connected | Ruled out on `1D:90`: with `btd` stopped — `ActiveInstances: 0x00`, and zero `LE Set Extended Advertising Enable` anywhere in the capture — the failure is byte-for-byte identical. |
+| Anything of ours at all | Ruled out on `1D:90`: with `btd`, `padd` **and** `configd` all stopped and the pairing driven entirely by `bluetoothctl` with its own `NoInputNoOutput` default agent, the pad still quit 818 µs after `Encryption Change`. |
+| The MITM/IO-capability request | Ruled out independently of Fault 1: a capture holding both conditions shows `MITM (0x2d)` quitting after 792 µs and `No MITM (0x29)` — the Fault 1 fix's exact signature, agent consulted and answered — quitting after 1112 µs. |
 | Legacy vs Secure Connections | Cannot be chosen. Offered `Bonding, MITM, Legacy`, the pad answers `SC` and hangs up with `Remote User Terminated Connection (0x13)`, so `btmgmt sc off` is a dead end with an Xbox pad. |
 | Authenticated pairing | After the Fault 1 fix the bond is just-works — `No MITM` on both sides. Unchanged. |
 | Address privacy | Public address, `Privacy = off` in `main.conf`, no `LE Set Random Address` issued. |
-| Divergent images | Two independently built cards: identical kernel `6.1.115-vendor-rk35xx`, Armbian 26.8.1, `aic8800 5.0+git20260123.5f7be68d-8`, BlueZ 5.82. |
-| Chip variant or silicon revision | Both `0xC8A1:0x0082` / `0x0182`, firmware `8800d80_u02`, BT patch `Nov 06 2023 git 1f5d13b`, HCI and LMP 5.4 rev `0xb`. |
+| The pad, its firmware, its batteries | The same pad bonds and drives on the same board the moment the card is swapped, and pairs to a laptop on demand. |
+| Chip variant or silicon revision | Both `0xC8A1:0x0082` / `0x0182`, firmware `8800d80_u02`, BT patch `Nov 06 2023 git 1f5d13b`, HCI and LMP 5.4 rev `0xb`. And the same *unit* both works and fails depending only on its card. |
 | Faulty AES engine | `LE Encrypt` with fixed inputs returns byte-identical ciphertext on both boards, with identical LE feature bits and supported states. |
+| Divergent images | This was the misleading one. Two cards of the *same* Armbian generation are identical, which is what that comparison showed. The generation itself is the variable. |
 
-## What still works on the failing board
+### One row of an earlier draft was wrong
 
-A third-party pad bonded over LE on `2A:39` and survived a forced disconnect:
+That draft said the ATT `0x0E` flood on every HID-over-GATT read, and the missing `[DeviceID]` and
+`[ConnectionParameters]` sections, were "downstream of a link that never gets encrypted". The flood
+is not. It appears on the **working** card too, while the pad is connected and driving with a live
+`uhid` input device:
 
 ```
-[LongTermKey]  Authenticated=0  EncSize=16
-               EDiv=38034  Rand=13255886507827937191
-> HCI Event: Encryption Change
-        Status: Success (0x00)
-        Encryption: Enabled with AES-CCM (0x01)
+bluetoothd: hog-lib.c:output_written_cb() Write output report failed: … unlikely error
+bluetoothd: hog-lib.c:info_read_cb() HID Information read failed: … unlikely error
+bluetoothd: deviceinfo.c:read_pnpid_cb() Error reading PNP_ID value: … unlikely error
 ```
 
-So storing a long-term key and re-encrypting a link with it does work on this
-controller. That bond was legacy and unauthenticated, where the Xbox bond is LESC —
-the two differ in more than one way, so this narrows the fault without naming it.
+This pad produces those reads and those errors normally. They are noise, they cost hours, and they
+should not be treated as a symptom of anything.
 
-The same pad in another mode pairs over BR/EDR instead (`Encryption: Enabled with
-E0`), which is a different transport and not a comparison for anything here.
+## Fixing a board
 
-## What is not known
-
-Why Fault 2 follows the board. Every measurable property of the two units is
-identical and no host-side variable is left. Whether it is silicon variance within
-one revision, or something in the vendor BT firmware that a difference we have not
-found triggers, is open.
-
-## Reproducing
-
-Read the adapter address first; the symptom follows the board, not the card.
+26.5.1 is in the public Armbian repo. A locally built kernel — 26.8.1 came from the internal build
+server — is **not**, so this is one-way without a rebuild. Back up `/boot` and
+`/lib/modules/$(uname -r)` first: the aic8800 driver carries WiFi as well as Bluetooth and the
+Zero 3W has no wired link, so a driver that fails to load takes ssh with it.
 
 ```bash
-hciconfig hci0 | grep -i "bd address"
+sudo apt-get update
+sudo apt-get install -y --allow-downgrades \
+    linux-image-vendor-rk35xx=26.5.1 \
+    linux-dtb-vendor-rk35xx=26.5.1 \
+    linux-headers-vendor-rk35xx=26.5.1
+sudo dpkg --configure -a
+sudo apt-mark hold linux-image-vendor-rk35xx linux-dtb-vendor-rk35xx linux-headers-vendor-rk35xx
 ```
+
+Expect the first `apt-get install` to fail configuring `linux-image`: dkms, pulled in by the headers
+package, runs its autoinstall inside the postinst. `dpkg --configure -a` finishes it cleanly.
+
+Then the step that is easy to miss, and without which **the downgrade changes nothing at all**.
+`aic8800-sdio-dkms` stays at 5.0 — there is no 4.0 in any repo — dkms rebuilds it during the kernel
+install, and its module in `updates/` outranks the good in-tree one:
+
+```bash
+cd /lib/modules/$(uname -r)/updates/dkms
+for m in aic8800_bsp_sdio aic8800_btlpm_sdio aic8800_fdrv_sdio; do
+    sudo mv "$m.ko" "$m.ko.disabled"
+done
+sudo depmod -a && sudo update-initramfs -u && sudo reboot
+```
+
+## Reading a board
+
+`dpkg -l` is **not** a valid check — the kernel package can read 26.5.1 while the 5.0 dkms module is
+the one loaded. Ask the running kernel instead:
+
+```bash
+cat /sys/module/aic8800_bsp/srcversion
+```
+
+| value | `lsmod` size | verdict |
+| --- | --- | --- |
+| `7ECB260741E5BC9FC904B92` | 77824 | good |
+| `738316A2E9D9825966BDB6B` | 86016 | broken |
 
 With the pad on and flapping, the disconnect reason is the diagnosis:
 
@@ -115,6 +209,18 @@ With the pad on and flapping, the disconnect reason is the diagnosis:
 sudo btmon | grep -A3 "Encryption Change"
 ```
 
-`Status: PIN or Key Missing (0x06)` is Fault 2. `Status: Success` with
-`Enabled with AES-CCM` is a healthy bond. A supervision timeout (`0x08`) is a range
-or interference problem instead, and `scripts/pad-link-test.sh` measures that.
+`Status: PIN or Key Missing (0x06)`, or `Status: Success` followed within a millisecond by
+`Reason: Remote User Terminated Connection (0x13)`, is Fault 2. `Status: Success` with the link
+still up — and `SMP: Identity Information` after it — is a healthy bond. A supervision timeout
+(`0x08`) is a range or interference problem instead, and `scripts/pad-link-test.sh` measures that.
+
+## What is not known
+
+What changed in the aic8800 driver between the 26.5.1 and 26.8.x kernel builds. The regression is
+in the driver module and nothing else — same firmware bytes, same kernel version, same BlueZ, same
+silicon — but the specific change has not been bisected, and until it is, pinning the kernel is the
+whole remedy.
+
+The durable fix belongs in the image build rather than on each board: pin
+`linux-image-vendor-rk35xx`, or find and carry the driver fix. Every card built from the newer
+generation regresses otherwise.


### PR DESCRIPTION
Cornered on 50:37:CD:16:1D:90, the one board run with two SD cards and nothing else changed. The aic8800 driver bundled in Armbian's kernel package regressed between 26.5.1 and 26.8.x: same board, same pad, same BlueZ 5.82, same kernel *version string*, and the pad goes from bonding and driving to hanging up 826us after Encryption Change, before it has distributed its keys. Putting the 26.5.1 driver back fixes it outright — `pad pair` first try, Identity Information on the wire, /dev/input/js0.

That identical version string is most of why this hid for weeks: uname -r, bluetoothctl --version and every fingerprint built from them match across a working and a broken board. Only the driver build differs, and `dpkg -l` cannot see it either — the kernel package can read 26.5.1 while the 5.0 dkms module is the one loaded. `cat /sys/module/aic8800_bsp/srcversion` is the only check that answers.

So the half-of-ten split is not silicon variance; it tracks which kernel package the card carries. Firmware is not involved at all: the five blobs are byte-identical between the two images, and the fix was re-verified with the newer firmware in place.

Three corrections to the previous draft, each of which cost hours:

  - The ATT 0x0E flood on HID-over-GATT reads is NOT downstream of an unencrypted link. It appears on the working card too, while the pad is connected and driving with a live uhid device. It is noise.
  - The adapter does not "keep the kernel's DisplayYesNo". bluetoothd issues Set IO Capability itself during adapter init, before any of our daemons are up, and on this board it is KeyboardDisplay (0x04). The mechanism behind Fault 1 is unchanged; the attribution was wrong.
  - "Every measurable property of the two units is identical" was true and misleading — both cards compared were the same Armbian generation. The generation is the variable.

Also records what Fault 2 is not, from this board: btd's advertising (identical failure with ActiveInstances 0x00 and no advertising commands in the capture), anything of ours at all (identical failure with btd, padd AND configd stopped and bluetoothctl driving), and the MITM/IO-capability request (one capture holds both 0x2d and 0x29 failing 792us and 1112us after Encryption Change).

What changed inside the driver is still not bisected. Until it is, pinning the kernel is the whole remedy, and it belongs in the image build rather than on each board.