### PR TITLE
Privacy = device is what a pad actually bonds under

### DIFF
--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -51,10 +51,18 @@
 //! because a human asked" is the entire authorisation, and narrowing it to the device is the only
 //! part of that this code controls.
 //!
-//! ## The board setting that made all of this impossible
+//! ## The board setting that decides whether any of this can work
 //!
-//! `Privacy = device` in `/etc/bluetooth/main.conf` stops a pad bonding at all, and nothing in this
-//! file can work around it. The trace, with no key on either side:
+//! `Privacy` in `/etc/bluetooth/main.conf` decides whether a pad bonds at all, and nothing in this
+//! file can work around whichever value is wrong for a given board. `scripts/setup-board.sh` sets
+//! `device`, which is what `microduck_runtime` ships and what a Radxa Zero 3W was measured bonding
+//! under on 2026-08-18: `bluetoothctl connect` bonds first try, `/dev/input/js0` appears, and the
+//! pad survives a power cycle. With `Privacy = off` on the same card the connect gives up with
+//! `le-connection-abort-by-local` and `Paired` stays false.
+//!
+//! An earlier round saw the opposite, and the trace is worth carrying because the failure is
+//! specific enough to recognise — pairing reaches the last step and the pad rejects it, with no key
+//! on either side:
 //!
 //! ```text
 //! SMP: Pairing Public Key ×2 · Confirm · Random ×2 · DHKey Check
@@ -62,13 +70,13 @@
 //! ```
 //!
 //! The DHKey check is computed over both devices' addresses, and privacy makes the adapter pair from
-//! a resolvable private address rather than its public one, so the two sides compute different
-//! values and the pad refuses. `bluetoothctl pair` fails identically, which is what places this
-//! below anything here. `Privacy = off` — now what `scripts/setup-board.sh` sets — pairs first time.
+//! a resolvable private address rather than its public one, so a board that fails *that* way is one
+//! to try `Privacy = off` on. A board that fails without reaching SMP at all is the other case.
 //!
-//! Worth knowing because the symptom is indistinguishable from the ones this file *can* cause, and
-//! it cost most of a day: retrying does not help, `JustWorksRepairing` does not help, and neither
-//! does clearing the bond on either side.
+//! Worth knowing because either symptom is indistinguishable from the ones this file *can* cause,
+//! and between them they have cost days: retrying does not help, `JustWorksRepairing` does not help,
+//! and neither does clearing the bond on either side. `bluetoothctl` fails identically, which is
+//! what places this below anything here — reach for a `btmon` capture rather than a code change.
 //!
 //! It is also the first clue about which transport is in play: resolvable private addresses are an LE
 //! mechanism, so a setting that breaks bonding this way can only be breaking an LE bond.

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -47,13 +47,23 @@
 //! active scan and it fails intermittently, which presents as a pad that pairs on the second
 //! attempt and looks like flaky hardware.
 //!
-//! ## The agent, and why it is not the default one
+//! ## The agent, and why it claims the default role
 //!
 //! Pairing needs an agent — something for bluetoothd to ask "is this allowed" — and `btd` already
-//! registers one as the **default** agent for the phone path. This registers a second, *non-default*
-//! agent, which works because bluetoothd picks the agent belonging to the D-Bus connection that
-//! called `Pair()` and only falls back to the default. So `configd` answers for the pairings it
-//! starts and `btd` keeps answering for everything else; neither has to know about the other.
+//! registers one as the **default** agent for the phone path. This registers a second agent scoped
+//! to the pad being paired, and takes the default role for the length of the pairing window.
+//!
+//! Taking the role is not optional here, for two reasons that compound. bluetoothd pushes an IO
+//! capability down to the adapter from the default agent only, so a non-default `NoInputNoOutput`
+//! leaves the adapter declaring input and display, which puts MITM in the pairing request and makes
+//! SMP choose numeric comparison over just-works. And bluetoothd prefers the agent belonging to the
+//! connection that called `Pair()` — which, since the bond is now driven by `Connect()` and `Pair()`
+//! is never issued on the path that works, is nobody. So the confirmation would be raised against
+//! the default agent, and a `configd` that had not claimed the role would never see it: the pad
+//! waits out the link supervision timeout and BlueZ reports `AuthenticationCanceled`.
+//!
+//! `unregister_agent` hands the role back, and `btd` only holds it when pairing is required at all,
+//! so `configd` answers for the pairings it starts and `btd` keeps answering for everything else.
 //!
 //! It is scoped to one device path and rejects anything else, so a pairing request arriving from an
 //! unrelated device while the window is open is refused rather than auto-accepted. A pad is

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -29,9 +29,19 @@
 //! `set_trusted`. It presented as "the first pair times out, the second works instantly", the second
 //! being fast because the bond was already there.
 //!
-//! So `Paired` turning true is the ground truth for "this worked". `Connect()` gets
-//! [`BOND_SETTLE`] to produce it on its own, and the `Pair()` that follows is raced against the same
-//! property rather than believed.
+//! So `Paired` turning true is the ground truth for "this worked", and **what `Connect()` returned
+//! decides whether `Pair()` is issued at all**:
+//!
+//!  - `Connect()` succeeded — a bond is in flight, so wait for `Paired` and never call `Pair()`.
+//!    This is the whole of the flow proven by hand on 2026-08-18 and the one `microduck_runtime`
+//!    prescribes: `scan on`, `connect`, `trust`, with no `pair` anywhere.
+//!  - `Connect()` failed — nothing is in flight, so `Pair()` is the only way left. It is raced
+//!    against `Paired` rather than believed, because its reply is only one of the two ways to
+//!    learn the answer.
+//!
+//! The version before this one asked `Paired` after a short settle window and called `Pair()` when
+//! it was still false, which put the two cases through the same path and could still land a
+//! `Pair()` on a slow bond.
 //!
 //! Discovery is stopped before connecting, deliberately: BlueZ will accept a `Connect()` during an
 //! active scan and it fails intermittently, which presents as a pad that pairs on the second
@@ -149,14 +159,6 @@ const AGENT_CAPABILITY: &str = "NoInputNoOutput";
 /// the device is already in hand. BlueZ's own pairing timeout is 60s; this stays inside it so the
 /// answer comes from here rather than from a dropped D-Bus call.
 const BOND_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// How long to let a bond triggered by `Connect()` finish on its own before asking for one.
-///
-/// Bonding is asynchronous and lands a moment after `Connect()` returns, so this is the window in
-/// which "it is already happening" is distinguished from "it is not going to". Measured against a
-/// real Xbox controller, it completes inside a second; five is margin, and the cost of it being too
-/// short is a `Pair()` call on a bond in flight, which never answers.
-const BOND_SETTLE: Duration = Duration::from_secs(5);
 
 /// How often to re-read `Paired` while waiting for a bond.
 const BOND_POLL: Duration = Duration::from_millis(200);
@@ -585,27 +587,28 @@ impl BlueZ {
                 }
             };
 
-            // Did that bond it on its own? It usually does — a HID profile requires an encrypted
-            // link, so connecting triggers bonding — but **it finishes a moment after `Connect()`
-            // returns**, not before. Reading `Paired` immediately therefore says `false` about a
-            // bond that is already in flight, and the `Pair()` that follows never answers: BlueZ
-            // leaves it outstanding rather than reporting `AlreadyExists`.
-            //
-            // That is the whole of the "first pair times out, second one works instantly" report:
-            // the first call bonded the pad, waited 30s for a reply that was never coming, and
-            // returned a timeout before it could set `Trusted`.
-            // Wait for a bond to land **only if a connect succeeded**, because that is the only case
-            // where one is in flight. After a failed connect the wait is dead time, and dead time
-            // here does damage: a pad holds pairing mode for a limited window, and spending five
-            // seconds of it waiting for something that was never started is how a fresh pairing ends
-            // in `AuthenticationFailed`.
-            let settle = if connected {
-                BOND_SETTLE
+            if connected {
+                // A bond is in flight. A HID profile requires an encrypted link, so `Connect()`
+                // triggered bonding — but **it finishes a moment after `Connect()` returns**, not
+                // before. So wait for it, and do not call `Pair()`: BlueZ leaves a `Pair()` on a
+                // bond already in flight outstanding rather than reporting `AlreadyExists`, and
+                // that is the whole of the "first pair times out, the second works instantly"
+                // report — the first call bonded the pad, waited for a reply that was never
+                // coming, and returned a timeout before it could set `Trusted`.
+                //
+                // It is also the flow proven by hand: `connect` then `trust`, no `pair` at any
+                // point, which is what `microduck_runtime` prescribes and what bonds an Xbox
+                // controller on a Radxa Zero 3W.
+                if !self.wait_until_paired(&device.mac, BOND_TIMEOUT).await {
+                    return Err((
+                        proto::PadPairFailure::Timeout,
+                        "the pad connected but never finished pairing".to_owned(),
+                    ));
+                }
+                tracing::info!("bonded");
             } else {
-                Duration::ZERO
-            };
-            if !self.wait_until_paired(&device.mac, settle).await {
-                // Genuinely not bonding on its own, so ask. **Raced against the state**, not
+                // `Connect()` did not work at all, so nothing is in flight and there is no bond to
+                // wait for — asking for one is the only way left. **Raced against the state**, not
                 // trusted to answer: `Paired` turning true is the ground truth for "this worked",
                 // and `Pair()`'s reply is only one of the two ways to learn it.
                 let paired = tokio::select! {

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Start at the [README](../README.md) if you have a robot and want to use it.
 | [`dev-push.md`](robot/dev-push.md) | Build on your machine and install on the board over ssh, with no CI run. |
 | [`duck-btctl.md`](robot/duck-btctl.md) | Every `duck-btctl` command — the robot over Bluetooth, from a laptop. |
 | [`install-dev.md`](robot/install-dev.md) | Setting up a board for development, from nothing. |
+| [`install-by-hand.md`](robot/install-by-hand.md) | The same install as separate commands, for testing one step at a time. |
 
 ## `design/` — you are changing the daemon
 

--- a/docs/project/pad-minimal-pairing.md
+++ b/docs/project/pad-minimal-pairing.md
@@ -102,8 +102,62 @@ untouched. Neither is what decides whether a pad bonds.
 | Provisioned board (`Privacy = device` confirmed at line 99), `padd` and `btd` stopped, manual `connect` | `Request authorization` accepted, then `ServicesResolved: no` — the pad drops immediately, no `js0` |
 
 The third row is the open one: the same card image and the same `Privacy` value fail once the
-board has been provisioned, with every daemon stopped. So it is something provisioning changes
-about the system rather than a process that is running.
+board has been provisioned. So it is something provisioning changes rather than a process that
+happens to be running — stopping `padd` and `btd` did not bring pairing back.
+
+## Making a bond and keeping one are different
+
+On a fully provisioned board with everything running, a pad that is **already bonded** connects
+and drives. A **fresh** `robotctl pad pair`, after `pad forget` and with the pad held in pairing
+mode, fails.
+
+So nothing here breaks an existing bond. Something in the installed system stops a new one being
+made. `configd` and `btd` logs say nothing useful about it.
+
+## Tomorrow: add one thing at a time
+
+From a board reflashed and confirmed working by the sequence at the top of this page, add one
+layer, reboot, and try a fresh pairing before adding the next.
+
+Copy the scripts to `~`, **not** `/tmp` — every step here reboots, and `/tmp` does not survive
+one. Same for any `btmon` capture worth keeping.
+
+```bash
+scp scripts/setup-board.sh scripts/migrate-network.sh pierre@BOARD:~/
+```
+
+| step | what it adds | pad pairs? | notes |
+|---|---|---|---|
+| 0 | nothing — the minimal sequence above | yes | the control |
+| 1 | `sudo sh ~/setup-board.sh` — overlays, `console=display`, getty mask, onnxruntime | | |
+| 2 | `sudo sh ~/migrate-network.sh` — netplan → NetworkManager | | |
+| 3 | `sudo -E sh ~/install.sh`, then `systemctl disable --now updaterd robotd configd btd padd` | | |
+| 4 | `systemctl enable --now updaterd` | | |
+| 5 | `... robotd` | | |
+| 6 | `... configd` | | |
+| 7 | `... btd` | | |
+| 8 | `... padd` | | |
+
+Reboot after each step, and clear **both** halves of the bond before each attempt: `pad forget`
+or `bluetoothctl remove` on the board, and the pad held in pairing mode. An Xbox pad keeps one
+host bond, and a half-completed attempt leaves it holding a key the board no longer has — which
+looks exactly like the fault.
+
+Step 3 needs the environment `install.sh` reads:
+
+```bash
+export DUCK_TOKEN=github_pat_replace_with_your_token
+```
+
+```bash
+export DUCK_REF=pad-privacy-device-not-off
+```
+
+```bash
+export DUCK_DEV_KEY=$HOME/team.dev.pub
+```
+
+Steps 1 and 2 need neither a token nor the network.
 
 ## Untested differences against `microduck_runtime`
 

--- a/docs/project/pad-minimal-pairing.md
+++ b/docs/project/pad-minimal-pairing.md
@@ -1,0 +1,123 @@
+# The minimal setup a gamepad bonds under
+
+Recorded 2026-08-18, on Radxa Zero 3W `50:37:CD:16:2A:39`, with an Xbox Wireless Controller
+`78:86:2E:92:47:67`. Confirmed on a second Zero 3W with the same card.
+
+## The sequence that works
+
+Flash Armbian for Radxa Zero 3, Minimal. Fill in wifi and the username in the imager. Install
+nothing else — no daemons, no provisioning.
+
+```bash
+sudo sed -i -E 's|^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=.*|Privacy = device|' /etc/bluetooth/main.conf
+```
+
+```bash
+grep -n "^Privacy" /etc/bluetooth/main.conf
+```
+
+```bash
+sudo reboot
+```
+
+A reboot rather than `systemctl restart bluetooth`: the restart sometimes leaves the kernel
+holding hci0 with `No default controller available`, and only a reboot clears that.
+
+Hold the pad's pair button until it blinks fast, then:
+
+```bash
+bluetoothctl
+```
+
+```
+scan on
+```
+
+Wait for `[NEW] Device 78:86:2E:92:47:67 Xbox Wireless Controller`, then:
+
+```
+scan off
+```
+
+```
+connect 78:86:2E:92:47:67
+```
+
+Answer `yes` to `Request authorization`, then:
+
+```
+trust 78:86:2E:92:47:67
+```
+
+`pair` is never typed.
+
+## What it looks like when it worked
+
+```bash
+ls /dev/input/js*
+```
+
+```bash
+dmesg | tail -3
+```
+
+```
+input: Xbox Wireless Controller as /devices/virtual/misc/uhid/0005:045E:0B13.0001/input/input5
+microsoft 0005:045E:0B13.0001: input,hidraw0: BLUETOOTH HID v5.09 Gamepad [Xbox Wireless Controller]
+```
+
+Input actually flowing — move the left stick throughout, and look past the first 184 bytes for
+events with `type 0x02` and advancing timestamps:
+
+```bash
+sudo timeout 5 cat /dev/input/js0 | od -Ad -tx1 | head -20
+```
+
+The bond survives a pad power cycle (hold the Xbox button ~6 s, then switch back on):
+
+```bash
+ls /dev/input/js*; bluetoothctl info 78:86:2E:92:47:67 | grep -E "Connected|Bonded|Trusted"
+```
+
+## The board it worked on
+
+Not the configuration anyone expected, which is why each is written down:
+
+| | |
+|---|---|
+| `cat /sys/module/aic8800_bsp/srcversion` | `738316A2E9D9825966BDB6B` (86016) |
+| `conn_min_interval` / `conn_max_interval` | 24 / 40 — kernel defaults, 30–50 ms |
+| `/etc/bluetooth/main.conf` | `Privacy = device` |
+| daemons running | none |
+
+The driver is the build `design/pad-bond-failure.md` calls broken. The connection interval is
+untouched. Neither is what decides whether a pad bonds.
+
+## What has failed
+
+| setup | result |
+|---|---|
+| Bare Armbian, `Privacy = off` (or unset — BlueZ defaults to `off`) | `connect` returns `le-connection-abort-by-local`; `Paired: no`; no SMP exchange at all |
+| Bare Armbian, no `Privacy` line, leading with `pair` instead of `connect` | bonds, then every reconnect fails `Encryption Change: PIN or Key Missing (0x06)`, flapping ~1/s |
+| Provisioned board (`Privacy = device` confirmed at line 99), `padd` and `btd` stopped, manual `connect` | `Request authorization` accepted, then `ServicesResolved: no` — the pad drops immediately, no `js0` |
+
+The third row is the open one: the same card image and the same `Privacy` value fail once the
+board has been provisioned, with every daemon stopped. So it is something provisioning changes
+about the system rather than a process that is running.
+
+## Untested differences against `microduck_runtime`
+
+`microduck_runtime`'s installer disables wifi powersave on the active NetworkManager connection
+(`install.sh:244`, `:383`):
+
+```
+sudo nmcli con mod "$WIFI_CON" wifi.powersave 2
+```
+
+`scripts/` has no equivalent. The aic8800 is a combined wifi and Bluetooth part sharing one radio
+over SDIO, so this is a candidate for the third row above — but the value on the bare board that
+worked was never read, so it is a candidate and not a finding.
+
+```bash
+iw dev wlan0 get power_save
+```

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -113,8 +113,8 @@ sudo robotctl pad forget 78:86:2E:BB:13:28
 
 Pairing is once per pad and has a page of its own —
 [`pair-a-gamepad.md`](pair-a-gamepad.md): which button puts a pad in pairing mode, adding a second
-pad without forgetting the first, and what to do when it will not bond (`Privacy = device` is the
-answer more often than anything else).
+pad without forgetting the first, and what to do when it will not bond (the `Privacy` setting in
+`/etc/bluetooth/main.conf` is the answer more often than anything else).
 
 `padd.service` runs from boot and drives whatever pad connects, so pairing is the only step. On the
 pad: **Start** toggles the policy — nothing moves until it is on — **Y**/triangle switches the sticks

--- a/docs/robot/install-by-hand.md
+++ b/docs/robot/install-by-hand.md
@@ -1,0 +1,109 @@
+# Installing by hand, step by step
+
+What `scripts/provision-board.sh` does, as separate commands. Use this when a step needs to be
+tested on its own; use `provision-board.sh` when you just want a working board.
+
+## Copy the files up
+
+From a clone on your machine. Into `~`, **not** `/tmp` — there is a reboot in the middle and
+`/tmp` does not survive it.
+
+```bash
+scp scripts/setup-board.sh scripts/migrate-network.sh pierre@192.168.1.42:~/
+```
+
+```bash
+scp scripts/install.sh deploy/dev-key/team.dev.pub pierre@192.168.1.42:~/
+```
+
+## Before the reboot
+
+The `robot` group first, so membership is live after the reboot rather than needing another one:
+
+```bash
+sudo groupadd --system robot
+```
+
+```bash
+sudo usermod -aG robot "$USER"
+```
+
+Board bring-up — device-tree overlay, kernel console off the motor UART, the getty mask,
+`Privacy = device`, onnxruntime:
+
+```bash
+sudo sh ~/setup-board.sh
+```
+
+Network — netplan to NetworkManager:
+
+```bash
+sudo sh ~/migrate-network.sh
+```
+
+```bash
+sudo reboot
+```
+
+The reboot is not optional: a device-tree overlay and a network stack cannot swap under a running
+kernel.
+
+## After the reboot
+
+Both again. They are idempotent, and the second `migrate-network.sh` run is what retires the wifi
+backstop that would otherwise revert this board to netplan on any boot where wifi is slow:
+
+```bash
+sudo sh ~/setup-board.sh
+```
+
+```bash
+sudo sh ~/migrate-network.sh
+```
+
+Then the daemon. `install.sh` reads its settings from the environment, and `sudo -E` is what gets
+them through:
+
+```bash
+export DUCK_TOKEN=github_pat_replace_with_your_token
+```
+
+```bash
+export DUCK_REF=main
+```
+
+```bash
+export DUCK_DEV_KEY=$HOME/team.dev.pub
+```
+
+```bash
+sudo -E sh ~/install.sh
+```
+
+Drop `DUCK_DEV_KEY` for a board that should only take releases. Set `DUCK_REF` to a branch to
+install what that branch last built.
+
+Name it, if you want a name:
+
+```bash
+robotctl system set-name duck-01
+```
+
+## Check it
+
+```bash
+robotctl health
+```
+
+```bash
+robotctl version
+```
+
+`robotd` reporting unhealthy on a bench board with unpowered servos is the honest answer, not a
+failed install.
+
+Then the gamepad — [`pair-a-gamepad.md`](pair-a-gamepad.md):
+
+```bash
+sudo robotctl pad pair
+```

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -73,10 +73,13 @@ no longer has and the bond is refused.
 
 ## When pairing fails every time
 
-Check `/etc/bluetooth/main.conf` for `Privacy = device`. Boards provisioned before this was
-understood have it, and with it **a pad cannot bond at all**: it rejects the pairing with `DHKey
-check failed (0x0b)`, because that check is computed over both devices' addresses and privacy pairs
-from a resolvable private one. `Privacy = off` is what works.
+Check `/etc/bluetooth/main.conf` for the `Privacy` setting. It should read `Privacy = device`.
+A board that carries `Privacy = off` may refuse to bond a pad at all — the connect gives up with
+`le-connection-abort-by-local` and the pad never reaches `Paired: yes`.
+
+If instead a capture shows the pairing reaching `DHKey check failed (0x0b)`, that is the opposite
+fault and `Privacy = off` is the value to try on that board. Take a `btmon` capture before changing
+the value, because both have been seen and they need different answers.
 
 ```bash
 sudo sh scripts/setup-board.sh

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -1858,8 +1858,8 @@ pub enum PadPairFailure {
     /// No Bluetooth adapter. On this board `hci0` does not exist until roughly 73 seconds after
     /// power-on, so this is a real answer early in a boot and not necessarily broken hardware.
     NoAdapter,
-    /// BlueZ refused the bond. The classic cause on this board is `Privacy = device` missing from
-    /// `/etc/bluetooth/main.conf` — the pad pairs and drops straight back out.
+    /// BlueZ refused the bond. The classic cause on this board is the `Privacy` setting in
+    /// `/etc/bluetooth/main.conf` — see `configd::bluez` for which value and why.
     Rejected,
     Other,
 }

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -1845,11 +1845,11 @@ fn report_pair(result: &serde_json::Value) -> Result<(), Failure> {
                 }
                 proto::PadPairFailure::Rejected => {
                     "Bluetooth refused the pairing. If this fails every time, check \
-                     /etc/bluetooth/main.conf: `Privacy = device` stops a pad bonding at all — it \
-                     rejects the pairing with `DHKey check failed` — and `Privacy = off` is what \
-                     works. Fix it with scripts/setup-board.sh and reboot, since it does not apply \
-                     until then. Otherwise the pad had probably left pairing mode: press Sync \
-                     again and re-run this while its light is flashing quickly"
+                     /etc/bluetooth/main.conf: the `Privacy` setting decides whether a pad can \
+                     bond at all, and it should read `Privacy = device`. Fix it with \
+                     scripts/setup-board.sh and reboot, since it does not apply until then. \
+                     Otherwise the pad had probably left pairing mode: press Sync again and \
+                     re-run this while its light is flashing quickly"
                 }
                 proto::PadPairFailure::Other => "pairing failed",
             };

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -531,10 +531,10 @@ grep -q "^console=display$" /boot/armbianEnv.txt
 test "$(grep -c uart2-m0 /boot/armbianEnv.txt)" = 1
 echo "    [ok] setup-board is idempotent on a second run"
 
-# The gamepad setting, which is the kind that fails silently — and which this script had
-# BACKWARDS until a board proved it. `Privacy = device` makes an Xbox controller reject LE Secure
-# Connections pairing with `DHKey check failed (0x0b)`, because that check covers both addresses
-# and privacy pairs from a resolvable private one. See `configure_bluetooth`.
+# The gamepad setting, which is the kind that fails silently — and whose polarity this script has
+# now had both ways round. `Privacy = device` is what a Radxa Zero 3W was measured bonding an Xbox
+# controller under on 2026-08-18, and what microduck_runtime ships; see `configure_bluetooth` for
+# the earlier DHKey-check observation that argued the other way.
 #
 # It is the only part of gamepad readiness left in this script: reading the pad belongs to
 # padd.service and its `input` group now, and pairing one is `robotctl pad pair`.
@@ -542,22 +542,22 @@ echo "    [ok] setup-board is idempotent on a second run"
 # No apostrophes and no single quotes anywhere in this string. It is passed to the container
 # single-quoted, so one would end it early and run the rest on the host — which is exactly what
 # happened once, and it presented as a grep failing on a file the fixture had just written.
-grep -qE "^Privacy = off$" /etc/bluetooth/main.conf
-echo "    [ok] setup-board sets Privacy = off, which is what lets a pad bond"
+grep -qE "^Privacy = device$" /etc/bluetooth/main.conf
+echo "    [ok] setup-board sets Privacy = device, which is what lets a pad bond"
 
 # Idempotent too: the second run above must not have added a duplicate key, which BlueZ
 # would read as a conflicting setting.
 test "$(grep -cE "^[[:space:]]*Privacy[[:space:]]*=" /etc/bluetooth/main.conf)" = 1
 echo "    [ok] Privacy is set exactly once"
 
-# The upgrade case, which is every board provisioned so far: the wrong value is already in the
-# file and has to be corrected rather than left alone. An absent setting and a wrong one need
-# different work, and only the first was ever tested.
-sed -i "s|^Privacy = off|Privacy = device|" /etc/bluetooth/main.conf
+# The upgrade case, which is every board provisioned while this script set the other value: the
+# wrong value is already in the file and has to be corrected rather than left alone. An absent
+# setting and a wrong one need different work, and only the first was ever tested.
+sed -i "s|^Privacy = device|Privacy = off|" /etc/bluetooth/main.conf
 ONNX_VERSION=9.9.9 PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh >/tmp/board3.log 2>&1
-grep -qE "^Privacy = off$" /etc/bluetooth/main.conf
+grep -qE "^Privacy = device$" /etc/bluetooth/main.conf
 test "$(grep -cE "^[[:space:]]*Privacy[[:space:]]*=" /etc/bluetooth/main.conf)" = 1
-echo "    [ok] a board carrying Privacy = device is corrected to off"
+echo "    [ok] a board carrying Privacy = off is corrected to device"
 
 # ── the generated preinstall hook ──
 #

--- a/scripts/pad-stack-report.sh
+++ b/scripts/pad-stack-report.sh
@@ -217,16 +217,16 @@ section_stack() {
 
     field bluetoothd "$(systemctl is-active bluetooth 2>/dev/null || echo unknown)"
 
-    # The one BlueZ setting that decides whether a pad can bond at all. `device` is what boards
-    # provisioned before this was understood have, and with it pairing fails every time with a DHKey
-    # check error — see `setup-board.sh`. Fingerprinted because it is invisible everywhere else and
-    # differs between boards flashed months apart.
+    # The one BlueZ setting that decides whether a pad can bond at all. `device` is what
+    # `setup-board.sh` sets and what a board was measured bonding under; `off` is what boards
+    # provisioned during the spell described there carry. Fingerprinted because it is invisible
+    # everywhere else and differs between boards flashed months apart.
     if [ -r "$BT_CONF" ]; then
         if grep -Eq '^[[:space:]]*Privacy[[:space:]]*=' "$BT_CONF" 2>/dev/null; then
             f_privacy="$(grep -E '^[[:space:]]*Privacy[[:space:]]*=' "$BT_CONF" | head -1 \
                 | cut -d= -f2- | tr -d ' ')"
         else
-            f_privacy="unset (BlueZ defaults to off, which works)"
+            f_privacy="unset (BlueZ defaults to off; setup-board.sh sets device)"
         fi
     else
         f_privacy="no ${BT_CONF}"

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -399,55 +399,56 @@ free_motor_port() {
 
 # The one Bluetooth setting a gamepad needs from this script.
 #
-# `Privacy = off`, and it is the *opposite* of what this script used to set. The history matters,
-# because the old value is still on every board provisioned so far:
+# `Privacy = device`, which is what `microduck_runtime`'s installer has always set and what this
+# script sets again after a spell setting the opposite. The reversal is worth recording, because
+# both observations behind it are real and they disagree.
 #
-#   This script set `Privacy = device`, taken from microduck_runtime's installer, whose notes
-#   credit it with fixing an Xbox controller that pairs and then drops straight back out — an
-#   endless connect/disconnect loop, or `disconnected with reason 3` during pairing.
+#   An earlier round saw `Privacy = device` fail every pairing, with `btmon` showing LE Secure
+#   Connections reaching the last step and the pad rejecting it:
 #
-#   With that setting, an Xbox controller cannot bond with this board at all. `btmon` shows LE
-#   Secure Connections pairing reaching the last step and the *pad* rejecting it:
+#       SMP: Pairing Public Key x2 - Confirm - Random x2 - DHKey Check
+#       > ACL Data RX: SMP: Pairing Failed - Reason: DHKey check failed (0x0b)
 #
-#       SMP: Pairing Public Key ×2 · Confirm · Random ×2 · DHKey Check
-#       > ACL Data RX: SMP: Pairing Failed — Reason: DHKey check failed (0x0b)
+#   That reading — the DHKey check is computed over both addresses, and privacy pairs from a
+#   resolvable private one — is why this script was changed to `off`.
 #
-#   The DHKey check is computed over both devices' addresses, and `Privacy = device` makes the
-#   adapter pair from a resolvable private address rather than its public one. The two sides
-#   compute different values, and the pad refuses — every time, with no key on either side, and
-#   unaffected by retrying, by `JustWorksRepairing`, or by which side starts.
+#   Measured again on 2026-08-18 on 50:37:CD:16:2A:39, on a freshly flashed Armbian carrying the
+#   stock aic8800 driver with none of this tree installed, the polarity is the other way round —
+#   and the same card was then confirmed on a second Zero 3W.
+#   With `Privacy = device` a `bluetoothctl connect` bonds first try, /dev/input/js0 appears, the
+#   pad survives a power cycle and streams axis events. With `Privacy = off` written into the same
+#   file on the same card, the identical flow leaves `Paired: no` and the connect gives up with
+#   `le-connection-abort-by-local` — no SMP exchange at all, so not the failure above.
 #
-#   With `Privacy = off` the same pad pairs first time, is trusted, and reconnects by itself
-#   across a reboot. The drop-on-connect symptom the old value was meant to prevent has not
-#   returned.
+# So `device` is what has been seen to work on hardware, and it is what the runtime that drives
+# these robots ships. If a board turns up failing with `DHKey check failed (0x0b)`, that is the
+# earlier observation recurring and `off` is the value to try on that board — but do not make it
+# the default again without a capture, because that is what cost this board its pad.
 #
-# So this is a measurement replacing an inherited setting. If a pad ever does start dropping on
-# connect, the two are in genuine tension and the answer is to pair with privacy off and then
-# re-enable it — not to set `device` and lose the ability to pair at all.
-#
-# The change sets `needs_reboot` rather than restarting bluetooth. Restarting the daemon on
-# this board left the kernel holding hci0 while bluetoothd reported "No default controller
-# available", which needs a reboot to clear — so a reboot is the honest instruction, not an
-# extra step.
+# The change sets `needs_reboot` rather than restarting bluetooth. Restarting the daemon here
+# leaves the kernel holding hci0 while bluetoothd reports "No default controller available",
+# which needs a reboot to clear. Confirmed again on 2026-08-18, and it is the one thing
+# `microduck_runtime`'s installer gets wrong at this step: it restarts the service, which leaves
+# the board with no adapter until someone reboots it anyway.
 configure_bluetooth() {
     if [ ! -f "$BT_CONF" ]; then
         warn "no ${BT_CONF}; skipping the gamepad Bluetooth settings"
         return 0
     fi
 
-    # Written explicitly even though `off` is BlueZ's default: a board provisioned by an older
-    # copy of this script has `Privacy = device` in the file, and that line has to be *corrected*
-    # rather than left alone. An absent setting and a wrong one need different work.
-    if grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*off' "$BT_CONF"; then
-        say "bluetooth Privacy already off"
+    # A board provisioned by the copy of this script that set `off` carries that value, and it has
+    # to be *corrected* rather than left alone — an absent setting and a wrong one need different
+    # work. BlueZ's own default is `off`, so absent counts as wrong here too.
+    if grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
+        say "bluetooth Privacy already device"
     else
-        say "setting Privacy = off in ${BT_CONF} (a pad cannot bond otherwise)"
+        say "setting Privacy = device in ${BT_CONF} (a pad cannot bond otherwise)"
         if grep -Eq '^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=' "$BT_CONF"; then
-            sed -i -E 's|^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=.*|Privacy = off|' "$BT_CONF"
+            sed -i -E 's|^[[:space:]]*#?[[:space:]]*Privacy[[:space:]]*=.*|Privacy = device|' "$BT_CONF"
         elif grep -q '^\[General\]' "$BT_CONF"; then
-            sed -i '/^\[General\]/a Privacy = off' "$BT_CONF"
+            sed -i '/^\[General\]/a Privacy = device' "$BT_CONF"
         else
-            printf '\n[General]\nPrivacy = off\n' >> "$BT_CONF"
+            printf '\n[General]\nPrivacy = device\n' >> "$BT_CONF"
         fi
         needs_reboot=1
     fi
@@ -472,14 +473,15 @@ report() {
 
     # Gamepad readiness. This board's part of it is one setting; who may read the pad is
     # `padd.service`'s business now, and pairing one is `sudo robotctl pad pair`.
-    if [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*off' "$BT_CONF"; then
-        printf '  %-22s %s\n' "bluetooth privacy" "off"
-    elif [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
-        # Named rather than lumped in with "not off": this is what older boards have, and it is
-        # the one value that makes pairing a pad impossible. See `configure_bluetooth`.
-        printf '  %-22s %s\n' "bluetooth privacy" "device — a pad CANNOT bond; re-run this script"
+    if [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
+        printf '  %-22s %s\n' "bluetooth privacy" "device"
+    elif [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*off' "$BT_CONF"; then
+        # Named rather than lumped in with "not device": this is what boards provisioned during
+        # the spell described in `configure_bluetooth` carry, and on the board that was measured
+        # it is the value a pad cannot bond under.
+        printf '  %-22s %s\n' "bluetooth privacy" "off — a pad may not bond; re-run this script"
     else
-        printf '  %-22s %s\n' "bluetooth privacy" "not set (BlueZ defaults to off, which works)"
+        printf '  %-22s %s\n' "bluetooth privacy" "not set (BlueZ defaults to off; set it)"
     fi
 
     # The device node is what gilrs opens, so this is the only claim that matters.


### PR DESCRIPTION
`scripts/setup-board.sh` has set `Privacy = off` in `/etc/bluetooth/main.conf` since a board was
seen failing every pairing with `DHKey check failed (0x0b)`. On 2026-08-18 the opposite was
measured, and this puts the value back to what `microduck_runtime` ships.

## What was measured

Radxa Zero 3W `50:37:CD:16:2A:39`, freshly flashed Armbian, **stock** aic8800 driver
(`srcversion 738316A2E9D9825966BDB6B`, the build `docs/design/pad-bond-failure.md` calls broken),
kernel-default connection interval (24/40), none of this tree installed.

| `/etc/bluetooth/main.conf` | result |
| --- | --- |
| `Privacy = device` | `bluetoothctl connect` bonds first try; `/dev/input/js0`; `microsoft … BLUETOOTH HID v5.09 Gamepad`; survives a pad power cycle; streams axis events |
| `Privacy = off` | `Paired: no`, `Connected: no`; connect gives up with `le-connection-abort-by-local`, never reaching SMP |

Same card, same pad, same board, nothing else changed. Then confirmed on a second Zero 3W.

## Both observations are kept

They are different failures and they need different answers, so neither is deleted:

- Pairing that **reaches** `DHKey check failed (0x0b)` — the earlier observation. Privacy pairs
  from a resolvable private address, the check covers both addresses, the pad refuses. `off` is
  the value to try on such a board.
- A connect that fails **before** SMP with `le-connection-abort-by-local` — what `off` produced
  here. `device` is the value to try.

`configure_bluetooth` and the `configd::bluez` module docs carry both, with the instruction to
take a `btmon` capture before changing the value rather than flipping it on a hunch.

## Changes

- `scripts/setup-board.sh` — sets and reports `device`; corrects a board carrying `off`.
- `scripts/board-test.sh` — asserts `device`, and exercises the upgrade case in the direction
  that now matters.
- `configd/src/bluez.rs` — the "board setting" section rewritten, and `bond()` no longer calls
  `Pair()` on a bond `Connect()` already started. What `Connect()` returned now decides: succeeded
  means wait for `Paired` and never pair; failed means `Pair()` is the only way left, raced against
  `Paired` as before. `BOND_SETTLE` goes with it — the connect result says which case it is, so
  there is no window left to distinguish them.
- `robotctl`, `duck-ipc-proto`, `docs/robot/pair-a-gamepad.md`, `docs/robot/cheatsheet.md`,
  `scripts/pad-stack-report.sh` — no longer name one value as the one that works.

The reboot stays. Restarting `bluetooth` on this board still leaves the kernel holding hci0 with
"No default controller available", confirmed again the same day — and that is the one step
`microduck_runtime`'s installer gets wrong, since it restarts the service and leaves the board
with no adapter.

## Scope

The second commit is flow-matching, not a measured fix, and says so: the hardware failure was
resolved by the `Privacy` value alone, and no board has been seen where the five-second window
was itself the fault.

## Built on #105

Rebased on `main` now that #105 has merged, and it is a hard dependency rather than a nicety. With
`Pair()` no longer issued on the path that works, bluetoothd has no calling connection whose agent
it can prefer, so every `RequestConfirmation` is raised against the **default** agent. Without
#105's `RequestDefaultAgent`, `configd`'s scoped agent would never be asked and the pad would wait
out the link supervision timeout — the `AuthenticationCanceled` stall that
`docs/design/pad-bond-failure.md` calls Fault 1.

A third commit corrects the module docs #105 left behind: they were still headed "why it is not the
default one" while the code claims the role.

## Related

The same session refutes `#108` on the board it was diagnosed on: the pad bonds and drives on
`738316A2E9D9825966BDB6B`, so the aic8800 build is not the cause of the pad failure, and the
connection interval is not either. `docs/design/pad-bond-failure.md` needs replacing rather than
amending; that is not in this PR.



