### PR TITLE
A degraded robot is a hardware fault, not a failed release

### DIFF
--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -636,9 +636,25 @@ and the next update that ships the unit reinstalls it.
   per-component timeout (motors ack, model loads, media pipeline inits).
 - Belt-and-suspenders for hard hangs (not just clean failures):
   - `systemd` `WatchdogSec` on `robotd` so a hang trips recovery.
-  - A **boot-counter** file `updaterd` inspects on start: if the last update
-    never reached "healthy" across 2 boots, revert unconditionally. Covers both
-    "started but sick" and "won't start at all."
+  - A **boot-counter** file `updaterd` inspects on start: if the last update never reached
+    "healthy" across 2 boots, ask the robot and then decide. Covers both "started but sick" and
+    "won't start at all."
+
+    **The budget decides when to ask; the robot decides whether to revert.** Reaching the end of
+    the budget means no apply ever confirmed the trial — and the usual cause is not a bad release
+    but an apply killed before its gate ran, which is what happens when the release's own
+    `hooks/postinstall` restarts `updaterd`. So the same three-way question the health gate asks:
+    *healthy* commits, *degraded* commits, anything else reverts.
+
+    Degraded commits for the reason §4's boot net gives for not being able to fix hardware: a
+    `robotd` with no servo power fails identically on golden. Reverting there hides a hardware
+    fault behind a software change, reverts the next release too, and — worst — replaces the code
+    under whoever is holding the robot without saying so. That is not hypothetical: a board that
+    had installed a branch build and paired a gamepad on it came back two boots later running the
+    stable release, and every command afterwards ran against code nobody had asked for.
+
+    What still reverts is what this net is for: `robotd` unhealthy, unreachable, or answering in a
+    shape this `updaterd` cannot read.
 - `keep_previous` (default 1) retained release dirs bound disk usage while
   always leaving a known-good target to roll back to.
 

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1305,13 +1305,6 @@ impl Engine {
                 continue;
             }
 
-            tracing::warn!(
-                component = %pending.component,
-                version = %pending.version,
-                boots = pending.boots,
-                "pending update never confirmed healthy; reverting"
-            );
-
             // A trial for a component that has since been removed from config must
             // not wedge startup; clear it and move on.
             let Ok(cfg) = self.config.component(&pending.component).cloned() else {
@@ -1322,6 +1315,65 @@ impl Engine {
                 self.boot_counter.confirm(&pending.component)?;
                 continue;
             };
+
+            // **The budget decides when to ask; the robot decides whether to revert.**
+            //
+            // A trial reaching this point means no apply ever confirmed it — the usual cause being
+            // an apply that was killed before its gate ran, which is what happens when the
+            // release's own `hooks/postinstall` restarts `updaterd` mid-apply. It does *not* mean
+            // the release is bad, and reverting one that is working replaces the code under
+            // whoever is looking at the robot, having told them nothing.
+            //
+            // So the same three-way question `health_gate` asks, in the same words, because the
+            // reasoning is identical:
+            //
+            //   - healthy: the release works. Confirm it. The budget was spent counting boots on a
+            //     release that was fine all along.
+            //   - degraded: the robot is not working *for a reason a rollback cannot fix* — no
+            //     servo power, a loose bus, absent hardware. Reverting hides a hardware fault
+            //     behind a software change, and the next release will be reverted too.
+            //   - anything else: revert, as before. `robotd` not answering, or answering
+            //     unhealthy, is the case this budget exists for.
+            //
+            // Only for a socket gate. `HealthCheck::None` has nothing to ask, and `Command` answers
+            // a two-way question — there is no "degraded" in an exit status.
+            if let HealthCheck::Socket { .. } = cfg.health {
+                match self.robot.health(ROBOT_QUERY_TIMEOUT).await {
+                    crate::robot::Health::Healthy => {
+                        tracing::warn!(
+                            component = %pending.component,
+                            version = %pending.version,
+                            boots = pending.boots,
+                            "trial was never confirmed, but the robot is healthy on it; \
+                             committing instead of reverting"
+                        );
+                        self.boot_counter.confirm(&pending.component)?;
+                        continue;
+                    }
+                    crate::robot::Health::Degraded(reason) => {
+                        tracing::warn!(
+                            component = %pending.component,
+                            version = %pending.version,
+                            boots = pending.boots,
+                            reason = %reason,
+                            "trial was never confirmed and the robot is degraded for a reason this \
+                             release cannot have caused and a rollback cannot fix; committing"
+                        );
+                        self.boot_counter.confirm(&pending.component)?;
+                        continue;
+                    }
+                    // Fall through to the revert below, which logs why.
+                    _ => {}
+                }
+            }
+
+            tracing::warn!(
+                component = %pending.component,
+                version = %pending.version,
+                boots = pending.boots,
+                "pending update never confirmed healthy; reverting"
+            );
+
             let store = self.store(&pending.component)?;
 
             // §8.2's chain: previous → golden. Escalate past `previous` when it is

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -892,11 +892,15 @@ async fn a_revert_whose_restart_fails_is_still_a_revert() {
 
 // ── crash recovery ───────────────────────────────────────────────────────────
 
-/// Simulates `kill -9` right after the symlink swap: the new release is live and
-/// the boot counter is still armed. The in-process health gate cannot help here —
-/// it died with the process — so the boot counter must catch it.
+/// Simulates `kill -9` right after the symlink swap: the new release is live and the boot counter is
+/// still armed. The in-process health gate cannot help — it died with the process — so the boot
+/// counter must catch it **when the robot is not working on the new release**.
+///
+/// The robot is unhealthy here on purpose. A crash after the swap is not by itself evidence against
+/// a release, and what happens when the robot *is* fine is
+/// [`an_unconfirmed_trial_on_a_healthy_robot_is_committed`].
 #[tokio::test]
-async fn crash_after_swap_is_reverted_by_boot_counter() {
+async fn crash_after_swap_is_reverted_when_the_robot_is_unhealthy() {
     let fx = Fixture::new();
     fx.publish("1.0.0", None);
     let mut engine = fx.engine_healthy();
@@ -916,14 +920,86 @@ async fn crash_after_swap_is_reverted_by_boot_counter() {
     // Post-crash state: 1.1.0 is live but never confirmed healthy.
     assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
 
-    // Restarts: the first is still "on trial", the second exhausts the budget.
-    let mut engine = fx.engine_healthy();
+    // Restarts: the first is still "on trial", the second exhausts the budget. The robot does not
+    // work on 1.1.0, which is what makes reverting the right answer.
+    let mut engine = fx.engine(Box::new(FakeRobot::unhealthy()), Faults::none(), "");
     assert!(engine.recover_on_start().await.unwrap().is_empty());
     let recovered = engine.recover_on_start().await.unwrap();
 
     assert_eq!(recovered.len(), 1, "should have reverted");
     assert_eq!(fx.live_version().as_deref(), Some("1.0.0"));
     assert_eq!(fx.live_marker().as_deref(), Some("version=1.0.0\n"));
+}
+
+/// **A release the robot is healthy on must not be reverted for want of a confirmation.**
+///
+/// The trial exists to catch a release that does not work. An apply killed before its gate ran —
+/// which is what happens when the release's own `hooks/postinstall` restarts `updaterd` — arms a
+/// trial nothing will ever confirm, and reverting on the budget alone then swaps working code out
+/// from under whoever is using the robot, silently. Observed on a board that had installed a branch
+/// build, paired a gamepad on it, and came back two boots later running the stable release.
+#[tokio::test]
+async fn an_unconfirmed_trial_on_a_healthy_robot_is_committed() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    let mut engine = fx.engine_healthy();
+    apply_latest(&mut engine).await.unwrap();
+
+    fx.publish("1.1.0", None);
+    let mut crashing = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults {
+            abort_after_swap: true,
+            ..Faults::none()
+        },
+        "",
+    );
+    let _ = apply_latest(&mut crashing).await;
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+
+    // Three restarts: more than the budget, so nothing here is the budget merely not having run out.
+    let mut engine = fx.engine_healthy();
+    for _ in 0..3 {
+        assert!(
+            engine.recover_on_start().await.unwrap().is_empty(),
+            "a healthy robot on the new release is not a rollback"
+        );
+    }
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+}
+
+/// And the case that prompted all of this: a bench board with no servo power.
+///
+/// `robotd` comes up and answers, and reports `degraded` because it can see no motor bus. That is a
+/// hardware fault. Reverting hides it behind a software change — and reverts the next release too,
+/// forever, on a board whose only problem is a switch nobody turned on.
+#[tokio::test]
+async fn an_unconfirmed_trial_on_a_degraded_robot_is_committed() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    let mut engine = fx.engine_healthy();
+    apply_latest(&mut engine).await.unwrap();
+
+    fx.publish("1.1.0", None);
+    let mut crashing = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults {
+            abort_after_swap: true,
+            ..Faults::none()
+        },
+        "",
+    );
+    let _ = apply_latest(&mut crashing).await;
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+
+    let mut engine = fx.engine(Box::new(DegradedRobot), Faults::none(), "");
+    for _ in 0..3 {
+        assert!(
+            engine.recover_on_start().await.unwrap().is_empty(),
+            "no motor bus is a hardware fault, not a failed release"
+        );
+    }
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
 }
 
 #[tokio::test]
@@ -1352,7 +1428,10 @@ async fn unrecoverable_first_install_reports_stuck_once() {
     );
     let _ = apply_latest(&mut crashing).await;
 
-    let mut engine = fx.engine_healthy();
+    // Unhealthy, because the subject is what happens when a revert is warranted and there is
+    // nowhere to revert *to*. On a robot that works, the trial is committed and there is nothing to
+    // report — see `an_unconfirmed_trial_on_a_healthy_robot_is_committed`.
+    let mut engine = fx.engine(Box::new(FakeRobot::unhealthy()), Faults::none(), "");
     assert!(
         engine.recover_on_start().await.unwrap().is_empty(),
         "on trial"
@@ -1427,7 +1506,12 @@ health = {{ probe = "none" }}
         .await
         .unwrap();
 
-    // The daemon trial must have survived, and still revert.
+    // The daemon trial must have survived, and still revert. A fresh engine with an *unhealthy*
+    // robot, because what is being asserted here is that the trial still exists and is still acted
+    // on — and a robot that works on the new release is committed rather than reverted, which would
+    // pass this assertion for the wrong reason. See
+    // `an_unconfirmed_trial_on_a_healthy_robot_is_committed`.
+    let mut engine = fx.engine(Box::new(FakeRobot::unhealthy()), Faults::none(), &extra);
     assert!(
         engine.recover_on_start().await.unwrap().is_empty(),
         "on trial"
@@ -1900,7 +1984,10 @@ async fn recovery_escalates_to_golden_when_previous_is_gone() {
     // Now 1.1.0 disappears (pruned, or a corrupted directory removed by hand).
     std::fs::remove_dir_all(fx.install.join("releases/1.1.0")).unwrap();
 
-    let mut engine = fx.engine(Box::new(FakeRobot::healthy()), Faults::none(), golden);
+    // Unhealthy on purpose: the subject here is *where* a revert lands, so there has to be one.
+    // A robot that works on the new release is committed instead — see
+    // `an_unconfirmed_trial_on_a_healthy_robot_is_committed`.
+    let mut engine = fx.engine(Box::new(FakeRobot::unhealthy()), Faults::none(), golden);
     engine.recover_on_start().await.unwrap();
     engine.recover_on_start().await.unwrap();
 


### PR DESCRIPTION
A bench board installed a branch build, paired a gamepad on it, and two boots later was running the
stable release again — silently. Every command afterwards ran against code nobody had asked for, and
the symptom presented as a feature that did not work.

```
"from":"0.5.1-dev.430.8e9590a","to":"0.5.1",
"outcome":{"kind":"rolled_back","reason":"never reported healthy across 2 boots"}
```

## Two causes, one fixed here

**The trial was armed and never confirmed.** `boot_counter.confirm` runs only after `post_swap`
returns (`engine.rs:735`), and `hooks/postinstall` restarts `updaterd` — the process running the
apply. So the apply died at `RunningPostHook` with `updaterd closed the connection`, leaving a trial
nothing would ever confirm. **Not fixed here**: that wants its own reasoning about where `confirm`
belongs relative to the restarts.

**`recover_on_start` reverted on the boot counter alone**, without ever asking the robot. That is
what this changes.

## The budget decides when to ask; the robot decides whether to revert

The same three-way question `health_gate` has always asked a few hundred lines away
(`engine.rs:1630`):

| answer | now | before |
|---|---|---|
| healthy | commit | revert |
| degraded | commit | revert |
| unhealthy / unreachable / incompatible | revert | revert |

Reaching the end of the budget means no apply confirmed the trial — which is not evidence against
the release. On a healthy robot, reverting swaps working code out from under whoever is using it.

Degraded commits for the reason §4 already gives for the boot net not being able to fix hardware: a
`robotd` with no servo power fails identically on golden. A bench board with the motor supply off can
*never* report healthy, so before this every release installed on one was reverted after two boots —
and so would the next, forever, on a board whose only problem is a switch nobody turned on. Worse, it
hides a hardware fault behind a software change.

Only for a socket gate. `HealthCheck::None` has nothing to ask, and `Command` answers a two-way
question — there is no "degraded" in an exit status.

## Tests

Three existing tests asserted a revert while handing recovery a **healthy** robot, which was
incidental to what each was actually testing — the previous→golden escalation chain, per-component
trial independence, and `Stuck` when there is nowhere to revert to. Each now uses an unhealthy robot,
so it still tests its own subject rather than passing for the wrong reason. Their comments say why.

Two new tests: an unconfirmed trial on a healthy robot, and on a degraded one, are both committed —
over three restarts, so neither passes merely because the budget had not run out. `DegradedRobot`
already existed in the fixture, described as "a bench board with the motor supply off, which is
exactly the configuration the update system gets tested on".

`docs/design/updater-design.md` §8 updated, since it owns this mechanism.

Full `updater` suite passes (163 + 69 + the rest, 7 binaries), clippy and fmt clean.
