### PR TITLE
provision: --name gives the board its name, instead of DUCK_NAME

### DIFF
--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -634,7 +634,8 @@ when the rest of the robot has not.
 
 #### Provisioning can name a board, and does not have to
 
-`DUCK_NAME` makes `provision.sh` call `robotctl system set-name` at the end. Optional on purpose:
+`provision.sh --name`, which `provision-board.sh --name` passes through, calls
+`robotctl system set-name` at the end. Optional on purpose:
 the derived default already distinguishes a board, so provisioning *improves* on a working name
 rather than being what supplies one. That is what makes this survive a board flashed by hand, which
 was the objection that ruled out assigning identity at provisioning time.

--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -71,9 +71,11 @@ by the health gate. A dev board quietly running the stable release when a branch
 worst failure to debug: everything looks installed and the code under test is not there. Give CI its
 minute or two before provisioning, and check with `gh run list --branch BRANCH` if it stops.
 
-Other useful flags: `--local` sends this clone's
-`provision.sh` instead of fetching it (which is how to test a change to the provisioning scripts
-without merging first), and `--no-dev-key` makes a board that only takes releases.
+Other useful flags: `--name Ducky` names the robot instead of leaving it the `duck-7f3a` it derives
+from its own serial (`robotctl system set-name` changes it later, so this only saves a command),
+`--local` sends this clone's `provision.sh` instead of fetching it (which is how to test a change to
+the provisioning scripts without merging first), and `--no-dev-key` makes a board that only takes
+releases.
 
 ## Check it worked
 

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -174,8 +174,9 @@ print((r.get("result") or {}).get("ip4") or "")')" || return 1
 # The command line beats the environment, and an address beats a name: an address needs no radio.
 # `DUCK_ROBOT` is the same variable `duck-btctl` defaults `--name` to, so one exported name serves
 # both tools — and empty means unset in both, so `DUCK_ROBOT= scripts/dev-push.sh radxa@…` works.
-# Not `DUCK_NAME`, which `provision.sh` reads and means the opposite way round: the name to *give*
-# a board, not which board to talk to.
+# `--name` here is `duck-btctl`'s sense of it: which robot to talk to. `provision-board.sh --name`
+# means the opposite way round — the name to *give* a board — because provisioning is the one place
+# a name is assigned rather than used to find something.
 if [ -z "$BOARD" ] && [ -z "$ROBOT" ]; then
     BOARD="${DUCK_BOARD:-}"
     [ -n "$BOARD" ] || ROBOT="${DUCK_ROBOT:-}"

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -22,6 +22,11 @@
 #                     if that build cannot be installed or is rolled back — a dev board quietly
 #                     running stable when a branch was asked for is worse than a clear stop.
 #                     Needs the branch build to exist, so give CI its minute or two first.
+#   --name NAME       name the robot, at the end of provisioning: `--name Ducky`. Optional —
+#                     without it the board names itself `duck-<four hex>` from its SoC serial,
+#                     which is already unique per board. Changeable later at any time with
+#                     `robotctl system set-name`, so this saves a command rather than deciding
+#                     anything permanent.
 #   --forget-host-key drop this host's key from known_hosts first. Reflashing the card
 #                     regenerates the board's host keys, so the same address then presents a
 #                     different one and ssh refuses outright — see `probe`.
@@ -89,6 +94,9 @@ NO_DEV_KEY=""
 USE_LOCAL=""
 NO_BLE=""
 WEIRD_BLE=""
+# The name to give the robot. Not `BLE_NAME` below, which points the other way: the name this board
+# already answers to, used to find it again after the reboot.
+ROBOT_NAME=""
 
 # ── the Bluetooth fallback ───────────────────────────────────────────────────
 #
@@ -154,6 +162,7 @@ usage() {
 while [ $# -gt 0 ]; do
     case "$1" in
         --ref)        REF="${2:?--ref needs a branch}"; shift 2 ;;
+        --name)       ROBOT_NAME="${2:?--name needs a name}"; shift 2 ;;
         --forget-host-key) FORGET_KEY=1; shift ;;
         --dev-key)    DEV_KEY="${2:?--dev-key needs a path}"; shift 2 ;;
         --no-dev-key) NO_DEV_KEY=1; shift ;;
@@ -662,11 +671,20 @@ _env="DUCK_TOKEN='${DUCK_TOKEN:-}'"
 [ -z "$DEV_KEY" ] || _env="${_env} DUCK_DEV_KEY=/tmp/team.dev.pub"
 [ -z "$WEIRD_BLE" ] || _env="${_env} DUCK_WEIRD_BLE=1"
 
+# The name is a flag rather than one more `DUCK_*`, because on the board it goes no further than
+# `robotctl system set-name`. Single-quoted with any quote of its own escaped: a name is free text,
+# and this whole string is handed to a shell on the board — `Pierre's duck` would otherwise arrive
+# as a syntax error rather than as a name.
+_args=""
+if [ -n "$ROBOT_NAME" ]; then
+    _args=" --name '$(printf '%s' "$ROBOT_NAME" | sed "s/'/'\\\\''/g")'"
+fi
+
 # `-t` so sudo can prompt for a password, and the exit status deliberately ignored: this
 # command ends by rebooting the machine it is running on, so ssh reporting a dropped connection
 # is the *expected* outcome. Whether it worked is decided below, by looking at the board.
 ssh -t -o StrictHostKeyChecking=accept-new "$HOST" \
-    "sudo env ${_env} sh /tmp/provision.sh" || true
+    "sudo env ${_env} sh /tmp/provision.sh${_args}" || true
 
 echo
 say "waiting for ${HOST} to come back (up to ${BOOT_TIMEOUT}s)"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -12,8 +12,9 @@
 #
 # `DUCK_NO_REBOOT=1` keeps the old four-command shape: it stops and tells you what to run.
 #
-# `DUCK_NAME="Ducky"` names the robot at the end. Optional: without it the board names itself
-# `duck-<four hex>` from its SoC serial, which is already unique per board.
+# `--name Ducky` names the robot at the end — `sudo sh /tmp/provision.sh --name Ducky`. Optional:
+# without it the board names itself `duck-<four hex>` from its SoC serial, which is already unique
+# per board.
 #
 # This orchestrates `setup-board.sh`, `migrate-network.sh` and `install.sh`; it does not
 # duplicate them. They stay separately runnable, and they stay separate for the reasons each
@@ -65,7 +66,6 @@ ENV_REF="${DUCK_REF:-}"
 ENV_TOKEN="${DUCK_TOKEN:-}"
 ENV_DEV_KEY="${DUCK_DEV_KEY:-}"
 ENV_FORCE="${DUCK_FORCE_REINSTALL:-}"
-ENV_NAME="${DUCK_NAME:-}"
 ENV_WEIRD_BLE="${DUCK_WEIRD_BLE:-}"
 
 REPO="${ENV_REPO:-pollen-robotics/microduck_daemon}"
@@ -82,13 +82,19 @@ RAW="https://raw.githubusercontent.com/${REPO}/${REF}/scripts"
 # during it. `finish` says where it ended up.
 TOKEN="$ENV_TOKEN"
 
-# A name for this robot, or empty to let it name itself.
+# A name for this robot, or empty to let it name itself. Set by `--name`; see `main`.
 #
 # Optional on purpose. Without one the robot derives `duck-7f3a` from its SoC serial, which is
 # already distinguishable from every other board flashed from the same image — so this improves on
 # a working default rather than supplying the only one. That is what keeps a hand-flashed board
 # usable, and it is why the default is derived rather than assigned here.
-NAME="$ENV_NAME"
+#
+# A flag rather than a `DUCK_*` knob, unlike everything above it. Those are environment variables
+# because they are passed on — `install.sh` reads the same names, so a fork or a pinned tag is one
+# decision for the whole bring-up. A name goes no further than `robotctl system set-name` at the
+# end of phase 2. It is also the only thing here that is per-board rather than per-session, and an
+# exported name is exactly the kind of thing that is still set when the next board is provisioned.
+NAME=""
 
 # Path to `team.dev.pub`, to make this a dev board. Usually somewhere under /tmp because it
 # arrived by `scp`, which is why phase 1 copies it somewhere that survives the reboot.
@@ -206,6 +212,17 @@ persist_self() {
   reboot would then have nothing to resume — finish by hand if that happens."
 }
 
+# One `KEY='value'` line for the state file, with any single quote in the value escaped.
+#
+# Quoted because `load_state` reads that file by sourcing it, and one of the values is free text:
+# `PROVISION_NAME=Ducky Two` sources as an assignment plus an attempt to run `Two`, which under
+# `set -eu` ends phase 2 on its first line. Naming a robot after two words would then have broken
+# provisioning rather than just the name. Applied to every value rather than to the name alone — a
+# rule that holds for all of them cannot be got wrong by the next one added.
+kv() {
+    printf "%s='%s'\n" "$1" "$(printf '%s' "$2" | sed "s/'/'\\\\''/g")"
+}
+
 # Write what phase 2 needs to know, 0600, root-only.
 #
 # This is where the token lives between the two phases. Not `~/.profile`, which was the
@@ -219,15 +236,17 @@ save_state() {
     : > "$STATE"
     chmod 600 "$STATE"
     {
-        printf 'DUCK_REPO=%s\n' "$REPO"
-        printf 'DUCK_REF=%s\n' "$REF"
-        printf 'DUCK_TOKEN=%s\n' "$TOKEN"
-        printf 'DUCK_DEV_KEY=%s\n' "$1"
-        printf 'DUCK_FORCE_REINSTALL=%s\n' "$FORCE_REINSTALL"
-        printf 'DUCK_NAME=%s\n' "$NAME"
-        printf 'DUCK_WEIRD_BLE=%s\n' "$WEIRD_BLE"
-        printf 'DUCK_ASKED_REF=%s\n' "$ASKED_REF"
-        printf 'PROVISION_BOOT_ID=%s\n' "$(boot_id)"
+        kv DUCK_REPO "$REPO"
+        kv DUCK_REF "$REF"
+        kv DUCK_TOKEN "$TOKEN"
+        kv DUCK_DEV_KEY "$1"
+        kv DUCK_FORCE_REINSTALL "$FORCE_REINSTALL"
+        kv DUCK_WEIRD_BLE "$WEIRD_BLE"
+        kv DUCK_ASKED_REF "$ASKED_REF"
+        # `PROVISION_*` for the two that are not environment knobs, so sourcing this file cannot
+        # set something an operator could also have exported.
+        kv PROVISION_NAME "$NAME"
+        kv PROVISION_BOOT_ID "$(boot_id)"
     } > "$STATE"
 }
 
@@ -245,9 +264,13 @@ load_state() {
     TOKEN="${ENV_TOKEN:-${DUCK_TOKEN:-}}"
     DEV_KEY="${ENV_DEV_KEY:-${DUCK_DEV_KEY:-}}"
     FORCE_REINSTALL="${ENV_FORCE:-${DUCK_FORCE_REINSTALL:-}}"
-    NAME="${ENV_NAME:-${DUCK_NAME:-}}"
     WEIRD_BLE="${ENV_WEIRD_BLE:-${DUCK_WEIRD_BLE:-}}"
     ASKED_REF="${ENV_REF:-${DUCK_ASKED_REF:-}}"
+    # No `ENV_` mirror for the name, unlike its neighbours. Theirs exist because sourcing this file
+    # sets the very `DUCK_*` variables the operator's environment did, so the typed value has to be
+    # kept somewhere else to still win. Nothing else writes `PROVISION_NAME`, so a `--name` on the
+    # phase 2 command line survives the sourcing and can simply be preferred.
+    NAME="${NAME:-${PROVISION_NAME:-}}"
     RAW="https://raw.githubusercontent.com/${REPO}/${REF}/scripts"
     return 0
 }
@@ -684,11 +707,13 @@ main() {
     [ "$(id -u)" = 0 ] || die "run as root — re-run that same command with sudo"
     command -v curl >/dev/null 2>&1 || die "curl is required"
 
-    case "${1:-}" in
-        --resumed) RESUMED=1 ;;
-        '') ;;
-        *) die "unknown argument: $1 (only --resumed, which systemd passes)" ;;
-    esac
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --name)    NAME="${2:?--name needs a name}"; shift 2 ;;
+            --resumed) RESUMED=1; shift ;;
+            *) die "unknown argument: $1 (--name NAME, or --resumed, which systemd passes)" ;;
+        esac
+    done
 
     if [ "$RESUMED" = 1 ]; then
         # Before the work, not after: one automatic attempt, whatever happens next.


### PR DESCRIPTION
`provision-board.sh` never forwarded `DUCK_NAME`, so naming a board while provisioning it only worked when `provision.sh` was run on the board by hand. Through the wrapper the name silently did nothing.

`--name NAME` now exists on both, and `DUCK_NAME` is gone.

```bash
./scripts/provision-board.sh --name Ducky radxa@192.168.1.42
```

It is a flag rather than one more `DUCK_*` because a name goes no further than `robotctl system set-name` at the end of phase 2 — the other knobs are environment variables because `install.sh` reads the same names, so a pinned tag is one decision for a whole bring-up. A name is also the only one that is per-board rather than per-session, and an exported name is exactly the kind of thing that is still set when the next board is provisioned.

`provision.sh --name` also works on the phase 2 command line, where it beats what the state file carried, like every other value there.

## The state file is now quoted

`/var/lib/robot/provision.env` crosses the reboot and is read by sourcing it, and a name is free text. `DUCK_NAME=Ducky Two` came back as an assignment plus an attempt to run `Two`, which under `set -eu` ended phase 2 on its first line — so a robot named after two words broke provisioning rather than just the name.

Every value is written `KEY='value'` with any quote of its own escaped, not the name alone: a rule that holds for all of them cannot be got wrong by the next one added. The two keys that are not environment knobs are `PROVISION_*`, so sourcing the file cannot set something an operator could also have exported. The name is escaped again on the way over ssh, which hands the whole command to a second shell on the board.

## Checked

- `shellcheck --shell=sh` and `sh -n` clean on the three scripts touched, which is what CI runs.
- Round-tripped `Ducky`, `Ducky Two`, `Pierre's duck`, `x$HOME\`id\``, `Été 🦆` through the state file and through the ssh command string — each arrives as one argument, unchanged.
- `--name` typed on the phase 2 command line beats the carried value; with no flag the carried value is used.

Not tested on a board.

Based on `scripts-work-with-privacy-device`, which is where these two scripts currently live.