### PR TITLE
A missing route refuses; a version difference does not

### DIFF
--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -138,15 +138,17 @@ One service, **one characteristic**. A client reads it once for the robot's API 
 NDJSON request bytes to it, and subscribes to it for answers — the same JSON-RPC lines every other
 transport carries. The read is not optional; see §5 for why it exists.
 
-**The version it returns is for saying so, not for refusing.** `API_VERSION` is an agreement between
-the binaries on one board, enforced by `updaterd`'s exact `!=` on `hello`; a client on a laptop or a
-phone is not one of those binaries and will routinely be a release either side of a robot. Nothing
-across this link checks it: `configd` gates no `net.*` or `system.*` call on a version, and
-`updaterd` requires no handshake before `update.status`. So a client that refuses on skew refuses
-calls the robot would have answered — and it refuses them on the transport that exists for a robot
-with no network, where `net.connect` is the way out of the skew. `duck-btctl` warns and proceeds,
-and an app should do the same: surface the mismatch, let the call go, and report the JSON-RPC error
-if a method whose shape changed is actually reached.
+**The version it returns is for saying so, not for refusing.** `API_VERSION` says the two peers were
+not built together; it does not say which calls stop working, and on this link it is usually none of
+them. Nothing across it checks the number — `configd` gates no `net.*` or `system.*` call on a
+version, `updaterd` requires no handshake before `update.status`, and `updaterd`'s `hello` no longer
+refuses on it either. So a client that refuses on skew refuses calls the robot would have answered —
+and it refuses them on the transport that exists for a robot with no network, where `net.connect` is
+the way out of the skew. `duck-btctl` warns and proceeds, and an app should do the same: surface the
+mismatch, let the call go, and report the JSON-RPC error if a method whose shape changed is actually
+reached. Those errors name themselves — `METHOD_NOT_FOUND` for a route this release does not have,
+`INVALID_PARAMS` for a parameter it does not know — which is what makes proceeding safe rather than
+merely optimistic.
 
 **No framing header.** The newline that already separates NDJSON messages is the frame delimiter in
 both directions. That is safe rather than lucky: `serde_json` escapes a newline inside a string as
@@ -677,11 +679,6 @@ The identity and the derived name are ordinary unit tests. The scenario this exi
 robots advertising at once and a client choosing correctly — is not testable off a board, and wants
 either three of them or a fake peripheral. Worth saying plainly rather than leaving the green suite
 to imply otherwise.
-
-### 8.3 `API_VERSION` skew
-
-`hello` should refuse only when the client is *newer* than the daemon —
-`install-path-gap.md` covers it. Small, self-contained, and it has already cost an hour twice.
 
 ### 8.4 PIN attempts across reconnects
 

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -110,7 +110,8 @@ naive "restart everything" would kill the executor mid-swap or mid-health-gate.
 **Excluded from the in-flight restart is not the same as skipped**, and reading it that way was the
 bug. Deferring them to "the next boot or an explicit later restart" left both running the old binary
 indefinitely: a resident `updaterd` rejected a newer `robotctl` with "client speaks API v4, daemon
-speaks v3", and `btd` fixes were tested against binaries that had never been running. So
+speaks v3" (that refusal is gone — the stale binary was the fault, not the disagreement), and `btd`
+fixes were tested against binaries that had never been running. So
 `RESTART_AFTER_REPLYING` schedules each through a systemd transient timer 5 s after the outcome is on
 the wire — long enough for a single write, short enough that nobody is waiting. The reason for each
 exclusion expires at exactly that moment: the update is finished, and the reply `btd` was carrying

--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -481,27 +481,37 @@ or to restart `updaterd` — neither of which is discoverable from the error.
 
 The handshake at least *caught* it and named both versions, which is more than case 1 managed.
 
-The proposed fix was **`hello` should refuse only when the client is *newer* than the daemon** — a v3
-daemon serves a v2 client perfectly when v3 only *added* methods, so refusing that direction costs
-the ability to recover and buys nothing. It would also have made `API_VERSION` mean "the newest
-contract I understand" rather than "the only contract I will speak".
+The first proposed fix was **`hello` should refuse only when the client is *newer* than the daemon**,
+and it was **decided against** (#77): it assumed bumps are additive, and they are not — v5 added
+`pad.*` and was additive, v4 made `system.authenticate` mandatory and was not. Accepting older
+clients on the strength of a pattern the constant does not track would have promised backward
+compatibility with nothing to enforce it.
 
-**Decided against** (#77), because writing the argument out exposed the premise underneath it: that
-bumps are additive. They are not, and the constant does not distinguish them — v5 added `pad.*` and
-was additive, v4 made `system.authenticate` mandatory and was not. Accepting older clients would
-promise backward compatibility on every past and future bump, with nothing to enforce it and no way
-to make a non-additive change afterwards. With one user and one robot, the freedom to change the
-wire shape is worth more than a promise the protocol cannot keep. `API_VERSION`'s doc comment now
-states that outright, which is the part that was genuinely missing: the rule existed only as an
-`!=` in one file.
+**Fixed instead by removing the gate outright.** The premise of that refusal survives — a bump
+promises nothing — but the conclusion does not follow from it. What breaks a mismatched peer is a
+*route it cannot reach* or a *parameter shape that moved*, and both of those already refuse
+themselves, by name, on the one call that cannot be served: `METHOD_NOT_FOUND` from
+`Request::as_call`, `INVALID_PARAMS` from a params decode. A gate on the handshake fired on every
+other call as well — every call, in fact, since `hello` precedes all of them — which is how a
+one-digit difference took away `update apply` and `version` at the same time. So `updaterd` now
+logs the pair of versions and serves the call; the difference reaches the client through
+`HelloResult::api_version`, and `robotctl` prints one warning line per run.
 
-What did change is the message, because the remaining cost was never leniency — it was that
-`client speaks API v2, daemon speaks v3` names no way out, on a board where the two halves are a
-symlink and a running process. The refusal now branches on direction: client newer is the seconds
-after an update, so retry and then `systemctl restart updaterd`; client older cannot happen through
-`/usr/local/bin/robotctl`, which is a symlink into `current`, so the answer is to use that one.
-`robotctl` correspondingly stopped appending "install matching versions", which was true and not
-actionable.
+Two things had to be true before the gate could go, and the second is the useful part:
+
+- **The refusal had to be redundant, not merely annoying.** It is: `robotd`, `configd` and `padd`
+  never checked the number at all, and `updaterd` required no handshake before `update.status`
+  anyway. `duck-btctl` had already reached the same conclusion from the far end of the link (#102).
+- **A silently ignored parameter had to stop being possible.** `serde` ignores what it does not
+  know, which is what made the gate feel load-bearing: v7 added `ApplyOptions::from_dir`, and a v6
+  daemon that ignored it would install from its *configured* source while the operator believed they
+  were sideloading a directory. Every params type now denies unknown fields, so that is an
+  `INVALID_PARAMS` naming the member. It reaches forward only — a daemon built before this still
+  ignores what it does not know — which is why an `API_VERSION` bump is still worth making.
+
+The message was rewritten before this and is now gone with the gate. It said `client speaks API v2,
+daemon speaks v3` and named no way out; the remedy it grew (retry, or use the symlink at
+`/usr/local/bin/robotctl`) now lives in `robotctl`'s warning, where nothing is being refused.
 
 ### Why these are not install-path bugs
 

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -51,17 +51,35 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// # The rule, since a bump has consequences and nothing else states them
 ///
 /// **A bump promises nothing in either direction.** It is not "additive unless stated": v5 was
-/// additive and v4 was not, and the constant does not distinguish them. So `updaterd` refuses on an
-/// exact `!=`, and that stays deliberate rather than pending — accepting an older client would
-/// promise backward compatibility on every past and future bump, with no mechanism to keep it and
-/// no way to make a non-additive change afterwards. There is one user and one robot; a promise is
-/// worth less here than the freedom to change the wire shape.
+/// additive and v4 was not, and the constant does not distinguish them. Every binary on a board is
+/// expected to come from one release, and the install path is what delivers that.
 ///
-/// **What a bump therefore costs.** Every client on a board must come from the same release as
-/// `updaterd`, and for a few seconds after an update they do not: `robotctl` is a symlink into
+/// **No daemon refuses a call because this number differs.** `updaterd` used to refuse `hello` on
+/// an exact `!=`. The premise was sound — a bump promises nothing — and the conclusion did not
+/// follow from it: what actually breaks a mismatched peer is a *route it cannot reach* or a
+/// *parameter shape that moved*, and each of those refuses itself, by name, on the one call that
+/// cannot be served. A gate on the handshake fired on all of them instead, including the calls that
+/// were perfectly serveable and including `update apply`, which is how a skew ends. The difference
+/// is now *reported* — in `updaterd`'s journal, and in [`HelloResult::api_version`] for a client to
+/// compare against its own — and refused nowhere. See `updater/src/ipc.rs`.
+///
+/// **What refuses instead, and it is narrower on purpose.** A method this release does not have is
+/// [`code::METHOD_NOT_FOUND`] naming the method ([`Request::as_call`]). A member of `params` this
+/// release does not know is [`code::INVALID_PARAMS`] naming the member, because every params type
+/// denies unknown fields — which is the strictness the handshake was reaching for, moved to where it
+/// can tell a changed call from an unchanged one. Both were wanted regardless of the gate: v7 added
+/// `ApplyOptions::from_dir`, and an older `updaterd` that merely *ignored* it would have installed
+/// from its configured source while the operator believed they were sideloading a directory. Silence
+/// was the danger there, not disagreement. It reaches only forward — a daemon built before this
+/// cannot refuse what it was already ignoring — which is one more reason the bump is still worth
+/// making.
+///
+/// **What a bump therefore costs.** Two peers from different releases are still not interchangeable:
+/// a method whose shape moved will fail. It fails on that method now rather than on the handshake,
+/// and for the few seconds after an update it costs nothing at all — `robotctl` is a symlink into
 /// `current`, so it follows the new release immediately, while `updaterd` is mid-restart of itself.
-/// Retrying is the fix. A client that is *persistently* older is a copy taken from somewhere other
-/// than `/usr/local/bin/robotctl`. Both directions are named in the refusal — `updater/src/ipc.rs`.
+/// A client that is *persistently* older is a copy taken from somewhere other than
+/// `/usr/local/bin/robotctl`.
 /// # v7 — `ApplyOptions::from_dir`
 ///
 /// First ships in 0.5.0, which is therefore the version a board has to be on before
@@ -71,7 +89,12 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// That is the reason to bump rather than a reason not to: serde ignores what it does not know, so a
 /// v6 `updaterd` would accept `update.apply --from /some/dir` and quietly install from its
 /// *configured* source instead — a mirror of the release the operator meant to sideload, or nothing
-/// at all. Refusing the call outright is what this constant is for.
+/// at all.
+///
+/// Refusing the call outright is what the handshake used to be for, and it is now the params
+/// decoder's job: an unknown member of `params` is an [`code::INVALID_PARAMS`] naming the member. A
+/// v6 daemon predates that and still ignores the field, which is exactly why the bump stays — it is
+/// the honest label for two peers that do not share a release.
 /// # v8 — `pad.input`
 ///
 /// A namespace addition of the kind v5 was, and it bumps for the same stated reason: the constant
@@ -80,8 +103,8 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// **What it costs here is smaller than usual, and worth being precise about.** The new method is
 /// served by `padd` on a socket of its own, so no existing client loses anything by not knowing it,
 /// and a `robotctl` that asks an older `padd` for it finds no socket at all rather than a refusal.
-/// The bump still lands on `updaterd`'s exact `!=` check, so every binary on a board must come from
-/// one release — which was already the rule.
+/// The bump lands on nothing that refuses: it records that two peers differ, and the rule that every
+/// binary on a board comes from one release is kept by the install path rather than by a handshake.
 pub const API_VERSION: u32 = 8;
 
 pub const DEFAULT_SOCKET: &str = "/run/updaterd.sock";
@@ -333,6 +356,12 @@ pub mod code {
     // Application-specific.
     pub const BUSY: i32 = 1;
     pub const UNKNOWN_COMPONENT: i32 = 2;
+    /// Retired: nothing emits this any more. A version *difference* is logged and served, and
+    /// what refuses is the route that is genuinely missing — see [`super::API_VERSION`].
+    ///
+    /// The constant stays, and the number is not reused, because a board running an `updaterd`
+    /// from 0.5.1 or earlier still answers `hello` with it and `robotctl` still maps it to an
+    /// exit status. Deleting it would make that board's refusal read as a generic failure.
     pub const PROTOCOL_MISMATCH: i32 = 3;
     pub const PREFLIGHT_FAILED: i32 = 4;
     pub const NETWORK: i32 = 5;
@@ -853,12 +882,26 @@ impl From<&str> for ComponentId {
     }
 }
 
+/// Every params type below denies unknown fields, and this is the one place that is worth saying
+/// why rather than repeating it fourteen times.
+///
+/// `serde` ignores what it does not know, so without this a client from another release can send a
+/// member that changes what a call *means* and be told nothing: v7's `ApplyOptions::from_dir` is the
+/// worked example — a daemon that ignores it installs from its configured source while the operator
+/// believes they are sideloading a directory. Refusing it names the member, on the one call that
+/// cannot be served, which is what [`API_VERSION`]'s handshake gate was standing in for until it was
+/// removed for firing on every other call too.
+///
+/// The robot-intent types (`MoveParams`, `HeadParams`, …) had it from the start; the updater and
+/// config ones did not, because the gate was covering for them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HelloParams {
     pub api_version: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ComponentParams {
     pub component: ComponentId,
 }
@@ -989,6 +1032,7 @@ pub enum Target {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ApplyOptions {
     /// Run every check (fetch, verify, compatibility, space) and stop before the symlink
     /// swap.
@@ -1017,6 +1061,7 @@ pub struct ApplyOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ApplyParams {
     pub component: ComponentId,
     pub target: Target,
@@ -1025,12 +1070,14 @@ pub struct ApplyParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SelectParams {
     pub component: ComponentId,
     pub version: semver::Version,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PinParams {
     pub component: ComponentId,
     /// `None` unpins.
@@ -1038,6 +1085,7 @@ pub struct PinParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LogParams {
     pub limit: usize,
 }
@@ -1050,6 +1098,7 @@ pub struct LogParams {
 /// `btd` and `robotctl` all log calls, and the credential-carrying one must not be readable
 /// afterwards by anyone who can run `journalctl`.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NetConnectParams {
     pub ssid: String,
     /// `None` for an open network. Either a passphrase or a 64-hex pre-shared key;
@@ -1078,11 +1127,13 @@ impl std::fmt::Debug for NetConnectParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NetForgetParams {
     pub ssid: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SetNameParams {
     pub name: String,
 }
@@ -1093,6 +1144,7 @@ pub struct SetNameParams {
 /// is the only thing standing between a paired-but-unauthenticated peer and the robot, and a
 /// journal is the wrong place for it.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AuthenticateParams {
     pub pin: String,
 }
@@ -1122,6 +1174,7 @@ pub struct AuthenticateResult {
 /// and a `u32` would store that as 0 and display it as "0". The robot and the phone must agree
 /// on six characters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SetPairingPinParams {
     pub pin: String,
 }
@@ -1130,6 +1183,7 @@ pub struct SetPairingPinParams {
 
 /// Pair the gamepad that is in pairing mode now.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PadPairParams {
     /// Which pad, when the address is already known. **Omit it in the normal case**: the point of
     /// this call is not having to find a MAC address first, so the robot looks for a pad that
@@ -1153,6 +1207,7 @@ pub struct PadPairParams {
 /// room any more — a colleague's controller that still steals the bond on boot — so identifying it
 /// by its current connection state would name the wrong thing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PadForgetParams {
     pub mac: String,
 }
@@ -2580,6 +2635,41 @@ mod tests {
             params: Some(serde_json::json!({ "wrong": "shape" })),
         };
         assert_eq!(malformed.as_call().unwrap_err().code, code::INVALID_PARAMS);
+    }
+
+    /// A `params` member this release does not know is refused, and named, for every method that
+    /// takes parameters.
+    ///
+    /// Pinned across all of them rather than left to fourteen `deny_unknown_fields` attributes being
+    /// remembered, because this is where the strictness the `hello` handshake used to supply now
+    /// lives — see [`API_VERSION`]. A params type added without the attribute fails here.
+    ///
+    /// Methods taking *no* parameters are exempt by design: `parse` ignores whatever arrived for
+    /// them, so that `{}`, `null` and an absent member all mean the same call.
+    #[test]
+    fn an_unknown_params_member_is_refused_by_name() {
+        for call in every_call() {
+            let Value::Object(mut params) = call.params() else {
+                panic!(
+                    "{} serialised its params as something other than an object",
+                    call.method()
+                );
+            };
+            if params.is_empty() {
+                continue;
+            }
+            params.insert("from_a_later_release".to_owned(), Value::Bool(true));
+
+            let error = Call::parse(call.method(), Some(&Value::Object(params)))
+                .expect_err(&format!("{} accepted an unknown member", call.method()));
+            assert_eq!(error.code, code::INVALID_PARAMS, "{}", call.method());
+            assert!(
+                error.message.contains("from_a_later_release"),
+                "{}: {}",
+                call.method(),
+                error.message
+            );
+        }
     }
 
     /// A no-parameter method must accept whatever a client sent for `params` — `{}`, `null`

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -537,6 +537,10 @@ struct Client {
     reader: BufReader<UnixStream>,
     writer: UnixStream,
     next_id: u64,
+    /// Which daemon is on the other end. The connect failure names it too, but that happens
+    /// before there is a `Self` to keep it in — this copy is for [`Client::hello_result`]'s skew
+    /// warning, which has to say which of three sockets disagreed.
+    service: &'static str,
 }
 
 impl Client {
@@ -552,7 +556,7 @@ impl Client {
     /// `systemctl status` for it. Hardcoding "updaterd" told anyone diagnosing a stopped
     /// `robotd` to go check the wrong service — a diagnostic that points at the wrong
     /// place is worse than none.
-    fn connect_to(service: &str, path: &std::path::Path) -> Result<Self, Failure> {
+    fn connect_to(service: &'static str, path: &std::path::Path) -> Result<Self, Failure> {
         let stream = UnixStream::connect(path)
             .map_err(|e| Failure::new(exit::UNREACHABLE, unreachable_hint(service, path, &e)))?;
         let writer = stream
@@ -562,6 +566,7 @@ impl Client {
             reader: BufReader::new(stream),
             writer,
             next_id: 1,
+            service,
         })
     }
 
@@ -624,30 +629,29 @@ impl Client {
         }
     }
 
-    /// Refuse a protocol mismatch loudly rather than sending requests the daemon
-    /// might misread. A stale `robotctl` in someone's shell is normal.
+    /// Confirm the daemon is answering JSON-RPC before sending it a command.
+    ///
+    /// **A liveness check, not a gate.** It used to be one: a daemon whose `API_VERSION` differed
+    /// refused the handshake and every command failed here, including the `update apply` that ends
+    /// the skew. No daemon refuses on that number now — see [`proto::API_VERSION`] — so what remains
+    /// is worth keeping for its own sake, because it turns a socket that accepts and then says
+    /// nothing into a failure before the real call goes out.
     fn hello(&mut self) -> Result<(), Failure> {
         self.hello_result().map(|_| ())
     }
 
-    /// As [`Self::hello`], but returns what the daemon said about itself.
-    ///
-    /// `version` needs the payload rather than a pass/fail, and needs it even when the
-    /// daemon speaks a different API version — "these two are out of step" is the single
-    /// most useful thing the command can report, so refusing to print it would defeat the
-    /// purpose. The protocol check still fails for every *other* command.
+    /// As [`Self::hello`], but returns what the daemon said about itself, which is what
+    /// `version` and `health` report.
     fn hello_result(&mut self) -> Result<proto::HelloResult, Failure> {
         let response = self.call(&proto::Call::Hello(proto::HelloParams {
             api_version: proto::API_VERSION,
         }))?;
         if let Some(error) = response.error {
-            // The daemon's message is passed through unadorned. It used to gain
-            // "robotctl and updaterd are out of step; install matching versions" here, which was
-            // true and not actionable — the daemon now says which of the two is behind and what
-            // to do, which this side cannot know, and two remedies would disagree.
+            // Passed through unadorned. This side cannot add a remedy the daemon does not
+            // already know, and two remedies would disagree.
             return Err(Failure::new(exit::FAILED, error.message));
         }
-        response
+        let hello: proto::HelloResult = response
             .result
             .and_then(|r| serde_json::from_value(r).ok())
             .ok_or_else(|| {
@@ -655,8 +659,36 @@ impl Client {
                     exit::FAILED,
                     "daemon answered hello in an unexpected shape".to_owned(),
                 )
-            })
+            })?;
+        warn_once_about_skew(self.service, hello.api_version);
+        Ok(hello)
     }
+}
+
+/// Say that this client and a daemon were not built together, once per run.
+///
+/// The daemon writes the same pair of versions to its journal and serves the call anyway, which is
+/// the right answer for the machine and an incomplete one for the person typing: they see the
+/// eventual `unknown method` or `unknown field` and nothing connecting it to a stale binary. One
+/// line of stderr closes that gap.
+///
+/// **Once**, because `version` and `health` ask three daemons and a real skew involves all three —
+/// this client is either from the installed release or it is not, so three lines would be three
+/// copies of one fact. And on stderr, because stdout is what `--json` pipes into something.
+fn warn_once_about_skew(service: &str, theirs: u32) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static SAID: AtomicBool = AtomicBool::new(false);
+
+    if theirs == proto::API_VERSION || SAID.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    eprintln!(
+        "warning: {service} speaks API v{theirs} and this robotctl speaks v{}, so they were not \
+         built together. Carrying on — a call that cannot be served will name itself. \
+         `/usr/local/bin/robotctl` follows the installed release: older than the daemon means this \
+         is a copy from somewhere else, newer means the few seconds after an update.",
+        proto::API_VERSION
+    );
 }
 
 // ── version reporting ────────────────────────────────────────────────────────

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -491,13 +491,7 @@ impl Server {
         match call {
             Call::Hello(params) => {
                 if params.api_version != proto::API_VERSION {
-                    return Response::err(
-                        Some(id),
-                        proto::Error::new(
-                            proto::code::PROTOCOL_MISMATCH,
-                            protocol_mismatch(params.api_version),
-                        ),
-                    );
+                    note_version_skew(params.api_version);
                 }
                 Response::ok(
                     Some(id),
@@ -868,33 +862,33 @@ impl Server {
     }
 }
 
-/// Why the handshake failed, and what the operator does about it.
+/// A client built against another `API_VERSION` is written down, not turned away.
 ///
-/// The refusal is an exact `!=` in both directions, and stays one — see [`proto::API_VERSION`] for
-/// why accepting an older client is a promise this protocol cannot keep. What was missing is not
-/// leniency but a remedy: the old text named both versions and stopped there, on a board where the
-/// two halves are a symlink and a running process and neither is obvious to reach.
+/// **This was a refusal, and the refusal was aimed at the wrong thing.** It fired on two numbers
+/// differing, while what it existed to prevent is a *call this release cannot serve* — and those are
+/// not the same event. Most bumps here add a namespace (v5's `pad.*`, v8's `pad.input`) and cost an
+/// older client nothing, so most of what the gate stopped were calls this daemon would have answered
+/// correctly. `hello` precedes every `robotctl` command, so the price of one differing digit was
+/// every command at once: `update apply`, which is how a skew ends, and `version`, which is how it
+/// gets diagnosed. On a board where the client is a symlink into `current` and the daemon is a
+/// resident process mid-restart of itself, that window opens on the ordinary path, not a broken one.
 ///
-/// The direction is the whole diagnosis, so it decides the sentence:
+/// **What refuses now is the call itself.** A method this release does not have comes back
+/// `METHOD_NOT_FOUND` naming it, and a `params` member it does not know comes back `INVALID_PARAMS`
+/// naming that — both from `proto::Request::as_call`, both narrower than a handshake can be, and both
+/// there already. The gate was a blunter second copy of them.
 ///
-/// - **Client newer.** Almost always the seconds after an update, while `updaterd` is restarting
-///   itself into the release `robotctl` already follows. Retrying is the fix, and saying so stops
-///   this reading as a broken install.
-/// - **Client older.** `robotctl` on PATH is a symlink into `current`, so it cannot lag by
-///   construction; a client that does is a copy from somewhere else — a scp'd binary, a laptop
-///   build, a shell open since before the update.
-fn protocol_mismatch(client: u32) -> String {
-    let daemon = proto::API_VERSION;
-    let remedy = if client > daemon {
-        "this client is from a newer release than the running updaterd, which is normal for a few \
-         seconds after an update while updaterd restarts itself — retry, and if it persists, \
-         `systemctl restart updaterd`"
-    } else {
-        "this client is from an older release than the running updaterd. `/usr/local/bin/robotctl` \
-         is a symlink into `current` and follows the installed release, so a client this old is a \
-         copy from somewhere else — use that one"
-    };
-    format!("client speaks API v{client}, daemon speaks v{daemon}: {remedy}")
+/// So the pair of versions goes to the journal, where it turns a later shape error from a puzzle into
+/// a diagnosis, and `HelloResult::api_version` hands the client the same fact so it can say so
+/// itself. `duck-btctl` reached this conclusion from the far end of the link first — see
+/// `btd/examples/duck-btctl.rs`.
+fn note_version_skew(client: u32) {
+    tracing::warn!(
+        client,
+        daemon = proto::API_VERSION,
+        "a client was built against a different API version — serving it anyway; a method this \
+         release does not have, or a parameter it does not know, will be refused by name"
+    );
 }
 
 async fn write_line<T: serde::Serialize>(

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -316,46 +316,31 @@ async fn socket_is_group_restricted() {
     assert_eq!(mode, 0o660, "socket mode is {mode:o}, want 660");
 }
 
+/// `hello` serves a client built against another `API_VERSION`, in both directions.
+///
+/// It used to refuse on an exact `!=`, and `hello` precedes every `robotctl` command — so one
+/// differing digit took away `update apply`, which is how a skew ends, and `version`, which is how
+/// it gets diagnosed. A client newer than the daemon is the ordinary few seconds after an update;
+/// a client older than it is a copy from somewhere other than `/usr/local/bin/robotctl`. Neither is
+/// a reason to refuse a call this release can serve, and both learn the daemon's version from the
+/// reply and can say so themselves.
+///
+/// What refuses is in `unknown_method_and_bad_params_are_reported_distinctly`: a route that is
+/// genuinely missing, and a parameter this release does not know.
 #[tokio::test]
-async fn hello_accepts_matching_version_and_refuses_a_mismatch() {
+async fn hello_serves_a_client_from_another_release() {
     let fx = Harness::new();
     let _server = fx.serve(fx.engine(true, Faults::none())).await;
     let mut client = Client::connect(&fx.socket).await;
 
-    let response = client.hello().await;
-    assert!(response.error.is_none(), "{:?}", response.error);
-    let result: proto::HelloResult = response.result_as().unwrap();
-    assert_eq!(result.api_version, proto::API_VERSION);
-
-    // A stale robotctl in someone's shell must get a clear refusal, not a
-    // misinterpreted request.
-    let response = client
-        .call(method::HELLO, serde_json::json!({ "api_version": 999 }))
-        .await;
-    let error = response.error.unwrap();
-    assert_eq!(error.code, proto::code::PROTOCOL_MISMATCH);
-    // Client newer than the daemon is what the seconds after an update look like, so the refusal
-    // has to say "retry" rather than leave an operator reinstalling a board that is already fine.
-    assert!(error.message.contains("newer release"), "{}", error.message);
-    assert!(
-        error.message.contains("systemctl restart updaterd"),
-        "{}",
-        error.message
-    );
-
-    // The other direction is a different situation with a different remedy, and a refusal naming
-    // only the two numbers made them look like one problem.
-    let response = client
-        .call(method::HELLO, serde_json::json!({ "api_version": 1 }))
-        .await;
-    let error = response.error.unwrap();
-    assert_eq!(error.code, proto::code::PROTOCOL_MISMATCH);
-    assert!(error.message.contains("older release"), "{}", error.message);
-    assert!(
-        error.message.contains("/usr/local/bin/robotctl"),
-        "{}",
-        error.message
-    );
+    for theirs in [proto::API_VERSION, 999, 1] {
+        let response = client
+            .call(method::HELLO, serde_json::json!({ "api_version": theirs }))
+            .await;
+        assert!(response.error.is_none(), "v{theirs}: {:?}", response.error);
+        let result: proto::HelloResult = response.result_as().unwrap();
+        assert_eq!(result.api_version, proto::API_VERSION, "v{theirs}");
+    }
 }
 
 #[tokio::test]
@@ -462,6 +447,7 @@ async fn refusals_carry_their_code_over_the_wire() {
     assert_eq!(fx.live_version(), None, "nothing may be installed");
 }
 
+/// The three ways a mismatched client actually fails, now that the handshake is not one of them.
 #[tokio::test]
 async fn unknown_method_and_bad_params_are_reported_distinctly() {
     let fx = Harness::new();
@@ -475,6 +461,27 @@ async fn unknown_method_and_bad_params_are_reported_distinctly() {
         .call(method::APPLY, serde_json::json!({ "wrong": "shape" }))
         .await;
     assert_eq!(response.error.unwrap().code, proto::code::INVALID_PARAMS);
+
+    // A member from a later release, on a method that exists. This is the case the handshake gate
+    // was standing in for: without it, serde would ignore the member and the apply would run
+    // against the *configured* source while the caller believed it was sideloading a directory.
+    let response = client
+        .call(
+            method::APPLY,
+            serde_json::json!({
+                "component": "daemon",
+                "target": "latest",
+                "from_a_later_release": true,
+            }),
+        )
+        .await;
+    let error = response.error.expect("an unknown member must be refused");
+    assert_eq!(error.code, proto::code::INVALID_PARAMS);
+    assert!(
+        error.message.contains("from_a_later_release"),
+        "{}",
+        error.message
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
`robotctl health` on a board reports this, and has for a while:

```
software
  updaterd  unavailable — client speaks API v7, daemon speaks v8: this client is
            from an older release than the running updaterd. …
```

`updaterd` refused `hello` on an exact `API_VERSION` `!=`, and `hello` precedes every `robotctl` command. So one differing digit took away every command at once — including `update apply`, which is how a skew ends, and `version`, which is how it gets diagnosed.

The premise of that refusal survives: a bump promises nothing in either direction. The conclusion does not follow from it. What breaks a mismatched peer is a *route it cannot reach* or a *parameter shape that moved*, and both of those already refuse themselves, by name, on the one call that cannot be served — `METHOD_NOT_FOUND` and `INVALID_PARAMS`, both from `Request::as_call`. The handshake gate was a blunter second copy of them, firing on every other call as well.

## What changed

- **`updaterd` serves a client from another release** and logs the pair of versions instead of refusing. The client learns the same fact from `HelloResult::api_version`.
- **`robotctl` prints one warning line per run** naming which of the three daemons disagreed, on stderr, once — a real skew involves all three, and three lines would be three copies of one fact.
- **Every params type denies unknown fields.** This is the part that had to be true before the gate could go: `serde` ignores what it does not know, so v7's `ApplyOptions::from_dir` sent to a v6 daemon would have installed from the *configured* source while the operator believed they were sideloading a directory. Silence was the danger, not disagreement. A test over `every_call()` fails if a params type is added without the attribute. It reaches forward only — a daemon built before this still ignores what it did not know — which is why an `API_VERSION` bump is still worth making.

## Every place the number is read

Audited, since the question was whether anything else locks a door on it:

| | before | after |
|---|---|---|
| `updaterd` `hello` | refused on `!=` | logs, serves |
| `robotd`, `configd`, `padd` `hello` | reported it, never gated | unchanged |
| `btd` | relays `hello` upstream, allows it before the PIN | unchanged |
| GATT read | reports the robot's version | unchanged |
| `duck-btctl` | warns (#102) | unchanged |
| `robotctl` | failed on the daemon's refusal | warns once |

## Install consequence

No wire shape changed, so `API_VERSION` stays at 8. A board only gets this once it installs a release containing it. Until then `sudo systemctl restart updaterd` puts the resident daemon back on the installed release, which clears the skew immediately.

Closes the `API_VERSION` skew item in `app-path-design.md` §8.3 and reverses the decision recorded against it in `install-path-gap.md` (#77), with the reasoning moved next to the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)