### PR TITLE
Updates from a phone: trigger, watch, and go back over Bluetooth

### DIFF
--- a/btd/examples/duck-btctl.rs
+++ b/btd/examples/duck-btctl.rs
@@ -1401,11 +1401,21 @@ fn progress_line(params: &serde_json::Value) -> String {
 /// about five seconds *after* the reply goes out (`docs/design/restart-order.md` §1). Every client
 /// has to expect that, and a phone app should show it as a step rather than an error.
 fn restart_note(command: &Command, reply: &serde_json::Value) -> Option<&'static str> {
-    let Command::Update(Update::Apply { .. } | Update::Rollback { .. } | Update::Select { .. }) =
-        command
-    else {
-        return None;
+    let component = match command {
+        Command::Update(
+            Update::Apply { component, .. }
+            | Update::Rollback { component }
+            | Update::Select { component, .. },
+        ) => component,
+        _ => return None,
     };
+    // `btd` ships in the daemon release and in nothing else, so only that component's transition
+    // takes the connection down. A model bundle restarts `robotd` and leaves this link alone —
+    // there are no model components configured today, and a note that is wrong the first time one
+    // appears is worse than no note.
+    if component != "daemon" {
+        return None;
+    }
     // Only when something actually moved. `already_current` and `dry_run_passed` restart nothing.
     match reply["result"]["outcome"].as_str()? {
         "applied" | "rolled_back" => Some(
@@ -1930,5 +1940,11 @@ mod tests {
             .expect("parses")
             .command;
         assert!(restart_note(&status, &applied).is_none());
+
+        // Nor a component whose release does not ship `btd`.
+        let model = Cli::try_parse_from(["duck-btctl", "update", "apply", "--component", "model"])
+            .expect("parses")
+            .command;
+        assert!(restart_note(&model, &applied).is_none());
     }
 }

--- a/btd/examples/duck-btctl.rs
+++ b/btd/examples/duck-btctl.rs
@@ -54,12 +54,25 @@ const SCAN_TIME: Duration = Duration::from_secs(8);
 /// finish in well under a second instead of always paying `SCAN_TIME`.
 const SCAN_POLL: Duration = Duration::from_millis(250);
 
-/// How long to wait for a reply once the request is written.
+/// How long to wait with **nothing at all arriving** before giving up on a request.
 ///
-/// Longer than any single call except `net.connect`, which polls NetworkManager for up to 45s
-/// and so gets its own budget below.
+/// Idle rather than total, and that distinction is what makes an update watchable. An apply takes
+/// as long as the robot needs — download, verify, extract, swap, hooks, the health gate — so a
+/// total budget either cuts off a working update or waits out a dead robot. But the useful signal
+/// is already arriving: every progress notification is proof the robot is alive and working, so
+/// each one starts the clock again. A stalled mirror still fails in seconds.
+///
+/// Longer than any single call except `net.connect`, which polls NetworkManager for up to 45s and
+/// so gets its own budget below.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(15);
 const SLOW_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
+/// An update's silences are longer than any other call's: a post-install hook may take two
+/// minutes, and the phase notification arrives before it rather than during it. So the budget is
+/// the longest gap an update can legitimately have, not the longest an update can take.
+const UPDATE_IDLE_TIMEOUT: Duration = Duration::from_secs(180);
+/// `update watch` follows progress until interrupted, so it has no deadline worth naming. A day
+/// is an arbitrary bound that keeps the reply loop one shape instead of two.
+const FOLLOW_TIMEOUT: Duration = Duration::from_secs(24 * 3600);
 
 /// Every step before the first reply gets its own budget and its own message.
 ///
@@ -622,6 +635,15 @@ enum Command {
     Scan,
     /// Version handshake plus update status.
     Status,
+    /// What the robot is running: the API version, the release, and the revision it was built from.
+    ///
+    /// `status` above answers this too, buried in an update report. This is the narrower question,
+    /// and the first one to ask of a robot that is behaving unexpectedly — a `revision` of `null`
+    /// means the release was built on somebody's laptop rather than by CI.
+    Version,
+    /// Updates: what is available, installing it, and going back.
+    #[command(subcommand)]
+    Update(Update),
     /// Name, serial and uptime.
     Info,
     /// Is the control loop healthy?
@@ -643,6 +665,86 @@ enum Command {
         /// Parameters as JSON. Defaults to `{}`.
         params: Option<String>,
     },
+}
+
+/// The update commands, named as `robotctl update` names them.
+///
+/// Deliberately the same words in the same order, so what someone learns on the robot transfers to
+/// the radio and back. What differs is the component: `robotctl` takes it as a positional argument
+/// because an operator may be updating a model bundle, and here it is a flag with a default,
+/// because a phone has one component to care about and today a robot has exactly one.
+#[derive(Subcommand)]
+enum Update {
+    /// Is there a newer release? Changes nothing.
+    ///
+    /// Answers `BUSY` rather than waiting if an update is already running.
+    Check {
+        #[arg(long, default_value = "daemon")]
+        component: String,
+    },
+    /// Install a release, and report progress while it happens.
+    ///
+    /// Answers once, when it is finished. The connection then drops a few seconds later, because
+    /// installing a daemon release restarts `btd` — see what this prints after the reply.
+    Apply {
+        #[arg(long, default_value = "daemon")]
+        component: String,
+        /// Exact version to install. Omit for whatever the source calls latest.
+        #[arg(long, conflicts_with = "git_ref")]
+        version: Option<duck_ipc_proto::semver::Version>,
+        /// Install what a branch last built, e.g. `--ref my-branch`.
+        ///
+        /// A dev build, so a robot only accepts one if the team key is in its trusted set and
+        /// `allow_dev_keys` is on: a customer robot refuses it.
+        #[arg(long = "ref", value_name = "REF", conflicts_with = "version")]
+        git_ref: Option<String>,
+        /// Install the release candidate from the staging channel.
+        ///
+        /// Pair it with `--version` to name one candidate rather than the newest.
+        #[arg(long, conflicts_with = "git_ref")]
+        staging: bool,
+        /// Verify everything, then stop before the symlink swap.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Per-component state: the version installed, the phase, health, and the last attempt.
+    ///
+    /// The same call as the top-level `status`, which keeps working because it is in every set of
+    /// notes anybody has written down.
+    Status,
+    /// Which releases are on the board, and which one is active.
+    Versions {
+        #[arg(long, default_value = "daemon")]
+        component: String,
+    },
+    /// Recent update attempts and outcomes — the record that survives a wiped journal.
+    Log {
+        #[arg(long, default_value_t = 20)]
+        limit: u32,
+    },
+    /// Go back to the release installed before this one.
+    ///
+    /// The undo, for a release that installed, passed its health gate and then behaved worse.
+    /// Discards nothing, and is gated and auto-reverted like any other transition.
+    Rollback {
+        #[arg(long, default_value = "daemon")]
+        component: String,
+    },
+    /// Activate a release already on the board, without downloading anything.
+    ///
+    /// `versions` above lists what there is to choose from. Gated like an apply, so a selection
+    /// that does not come up is reverted.
+    Select {
+        version: duck_ipc_proto::semver::Version,
+        #[arg(long, default_value = "daemon")]
+        component: String,
+    },
+    /// Follow progress until interrupted.
+    ///
+    /// Prints where any update in flight has got to — `updaterd` replays the latest progress to a
+    /// new subscriber — and then everything that follows. It never receives a reply, so it ends
+    /// with Ctrl-C.
+    Watch,
 }
 
 #[derive(Subcommand)]
@@ -947,46 +1049,73 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut reassembler = Reassembler::new();
-    let deadline = tokio::time::Instant::now() + timeout;
+    // The deadline is **idle**, not total: it is pushed back by every notification that arrives,
+    // because a robot sending progress is a robot that is working. See `REPLY_TIMEOUT`.
+    let mut deadline = tokio::time::Instant::now() + timeout;
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            return Err(format!("no reply within {timeout:?}").into());
+            return Err(silence(timeout).into());
         }
 
         let Ok(Some(notification)) = tokio::time::timeout(remaining, notifications.next()).await
         else {
-            return Err(format!("no reply within {timeout:?}").into());
+            return Err(silence(timeout).into());
         };
+        deadline = tokio::time::Instant::now() + timeout;
 
         for line in reassembler.push(&notification.value)? {
             if cli.verbose {
                 eprintln!("← {line}");
             }
-            // Notifications with no `id` are a progress stream, not an answer; print them and
+            // Notifications with no `id` are a progress stream, not an answer; report them and
             // keep waiting for the response that closes the call.
             let value: serde_json::Value = serde_json::from_str(&line)?;
             let is_answer = value.get("id").is_some_and(|id| !id.is_null());
 
-            println!("{}", serde_json::to_string_pretty(&value)?);
-            if is_answer {
-                let _ = peripheral.disconnect().await;
-                // A JSON-RPC error is the robot answering, not this tool failing — so it is
-                // printed above and reported through the exit status rather than as a panic.
-                return if value.get("error").is_some() {
-                    Err("the robot returned an error".into())
+            if !is_answer {
+                if value["method"] == "update.progress" {
+                    eprintln!("· {}", progress_line(&value["params"]));
                 } else {
-                    // After the reply, and only for one that succeeded: a rename that the robot
-                    // refused leaves nothing stale.
-                    if let Some(note) = target.stale_after_rename(&cli.command) {
-                        eprintln!("{note}");
-                    }
-                    Ok(())
-                };
+                    // Nothing else streams today. Printed whole rather than summarised, because a
+                    // notification this tool does not know about is worth seeing in full.
+                    eprintln!("· {}", serde_json::to_string(&value)?);
+                }
+                continue;
             }
+
+            println!("{}", serde_json::to_string_pretty(&value)?);
+            let _ = peripheral.disconnect().await;
+            // A JSON-RPC error is the robot answering, not this tool failing — so it is
+            // printed above and reported through the exit status rather than as a panic.
+            return if value.get("error").is_some() {
+                Err("the robot returned an error".into())
+            } else {
+                // After the reply, and only for one that succeeded: a rename that the robot
+                // refused leaves nothing stale.
+                if let Some(note) = target.stale_after_rename(&cli.command) {
+                    eprintln!("{note}");
+                }
+                if let Some(note) = restart_note(&cli.command, &value) {
+                    eprintln!("{note}");
+                }
+                Ok(())
+            };
         }
     }
+}
+
+/// What to say when the robot stops talking, which depends on what was expected of it.
+///
+/// The budget is a silence rather than a total, so "no reply within 180s" would be a lie about an
+/// update that had been running for ten minutes and then stalled.
+fn silence(idle: Duration) -> String {
+    format!(
+        "nothing from the robot for {idle:?}, so it has stopped answering. Anything it had \
+             already started — an update in particular — carries on without this connection: \
+             reconnect and run `duck-btctl update status`."
+    )
 }
 
 /// Write one NDJSON line, chunked.
@@ -1100,6 +1229,12 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         // request: there is no method to send, and connecting is the thing it exists not to do.
         Command::Scan => unreachable!("scan returns before anything connects"),
         Command::Status => ("update.status", serde_json::json!({}), REPLY_TIMEOUT),
+        Command::Version => (
+            "hello",
+            serde_json::json!({ "api_version": duck_ipc_proto::API_VERSION }),
+            REPLY_TIMEOUT,
+        ),
+        Command::Update(update) => return update_request_line(update),
         Command::Info => ("system.info", serde_json::json!({}), REPLY_TIMEOUT),
         Command::Health => ("robot.health", serde_json::json!({}), REPLY_TIMEOUT),
         Command::Name { name } => (
@@ -1143,6 +1278,143 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         "params": params,
     });
     Ok((serde_json::to_string(&request)?, timeout))
+}
+
+/// The update commands, built from `duck_ipc_proto`'s own types rather than as hand-written JSON.
+///
+/// `update.apply`'s target is an externally tagged enum — `"latest"`, `{"exact":"0.5.1"}`,
+/// `{"ref":"my-branch"}` — and getting that shape wrong by hand is a `PARSE_ERROR` from the robot
+/// with no clue in it. Serialising the type the daemon deserialises cannot be wrong.
+fn update_request_line(update: &Update) -> Result<(String, Duration), Box<dyn std::error::Error>> {
+    use duck_ipc_proto as proto;
+
+    let component = |name: &str| proto::ComponentId::new(name.to_owned());
+    let (method, params, timeout) = match update {
+        Update::Check { component: c } => (
+            proto::method::CHECK,
+            serde_json::to_value(proto::ComponentParams {
+                component: component(c),
+            })?,
+            // Reaches the network. It answers BUSY at once during an update rather than waiting,
+            // so the budget is for a slow mirror, not for a busy robot.
+            SLOW_REPLY_TIMEOUT,
+        ),
+        Update::Apply {
+            component: c,
+            version,
+            git_ref,
+            staging,
+            dry_run,
+        } => {
+            let target = match (version.clone(), git_ref, staging) {
+                (Some(version), _, true) => proto::Target::StagingExact(version),
+                (Some(version), _, false) => proto::Target::Exact(version),
+                (None, Some(git_ref), _) => proto::Target::Ref(git_ref.clone()),
+                (None, None, true) => proto::Target::Staging,
+                (None, None, false) => proto::Target::Latest,
+            };
+            (
+                proto::method::APPLY,
+                serde_json::to_value(proto::ApplyParams {
+                    component: component(c),
+                    target,
+                    options: proto::ApplyOptions {
+                        dry_run: *dry_run,
+                        ..Default::default()
+                    },
+                })?,
+                UPDATE_IDLE_TIMEOUT,
+            )
+        }
+        Update::Status => (proto::method::STATUS, serde_json::json!({}), REPLY_TIMEOUT),
+        Update::Versions { component: c } => (
+            proto::method::LIST_INSTALLED,
+            serde_json::to_value(proto::ComponentParams {
+                component: component(c),
+            })?,
+            REPLY_TIMEOUT,
+        ),
+        Update::Log { limit } => (
+            proto::method::LOG,
+            serde_json::to_value(proto::LogParams {
+                limit: *limit as usize,
+            })?,
+            REPLY_TIMEOUT,
+        ),
+        Update::Rollback { component: c } => (
+            proto::method::ROLLBACK,
+            serde_json::to_value(proto::ComponentParams {
+                component: component(c),
+            })?,
+            UPDATE_IDLE_TIMEOUT,
+        ),
+        Update::Select {
+            version,
+            component: c,
+        } => (
+            proto::method::SELECT,
+            serde_json::to_value(proto::SelectParams {
+                component: component(c),
+                version: version.clone(),
+            })?,
+            UPDATE_IDLE_TIMEOUT,
+        ),
+        Update::Watch => (
+            proto::method::SUBSCRIBE,
+            serde_json::json!({}),
+            FOLLOW_TIMEOUT,
+        ),
+    };
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    Ok((serde_json::to_string(&request)?, timeout))
+}
+
+/// One progress notification, as a line for a person.
+///
+/// Progress goes to stderr like everything that is not an answer, so `duck-btctl … > reply.json`
+/// keeps the two apart — and printing it as pretty JSON, which is what this used to do, put a
+/// dozen lines of punctuation on stdout for every percent of a download.
+fn progress_line(params: &serde_json::Value) -> String {
+    let phase = params["phase"].as_str().unwrap_or("?");
+    let component = params["component"].as_str().unwrap_or("?");
+    let percent = params["percent"]
+        .as_u64()
+        .map(|p| format!(" {p}%"))
+        .unwrap_or_default();
+    let detail = params["detail"]
+        .as_str()
+        .map(|d| format!(" — {d}"))
+        .unwrap_or_default();
+    format!("{component}: {phase}{percent}{detail}")
+}
+
+/// What to say after an update replies, because the connection is about to drop.
+///
+/// Not a failure, and it should not read as one: `updaterd` and `btd` are the two units an update
+/// never restarts mid-flight — `btd` may be the transport it arrived over — so both are restarted
+/// about five seconds *after* the reply goes out (`docs/design/restart-order.md` §1). Every client
+/// has to expect that, and a phone app should show it as a step rather than an error.
+fn restart_note(command: &Command, reply: &serde_json::Value) -> Option<&'static str> {
+    let Command::Update(Update::Apply { .. } | Update::Rollback { .. } | Update::Select { .. }) =
+        command
+    else {
+        return None;
+    };
+    // Only when something actually moved. `already_current` and `dry_run_passed` restart nothing.
+    match reply["result"]["outcome"].as_str()? {
+        "applied" | "rolled_back" => Some(
+            "note: the robot restarts its daemons now, and `btd` about five seconds after this \
+             reply — so this connection drops. That is the update working. Reconnect and run \
+             `duck-btctl update status`: `last_attempt` carries the outcome of what just ran.",
+        ),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -1488,5 +1760,175 @@ mod tests {
         assert!(answers_to("duck [1]", "duck [1]"));
         assert!(!answers_to("[duck-c51b]", "duck-c51b"));
         assert!(!answers_to("duck-c51b [", "duck-c51b"));
+    }
+
+    /// Every shape `update apply` can ask for, on the wire.
+    ///
+    /// `Target` is an externally tagged enum, so each of these is a *different JSON shape* rather
+    /// than a different value in one field, and a mistake is a parse error from the robot with
+    /// nothing in it to act on. Built from the daemon's own type for that reason, and pinned here
+    /// because the flags are what a person types.
+    #[test]
+    fn apply_asks_for_the_target_the_flags_named() {
+        let wire = |args: &[&str]| {
+            let mut argv = vec!["duck-btctl", "update", "apply"];
+            argv.extend_from_slice(args);
+            let cli = Cli::try_parse_from(argv).expect("parses");
+            request_line(&cli.command).expect("a request").0
+        };
+
+        assert!(wire(&[]).contains(r#""target":"latest""#));
+        assert!(wire(&["--version", "0.5.1"]).contains(r#""target":{"exact":"0.5.1"}"#));
+        assert!(wire(&["--ref", "my-branch"]).contains(r#""target":{"ref":"my-branch"}"#));
+        assert!(wire(&["--staging"]).contains(r#""target":"staging""#));
+        assert!(
+            wire(&["--staging", "--version", "0.6.0"])
+                .contains(r#""target":{"staging_exact":"0.6.0"}"#),
+            "a named candidate, which is neither of the two flags on its own"
+        );
+
+        let plain = wire(&[]);
+        assert!(plain.contains(r#""method":"update.apply""#), "{plain}");
+        assert!(
+            plain.contains(r#""component":"daemon""#),
+            "the default component"
+        );
+        assert!(
+            plain.contains(r#""dry_run":false"#),
+            "the options travel spelled out, which is what the daemon parses: {plain}"
+        );
+        assert!(wire(&["--dry-run"]).contains(r#""dry_run":true"#));
+    }
+
+    /// A ref and a version are alternatives, not a precedence to resolve by guessing — the same
+    /// refusal `robotctl` makes, so a command copied between them fails the same way.
+    #[test]
+    fn a_ref_and_a_version_cannot_both_be_named() {
+        assert!(
+            Cli::try_parse_from([
+                "duck-btctl",
+                "update",
+                "apply",
+                "--ref",
+                "my-branch",
+                "--version",
+                "0.5.1",
+            ])
+            .is_err()
+        );
+    }
+
+    /// The read-only commands and going back, each reaching the method it is named after. A table,
+    /// because the value of these commands over `call` is that the method is not typed by hand.
+    #[test]
+    fn every_update_command_asks_for_its_own_method() {
+        for (args, method) in [
+            (vec!["check"], "update.check"),
+            (vec!["status"], "update.status"),
+            (vec!["versions"], "update.listInstalled"),
+            (vec!["log"], "update.log"),
+            (vec!["watch"], "update.subscribe"),
+            (vec!["rollback"], "update.rollback"),
+            (vec!["select", "0.5.1"], "update.select"),
+        ] {
+            let mut argv = vec!["duck-btctl", "update"];
+            argv.extend_from_slice(&args);
+            let cli = Cli::try_parse_from(argv).expect("parses");
+            let (line, _) = request_line(&cli.command).expect("a request");
+            assert!(line.contains(&format!(r#""method":"{method}""#)), "{line}");
+        }
+    }
+
+    /// `select` sends the version as a version, and defaults the component like the rest.
+    #[test]
+    fn select_names_a_version_and_defaults_the_component() {
+        let cli = Cli::try_parse_from(["duck-btctl", "update", "select", "0.5.1"]).expect("parses");
+        let (line, _) = request_line(&cli.command).expect("a request");
+        assert!(line.contains(r#""version":"0.5.1""#), "{line}");
+        assert!(line.contains(r#""component":"daemon""#), "{line}");
+    }
+
+    /// An update waits on silence, not on a total, and it waits longer than anything else does.
+    /// A total budget would cut off a working update; this is the longest gap one can legitimately
+    /// have (a post-install hook) rather than the longest one can take.
+    #[test]
+    fn an_update_is_given_the_longest_silence() {
+        let budget = |args: &[&str]| {
+            let mut argv = vec!["duck-btctl"];
+            argv.extend_from_slice(args);
+            let cli = Cli::try_parse_from(argv).expect("parses");
+            request_line(&cli.command).expect("a request").1
+        };
+
+        assert_eq!(budget(&["update", "apply"]), UPDATE_IDLE_TIMEOUT);
+        assert_eq!(budget(&["update", "rollback"]), UPDATE_IDLE_TIMEOUT);
+        assert_eq!(budget(&["update", "select", "0.5.1"]), UPDATE_IDLE_TIMEOUT);
+        assert!(budget(&["update", "apply"]) > budget(&["update", "status"]));
+        assert_eq!(
+            budget(&["update", "watch"]),
+            FOLLOW_TIMEOUT,
+            "watch ends with Ctrl-C, not with a deadline"
+        );
+    }
+
+    /// Progress reads as a line rather than as JSON, and survives a field it does not have.
+    ///
+    /// The phase is always there; the percent only during a download, and the detail rarely. A
+    /// `None` percent must not print as `null%`, which is what a naive format would do.
+    #[test]
+    fn progress_prints_as_a_line() {
+        let full = serde_json::json!({
+            "component": "daemon",
+            "phase": "downloading",
+            "percent": 42,
+            "detail": null,
+        });
+        assert_eq!(progress_line(&full), "daemon: downloading 42%");
+
+        let bare = serde_json::json!({ "component": "daemon", "phase": "health_gate" });
+        assert_eq!(progress_line(&bare), "daemon: health_gate");
+
+        let detailed = serde_json::json!({
+            "component": "daemon",
+            "phase": "verifying",
+            "detail": "0.6.0",
+        });
+        assert_eq!(progress_line(&detailed), "daemon: verifying — 0.6.0");
+    }
+
+    /// The disconnect that follows an update is announced, and only when something moved.
+    ///
+    /// `already_current` restarts nothing, so telling someone their connection is about to drop
+    /// would be a false alarm — and the note is what stops a *real* drop from reading as a failed
+    /// update, so it has to be trustworthy.
+    #[test]
+    fn a_restart_is_announced_only_when_the_release_changed() {
+        let apply = Cli::try_parse_from(["duck-btctl", "update", "apply"])
+            .expect("parses")
+            .command;
+
+        let applied = serde_json::json!({
+            "id": 1,
+            "result": { "outcome": "applied", "from": "0.5.1", "to": "0.6.0" },
+        });
+        assert!(restart_note(&apply, &applied).is_some());
+
+        let unchanged = serde_json::json!({
+            "id": 1,
+            "result": { "outcome": "already_current", "version": "0.6.0" },
+        });
+        assert!(restart_note(&apply, &unchanged).is_none());
+
+        let dry_run = serde_json::json!({
+            "id": 1,
+            "result": { "outcome": "dry_run_passed", "candidate": "0.6.0" },
+        });
+        assert!(restart_note(&apply, &dry_run).is_none());
+
+        // And nothing else announces one, however it answered.
+        let status = Cli::try_parse_from(["duck-btctl", "update", "status"])
+            .expect("parses")
+            .command;
+        assert!(restart_note(&status, &applied).is_none());
     }
 }

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -128,6 +128,25 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         Log(_) => Some((Updater, Prompt)),
         ListInstalled(_) => Some((Updater, Prompt)),
 
+        // Going back. Both are permitted, and both are less consequential than the `Apply`
+        // above them: they move the robot to a release that has already run on this board,
+        // download nothing, and are gated and auto-reverted like any other transition
+        // (`Engine::rollback` and `Engine::select` both go through `transition_to`).
+        //
+        // They were refused until the update path was driven from a phone, on the reasoning that
+        // the engine reverts a bad release on its own. It does — the one that fails its health
+        // gate. That is not the case an owner reaches for a phone about, which is a release that
+        // installs, passes its gate, and then behaves *worse*: a policy that walks unsteadily
+        // rather than not at all, a pad that stops reconnecting. Nothing reverts that but a
+        // person, and the person is holding a phone and has no ssh.
+        //
+        // `Rollback` is the undo — the previous release, no arguments, one tap. `Select` is the
+        // same authority plus a version number, and it is what a list of installed releases is
+        // *for*: `ListInstalled` is already routed above, so an app can show them, and being able
+        // to show them without being able to choose one would be the odd half.
+        Rollback(_) => Some((Updater, Operation)),
+        Select(_) => Some((Updater, Operation)),
+
         // Is the robot alright? The one `robot.*` call an app has any use for.
         RobotHealth => Some((Robot, Prompt)),
 
@@ -189,19 +208,17 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
 
         // ── refused ─────────────────────────────────────────────────────────
 
-        // Operator surgery. Choosing which installed release runs, or pinning one, is a
-        // considered decision made with `robotctl` and a record of who did it — not a
-        // mistap in a phone UI.
-        Select(_) | Pin(_) => None,
-
-        // Recovery, and deliberately not here *yet*. The engine reverts a bad release on its
-        // own (health gate plus boot counter), so the phone needs no button for the ordinary
-        // case. Recovery mode (§8.2) is what should reopen this, with its own thinking about
-        // what a stranger holding a broken robot is allowed to trigger.
-        Rollback(_) => None,
+        // Pinning, and it stays refused while `Select` above it does not. The difference is what
+        // the mistake looks like afterwards: a wrong `select` is one release away from being
+        // undone and the robot says which release it is on, whereas a robot pinned by a mistap
+        // refuses every later update and reports itself as up to date. That is the one failure
+        // here that looks exactly like correct behaviour, and it needs `robotctl` and a person
+        // who meant it.
+        Pin(_) => None,
 
         // Factory reset in all but name: back to the golden image, discarding every release
-        // since. Never over a radio.
+        // since. Never over a radio — and note that `Rollback` and `Select` being routed does
+        // not weaken this, because neither discards anything.
         ResetToGolden(_) => None,
 
         // `updaterd`'s private questions to `robotd` — may I restart the control loop, which
@@ -313,6 +330,11 @@ mod tests {
             mutating_and_allowed,
             vec![
                 proto::method::APPLY,
+                // Going back, both of them. Routed when the update path was driven from a phone:
+                // an owner whose robot got worse after an update has no other way to undo it, and
+                // neither call discards anything or downloads anything.
+                proto::method::ROLLBACK,
+                proto::method::SELECT,
                 proto::method::NET_CONNECT,
                 proto::method::NET_FORGET,
                 proto::method::SYSTEM_SET_NAME,
@@ -395,18 +417,16 @@ mod tests {
 
     /// The refusals, named individually. If a future change makes one of these reachable it
     /// should have to delete a line here and say why in the commit.
+    ///
+    /// Two lines were deleted from it when the update path was driven from a phone —
+    /// `update.rollback` and `update.select` — and the reasoning is on their arms in
+    /// `destination_for`. What is left is a factory reset, a pin whose mistake looks like correct
+    /// behaviour, and `updaterd`'s private questions to `robotd`.
     #[test]
     fn the_refused_calls_stay_refused() {
         for call in [
-            proto::Call::Rollback(proto::ComponentParams {
-                component: component(),
-            }),
             proto::Call::ResetToGolden(proto::ComponentParams {
                 component: component(),
-            }),
-            proto::Call::Select(proto::SelectParams {
-                component: component(),
-                version: semver::Version::new(1, 0, 0),
             }),
             proto::Call::Pin(proto::PinParams {
                 component: component(),
@@ -520,6 +540,13 @@ mod tests {
                 target: proto::Target::Latest,
                 options: proto::ApplyOptions::default(),
             }),
+            proto::Call::Rollback(proto::ComponentParams {
+                component: component(),
+            }),
+            proto::Call::Select(proto::SelectParams {
+                component: component(),
+                version: semver::Version::new(1, 0, 0),
+            }),
             proto::Call::Check(proto::ComponentParams {
                 component: component(),
             }),
@@ -532,6 +559,28 @@ mod tests {
         ] {
             let (_, lane) = destination_for(&call).expect("routed");
             assert_ne!(lane, Lane::Prompt, "{}", call.method());
+        }
+    }
+
+    /// Going back is reachable, and reaches `updaterd`. The pair of them is what §2.4 of
+    /// `docs/project/update-over-ble.md` decided.
+    #[test]
+    fn going_back_is_reachable_from_the_phone() {
+        for call in [
+            proto::Call::Rollback(proto::ComponentParams {
+                component: component(),
+            }),
+            proto::Call::Select(proto::SelectParams {
+                component: component(),
+                version: semver::Version::new(0, 5, 1),
+            }),
+        ] {
+            assert_eq!(
+                destination_for(&call),
+                Some((Upstream::Updater, Lane::Operation)),
+                "{}",
+                call.method()
+            );
         }
     }
 

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -1,18 +1,21 @@
-//! Which calls BLE may make, and which socket answers them.
+//! Which calls BLE may make, which socket answers them, and which connection carries them.
 //!
 //! BLE exposes a **subset** of the robot API (`architecture.md` §4.1): provisioning, status,
-//! and the update trigger with its progress. It is too slow and too constrained for the full
+//! and the update commands with their progress. It is too slow and too constrained for the full
 //! surface, and — more to the point — a radio anybody within a few metres can talk to is not
 //! the transport over which to offer "reset this robot to factory state".
 //!
-//! One table decides both questions, because they are the same question: a call is permitted
-//! exactly when this file names the service that answers it.
+//! One table decides all three questions, because they are the same question asked about the
+//! same call: a call is permitted exactly when this file names the service that answers it, and
+//! the [`Lane`] it names is which of that service's connections it travels on.
 //!
 //! **The match is deliberately exhaustive.** Adding a variant to [`proto::Call`] makes this
 //! file fail to compile, so a new method cannot reach the radio because someone forgot this
 //! file existed. A `_ => None` wildcard would be the safe default in the moment and the wrong
 //! one over time: it would silently deny new methods, and the first symptom would be a phone
-//! app that cannot see a feature nobody remembered to route.
+//! app that cannot see a feature nobody remembered to route. The lane lives in the same table
+//! for the same reason — a new long-running method given the wrong lane is a session that
+//! stops answering, which is [`Lane`]'s whole subject.
 
 use duck_ipc_proto as proto;
 
@@ -29,11 +32,63 @@ pub enum Upstream {
     Config,
 }
 
+/// Which connection to a service carries a call.
+///
+/// **Every daemon here serves one connection one request at a time**: `updaterd` and `configd`
+/// both read a line, await the whole call, and only then read the next
+/// (`updater/src/ipc.rs::handle_connection`, `configd/src/main.rs::handle`). A single connection
+/// per service would therefore put every call on one queue behind the slowest thing on it, and
+/// two orderings a phone app reaches for first are broken by that:
+///
+/// - `update.apply` then `update.status` — the status line waits in a socket `updaterd` will not
+///   read for minutes, so the client times out having heard nothing while the robot is fine.
+/// - `update.subscribe` then `update.apply` — worse. `stream_progress` owns its connection until
+///   the peer goes away and never reads another request, so the apply is written into a socket
+///   nobody reads: it never runs, never replies and never errors. An update the owner asked for
+///   that the robot silently did not perform.
+///
+/// So calls are grouped by *how long they hold a connection*, and each group gets its own. Four
+/// lanes is at most four sockets per service per session, which costs nothing and is bounded
+/// without any bookkeeping — the alternative, a connection per call, needs `btd` to know when a
+/// call ended, which needs it to parse replies. It deliberately never does (`session`).
+///
+/// Calls that share a lane are queued behind each other, and each grouping says why that is the
+/// right answer rather than a compromise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Lane {
+    /// Answers as fast as the daemon can look something up. Reads from memory, and the writes
+    /// that only store a value.
+    ///
+    /// Queueing these behind each other is invisible, and keeping them off the other lanes is
+    /// the point: a status poll during an update must answer, and `updaterd` is built so it can
+    /// — `update.status` falls back to a cached snapshot rather than waiting for the engine
+    /// (`updater/src/ipc.rs`). That fallback is wasted if the request never gets read.
+    Prompt,
+    /// Seconds: a read that goes to the network or sweeps a radio.
+    ///
+    /// Two of them, and queueing them behind each other is fine. What matters is that neither
+    /// sits in front of a `Prompt` call nor behind an `Operation` one — `update.check` during an
+    /// update should come straight back `BUSY`, not resolve whenever the update finishes.
+    Slow,
+    /// As long as it takes, and it changes the robot: an update, joining a network, bonding a pad.
+    ///
+    /// Minutes, for a daemon update. Sharing one lane is correct rather than tolerated: `updaterd`
+    /// single-flights mutations behind a file lock and answers `BUSY` for a second one, and two
+    /// radio operations at once on `configd` is not a thing to want either. So a second
+    /// `Operation` waiting for the first is the behaviour to have.
+    Operation,
+    /// Never answers. The service writes notifications until the peer goes away.
+    ///
+    /// One call, `update.subscribe`, and it must be alone: a connection handed to a progress
+    /// stream reads no further requests at all.
+    Stream,
+}
+
 /// What happens to a call that arrives over BLE.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Route {
-    /// Forwarded verbatim to a service.
-    To(Upstream),
+    /// Forwarded verbatim to a service, on that service's connection for this lane.
+    To(Upstream, Lane),
     /// Answered by `btd` itself. Only `system.authenticate`: the PIN check belongs to the
     /// transport, because BLE cannot express a fixed printed passkey and the check therefore had
     /// to move up a layer (`docs/design/app-path-design.md` §5).
@@ -42,15 +97,17 @@ pub enum Route {
     Refused,
 }
 
-/// Where this call goes, or `None` if BLE may not make it.
+/// Where this call goes and on which connection, or `None` if BLE may not make it.
 ///
 /// Read the `None` arms as the security boundary: each one is a deliberate decision that a
 /// phone in the room does not get to do this.
-pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
+pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
+    use Lane::*;
+    use Upstream::*;
     use proto::Call::*;
     match call {
         // The version handshake. Must be reachable or no client can establish anything.
-        Hello(_) => Some(Upstream::Updater),
+        Hello(_) => Some((Updater, Prompt)),
 
         // ── the update subset §4.1 names ────────────────────────────────────
         //
@@ -59,45 +116,53 @@ pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
         // policy, and does — `deploy/updater.toml` names `btd` in `allow_users`, which is a
         // narrower claim than granting the robot group. Routing it here without that grant would
         // have produced a phone button that always returned PERMISSION_DENIED.
-        Apply(_) => Some(Upstream::Updater),
-        Check(_) => Some(Upstream::Updater),
-        Status => Some(Upstream::Updater),
-        Subscribe => Some(Upstream::Updater),
+        Apply(_) => Some((Updater, Operation)),
+        // Reaches the network, so `Slow` — and off the `Operation` lane deliberately, because
+        // "is there an update?" asked during one has an immediate answer (`BUSY`) and queueing
+        // it would turn that into a spinner that resolves minutes later.
+        Check(_) => Some((Updater, Slow)),
+        Status => Some((Updater, Prompt)),
+        Subscribe => Some((Updater, Stream)),
         // Read-only, and what support asks for first. `update.log` is the record that
         // survives a wiped journal (§8.2), so a phone able to read it is worth having.
-        Log(_) => Some(Upstream::Updater),
-        ListInstalled(_) => Some(Upstream::Updater),
+        Log(_) => Some((Updater, Prompt)),
+        ListInstalled(_) => Some((Updater, Prompt)),
 
         // Is the robot alright? The one `robot.*` call an app has any use for.
-        RobotHealth => Some(Upstream::Robot),
+        RobotHealth => Some((Robot, Prompt)),
 
         // ── provisioning, which is what §4.1 puts BLE here for ──────────────
         //
         // This is the case the whole transport exists to serve: a robot that has never seen a
         // network cannot be configured over that network, so BLE is the only way in. All four
         // are permitted, including the two that change things.
-        NetStatus => Some(Upstream::Config),
-        NetScan => Some(Upstream::Config),
+        NetStatus => Some((Config, Prompt)),
+        // `configd` re-sweeps the radio rather than returning the last scan, which takes seconds.
+        NetScan => Some((Config, Slow)),
         // Carries a wifi passphrase, which §7 requires to travel over a paired, encrypted link.
         // It does: the characteristic sets `encrypt_authenticated_write` and the PIN agent makes
         // the bond an authenticated one (`crate::pairing`). Routing this before that existed
         // would have been the ordering mistake.
-        NetConnect(_) => Some(Upstream::Config),
-        NetForget(_) => Some(Upstream::Config),
+        //
+        // `Operation` because `configd` polls NetworkManager for up to 45 seconds before calling
+        // a join failed, and a phone showing "connecting…" wants `net.status` to keep answering
+        // throughout — which is the same defect as the update one, on the path BLE exists for.
+        NetConnect(_) => Some((Config, Operation)),
+        NetForget(_) => Some((Config, Prompt)),
 
         // Name and identity. Renaming from the app is the reason `system.setName` exists.
-        SystemInfo => Some(Upstream::Config),
-        SystemSetName(_) => Some(Upstream::Config),
+        SystemInfo => Some((Config, Prompt)),
+        SystemSetName(_) => Some((Config, Prompt)),
 
         // Which daemons are up and which release each is running. Routed because an app that can
         // trigger an update should be able to show whether it took — and because the one daemon it
         // cannot report on this way is `btd` itself, which answering at all proves is running.
-        SystemServices => Some(Upstream::Config),
+        SystemServices => Some((Config, Prompt)),
 
         // Rebooting is drastic but recoverable, and it is what an app offers when a robot is
         // confused — the alternative being "unplug it", which for a walking robot is worse.
         // Unlike `resetToGolden` it discards nothing.
-        SystemReboot => Some(Upstream::Config),
+        SystemReboot => Some((Config, Prompt)),
 
         // ── the gamepad ─────────────────────────────────────────────────────
         //
@@ -108,10 +173,11 @@ pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
         //
         // `pad.pair` is the more consequential of the two, because a bonded pad can enable the
         // policy afterwards. That is deliberate: it is the same authority as standing next to the
-        // robot with a controller, and the PIN gate is what stands in front of it.
-        PadStatus => Some(Upstream::Config),
-        PadPair(_) => Some(Upstream::Config),
-        PadForget(_) => Some(Upstream::Config),
+        // robot with a controller, and the PIN gate is what stands in front of it. It waits on a
+        // pad for its whole timeout, so it shares the `Operation` lane with the wifi join.
+        PadStatus => Some((Config, Prompt)),
+        PadPair(_) => Some((Config, Operation)),
+        PadForget(_) => Some((Config, Prompt)),
 
         // Answered by `btd`, so it has no upstream. See `route_for`.
         SystemAuthenticate(_) => None,
@@ -185,12 +251,20 @@ pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
     }
 }
 
+/// The service that answers a call, ignoring which connection carries it.
+///
+/// The permission question on its own, which is what most callers and every test about the
+/// security boundary are asking.
+pub fn upstream_for(call: &proto::Call) -> Option<Upstream> {
+    destination_for(call).map(|(upstream, _)| upstream)
+}
+
 /// The full routing decision, including the one call the transport answers itself.
 pub fn route_for(call: &proto::Call) -> Route {
     match call {
         proto::Call::SystemAuthenticate(_) => Route::Local,
-        other => match upstream_for(other) {
-            Some(upstream) => Route::To(upstream),
+        other => match destination_for(other) {
+            Some((upstream, lane)) => Route::To(upstream, lane),
             None => Route::Refused,
         },
     }
@@ -265,8 +339,8 @@ mod tests {
             }),
         ] {
             assert_eq!(
-                route_for(&call),
-                Route::To(Upstream::Config),
+                upstream_for(&call),
+                Some(Upstream::Config),
                 "{}",
                 call.method()
             );
@@ -381,6 +455,84 @@ mod tests {
             "{}",
             err.message
         );
+    }
+
+    /// Nothing a phone does during an update may share a connection with the update.
+    ///
+    /// This is the defect the lanes exist for, and it is asserted as a property rather than as a
+    /// table: whatever else changes, `update.apply` must not be able to block a status poll, a
+    /// check, or the progress stream, because every daemon here serves one connection one request
+    /// at a time. The three calls below are the three an app makes *while* an update runs.
+    #[test]
+    fn an_apply_shares_its_connection_with_nothing_a_client_does_during_one() {
+        let apply = destination_for(&proto::Call::Apply(proto::ApplyParams {
+            component: component(),
+            target: proto::Target::Latest,
+            options: proto::ApplyOptions::default(),
+        }))
+        .expect("apply is routed");
+
+        for call in [
+            proto::Call::Status,
+            proto::Call::Subscribe,
+            proto::Call::Check(proto::ComponentParams {
+                component: component(),
+            }),
+        ] {
+            let during = destination_for(&call).expect("routed");
+            assert_eq!(during.0, apply.0, "{} is served by updaterd", call.method());
+            assert_ne!(
+                during.1,
+                apply.1,
+                "{} would queue behind an apply",
+                call.method()
+            );
+        }
+    }
+
+    /// The progress stream must be alone on its lane, which is a stronger claim than the test
+    /// above: a connection handed to `stream_progress` reads no further requests *ever*, so a
+    /// second call sharing it is not delayed but lost.
+    #[test]
+    fn nothing_else_travels_on_the_stream_lane() {
+        let others: Vec<&str> = every_call()
+            .iter()
+            .filter(|c| !matches!(c, proto::Call::Subscribe))
+            .filter(|c| destination_for(c).is_some_and(|(_, lane)| lane == Lane::Stream))
+            .map(proto::Call::method)
+            .collect();
+
+        assert_eq!(others, Vec::<&str>::new());
+        assert_eq!(
+            destination_for(&proto::Call::Subscribe).map(|(_, lane)| lane),
+            Some(Lane::Stream)
+        );
+    }
+
+    /// A call that holds its connection for as long as the robot needs is never on the lane the
+    /// quick answers use. Named one by one, because the cost of getting one wrong is a session
+    /// that stops answering and the fix is one word.
+    #[test]
+    fn the_calls_that_take_their_time_are_off_the_prompt_lane() {
+        for call in [
+            proto::Call::Apply(proto::ApplyParams {
+                component: component(),
+                target: proto::Target::Latest,
+                options: proto::ApplyOptions::default(),
+            }),
+            proto::Call::Check(proto::ComponentParams {
+                component: component(),
+            }),
+            proto::Call::NetScan,
+            proto::Call::NetConnect(proto::NetConnectParams {
+                ssid: "Home".into(),
+                psk: None,
+            }),
+            proto::Call::PadPair(proto::PadPairParams::default()),
+        ] {
+            let (_, lane) = destination_for(&call).expect("routed");
+            assert_ne!(lane, Lane::Prompt, "{}", call.method());
+        }
     }
 
     /// Every variant, so the tests above cannot silently skip one. The exhaustive match in

--- a/btd/src/session.rs
+++ b/btd/src/session.rs
@@ -184,8 +184,8 @@ async fn dispatch(
         };
     }
 
-    let upstream = match route::route_for(&call) {
-        Route::To(upstream) => upstream,
+    let (upstream, lane) = match route::route_for(&call) {
+        Route::To(upstream, lane) => (upstream, lane),
         Route::Local => {
             let proto::Call::SystemAuthenticate(params) = &call else {
                 // `route_for` returns `Local` for exactly one variant; anything else here is a
@@ -212,7 +212,7 @@ async fn dispatch(
         }
     };
 
-    if let Err(e) = pool.send(upstream, line).await {
+    if let Err(e) = pool.send(upstream, lane, line).await {
         tracing::warn!(method = call.method(), upstream = ?upstream, error = %e, "upstream unreachable");
         // Naming the service is what makes this diagnosable from a phone screenshot: "robotd
         // is not answering" is a different problem from "the robot refused".
@@ -796,6 +796,134 @@ mod tests {
                 .await
                 .contains(r#""authenticated":false"#),
             "a PIN missing its leading zero must not authenticate"
+        );
+    }
+
+    /// A stand-in with `updaterd`'s connection model, which is the whole reason lanes exist:
+    /// **one request at a time per connection**, and a connection handed to `update.subscribe`
+    /// never reads another line (`Server::stream_progress` owns it until the peer goes away).
+    ///
+    /// Every line it receives is reported as `<connection number> <line>`, so a test can assert
+    /// which calls travelled together rather than only that they arrived.
+    fn spawn_serial_updaterd(dir: &std::path::Path) -> (PathBuf, Receiver<String>) {
+        let path = dir.join("updaterd.sock");
+        let (seen, seen_rx) = mpsc::channel(16);
+        let listener = UnixListener::bind(&path).expect("bind");
+
+        tokio::spawn(async move {
+            let mut connection = 0u32;
+            while let Ok((stream, _)) = listener.accept().await {
+                connection += 1;
+                let seen = seen.clone();
+                let n = connection;
+                tokio::spawn(async move {
+                    // Held for the task's life: dropping the stream would close the socket, and a
+                    // client that learns of a swallowed request by disconnection has not
+                    // reproduced the bug — it would reconnect and recover.
+                    let (read, _write) = stream.into_split();
+                    let mut lines = BufReader::new(read).lines();
+                    while let Ok(Some(line)) = lines.next_line().await {
+                        let subscribe = line.contains(proto::method::SUBSCRIBE);
+                        let _ = seen.send(format!("{n} {line}")).await;
+                        if subscribe {
+                            std::future::pending::<()>().await;
+                        }
+                    }
+                });
+            }
+        });
+        (path, seen_rx)
+    }
+
+    async fn next_line(seen: &mut Receiver<String>, what: &str) -> String {
+        tokio::time::timeout(std::time::Duration::from_secs(2), seen.recv())
+            .await
+            .unwrap_or_else(|_| panic!("updaterd never saw the {what}"))
+            .expect("daemon gone")
+    }
+
+    /// Subscribing must not swallow the update that follows it.
+    ///
+    /// This is the failure the lanes were added for, and it is the worst one in the transport:
+    /// with a single connection per service, the apply was written into a socket that
+    /// `stream_progress` had stopped reading. No reply, no error, no update — an owner tapping
+    /// "update" and a robot doing nothing at all. Nothing else in this file would have caught it,
+    /// because every other test makes one call.
+    #[tokio::test]
+    async fn an_apply_still_reaches_updaterd_while_a_progress_stream_is_open() {
+        let dir = tempdir();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "configd.sock", vec![pin_reply("424242")]);
+        let (_, mut seen) = spawn_serial_updaterd(dir.path());
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(23, "AA:BB");
+        tokio::spawn(run(
+            link,
+            sockets(dir.path(), "updaterd.sock", "robotd.sock"),
+        ));
+        authenticate(&to_robot, &mut from_robot).await;
+
+        let subscribe = r#"{"jsonrpc":"2.0","id":1,"method":"update.subscribe","params":{}}"#;
+        to_robot
+            .send(format!("{subscribe}\n").into_bytes())
+            .await
+            .unwrap();
+        let streaming = next_line(&mut seen, "subscribe").await;
+
+        let apply = r#"{"jsonrpc":"2.0","id":2,"method":"update.apply","params":{"component":"daemon","target":"latest"}}"#;
+        to_robot
+            .send(format!("{apply}\n").into_bytes())
+            .await
+            .unwrap();
+        let applying = next_line(&mut seen, "apply").await;
+
+        assert!(
+            applying.contains(apply),
+            "not forwarded verbatim: {applying}"
+        );
+        // And on its own connection, which is *why* it arrived.
+        let connection = |line: &str| line.split(' ').next().unwrap().to_owned();
+        assert_ne!(connection(&streaming), connection(&applying));
+    }
+
+    /// A status poll during an update must not queue behind it.
+    ///
+    /// `updaterd` goes to some trouble to answer `update.status` while the engine is busy — a
+    /// cached snapshot with the live phase patched in — and all of it is wasted if the request
+    /// sits unread in a socket for the minutes an update takes. The assertion is that the two
+    /// calls travel on different connections, because that is the property the daemon's effort
+    /// depends on.
+    #[tokio::test]
+    async fn a_status_poll_does_not_travel_behind_an_apply() {
+        let dir = tempdir();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "configd.sock", vec![pin_reply("424242")]);
+        let (_, mut seen) = spawn_serial_updaterd(dir.path());
+        let (_, _) = FakeDaemon::spawn(dir.path(), "robotd.sock", vec![]);
+
+        let (link, to_robot, mut from_robot) = Link::pair(23, "AA:BB");
+        tokio::spawn(run(
+            link,
+            sockets(dir.path(), "updaterd.sock", "robotd.sock"),
+        ));
+        authenticate(&to_robot, &mut from_robot).await;
+
+        for request in [
+            r#"{"jsonrpc":"2.0","id":1,"method":"update.apply","params":{"component":"daemon","target":"latest"}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"update.status","params":{}}"#,
+        ] {
+            to_robot
+                .send(format!("{request}\n").into_bytes())
+                .await
+                .unwrap();
+        }
+
+        let applying = next_line(&mut seen, "apply").await;
+        let polling = next_line(&mut seen, "status poll").await;
+        let connection = |line: &str| line.split(' ').next().unwrap().to_owned();
+        assert_ne!(
+            connection(&applying),
+            connection(&polling),
+            "the status poll shares the apply's queue"
         );
     }
 

--- a/btd/src/upstream.rs
+++ b/btd/src/upstream.rs
@@ -18,7 +18,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 
-use crate::route::Upstream;
+use crate::route::{Lane, Upstream};
 
 /// Long enough for a loaded board, short enough that a phone gets an answer rather than a
 /// spinner. A unix socket connect either succeeds immediately or the daemon is not there.
@@ -128,9 +128,15 @@ struct Conn {
 /// version has no reason to make `robotd` accept a connection it will never use. And because
 /// connecting eagerly would mean a dead `robotd` delayed or failed a session that did not need
 /// it.
+///
+/// **Keyed on the lane as well as the service**, which is what keeps a minutes-long update from
+/// silencing everything else the client asks. Every daemon here serves one connection one request
+/// at a time, so calls that share a connection share a queue — see [`Lane`] for the two orderings
+/// a single connection per service broke. At most four sockets per service per session, and in
+/// practice two.
 pub struct Pool {
     sockets: Sockets,
-    conns: HashMap<Upstream, Conn>,
+    conns: HashMap<(Upstream, Lane), Conn>,
     /// Every reply and notification from every upstream, merged. Merging is safe because
     /// JSON-RPC correlates by `id`, which is the client's business — `btd` forwards lines
     /// without reading them.
@@ -146,15 +152,16 @@ impl Pool {
         }
     }
 
-    /// Send one line to `upstream`, connecting first if needed.
-    pub async fn send(&mut self, upstream: Upstream, line: &str) -> io::Result<()> {
-        if !self.conns.contains_key(&upstream) {
+    /// Send one line to `upstream` on `lane`'s connection, connecting first if needed.
+    pub async fn send(&mut self, upstream: Upstream, lane: Lane, line: &str) -> io::Result<()> {
+        let key = (upstream, lane);
+        if !self.conns.contains_key(&key) {
             let conn = self.open(upstream).await?;
-            self.conns.insert(upstream, conn);
+            self.conns.insert(key, conn);
         }
 
         // Unwrap is sound: just inserted, or the contains_key above held.
-        let conn = self.conns.get_mut(&upstream).expect("connection present");
+        let conn = self.conns.get_mut(&key).expect("connection present");
 
         let mut bytes = line.as_bytes().to_vec();
         bytes.push(b'\n');
@@ -168,11 +175,13 @@ impl Pool {
             Ok(Err(e)) => {
                 // A broken pipe here is ordinary — the daemon restarted. Drop the connection
                 // so the next call reconnects rather than writing into a dead socket forever.
-                self.conns.remove(&upstream);
+                // This lane's connection only: the others may be perfectly alive, and a restart
+                // that broke one breaks the next write to each of them anyway.
+                self.conns.remove(&key);
                 Err(e)
             }
             Err(_) => {
-                self.conns.remove(&upstream);
+                self.conns.remove(&key);
                 Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     "upstream write timed out",

--- a/btd/src/upstream.rs
+++ b/btd/src/upstream.rs
@@ -156,7 +156,7 @@ impl Pool {
     pub async fn send(&mut self, upstream: Upstream, lane: Lane, line: &str) -> io::Result<()> {
         let key = (upstream, lane);
         if !self.conns.contains_key(&key) {
-            let conn = self.open(upstream).await?;
+            let conn = self.open(upstream, lane).await?;
             self.conns.insert(key, conn);
         }
 
@@ -190,7 +190,7 @@ impl Pool {
         }
     }
 
-    async fn open(&self, upstream: Upstream) -> io::Result<Conn> {
+    async fn open(&self, upstream: Upstream, lane: Lane) -> io::Result<Conn> {
         let path = self.sockets.path(upstream);
         let stream = tokio::time::timeout(CONNECT_TIMEOUT, UnixStream::connect(path))
             .await
@@ -198,7 +198,10 @@ impl Pool {
 
         let (read, write) = stream.into_split();
         let replies = self.replies.clone();
-        let label = format!("{upstream:?}");
+        // The lane is in the label because there are now several connections to each service,
+        // and "Updater closed" without it names four possible sockets — including the progress
+        // stream, whose closing is ordinary, and the operation lane, whose closing is not.
+        let label = format!("{upstream:?}/{lane:?}");
 
         // The read half is pumped for the session's lifetime. Responses and notifications are
         // the same thing to us: a line to forward. That is what makes `update.subscribe`'s
@@ -225,7 +228,7 @@ impl Pool {
             tracing::debug!(upstream = %label, "upstream closed");
         });
 
-        tracing::debug!(upstream = ?upstream, path = %path.display(), "connected");
+        tracing::debug!(upstream = ?upstream, lane = ?lane, path = %path.display(), "connected");
         Ok(Conn { write })
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 | [`ci-setup.md`](project/ci-setup.md) | One-time setup for the release pipeline: keys, secrets, rotation. |
 | [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what closed it. Closed. |
 | [`slice-2-bringup.md`](project/slice-2-bringup.md) | What a real Radxa Zero 3W did with slice 2. |
-| [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what works, what blocks it, and two decisions. Open. |
+| [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what it turned up, and what rollback over a radio was decided on. |
 
 ## Elsewhere
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 | [`ci-setup.md`](project/ci-setup.md) | One-time setup for the release pipeline: keys, secrets, rotation. |
 | [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what closed it. Closed. |
 | [`slice-2-bringup.md`](project/slice-2-bringup.md) | What a real Radxa Zero 3W did with slice 2. |
+| [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what works, what blocks it, and two decisions. Open. |
 
 ## Elsewhere
 

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -184,11 +184,20 @@ Refused, each for a reason:
 
 | refused | why |
 |---|---|
-| `update.select`, `update.pin` | Operator surgery, made with `robotctl` and a record of who did it — not a mistap in a phone UI |
-| `update.rollback` | The engine reverts a bad release itself, so the phone needs no button for the ordinary case. Recovery mode (§8.2) should reopen this deliberately |
+| `update.pin` | A robot pinned by a mistap refuses every later update and reports itself as up to date — the one failure here that looks like correct behaviour. `robotctl`, and a person who meant it |
 | `update.resetToGolden` | Factory reset in all but name. Never over a radio |
 | `robot.safeToRestart`, `robot.modelApi`, `robot.remoteSessionActive` | `updaterd`'s private questions to `robotd`; a phone reading them learns nothing it can act on |
 | `system.pairingPin`, `system.setPairingPin` | **The load-bearing one.** A passkey an unpaired peer could read — or overwrite — would make pairing theatre. `btd` reads it over the unix socket instead |
+
+**`update.rollback` and `update.select` were on that list and are not now.** They were refused on
+the reasoning that the engine reverts a bad release itself, which it does — the one that fails its
+health gate. That is not the case an owner reaches for a phone about, which is a release that
+installs, passes its gate and then behaves *worse*: a policy that walks unsteadily rather than not
+at all, a pad that stops reconnecting. Nothing reverts that but a person, and the person is holding
+a phone and has no ssh. Both move to a release that has already run on this board, download
+nothing, and are gated and auto-reverted like any other transition. `update.apply` was already
+routed and is the more consequential of the three, so this widens what a peer in radio range can do
+by close to nothing. `docs/project/update-over-ble.md` §2.4 is the decision and its trade-offs.
 
 ## 4. Authorisation: two layers, kept apart
 
@@ -363,7 +372,7 @@ choosing.
 |---|---|---|
 | `Prompt` | as long as a lookup | `hello`, `update.status`, `update.log`, `update.listInstalled`, `robot.health`, `net.status`, `net.forget`, `system.*`, `pad.status`, `pad.forget` |
 | `Slow` | seconds — the network, or a radio sweep | `update.check`, `net.scan` |
-| `Operation` | as long as it takes, and changes the robot | `update.apply`, `net.connect`, `pad.pair` |
+| `Operation` | as long as it takes, and changes the robot | `update.apply`, `update.rollback`, `update.select`, `net.connect`, `pad.pair` |
 | `Stream` | forever, and answers nothing | `update.subscribe` |
 
 Sharing a lane is queueing, and each grouping is one where that is the right answer: `updaterd`

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -169,9 +169,10 @@ The cost of one characteristic is that it reads oddly in nRF Connect, where the 
 
 ### 3.1 The routed subset is the security boundary
 
-BLE exposes a subset (§4.1). One table in `btd/src/route.rs` decides both *whether* a call is
-permitted and *which socket* answers it, because those are the same question: a call is allowed
-exactly when the table names a service for it.
+BLE exposes a subset (§4.1). One table in `btd/src/route.rs` decides *whether* a call is
+permitted, *which socket* answers it and *which connection to that socket* carries it. The first
+two are the same question — a call is allowed exactly when the table names a service for it — and
+the third is in the same table so that a new method cannot be added without answering it (§3.5).
 
 **The match over `Call` is exhaustive on purpose.** Adding a protocol method fails `btd`'s build
 until someone decides about it. A `_ => None` wildcard would be the safe default in the moment and
@@ -335,6 +336,46 @@ it: arrivals per device with signal strength, then the robot's silences.
 Nine times as often, and — the part that matters — nothing left within a factor of two of `duck-btctl`'s
 eight-second window, so the failure it was diagnosed from cannot occur. The robot went from 34th of
 106 devices heard to 7th of 74.
+
+### 3.5 One connection per lane, because a daemon serves one request at a time
+
+`btd` opens sockets to `updaterd`, `robotd` and `configd` on demand and keeps them for the session
+(`btd/src/upstream.rs`). It held **one per service**, and both daemons behind it serve a connection
+one request at a time: read a line, await the whole call, then read the next
+(`updater/src/ipc.rs::handle_connection`, `configd/src/main.rs::handle`). So every call on a session
+queued behind the slowest thing on that queue, and the two orderings an app reaches for first were
+broken by it:
+
+| the client does | what happened |
+|---|---|
+| `update.apply`, then `update.status` while it runs | the status line waited in a socket `updaterd` would not read for minutes. The client timed out having heard nothing, while the robot was fine and updating |
+| `update.subscribe`, then `update.apply` | worse. `stream_progress` owns its connection until the peer goes away and never reads another request, so the apply was written into a socket nobody read: it never ran, never replied and never errored |
+
+The second is the one to remember. An owner taps "update", the robot does nothing at all, and there
+is no error anywhere to find — the request is sitting in a socket buffer.
+
+So calls are grouped by **how long they hold a connection**, and each group gets its own connection.
+The lane is decided in `route.rs` next to the permission and the service (§3.1), which is what makes
+the exhaustive match cover it too: a new long-running method cannot be added without someone
+choosing.
+
+| lane | holds its connection for | calls |
+|---|---|---|
+| `Prompt` | as long as a lookup | `hello`, `update.status`, `update.log`, `update.listInstalled`, `robot.health`, `net.status`, `net.forget`, `system.*`, `pad.status`, `pad.forget` |
+| `Slow` | seconds — the network, or a radio sweep | `update.check`, `net.scan` |
+| `Operation` | as long as it takes, and changes the robot | `update.apply`, `net.connect`, `pad.pair` |
+| `Stream` | forever, and answers nothing | `update.subscribe` |
+
+Sharing a lane is queueing, and each grouping is one where that is the right answer: `updaterd`
+single-flights mutations behind a file lock and answers `BUSY` for a second one, and two radio
+operations at once on `configd` is not a thing to want. `update.check` is deliberately *not* on the
+`Operation` lane — asked during an update it has an immediate answer, and queueing it would turn
+`BUSY` into a spinner that resolves minutes later.
+
+At most four sockets per service per session, and in practice two. A connection per call would be
+the tidier model and needs `btd` to know when a call ended, which needs it to parse replies — it
+never does (§3), and that property is what keeps the routed subset a transport rather than a second
+implementation of the API.
 
 ## 5. Pairing: just-works, and a PIN the transport checks
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -219,6 +219,11 @@ What that leaves for M6 proper: recovery mode, manifest staleness, authority arb
 provisioning step the pairing PIN now depends on (below). It also means the app has something to
 talk to before the app exists, which is the right order for finding out that an API is wrong.
 
+**The update path over Bluetooth is now driven rather than merely routed**, which is what that
+order was for: `update-over-ble.md` records what driving it from `duck-btctl` turned up, including
+one defect that made "start an update and watch it" an update the robot silently never performed.
+`update.rollback` and `update.select` are reachable from a phone as of that work.
+
 **Done when:** a non-developer updates the robot from the phone, and a deliberately
 bricked release recovers without a laptop.
 

--- a/docs/project/update-over-ble.md
+++ b/docs/project/update-over-ble.md
@@ -1,246 +1,168 @@
 # Updating a robot from a phone
 
-Status: open, two decisions wanted · Date: 2026-08-19 · Owner: pierre
+Status: shipped, not yet run on a board · Date: 2026-08-19 · Owner: pierre
 
-The update path over Bluetooth is most of the way there and nobody has driven it. `btd` already
-routes the update subset, `updaterd` already streams progress to whoever asked, and
-`duck-btctl` can reach all of it through `call`. What is missing is one defect that makes the
-app's own flow — start an update, watch it — a black hole, two smaller ones in `updaterd`, a
-decision about `update.rollback`, and a client surface worth typing.
+The update path over Bluetooth was most of the way there and nobody had driven it. `btd` already
+routed the update subset, `updaterd` already streamed progress to whoever asked, and `duck-btctl`
+could reach all of it through `call`. Driving it turned up one defect that made the app's own flow
+— start an update, watch it — an update the robot silently never performed, two smaller ones in
+`updaterd`, and a client surface worth typing.
 
-Ordered by what blocks what. §2.1 is first because nothing below it is testable while it stands.
+This records what was found and what was decided. The mechanisms live next to the code:
+[`app-path-design.md`](../design/app-path-design.md) §3.5 owns the connection lanes and §3.1 the
+routed subset, and `btd/src/route.rs` carries the reasoning for every route on the arm that makes
+it.
 
-## 1. What already works, so it is not rebuilt
+## 1. What already worked, and was not rebuilt
 
-**The routed subset covers the reads and the trigger.** `btd/src/route.rs` already sends `hello`,
-`update.check`, `update.apply`, `update.status`, `update.subscribe`, `update.log` and
-`update.listInstalled` to `updaterd`, and `robot.health` to `robotd`. Nothing in the plan below
-adds a method to the protocol; the only routing change under discussion is §2.4.
+**The routed subset covered the reads and the trigger.** `hello`, `update.check`, `update.apply`,
+`update.status`, `update.subscribe`, `update.log` and `update.listInstalled` already reached
+`updaterd`, and `robot.health` `robotd`. Nothing here added a method to the protocol.
 
-**An apply already streams its own progress.** `updaterd`'s `run_mutating` writes
-`update.progress` notifications to the connection the apply arrived on, before the reply
-(`updater/src/ipc.rs`). `btd`'s pool pumps every line from an upstream into the session's
-outbound queue without reading it (`btd/src/upstream.rs`), and `duck-btctl` prints id-less lines
-and keeps waiting. So progress reaches a BLE client during an apply with no subscription at all.
+**An apply already streamed its own progress.** `updaterd`'s `run_mutating` writes
+`update.progress` notifications to the connection the apply arrived on, before the reply; `btd`
+pumps every line from an upstream into the session without reading it; `duck-btctl` printed id-less
+lines and kept waiting. So progress reached a BLE client during an apply with no subscription at
+all — and `duck-btctl.md` claimed the opposite, *"an apply on its own connection is silent until it
+is done"*, which is corrected.
 
-`docs/robot/duck-btctl.md` says the opposite — *"an apply on its own connection is silent until it
-is done"*. That is false as the code stands. It should be confirmed against a board and then the
-line fixed, because it currently tells an app author to build the mechanism §2.1 exists to fix.
+**A client that reconnects mid-update was not lost.** `updaterd` keeps the latest `Progress` per
+component and replays it to a new subscriber, and `update.status` answers during an update from a
+cached snapshot with the live phase patched in. Both are what a phone needs after the link drops.
 
-**A client that reconnects mid-update is not lost.** `updaterd` keeps the latest `Progress` per
-component and replays it to a new subscriber before forwarding anything live
-(`Server::stream_progress`), and `update.status` answers *during* an update — it takes the engine
-lock with `try_lock` and falls back to a cached snapshot with the phase patched in from that same
-`latest`. Both are what a phone needs after the link drops, and both already exist.
+**And the reply gets out before the transport dies.** `updaterd` and `btd` are the two units an
+update never restarts, and both are restarted about five seconds *after* the reply
+([`restart-order.md`](../design/restart-order.md) §1).
 
-**The reply gets out before the transport dies.** `updaterd` and `btd` are the two units an update
-never restarts, and both are restarted about five seconds *after* the reply
-(`RESTART_AFTER_REPLYING`, `docs/design/restart-order.md` §1). So a phone-triggered daemon update
-answers the phone, and then drops the link. That ordering is deliberate and load-bearing for this
-whole path.
+## 2. What was wrong
 
-**And the update does not depend on the phone.** `architecture.md` §1.1: the robot pulls, the
-update runs to completion whether or not anyone is watching, and `updaterd` stops writing to a
-client that has gone without stopping the operation.
+### 2.1 A long call silenced the rest of the session · `btd` · **fixed**
 
-## 2. What is missing
+`Pool` held one connection per service per session, and both daemons behind it serve one connection
+one request at a time. So `update.subscribe` followed by `update.apply` wrote the apply into a
+socket `stream_progress` had stopped reading: it never ran, never replied and never errored. An
+owner taps "update", the robot does nothing, and there is no error anywhere to find. `update.apply`
+followed by `update.status` was the same defect with a milder symptom — a status poll that timed
+out while the robot was fine and updating.
 
-### 2.1 A long call blocks every other call on the session · `btd`
+Calls are now grouped by how long they hold a connection and each group gets its own:
+`app-path-design.md` §3.5 has the lanes, why sharing one is correct where it happens, and why a
+connection per call was rejected. Both failures have tests that fail without the fix.
 
-`Pool` holds **one** connection per service per BLE session, made on demand. `updaterd` serves
-one connection with one request at a time: `handle_connection` reads a line, awaits `dispatch`,
-then reads the next.
+This was the only change here a mobile app could not have worked around.
 
-Both orderings of "update the robot and show progress" fail, and neither says so:
+### 2.2 Progress was a firehose aimed at a 20-byte pipe · `updaterd` · **fixed**
 
-| the client does | what happens |
-|---|---|
-| `update.apply`, then `update.status` while it runs | the status line is written into a socket `updaterd` will not read until the apply finishes, minutes later. The client times out having heard nothing. |
-| `update.subscribe`, then `update.apply` | `stream_progress` owns that connection until the peer goes away and never reads a request again. The apply is written into a socket nobody is reading: it never runs, never replies, and never errors. |
+The source reports every HTTP chunk it writes — thousands, for a release artifact — and every
+subscriber paid for all of them. A progress line is around a hundred bytes, which is five or six
+notifications at the 20-byte floor `btd` frames to, and `btd` drops lines when the client falls
+behind, so a phone saw an arbitrary subset of the percentages and a bar that jumped 12 → 61 → 34.
 
-The second is worse than a bug — it is an update the owner asked for, that the robot silently did
-not perform. A mobile app will hit it on the first screen that has both a progress bar and a
-refresh, and a status poller makes the first case routine.
+Now at most one notification per whole percent and at most four a second, coalesced in the engine
+where the numbers are made, so `robotctl update watch` gets the same stream. A percent suppressed
+by the gap is still published when the download ends, or a fast download visibly finishes at 97%.
 
-**Fix: a lane per class of call.** `route.rs` already answers two questions per method — may BLE
-make this call, and which service owns it — and this is the third of the same kind: which
-connection carries it. Three lanes per service — one for short request/response calls, one for
-long mutations, one for a stream — and `Pool` keys its map on `(service, lane)`. A session touching
-all three costs three sockets instead of one, and the exhaustive match in `route.rs` means a new
-method has to be given a lane by whoever adds it.
+### 2.3 `update.check` blocked on the engine lock · `updaterd` · **fixed**
 
-Reusing one long lane for successive long calls is correct rather than a compromise: `updaterd`
-single-flights mutations behind a file lock and answers `BUSY` for the second, so serialising two
-applies is what should happen anyway.
+`ipc.rs` states the rule in its own header — read-only requests use `try_lock` so `status` and
+`subscribe` stay answerable during an update — and `check` did not follow it. Asked during an
+apply it answered whenever the apply finished, minutes later, which on a phone is
+indistinguishable from a robot that has stopped answering. It now answers `BUSY` at once, and so
+does `update.pin`.
 
-Two alternatives, both rejected. **Refuse a second updater call while one is outstanding**, with
-`BUSY` — honest instead of silent, three lines, and it breaks exactly the screen this exists to
-serve: the status poll fails during the one update it wants to watch. **A connection per call**
-would be the clean model, but closing one needs `btd` to know a call has ended, which needs it to
-parse replies; it deliberately never does, and that property is what keeps it a transport rather
-than a second implementation of the API.
+### 2.4 Decided: going back is reachable from a phone
 
-### 2.2 Progress is a firehose aimed at a 20-byte pipe · `updaterd`
+`update.rollback` and `update.select` were refused; both are now routed. `update.pin` and
+`update.resetToGolden` stay refused. The reasoning is on the arms in `btd/src/route.rs` and
+summarised in `app-path-design.md` §3.1; what decided it:
 
-The download pump sends a `Progress` per HTTP chunk (`updater/src/source/http.rs` calls
-`progress.send` on every chunk written). A serialised progress line is around a hundred bytes,
-which is five or six notifications at the 20-byte floor `btd` frames to, and a daemon artifact is
-thousands of chunks. `btd` drops lines when the outbound queue is full — correctly: progress is
-advisory and blocking would stall every other upstream — so what a phone actually sees is an
-arbitrary subset of the percentages, and the last one before a phase change is as droppable as
-any other. A bar that jumps 12 → 61 → 34 is worse than one that moves once a second.
+`update.apply` was already routed and is the more consequential of the three — it installs code
+that has never run on this board, from the network — while rollback and select move to a release
+that ran on it yesterday, download nothing, and are gated and auto-reverted like any other
+transition. The engine's own auto-revert covers the release that fails its health gate, which is
+not the case an owner reaches for a phone about: that is a release that installs, passes its gate,
+and then behaves *worse* — a policy that walks unsteadily rather than not at all, a pad that stops
+reconnecting. Nothing reverts that but a person, and the person is holding a phone and has no ssh.
 
-**Fix: decimate where the numbers are made.** In the pump, emit only when the whole percent
-changes, and no more than a few times a second. That is at most 101 events for a download instead
-of thousands, it is one small change in `engine.rs`, and it fixes `robotctl update watch` at the
-same time — every transport pays for this today, BLE is only where it is fatal.
+Both were opened rather than only `rollback`, because `update.listInstalled` is already routed: an
+app can show every release on the board, and being able to show them without being able to choose
+one is the odd half. `select` needs a version picked from a list, which is a bigger surface to get
+wrong from a mistap, and that is the cost accepted.
 
-Conflating in `btd`'s outbound queue — keep the newest progress line, drop the older ones — would
-be the transport-local fix and needs `btd` to parse notifications. Same objection as §2.1.
-
-### 2.3 `update.check` blocks on the engine lock · `updaterd`
-
-`ipc.rs`'s own header states the rule: a long operation holds the engine mutex, so read-only
-requests use `try_lock` and fall back rather than blocking — "that is what keeps `status` and
-`subscribe` answerable *during* an update". `Call::Check` does not follow it. It takes
-`self.engine.lock().await`, so a phone asking "is there an update?" during an apply gets a spinner
-that resolves whenever the apply finishes, with nothing to tell it apart from a dead robot.
-
-**Fix: `try_lock`, and `BUSY` when it fails**, which is already the idiom for a mutation that
-arrives during one. `Call::Pin` has the same shape and the same fix, and is mutating, so `BUSY` is
-exactly right there.
-
-### 2.4 Decision: `update.rollback` over Bluetooth
-
-Refused today, with the reasoning in `route.rs`: the engine reverts a release that fails its own
-health gate, so the phone needs no button for the ordinary case, and recovery mode should be what
-reopens it.
-
-**The case for opening it.** `update.apply` is already routed and is strictly the more
-consequential of the two: it installs code that has never run on this board, from the network,
-and rollback returns to a release that ran on it yesterday. The gate covers the release that fails
-to come up, which is not the case an owner reaches for a phone about — that is a release that
-installs, passes its gate, and then behaves worse: a walking policy that is unsteady rather than
-dead, a robot that gets warm, a pad that stops reconnecting. Nothing reverts that but a person, and
-the person has a phone in their hand and no ssh. A rollback discards nothing, and it is gated and
-auto-reverted like any transition (`Engine::rollback` goes through `transition_to`).
-
-**The case against.** It churns the boot counter, and the link it would arrive over is
-unencrypted with a printed default PIN (`app-path-design.md` §5.5, §8.1), so anyone in radio range
-who has read this repository can revert someone's robot. That is already true of `apply`, which is
-the honest way to put it: opening rollback widens what that peer can do by roughly nothing.
-
-**Recommendation: open `update.rollback`.** Keep `resetToGolden` refused — it is a factory reset in
-all but name, and never over a radio.
-
-**And a second question with it: `update.select`.** `update.listInstalled` is already routed, so a
-phone can already show every release on the board. Once it shows the list, the natural gesture is
-"go back to *that* one", which is `select` rather than `rollback` — `rollback` only ever means the
-previous release. `select` downloads nothing, verifies nothing over the network, and is "gated and
-rolled back like an update" by its own doc comment, so it is technically the *safest* of the three.
-What it is not is a one-tap undo: it needs a version picked out of a list, which is the shape of an
-operator decision made with a record of who made it, and that is why it sits with `pin` today.
-
-Either answer is defensible and they lead to different app screens, which is why it is a question
-and not a recommendation:
-
-- **Rollback only** — one button, "undo the last update". The app never shows a version picker,
-  `listInstalled` stays informational, and `select` stays operator surgery.
-- **Rollback and select** — the app shows the installed releases and can activate any of them.
-  More useful on a bench and to anyone diagnosing a robot they cannot ssh into; a bigger surface
-  to get wrong from a mistap, and the update log will not say which phone made the choice (§2.5).
-
-`pin` stays refused under either: a robot pinned by a mistap refuses every later update and
+`pin` is the interesting refusal. A wrong `select` is one release away from being undone and the
+robot says which release it is on; a robot pinned by a mistap refuses every later update and
 reports itself as up to date, which is the one failure here that looks like correct behaviour.
 
-### 2.5 A phone-triggered update is logged as `btd`
+### 2.5 A phone-triggered update is logged as `btd` · **recorded, not fixed**
 
 `updaterd` records the caller's uid and pid from `SO_PEERCRED` on every mutation, which is how
 support answers "who triggered this rollback". Over BLE the answer is always `btd`, for every
-phone. Recorded rather than fixed: `btd` forwards params verbatim and adding a "who" field would
-make it an author of requests rather than a pipe. Worth reopening only if support actually needs
-to tell two phones apart.
+phone. `btd` forwards params verbatim and adding a "who" field would make it an author of requests
+rather than a pipe. Worth reopening only if support needs to tell two phones apart.
 
-### 2.6 Client deadlines are total, not idle · `duck-btctl`, and the app
+### 2.6 Client deadlines were total, not idle · `duck-btctl` · **fixed**
 
-`duck-btctl` waits a fixed budget for a reply — 15 seconds, or 60 for the slow calls. A daemon
-apply is minutes: download, verify, extract, swap, hooks, the health gate. Raising the number is
-the wrong shape of fix, because the useful signal is already arriving: every progress notification
-is proof the robot is alive and working.
-
-**Reset the deadline on every line received**, and give an apply a generous idle budget on top.
-Then a stalled mirror times out in seconds while a slow-but-progressing update never does. The app
-inherits the principle rather than the code, and it belongs in the app's own notes.
+A fixed budget either cuts off a working update or waits out a dead robot, and the useful signal
+was already arriving: every progress notification is proof the robot is working. Deadlines are now
+silences — three minutes for an update, which is the longest gap one can legitimately have (a
+post-install hook), not the longest one can take. A phone app inherits the principle, not the code.
 
 ### 2.7 The link drops about five seconds after a daemon apply replies
 
-Not a defect — §1's ordering, working. But every client has to expect it, and neither the tool nor
-a future app should render a disconnect that the robot announced as a failure of the update that
-just succeeded. The sequence to build against:
+Not a defect — §1's ordering, working — but every client has to expect it, and a disconnect the
+robot announced must not read as a failed update. The sequence to build against:
 
-1. `update.apply` replies with its outcome. This is the answer; the update is done.
+1. `update.apply` replies with its outcome. That is the answer; the update is done.
 2. About five seconds later `btd` restarts and the connection drops.
-3. Reconnect, `hello`, and `update.status`. `last_attempt` carries the outcome of what just ran,
-   so a client that missed the reply in step 1 can still report it.
+3. Reconnect, and read `update.status`. `last_attempt` carries the outcome, so a client that missed
+   the reply in step 1 can still report it.
 
-`duck-btctl` should print step 2 before it happens, so the disconnect reads as expected.
+`duck-btctl` prints step 2 before it happens.
 
 ### 2.8 Open, deliberately: `from_dir` over Bluetooth
 
 `ApplyOptions.from_dir` names a directory on the robot, which is meaningless to a phone and useful
 on a bench. Filtering it would mean `route.rs` deciding on params rather than methods, and
-inspecting params is what `btd` does not do (§2.1's third paragraph). Preflight already refuses the
-cases that bite — `PrivateTmp` makes `/tmp` a different directory for `updaterd` than for the shell
-that copied into it, and it says so — so this is left as it is, and named here so the next person
-finds a decision rather than an oversight.
+inspecting params is what `btd` does not do. Preflight already refuses the cases that bite — and
+says so — so this is left as it is, named here so the next person finds a decision rather than an
+oversight.
 
-## 3. The `duck-btctl` surface
+## 3. What `duck-btctl` offers now
 
-Today every update operation goes through `call` with hand-written JSON. The commands below mirror
-`robotctl update` name for name, so what someone learns on the robot transfers to the radio and
-back:
+`version`, and `update` with `check`, `apply`, `status`, `versions`, `log`, `rollback`, `select`
+and `watch` — the same words `robotctl update` uses, so a command learned on the robot works over
+the radio. Params are built from `duck_ipc_proto`'s own types rather than hand-written JSON, which
+is what `call` left to whoever was typing: `update.apply`'s target is an externally tagged enum, so
+`--ref` and `--version` are different JSON *shapes*, and a wrong one is a parse error with nothing
+in it to act on. [`duck-btctl.md`](../robot/duck-btctl.md) has every command.
 
-| `duck-btctl` | method |
-|---|---|
-| `version` | `hello` — the API version, the daemon's version, and the revision it was built from |
-| `update check` | `update.check` |
-| `update apply [--version V \| --ref R \| --staging] [--dry-run]` | `update.apply` |
-| `update status` | `update.status` |
-| `update versions` | `update.listInstalled` |
-| `update log [--limit N]` | `update.log` |
-| `update watch` | `update.subscribe` |
-| `update rollback` | `update.rollback`, if §2.4 opens it |
+Progress prints as one line per event on stderr, which that page already promised and the tool did
+not do.
 
-`status` stays what it is — the handshake plus the update status — because it is in every set of
-notes anyone has written down, and `version` is the narrower question it currently buries.
+`duck-btctl` is a stopgap, and this is where that mattered: §2.1, §2.2 and §2.3 are robot-side, so
+the app inherits the fixes, while §2.6's deadline shape is client-side, so the tool got it right
+and the app's own notes will have to say why.
 
-Progress prints as a line a person can read (the phase, and the percent when there is one) rather
-than as the raw notification, with the reply still going to stdout as JSON so redirection keeps
-working. `--verbose` keeps showing every line on the wire.
+## 4. What is left
 
-`duck-btctl` is a stopgap and this is where that matters: the three fixes above are robot-side, so
-the app inherits them, and §2.6's timeout shape is client-side, so the tool gets it right and the
-app's notes say why.
+**None of it has run on a board.** Everything above is covered by tests, and the tests cannot see
+what a phone sees: whether progress arrives smoothly over a real 20-byte link, whether an apply's
+reply reaches the client before `btd` restarts, and whether the fourth socket per service costs
+anything on a Zero 3W. That is the next session, with `duck-btctl update apply --ref` against a dev
+board.
 
-## 4. Order
+**The stale claim in `duck-btctl.md` was corrected from reading the code, not from a board.** If an
+apply over BLE turns out to be silent after all, the mechanism to look at is the outbound queue in
+`btd/src/link.rs`, not the routing.
 
-1. **§2.1**, the lanes. Nothing below is testable while a second call during an apply is a black
-   hole, and it is the only change here a mobile app cannot work around.
-2. **§2.3** then **§2.2** — small, independent, and they make progress worth watching.
-3. **§2.4**, once answered: the route entries, and the named-one-by-one tests in `route.rs` that
-   are the security boundary.
-4. **§3** with **§2.6** and **§2.7** — the surface, on top of a transport that behaves.
-5. Docs: `duck-btctl.md`'s stale claim (§1) and its command list, and `app-path-design.md` §3.1
-   for whatever §2.4 decides.
-
-## 5. What this does not do
+## 5. What this deliberately does not do
 
 **No cancel.** The engine has none, and a half-applied update is worse than a slow one. A client
 that walks away is already handled: the update finishes.
 
 **No auto-apply toggle from the phone.** `deploy/updater.toml` deliberately does not opt client
-robots into unattended restarts, and that decision is not one to expose as a switch before there
-is a robot fleet to reason about.
+robots into unattended restarts, and that is not a decision to expose as a switch before there is
+a fleet to reason about.
 
-**No encryption.** `app-path-design.md` §8.1 owns it, it blocks nothing here, and every claim
-above about what a peer in radio range can do is written on the assumption that it is still off.
+**No encryption.** `app-path-design.md` §8.1 owns it, it blocked nothing here, and every claim
+above about what a peer in radio range can do assumes it is still off.

--- a/docs/project/update-over-ble.md
+++ b/docs/project/update-over-ble.md
@@ -1,0 +1,246 @@
+# Updating a robot from a phone
+
+Status: open, two decisions wanted · Date: 2026-08-19 · Owner: pierre
+
+The update path over Bluetooth is most of the way there and nobody has driven it. `btd` already
+routes the update subset, `updaterd` already streams progress to whoever asked, and
+`duck-btctl` can reach all of it through `call`. What is missing is one defect that makes the
+app's own flow — start an update, watch it — a black hole, two smaller ones in `updaterd`, a
+decision about `update.rollback`, and a client surface worth typing.
+
+Ordered by what blocks what. §2.1 is first because nothing below it is testable while it stands.
+
+## 1. What already works, so it is not rebuilt
+
+**The routed subset covers the reads and the trigger.** `btd/src/route.rs` already sends `hello`,
+`update.check`, `update.apply`, `update.status`, `update.subscribe`, `update.log` and
+`update.listInstalled` to `updaterd`, and `robot.health` to `robotd`. Nothing in the plan below
+adds a method to the protocol; the only routing change under discussion is §2.4.
+
+**An apply already streams its own progress.** `updaterd`'s `run_mutating` writes
+`update.progress` notifications to the connection the apply arrived on, before the reply
+(`updater/src/ipc.rs`). `btd`'s pool pumps every line from an upstream into the session's
+outbound queue without reading it (`btd/src/upstream.rs`), and `duck-btctl` prints id-less lines
+and keeps waiting. So progress reaches a BLE client during an apply with no subscription at all.
+
+`docs/robot/duck-btctl.md` says the opposite — *"an apply on its own connection is silent until it
+is done"*. That is false as the code stands. It should be confirmed against a board and then the
+line fixed, because it currently tells an app author to build the mechanism §2.1 exists to fix.
+
+**A client that reconnects mid-update is not lost.** `updaterd` keeps the latest `Progress` per
+component and replays it to a new subscriber before forwarding anything live
+(`Server::stream_progress`), and `update.status` answers *during* an update — it takes the engine
+lock with `try_lock` and falls back to a cached snapshot with the phase patched in from that same
+`latest`. Both are what a phone needs after the link drops, and both already exist.
+
+**The reply gets out before the transport dies.** `updaterd` and `btd` are the two units an update
+never restarts, and both are restarted about five seconds *after* the reply
+(`RESTART_AFTER_REPLYING`, `docs/design/restart-order.md` §1). So a phone-triggered daemon update
+answers the phone, and then drops the link. That ordering is deliberate and load-bearing for this
+whole path.
+
+**And the update does not depend on the phone.** `architecture.md` §1.1: the robot pulls, the
+update runs to completion whether or not anyone is watching, and `updaterd` stops writing to a
+client that has gone without stopping the operation.
+
+## 2. What is missing
+
+### 2.1 A long call blocks every other call on the session · `btd`
+
+`Pool` holds **one** connection per service per BLE session, made on demand. `updaterd` serves
+one connection with one request at a time: `handle_connection` reads a line, awaits `dispatch`,
+then reads the next.
+
+Both orderings of "update the robot and show progress" fail, and neither says so:
+
+| the client does | what happens |
+|---|---|
+| `update.apply`, then `update.status` while it runs | the status line is written into a socket `updaterd` will not read until the apply finishes, minutes later. The client times out having heard nothing. |
+| `update.subscribe`, then `update.apply` | `stream_progress` owns that connection until the peer goes away and never reads a request again. The apply is written into a socket nobody is reading: it never runs, never replies, and never errors. |
+
+The second is worse than a bug — it is an update the owner asked for, that the robot silently did
+not perform. A mobile app will hit it on the first screen that has both a progress bar and a
+refresh, and a status poller makes the first case routine.
+
+**Fix: a lane per class of call.** `route.rs` already answers two questions per method — may BLE
+make this call, and which service owns it — and this is the third of the same kind: which
+connection carries it. Three lanes per service — one for short request/response calls, one for
+long mutations, one for a stream — and `Pool` keys its map on `(service, lane)`. A session touching
+all three costs three sockets instead of one, and the exhaustive match in `route.rs` means a new
+method has to be given a lane by whoever adds it.
+
+Reusing one long lane for successive long calls is correct rather than a compromise: `updaterd`
+single-flights mutations behind a file lock and answers `BUSY` for the second, so serialising two
+applies is what should happen anyway.
+
+Two alternatives, both rejected. **Refuse a second updater call while one is outstanding**, with
+`BUSY` — honest instead of silent, three lines, and it breaks exactly the screen this exists to
+serve: the status poll fails during the one update it wants to watch. **A connection per call**
+would be the clean model, but closing one needs `btd` to know a call has ended, which needs it to
+parse replies; it deliberately never does, and that property is what keeps it a transport rather
+than a second implementation of the API.
+
+### 2.2 Progress is a firehose aimed at a 20-byte pipe · `updaterd`
+
+The download pump sends a `Progress` per HTTP chunk (`updater/src/source/http.rs` calls
+`progress.send` on every chunk written). A serialised progress line is around a hundred bytes,
+which is five or six notifications at the 20-byte floor `btd` frames to, and a daemon artifact is
+thousands of chunks. `btd` drops lines when the outbound queue is full — correctly: progress is
+advisory and blocking would stall every other upstream — so what a phone actually sees is an
+arbitrary subset of the percentages, and the last one before a phase change is as droppable as
+any other. A bar that jumps 12 → 61 → 34 is worse than one that moves once a second.
+
+**Fix: decimate where the numbers are made.** In the pump, emit only when the whole percent
+changes, and no more than a few times a second. That is at most 101 events for a download instead
+of thousands, it is one small change in `engine.rs`, and it fixes `robotctl update watch` at the
+same time — every transport pays for this today, BLE is only where it is fatal.
+
+Conflating in `btd`'s outbound queue — keep the newest progress line, drop the older ones — would
+be the transport-local fix and needs `btd` to parse notifications. Same objection as §2.1.
+
+### 2.3 `update.check` blocks on the engine lock · `updaterd`
+
+`ipc.rs`'s own header states the rule: a long operation holds the engine mutex, so read-only
+requests use `try_lock` and fall back rather than blocking — "that is what keeps `status` and
+`subscribe` answerable *during* an update". `Call::Check` does not follow it. It takes
+`self.engine.lock().await`, so a phone asking "is there an update?" during an apply gets a spinner
+that resolves whenever the apply finishes, with nothing to tell it apart from a dead robot.
+
+**Fix: `try_lock`, and `BUSY` when it fails**, which is already the idiom for a mutation that
+arrives during one. `Call::Pin` has the same shape and the same fix, and is mutating, so `BUSY` is
+exactly right there.
+
+### 2.4 Decision: `update.rollback` over Bluetooth
+
+Refused today, with the reasoning in `route.rs`: the engine reverts a release that fails its own
+health gate, so the phone needs no button for the ordinary case, and recovery mode should be what
+reopens it.
+
+**The case for opening it.** `update.apply` is already routed and is strictly the more
+consequential of the two: it installs code that has never run on this board, from the network,
+and rollback returns to a release that ran on it yesterday. The gate covers the release that fails
+to come up, which is not the case an owner reaches for a phone about — that is a release that
+installs, passes its gate, and then behaves worse: a walking policy that is unsteady rather than
+dead, a robot that gets warm, a pad that stops reconnecting. Nothing reverts that but a person, and
+the person has a phone in their hand and no ssh. A rollback discards nothing, and it is gated and
+auto-reverted like any transition (`Engine::rollback` goes through `transition_to`).
+
+**The case against.** It churns the boot counter, and the link it would arrive over is
+unencrypted with a printed default PIN (`app-path-design.md` §5.5, §8.1), so anyone in radio range
+who has read this repository can revert someone's robot. That is already true of `apply`, which is
+the honest way to put it: opening rollback widens what that peer can do by roughly nothing.
+
+**Recommendation: open `update.rollback`.** Keep `resetToGolden` refused — it is a factory reset in
+all but name, and never over a radio.
+
+**And a second question with it: `update.select`.** `update.listInstalled` is already routed, so a
+phone can already show every release on the board. Once it shows the list, the natural gesture is
+"go back to *that* one", which is `select` rather than `rollback` — `rollback` only ever means the
+previous release. `select` downloads nothing, verifies nothing over the network, and is "gated and
+rolled back like an update" by its own doc comment, so it is technically the *safest* of the three.
+What it is not is a one-tap undo: it needs a version picked out of a list, which is the shape of an
+operator decision made with a record of who made it, and that is why it sits with `pin` today.
+
+Either answer is defensible and they lead to different app screens, which is why it is a question
+and not a recommendation:
+
+- **Rollback only** — one button, "undo the last update". The app never shows a version picker,
+  `listInstalled` stays informational, and `select` stays operator surgery.
+- **Rollback and select** — the app shows the installed releases and can activate any of them.
+  More useful on a bench and to anyone diagnosing a robot they cannot ssh into; a bigger surface
+  to get wrong from a mistap, and the update log will not say which phone made the choice (§2.5).
+
+`pin` stays refused under either: a robot pinned by a mistap refuses every later update and
+reports itself as up to date, which is the one failure here that looks like correct behaviour.
+
+### 2.5 A phone-triggered update is logged as `btd`
+
+`updaterd` records the caller's uid and pid from `SO_PEERCRED` on every mutation, which is how
+support answers "who triggered this rollback". Over BLE the answer is always `btd`, for every
+phone. Recorded rather than fixed: `btd` forwards params verbatim and adding a "who" field would
+make it an author of requests rather than a pipe. Worth reopening only if support actually needs
+to tell two phones apart.
+
+### 2.6 Client deadlines are total, not idle · `duck-btctl`, and the app
+
+`duck-btctl` waits a fixed budget for a reply — 15 seconds, or 60 for the slow calls. A daemon
+apply is minutes: download, verify, extract, swap, hooks, the health gate. Raising the number is
+the wrong shape of fix, because the useful signal is already arriving: every progress notification
+is proof the robot is alive and working.
+
+**Reset the deadline on every line received**, and give an apply a generous idle budget on top.
+Then a stalled mirror times out in seconds while a slow-but-progressing update never does. The app
+inherits the principle rather than the code, and it belongs in the app's own notes.
+
+### 2.7 The link drops about five seconds after a daemon apply replies
+
+Not a defect — §1's ordering, working. But every client has to expect it, and neither the tool nor
+a future app should render a disconnect that the robot announced as a failure of the update that
+just succeeded. The sequence to build against:
+
+1. `update.apply` replies with its outcome. This is the answer; the update is done.
+2. About five seconds later `btd` restarts and the connection drops.
+3. Reconnect, `hello`, and `update.status`. `last_attempt` carries the outcome of what just ran,
+   so a client that missed the reply in step 1 can still report it.
+
+`duck-btctl` should print step 2 before it happens, so the disconnect reads as expected.
+
+### 2.8 Open, deliberately: `from_dir` over Bluetooth
+
+`ApplyOptions.from_dir` names a directory on the robot, which is meaningless to a phone and useful
+on a bench. Filtering it would mean `route.rs` deciding on params rather than methods, and
+inspecting params is what `btd` does not do (§2.1's third paragraph). Preflight already refuses the
+cases that bite — `PrivateTmp` makes `/tmp` a different directory for `updaterd` than for the shell
+that copied into it, and it says so — so this is left as it is, and named here so the next person
+finds a decision rather than an oversight.
+
+## 3. The `duck-btctl` surface
+
+Today every update operation goes through `call` with hand-written JSON. The commands below mirror
+`robotctl update` name for name, so what someone learns on the robot transfers to the radio and
+back:
+
+| `duck-btctl` | method |
+|---|---|
+| `version` | `hello` — the API version, the daemon's version, and the revision it was built from |
+| `update check` | `update.check` |
+| `update apply [--version V \| --ref R \| --staging] [--dry-run]` | `update.apply` |
+| `update status` | `update.status` |
+| `update versions` | `update.listInstalled` |
+| `update log [--limit N]` | `update.log` |
+| `update watch` | `update.subscribe` |
+| `update rollback` | `update.rollback`, if §2.4 opens it |
+
+`status` stays what it is — the handshake plus the update status — because it is in every set of
+notes anyone has written down, and `version` is the narrower question it currently buries.
+
+Progress prints as a line a person can read (the phase, and the percent when there is one) rather
+than as the raw notification, with the reply still going to stdout as JSON so redirection keeps
+working. `--verbose` keeps showing every line on the wire.
+
+`duck-btctl` is a stopgap and this is where that matters: the three fixes above are robot-side, so
+the app inherits them, and §2.6's timeout shape is client-side, so the tool gets it right and the
+app's notes say why.
+
+## 4. Order
+
+1. **§2.1**, the lanes. Nothing below is testable while a second call during an apply is a black
+   hole, and it is the only change here a mobile app cannot work around.
+2. **§2.3** then **§2.2** — small, independent, and they make progress worth watching.
+3. **§2.4**, once answered: the route entries, and the named-one-by-one tests in `route.rs` that
+   are the security boundary.
+4. **§3** with **§2.6** and **§2.7** — the surface, on top of a transport that behaves.
+5. Docs: `duck-btctl.md`'s stale claim (§1) and its command list, and `app-path-design.md` §3.1
+   for whatever §2.4 decides.
+
+## 5. What this does not do
+
+**No cancel.** The engine has none, and a half-applied update is worse than a slow one. A client
+that walks away is already handled: the update finishes.
+
+**No auto-apply toggle from the phone.** `deploy/updater.toml` deliberately does not opt client
+robots into unattended restarts, and that decision is not one to expose as a switch before there
+is a robot fleet to reason about.
+
+**No encryption.** `app-path-design.md` §8.1 owns it, it blocks nothing here, and every claim
+above about what a peer in radio range can do is written on the assumption that it is still off.

--- a/docs/robot/duck-btctl.md
+++ b/docs/robot/duck-btctl.md
@@ -181,6 +181,100 @@ duck-btctl --name <robot-name> status
 
 The version handshake and the update status.
 
+## Which release is it running
+
+```bash
+duck-btctl --name <robot-name> version
+```
+
+The API version, the release, and the git revision it was built from. A `revision` of `null` means
+the release was built on somebody's laptop rather than by CI.
+
+## Updates
+
+Same words as `robotctl update`, so a command learned on the robot works here. Every one of them
+takes `--component <name>` and defaults to `daemon`, which is the only component a robot has today.
+
+```bash
+duck-btctl --name <robot-name> update check
+```
+
+```bash
+duck-btctl --name <robot-name> update status
+```
+
+```bash
+duck-btctl --name <robot-name> update versions
+```
+
+```bash
+duck-btctl --name <robot-name> update log --limit 20
+```
+
+Installing takes minutes and prints progress lines as it goes:
+
+```bash
+duck-btctl --name <robot-name> update apply
+```
+
+```
+· daemon: preflight
+· daemon: downloading 12%
+· daemon: downloading 47%
+· daemon: verifying
+· daemon: swapping
+· daemon: health_gate
+{
+  "outcome": "applied",
+  "from": "0.5.1",
+  "to": "0.6.0"
+}
+note: the robot restarts its daemons now, and `btd` about five seconds after this reply — so this
+connection drops. That is the update working. Reconnect and run `duck-btctl update status`:
+`last_attempt` carries the outcome of what just ran.
+```
+
+The connection dropping after an apply is the update working, not a failure. Reconnect and read
+`update status`.
+
+A branch build, an exact version, or the staging candidate:
+
+```bash
+duck-btctl --name <robot-name> update apply --ref my-branch
+```
+
+```bash
+duck-btctl --name <robot-name> update apply --version 0.5.1
+```
+
+```bash
+duck-btctl --name <robot-name> update apply --staging
+```
+
+`--dry-run` verifies everything and stops before the swap. `--ref` and `--version` are alternatives;
+asking for both is refused.
+
+Going back — the previous release, or one named from `update versions`:
+
+```bash
+duck-btctl --name <robot-name> update rollback
+```
+
+```bash
+duck-btctl --name <robot-name> update select 0.5.1
+```
+
+Both are gated like an apply, so one that does not come up is reverted. Neither discards anything.
+
+Progress for an update somebody else started, or one triggered by the robot itself:
+
+```bash
+duck-btctl --name <robot-name> update watch
+```
+
+It prints where the update in flight has got to and then everything that follows. It never receives
+a reply, so it ends with Ctrl-C.
+
 ## Anything else — `call`
 
 ```bash
@@ -192,24 +286,14 @@ written without the `duck-btctl --name <robot-name>` in front of them:
 
 | | |
 |---|---|
-| `call update.check '{"component":"daemon"}'` | Is there a newer release? |
-| `call update.apply '{"component":"daemon","target":"latest"}'` | Install the latest stable release. |
-| `call update.apply '{"component":"daemon","target":{"ref":"my-branch"}}'` | Install what a branch last built. |
-| `call update.apply '{"component":"daemon","target":{"exact":"0.5.1"}}'` | Install one exact version. |
-| `call update.listInstalled '{"component":"daemon"}'` | Which releases are on the board. |
-| `call update.log '{"limit":20}'` | The update record that survives a wiped journal. |
 | `call system.services` | Which daemons are up, and the release each runs. |
 | `call pad.status` | Is a gamepad bonded, and is it connected? |
 | `call pad.pair '{"timeout_seconds":30}'` | Bond a pad held in pairing mode. |
 | `call pad.forget '{"mac":"<address>"}'` | Drop a bond. |
 
-An apply answers once, when it is finished, and `call` waits 60 seconds for that answer. A daemon
-update can take longer — the robot carries on regardless, and `status` afterwards says how it
-went.
-
-`call update.subscribe` is the progress stream. It never sends an answer, so it prints progress
-until the same 60 seconds run out. Nothing else streams: an apply on its own connection is silent
-until it is done.
+`call` waits 60 seconds for an answer. The update commands above wait on *silence* instead — three
+minutes with nothing arriving at all — which is why they are the way to run an update rather than
+`call update.apply`.
 
 ## Global options
 
@@ -225,10 +309,16 @@ until it is done.
 
 Replies go to stdout as pretty JSON, and everything else — progress, diagnosis, what the radio
 saw — to stderr. So `duck-btctl ... info > reply.json` keeps the two apart, and a JSON-RPC error
-from the robot still exits non-zero.
+from the robot still exits non-zero. Progress lines start with `·` and are one line each, so
+`update apply > outcome.json` leaves them on screen and keeps the outcome in the file.
 
 One command is one connection: it finds the robot, pairs if it has to, proves the PIN, asks, and
 disconnects.
+
+Every command gives up after a period of silence rather than after a fixed total, so a slow update
+is never cut off and a robot that stops answering is reported in seconds. An update in flight
+survives that: the robot pulls, so it carries on with nobody watching, and `update status` afterwards
+says how it went.
 
 ## What is refused
 

--- a/docs/robot/duck-btctl.md
+++ b/docs/robot/duck-btctl.md
@@ -233,10 +233,10 @@ disconnects.
 ## What is refused
 
 Motor control (`robot.move`, `robot.head`, `robot.enable`, `robot.stop`, `robot.init`,
-`robot.relax`), high-rate telemetry (`robot.subscribe`), the operator decisions (`update.select`,
-`update.pin`, `update.rollback`, `update.resetToGolden`) and the pairing PIN
-(`system.pairingPin`, `system.setPairingPin`) are refused by `btd` itself and never reach a daemon.
-They come back as error code 14, "not available over Bluetooth".
+`robot.relax`), high-rate telemetry (`robot.subscribe`), the two update commands a person has to
+mean (`update.pin`, `update.resetToGolden`) and the pairing PIN (`system.pairingPin`,
+`system.setPairingPin`) are refused by `btd` itself and never reach a daemon. They come back as
+error code 14, "not available over Bluetooth".
 
 That is a security boundary rather than a missing feature, and each refusal has its reason next
 to it in `btd/src/route.rs` — [`app-path-design.md`](../design/app-path-design.md) §3.1 is the

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -49,6 +49,73 @@ const HOOK_TIMEOUT: Duration = Duration::from_secs(120);
 /// Interval between health probes while the gate is open.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Shortest gap between two download-progress notifications.
+///
+/// The source reports every HTTP chunk it writes, which for a release artifact is thousands of
+/// events, and every subscriber pays for all of them. Over BLE that is fatal rather than
+/// wasteful: a progress line is around a hundred bytes, which is five or six notifications at the
+/// 20-byte floor `btd` frames to, and `btd` drops lines when the client falls behind — so a phone
+/// saw an arbitrary subset of the percentages and a bar that jumped 12 → 61 → 34. Four a second,
+/// each a different whole percent, is a bar that moves smoothly and a stream a 20-byte pipe can
+/// carry.
+const PROGRESS_MIN_GAP: Duration = Duration::from_millis(250);
+
+/// Which of a download's progress reports are worth publishing.
+///
+/// [`PROGRESS_MIN_GAP`] is why this exists at all. Two rules, and the third method is why it is a
+/// type rather than three variables: a percent held back by the gap has to be published when the
+/// download ends, or a download whose last change lands inside the gap visibly finishes at 97%.
+struct DownloadProgress {
+    /// The last percent published, so an unchanged one is dropped. Starts at 0 because the caller
+    /// publishes that before the first chunk arrives.
+    sent: Option<u8>,
+    last: tokio::time::Instant,
+    /// Computed, suppressed by the gap, and not yet superseded.
+    held: Option<u8>,
+}
+
+impl DownloadProgress {
+    fn started(now: tokio::time::Instant) -> Self {
+        Self {
+            sent: Some(0),
+            last: now,
+            held: None,
+        }
+    }
+
+    /// Whether this report should be published.
+    fn admit(&mut self, percent: Option<u8>, now: tokio::time::Instant) -> bool {
+        let due = now.duration_since(self.last) >= PROGRESS_MIN_GAP;
+
+        // With no total there is no percent to coalesce on, so the gap is the only thing
+        // rationing "still downloading" — and there is no number worth holding back either.
+        if percent.is_none() {
+            if due {
+                self.last = now;
+                return true;
+            }
+            return false;
+        }
+
+        if percent == self.sent {
+            return false;
+        }
+        if due {
+            self.sent = percent;
+            self.held = None;
+            self.last = now;
+            return true;
+        }
+        self.held = percent;
+        false
+    }
+
+    /// The percent held back by the gap, once there are no more reports coming.
+    fn flush(&mut self) -> Option<u8> {
+        self.held.take()
+    }
+}
+
 /// Headroom multiplier over the artifact size: download + extracted copy + slack.
 const SPACE_MULTIPLIER: u64 = 3;
 
@@ -579,16 +646,28 @@ impl Engine {
             let progress = progress.clone();
             let component = component.to_owned();
             tokio::spawn(async move {
-                while let Some((done, total)) = rx.recv().await {
-                    let percent = total
-                        .filter(|t| *t > 0)
-                        .map(|t| ((done.min(t) * 100) / t) as u8);
+                let send = |percent| {
                     let _ = progress.send(Progress {
                         component: ComponentId::new(component.clone()),
                         phase: Phase::Downloading,
                         percent,
                         detail: None,
                     });
+                };
+
+                // Coalesced rather than forwarded one-for-one: the source speaks once per HTTP
+                // chunk and nobody watching needs that. See `DownloadProgress`.
+                let mut gate = DownloadProgress::started(tokio::time::Instant::now());
+                while let Some((done, total)) = rx.recv().await {
+                    let percent = total
+                        .filter(|t| *t > 0)
+                        .map(|t| ((done.min(t) * 100) / t) as u8);
+                    if gate.admit(percent, tokio::time::Instant::now()) {
+                        send(percent);
+                    }
+                }
+                if let Some(percent) = gate.flush() {
+                    send(Some(percent));
                 }
             })
         };
@@ -2936,5 +3015,119 @@ esac
         assert!(log.contains("restart configd"), "{log}");
         // Never both in one command, which is what broke.
         assert!(!log.contains("restart robotd configd"), "{log}");
+    }
+}
+
+/// How much of a download's chatter reaches whoever is watching.
+///
+/// Unit tests with an injected clock rather than a real download: the property under test is a
+/// count of notifications per second, and sleeping to observe it would make the suite slower and
+/// the assertion flakier.
+#[cfg(test)]
+mod download_progress {
+    use super::*;
+
+    /// The headline: thousands of chunk reports become at most a hundred and one notifications,
+    /// which is what makes the stream carryable over a 20-byte BLE pipe. Before this, a phone
+    /// received an arbitrary subset of them — `btd` drops progress when the client falls behind —
+    /// and showed a bar that jumped 12 → 61 → 34.
+    #[test]
+    fn a_whole_download_publishes_at_most_one_notification_per_percent() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        // 5000 chunks over 20 seconds: a release artifact on a decent connection.
+        let total = 5000u64;
+        let mut published = 0;
+        for chunk in 1..=total {
+            let now = start + Duration::from_millis(chunk * 4);
+            let percent = Some(((chunk * 100) / total) as u8);
+            if gate.admit(percent, now) {
+                published += 1;
+            }
+        }
+
+        assert!(
+            (1..=101).contains(&published),
+            "published {published} of {total} reports"
+        );
+    }
+
+    /// And the rate is bounded, not only the count. A small artifact that downloads in a second
+    /// would otherwise send a hundred notifications into that second, which over BLE is the same
+    /// flood in less time.
+    #[test]
+    fn nothing_is_published_more_often_than_four_times_a_second() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        let mut published = 0;
+        for chunk in 1..=1000u64 {
+            let now = start + Duration::from_millis(chunk);
+            if gate.admit(Some((chunk / 10) as u8), now) {
+                published += 1;
+            }
+        }
+
+        assert!(published <= 4, "{published} notifications in one second");
+    }
+
+    /// A percent that does not move is not news. This is what collapses the tail of a download,
+    /// where many chunks land on the same whole percent.
+    #[test]
+    fn an_unchanged_percent_is_never_republished() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        assert!(
+            !gate.admit(Some(0), start + Duration::from_secs(1)),
+            "0% was already published by the caller"
+        );
+        assert!(gate.admit(Some(1), start + Duration::from_secs(2)));
+        assert!(!gate.admit(Some(1), start + Duration::from_secs(3)));
+        assert!(gate.admit(Some(2), start + Duration::from_secs(4)));
+    }
+
+    /// The last number always gets out.
+    ///
+    /// Without this a download whose final percent change lands inside the gap — every download
+    /// that finishes quickly — visibly stops at 97% and then jumps to the next phase. The same
+    /// concern made the pump `drop` its sender rather than `abort` the task.
+    #[test]
+    fn a_percent_held_back_by_the_gap_is_published_when_the_download_ends() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        assert!(gate.admit(Some(96), start + Duration::from_secs(1)));
+        assert!(!gate.admit(Some(97), start + Duration::from_millis(1050)));
+        assert!(!gate.admit(Some(100), start + Duration::from_millis(1100)));
+
+        assert_eq!(gate.flush(), Some(100), "the download ended at 100%");
+        assert_eq!(gate.flush(), None, "and only once");
+    }
+
+    /// A published percent leaves nothing to flush, so the end of a download does not repeat it.
+    #[test]
+    fn nothing_is_held_when_the_last_report_was_published() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        assert!(gate.admit(Some(100), start + Duration::from_secs(1)));
+        assert_eq!(gate.flush(), None);
+    }
+
+    /// A mirror that sends no `Content-Length` gives every report the same content — "still
+    /// downloading" — so the gap is the only thing rationing them, and there is no number to
+    /// hold back at the end.
+    #[test]
+    fn with_no_total_the_gap_alone_rations_the_stream() {
+        let start = tokio::time::Instant::now();
+        let mut gate = DownloadProgress::started(start);
+
+        assert!(!gate.admit(None, start + Duration::from_millis(10)));
+        assert!(gate.admit(None, start + Duration::from_millis(300)));
+        assert!(!gate.admit(None, start + Duration::from_millis(400)));
+        assert!(gate.admit(None, start + Duration::from_millis(600)));
+        assert_eq!(gate.flush(), None);
     }
 }

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -518,13 +518,22 @@ impl Server {
                 })
                 .await
                 .map_or_else(|e| e, |v| Response::ok(Some(id), &v)),
-            Call::Check(params) => {
-                let engine = self.engine.lock().await;
-                match engine.check(params.component.as_str()).await {
+            // `try_lock`, like every other read here, and for a reason the header states:
+            // a request that blocks on the engine mutex is answered whenever the update
+            // finishes, which is minutes for a daemon release. A client asking "is there an
+            // update?" during one has an immediate answer — there is one running — and getting
+            // `BUSY` back at once is what lets it say so. Blocking instead produced a spinner
+            // indistinguishable from a robot that had stopped answering.
+            Call::Check(params) => match self.engine.try_lock() {
+                Ok(engine) => match engine.check(params.component.as_str()).await {
                     Ok(result) => Response::ok(Some(id), &result),
                     Err(e) => Response::err(Some(id), e.to_rpc_error()),
-                }
-            }
+                },
+                Err(_) => Response::err(
+                    Some(id),
+                    proto::Error::new(proto::code::BUSY, "an update is in progress; retry shortly"),
+                ),
+            },
 
             // ── mutating ─────────────────────────────────────────────────────
             Call::Apply(params) => {
@@ -569,13 +578,19 @@ impl Server {
                 })
                 .await
             }
-            Call::Pin(params) => {
-                let mut engine = self.engine.lock().await;
-                match engine.pin(params.component.as_str(), params.version).await {
+            // Also `try_lock`, and the same `BUSY` every other mutation answers with. Pinning
+            // during an update is a request about which version may be installed, made while one
+            // is being installed: waiting for the answer to become moot is worse than saying so.
+            Call::Pin(params) => match self.engine.try_lock() {
+                Ok(mut engine) => match engine.pin(params.component.as_str(), params.version).await {
                     Ok(()) => Response::ok(Some(id), &serde_json::json!({})),
                     Err(e) => Response::err(Some(id), e.to_rpc_error()),
-                }
-            }
+                },
+                Err(_) => Response::err(
+                    Some(id),
+                    proto::Error::new(proto::code::BUSY, "another update is already in progress"),
+                ),
+            },
 
             // Owned by `handle_connection`, which hands the whole connection to
             // `stream_progress` instead of answering once.

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -551,6 +551,51 @@ async fn status_answers_while_an_update_is_running() {
     let _ = applier.await_response(&apply_id).await;
 }
 
+/// `check` must come straight back during an update, and say why.
+///
+/// It used to take the engine lock and wait, so "is there an update available?" asked while one
+/// was running answered whenever that update finished — minutes, for a daemon release. On a phone
+/// that is indistinguishable from a robot that has stopped answering, and it is the wrong answer
+/// besides: there is something to say, and it is that an update is in progress.
+#[tokio::test]
+async fn check_says_busy_rather_than_waiting_for_the_update_to_finish() {
+    let fx = Harness::new();
+    fx.publish("1.0.0", false);
+    let engine = fx.engine(
+        true,
+        Faults {
+            hang_health: true,
+            ..Faults::none()
+        },
+    );
+    let _server = fx.serve(engine).await;
+
+    let mut applier = Client::connect(&fx.socket).await;
+    applier.hello().await;
+    let apply_id = applier
+        .send(
+            method::APPLY,
+            serde_json::json!({ "component": "daemon", "target": "latest" }),
+        )
+        .await;
+
+    // Let it get into the gate, where it holds the engine.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let mut observer = Client::connect(&fx.socket).await;
+    observer.hello().await;
+    let response = tokio::time::timeout(
+        Duration::from_secs(1),
+        observer.call(method::CHECK, serde_json::json!({ "component": "daemon" })),
+    )
+    .await
+    .expect("check must not block on the in-flight update");
+
+    assert_eq!(response.error.expect("busy").code, proto::code::BUSY);
+
+    let _ = applier.await_response(&apply_id).await;
+}
+
 /// The robot pulls, so a client vanishing mid-update is normal and must not cancel
 /// it (`architecture.md` §1.1).
 #[tokio::test]


### PR DESCRIPTION
The update path over Bluetooth was routed but never driven. Driving it from `duck-btctl` turned up one defect that made the app's own flow — start an update, watch it — an update the robot silently never performed, plus two smaller ones in `updaterd`.

## The one that mattered

`btd`'s `Pool` held one connection per service per session, and `updaterd` and `configd` both serve a connection one request at a time. So:

- **`update.subscribe` then `update.apply`** — `stream_progress` owns its connection until the peer goes away and never reads another request, so the apply was written into a socket nobody read. It never ran, never replied and never errored. An owner taps "update", the robot does nothing, and there is no error anywhere to find.
- **`update.apply` then `update.status`** — the status line waited in a socket `updaterd` would not read for minutes, so the client timed out while the robot was fine and updating. `updaterd` goes to some trouble to answer a status poll during an update, and all of it was wasted.

Calls are now grouped by how long they hold a connection — `Prompt`, `Slow`, `Operation`, `Stream` — and each group gets its own. The lane is decided in `route.rs` beside the permission and the service, so the exhaustive match makes a new method's author choose one. `app-path-design.md` §3.5 owns the mechanism.

Both failures have tests that fail without the fix: a fake with `updaterd`'s connection model, reporting which connection each line arrived on.

## Going back is reachable from a phone

`update.rollback` and `update.select` were refused, on the reasoning that the engine reverts a bad release itself. It does — the one that fails its health gate. That is not the case an owner reaches for a phone about, which is a release that installs, passes its gate and then behaves *worse*: a policy that walks unsteadily rather than not at all, a pad that stops reconnecting. Nothing reverts that but a person, and the person is holding a phone and has no ssh.

Both move to a release that already ran on this board, download nothing, and are gated and auto-reverted like any other transition. `update.apply` was already routed and is the more consequential of the three.

`update.pin` stays refused, and it is the interesting one: a wrong `select` is one release away from being undone and the robot says which release it is on, whereas a robot pinned by a mistap refuses every later update and reports itself as up to date — the one failure here that looks like correct behaviour. `update.resetToGolden` stays refused because it discards releases.

`updaterd`'s peer policy is per-peer rather than per-method, so `allow_users = ["btd"]` already covers both and no config changes.

## Two more in `updaterd`

**`update.check` blocked on the engine lock**, against the rule `ipc.rs` states in its own header. Asked during an apply it answered whenever the apply finished, which on a phone is indistinguishable from a robot that has stopped answering. It has an immediate answer and now gives it: `BUSY`. `update.pin` had the same shape.

**Download progress went out per HTTP chunk** — thousands of events for a release artifact, every subscriber paying for all of them. A progress line is around a hundred bytes, which is five or six notifications at the 20-byte floor `btd` frames to, and `btd` drops lines when the client falls behind: a phone saw an arbitrary subset and a bar that jumped 12 → 61 → 34. Now at most one per whole percent and four a second, coalesced in the engine so `robotctl update watch` gets the same stream. A percent suppressed by the gap is still published when the download ends, so a fast download does not visibly finish at 97%.

## `duck-btctl`

`version`, and `update` with `check`, `apply`, `status`, `versions`, `log`, `rollback`, `select`, `watch` — the words `robotctl update` uses, so a command learned on the robot works over the radio. Params come from `duck_ipc_proto`'s own types rather than hand-written JSON: `update.apply`'s target is an externally tagged enum, so `--ref` and `--version` are different JSON *shapes*, and a wrong one is a parse error with nothing in it to act on.

Deadlines are silences rather than totals. A total budget either cuts off a working update or waits out a dead robot, and the useful signal was already arriving — every progress notification is proof the robot is working, so each one restarts the clock. An update gets three minutes of silence: the longest gap one can legitimately have (a post-install hook), not the longest one can take.

An apply that changed something now says what is about to happen to the connection — `btd` is restarted about five seconds after the reply, so the link drops, and that is the update working.

## Not run on a board

Everything here is covered by tests, and the tests cannot see what a phone sees: whether progress arrives smoothly over a real 20-byte link, whether the reply beats `btd`'s restart, or what the extra sockets cost on a Zero 3W. `docs/project/update-over-ble.md` §4 says so, along with the two things recorded rather than fixed — a phone-triggered update is logged as `btd`, and `from_dir` is not filtered because inspecting params is what `btd` does not do.

One correction in `duck-btctl.md` came from reading the code rather than from hardware: it claimed an apply is silent until it finishes, and `run_mutating` streams progress on the apply's own connection, which `btd` forwards and the tool prints. If a board disagrees, the place to look is the outbound queue in `btd/src/link.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)