### PR TITLE
setup-board: pause btd without imposing Privacy = device

### DIFF
--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -47,43 +47,63 @@ export DUCK_TOKEN=github_pat_replace_with_your_token
 ```
 
 ```bash
-./scripts/provision-board.sh --weird-ble --name <MY_COOL_ROBOT_NAME> radxa@192.168.1.42
+./scripts/provision-board.sh --pause-btd-on-pair --name <MY_COOL_ROBOT_NAME> radxa@192.168.1.42
 ```
 
 That sends your dev key, starts provisioning, waits out the reboot, streams the log, and ends on
 `robotctl health`.
 
-### Why `--weird-ble` is in that command
+### Why `--pause-btd-on-pair` is in that command
 
-Roughly half the Radxa Zero 3W units here cannot bond a gamepad under BlueZ's default settings, and
-nothing measurable tells them apart from the ones that can — same kernel, same BlueZ, same firmware
-bytes. So the flag is the default here: a board that needed it and was provisioned without it
-presents as a gamepad that will not pair, for no visible reason — and every plausible cause you
-chase first is somewhere else entirely. A board that did not need it pays a smaller price, described
-below.
+On the aic8800 radio a pad cannot form a **new** bond while `btd` is advertising. That flag leaves a
+marker so `robotctl pad pair` stops `btd` and power-cycles the adapter for the pairing window, then
+starts it again. An existing bond is unaffected — a bonded pad connects and drives with the whole
+stack up — so the cost is one daemon being down for the length of a pairing.
 
-**Drop it once you know the board is fine.** On a board that bonds a pad under the defaults, the flag
-buys nothing and costs something real: `Privacy = device` means a pad cannot form a *new* bond while
-`btd` advertises, so `robotctl pad pair` has to stop `btd` and power-cycle the adapter for every
-pairing. To find out, and to undo it:
+It is the default here because a board that needed it and was provisioned without it presents as a
+gamepad that will not pair, and every plausible cause you chase first is somewhere else.
+
+### The three configurations, and how to tell which you have
+
+There are two independent faults, so there are two flags. **Pair a pad and read the failure**, then
+pick:
+
+| what you see | what the board wants |
+|---|---|
+| the pad bonds and drives | nothing — provision with no flag |
+| the pad will not bond; the last SMP step never completes | `--pause-btd-on-pair` |
+| the pad will not bond even with `btd` paused | `--weird-ble` (implies the pause, and adds `Privacy = device`) |
+| the pad bonds, then **flaps** — `PIN or Key Missing (0x06)`, no input device | `--weird-ble` is wrong for this board: drop it, keep the pause |
+
+That last row is the one to watch for. `Privacy = device` on a board that only needed the pause
+produces a bond that immediately stops working, which is harder to diagnose than a pad that plainly
+will not pair — measured on `50:37:CD:16:1D:90`, where `off` plus the pause bonds and holds while
+`device` flaps 46 times in 45 seconds. `--weird-ble` is therefore **not** the default any more.
+
+To move a board from `--weird-ble` to the pause alone, keeping the marker:
 
 ```bash
-sudo rm /var/lib/robot/weird-ble
+sudo sed -i 's/^Privacy = device/Privacy = off/' /etc/bluetooth/main.conf && sudo reboot
 ```
 
-```bash
-sudo sed -i '/^Privacy = device/d' /etc/bluetooth/main.conf && sudo reboot
-```
-
-Then pair a pad. If it bonds, that board never needed the flag — provision it without one next time.
-If it does not, put both back with the copy of the script provisioning leaves on the board:
+To go the other way, with the copy of the script provisioning leaves on the board:
 
 ```bash
 sudo DUCK_WEIRD_BLE=1 /usr/local/sbin/robot-setup-board && sudo reboot
 ```
 
-Both are workarounds for the aic8800 radio, not properties of the design; they go when the radio
-does. [`pair-a-gamepad.md`](pair-a-gamepad.md) has the detail.
+And to check a board needs neither, drop both and pair a pad:
+
+```bash
+sudo rm /var/lib/robot/weird-ble
+sudo sed -i '/^Privacy = /d' /etc/bluetooth/main.conf && sudo reboot
+```
+
+Re-pair after any change to `Privacy`: it changes the address the stored keys were derived against,
+so existing bonds stop matching and flap with `PIN or Key Missing` until they are re-made.
+
+All of this is a workaround for the aic8800 radio, not a property of the design; it goes when the
+radio does. [`pair-a-gamepad.md`](pair-a-gamepad.md) has the detail.
 
 It is a **viewer**, not the thing doing the work — provisioning installs a systemd unit that
 resumes at boot, so the board finishes whether or not you are still watching. Ctrl-C costs you

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -78,19 +78,27 @@ it in pairing mode alone does not reliably do so.
 
 ## When a pad will not bond at all
 
-Some Radxa Zero 3W units cannot bond a gamepad under BlueZ's default settings — roughly half of ten,
-with nothing measurable to tell them apart from the ones that can. Re-provision such a board with
-`--weird-ble`:
+On the aic8800 radio a pad cannot form a **new** bond while `btd` is advertising. Re-provision such a
+board with `--pause-btd-on-pair`:
 
 ```bash
-./scripts/provision-board.sh --weird-ble pierre@192.168.1.42
+./scripts/provision-board.sh --pause-btd-on-pair pierre@192.168.1.42
 ```
 
-That sets `Privacy = device`, which those boards need, and leaves a marker at
-`/var/lib/robot/weird-ble`. On a board with that marker, `sudo robotctl pad pair` handles the rest by
-itself — it stops `btd`, power-cycles the adapter, pairs, and starts `btd` again. It says so as it
-goes. An existing bond is unaffected by any of this, so a paired pad connects and drives with
-everything running.
+That leaves a marker at `/var/lib/robot/weird-ble` and changes nothing else. On a board with that
+marker, `sudo robotctl pad pair` handles the rest by itself — it stops `btd`, power-cycles the
+adapter, pairs, and starts `btd` again. It says so as it goes. An existing bond is unaffected by any
+of this, so a paired pad connects and drives with everything running.
+
+Some units additionally cannot bond under BlueZ's default `Privacy = off` at all, even with `btd`
+paused. Those want `--weird-ble`, which implies the pause and also sets `Privacy = device`.
+
+**Try the pause first.** `Privacy = device` on a board that only needed the pause produces a worse
+failure than no flag at all: the pad bonds and then flaps with
+`Encryption Change: PIN or Key Missing (0x06)`, never creating an input device. If you see that, drop
+`--weird-ble` and keep the pause —
+[`install-dev.md`](install-dev.md#the-three-configurations-and-how-to-tell-which-you-have) has the
+table and the commands to move a board between the two.
 
 Pairing by hand on such a board needs the same two steps:
 

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -559,6 +559,23 @@ if [ -e /var/lib/robot/weird-ble ]; then
 fi
 echo "    [ok] without --weird-ble, setup-board leaves Privacy and the marker alone"
 
+# --pause-btd-on-pair alone: the marker, and Privacy left at the BlueZ default. That is the
+# combination a board wants when a pad pairs and then flaps -- measured on 50:37:CD:16:1D:90, where
+# off plus the pause bonds and holds 45/45 while device flaps with PIN or Key Missing.
+DUCK_PAUSE_BTD=1 ONNX_VERSION=9.9.9 PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh \
+    > /tmp/pause.log 2>&1
+test -f /var/lib/robot/weird-ble \
+    || { echo "    [FAIL] --pause-btd-on-pair did not write the marker"; exit 1; }
+if grep -qE "^[[:space:]]*Privacy[[:space:]]*=" /etc/bluetooth/main.conf; then
+    echo "    [FAIL] --pause-btd-on-pair set Privacy; it must not"
+    exit 1
+fi
+echo "    [ok] --pause-btd-on-pair writes the marker and leaves Privacy alone"
+
+# Removed again so the --weird-ble cases below still prove that THEY write the marker, rather than
+# passing on one this case left behind.
+rm -f /var/lib/robot/weird-ble
+
 # And with it: the setting, and the marker robotctl reads to decide whether to pause btd.
 DUCK_WEIRD_BLE=1 ONNX_VERSION=9.9.9 PATH="/stub:$PATH" sh /bin/scripts/setup-board.sh \
     > /tmp/weird.log 2>&1
@@ -566,6 +583,8 @@ grep -qE "^Privacy = device$" /etc/bluetooth/main.conf
 echo "    [ok] --weird-ble sets Privacy = device, which is what lets such a board bond a pad"
 test -f /var/lib/robot/weird-ble \
     || { echo "    [FAIL] the weird-ble marker was not written"; exit 1; }
+# --weird-ble implies the pause, so a board provisioned before --pause-btd-on-pair existed keeps
+# behaving exactly as it did.
 test "$(stat -c %a /var/lib/robot/weird-ble)" = "644" \
     || { echo "    [FAIL] the marker is not readable by robotctl"; exit 1; }
 echo "    [ok] --weird-ble leaves the marker robotctl reads, mode 644"

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -37,9 +37,16 @@
 #                     deploy/dev-key/team.dev.pub.
 #   --dev-key PATH    somewhere else to find it.
 #   --no-ble          do not use Bluetooth to re-find the board. See below for what that costs.
-#   --weird-ble       for a Radxa Zero 3W whose Bluetooth cannot bond a gamepad at all. Sets
-#                     `Privacy = device` and leaves /var/lib/robot/weird-ble, which makes
-#                     `robotctl pad pair` stop `btd` and power-cycle the adapter for a pairing.
+#   --pause-btd-on-pair
+#                     for a Radxa Zero 3W that pairs a gamepad only while `btd` is out of the way.
+#                     Leaves /var/lib/robot/weird-ble, which makes `robotctl pad pair` stop `btd`
+#                     and power-cycle the adapter for the pairing window — and **does not touch
+#                     `Privacy`**. This is what a board wants when a pad pairs and then flaps with
+#                     `PIN or Key Missing`: that is `Privacy = device` on a board that needed only
+#                     the pause. Try this before `--weird-ble`.
+#   --weird-ble       for a Radxa Zero 3W whose Bluetooth cannot bond a gamepad at all, even with
+#                     `btd` paused. Implies `--pause-btd-on-pair`, and additionally sets
+#                     `Privacy = device`.
 #                     **The default in docs/robot/install-dev.md**, because about half these
 #                     boards need it and nothing measurable says which — and a board that needed
 #                     it and did not get it presents as a pad that will not pair, for no visible
@@ -98,6 +105,7 @@ NO_DEV_KEY=""
 USE_LOCAL=""
 NO_BLE=""
 WEIRD_BLE=""
+PAUSE_BTD=""
 # The name to give the robot. Not `BLE_NAME` below, which points the other way: the name this board
 # already answers to, used to find it again after the reboot.
 ROBOT_NAME=""
@@ -172,6 +180,7 @@ while [ $# -gt 0 ]; do
         --no-dev-key) NO_DEV_KEY=1; shift ;;
         --no-ble)     NO_BLE=1; shift ;;
         --weird-ble)  WEIRD_BLE=1; shift ;;
+        --pause-btd-on-pair) PAUSE_BTD=1; shift ;;
         --local)      USE_LOCAL=1; shift ;;
         -h|--help)    usage 0 ;;
         -*)           die "unknown option: $1" ;;
@@ -674,6 +683,7 @@ _env="DUCK_TOKEN='${DUCK_TOKEN:-}'"
 [ -z "$REF" ]     || _env="${_env} DUCK_REF='${REF}'"
 [ -z "$DEV_KEY" ] || _env="${_env} DUCK_DEV_KEY=/tmp/team.dev.pub"
 [ -z "$WEIRD_BLE" ] || _env="${_env} DUCK_WEIRD_BLE=1"
+[ -z "$PAUSE_BTD" ]  || _env="${_env} DUCK_PAUSE_BTD=1"
 
 # The name is a flag rather than one more `DUCK_*`, because on the board it goes no further than
 # `robotctl system set-name`. Single-quoted with any quote of its own escaped: a name is free text,

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -48,15 +48,27 @@ CMDLINE="${CMDLINE:-/proc/cmdline}"
 
 BT_CONF=/etc/bluetooth/main.conf
 
-# Does this board need the Bluetooth workarounds? `--weird-ble` on provision-board.sh.
+# Does this board need `Privacy = device`? `--weird-ble` on provision-board.sh.
 #
-# Off by default: most Zero 3W units bond a pad under BlueZ's own default and want nothing from
+# Off by default: some Zero 3W units bond a pad under BlueZ's own default and want nothing from
 # this script. See `configure_bluetooth`.
 WEIRD_BLE="${DUCK_WEIRD_BLE:-}"
+
+# Does `robotctl pad pair` have to pause `btd` on this board? `--pause-btd-on-pair`.
+#
+# Separate from `WEIRD_BLE` because they fix different faults, and a board can need this one
+# without wanting `Privacy = device` — measured, see `configure_bluetooth`. `--weird-ble` implies
+# it, so every board provisioned before this flag existed keeps behaving the same way.
+PAUSE_BTD="${DUCK_PAUSE_BTD:-}"
 
 # Where the answer is left for `robotctl`, which has to pause `btd` while a pad bonds on such a
 # board. Under /var/lib rather than in a release directory: it is a fact about this board and must
 # survive an update and a rollback.
+#
+# The name is now narrower than what it means — it marks "pause btd for a pairing", which is no
+# longer tied to `Privacy = device`. Kept as-is deliberately: `robotctl` reads this exact path, and
+# renaming it would make every board already carrying one stop pausing `btd` with nothing to say
+# why. Rename both together, or neither.
 WEIRD_BLE_MARKER=/var/lib/robot/weird-ble
 
 # A gamepad is paired with `sudo robotctl pad pair` on the installed release, with the pad held in
@@ -430,26 +442,63 @@ free_motor_port() {
 # pairing reaching the last SMP step and the pad answering `DHKey check failed (0x0b)`. That was
 # `device` with `btd` running — the interaction above, not evidence against the setting.
 #
-# Both are workarounds for the aic8800 radio, which is not what ships. When the radio changes, this
-# flag and `BtdPaused` in robotctl/src/main.rs both go.
+# ## Two faults, two flags
+#
+# `--weird-ble` used to do both halves of the workaround at once, and on `50:37:CD:16:1D:90` that
+# combination cannot be made to work. Measured there on 2026-08-19, one variable at a time, daemon
+# 0.6.0 throughout:
+#
+#   | Privacy | btd paused for the pairing | result                                          |
+#   |---------|----------------------------|-------------------------------------------------|
+#   | off     | no                         | pairing dies ~800us after Encryption Change     |
+#   |         |                            | with Remote User Terminated (0x13)              |
+#   | off     | YES                        | bonds, held 45/45 samples, real input, driving   |
+#   | device  | yes                        | bonds, then flaps: 46x PIN or Key Missing (0x06) |
+#
+# So the two halves fix different faults and are not a package:
+#
+#   - **`btd` advertising breaks a NEW bond.** Pausing it for the pairing window fixes that, and it
+#     is what makes the aic8800 driver build irrelevant — every earlier failure blamed on the driver
+#     had `btd` advertising, which was the uncontrolled variable.
+#   - **`Privacy = device` breaks RECONNECTION** on a board that does not need it. A clean bond then
+#     flaps with `PIN or Key Missing`, on either driver build, whether or not the bond was made under
+#     `device`. On such a board the flag is not merely unnecessary, it is harmful — and it fails in a
+#     worse way than not pairing at all, because it looks like it worked.
+#
+# Hence `--pause-btd-on-pair` for the first alone. `--weird-ble` still implies it, so nothing that
+# was provisioned before this behaves differently. A board that pairs with the pause and `off` wants
+# the new flag; a board that cannot bond under `off` at all still wants `--weird-ble`.
+#
+# Both are workarounds for the aic8800 radio, which is not what ships. When the radio changes, both
+# flags and `BtdPaused` in robotctl/src/main.rs all go.
 #
 # The change sets `needs_reboot` rather than restarting bluetooth. Restarting the daemon here leaves
 # the kernel holding hci0 while bluetoothd reports "No default controller available", which needs a
 # reboot to clear.
 configure_bluetooth() {
-    if [ -z "$WEIRD_BLE" ]; then
-        # Reported rather than silent, because a board that needs the workaround and was provisioned
-        # without the flag presents as a pad that will not pair for no visible reason.
-        say "leaving bluetooth Privacy alone (no --weird-ble); a pad that will not bond may need it"
-        # The marker is deliberately *not* removed here. Without the flag this function changes
+    if [ -z "$WEIRD_BLE" ] && [ -z "$PAUSE_BTD" ]; then
+        # Reported rather than silent, because a board that needs either workaround and was
+        # provisioned without the flag presents as a pad that will not pair for no visible reason.
+        say "leaving bluetooth alone (no --weird-ble, no --pause-btd-on-pair)"
+        say "  a pad that pairs and then flaps wants neither; one that will not pair wants one"
+        # The marker is deliberately *not* removed here. Without a flag this function changes
         # nothing, so a board that has `Privacy = device` still has it — and clearing the marker
         # would leave `robotctl` no longer pausing `btd` on a board that still needs it, which is
-        # the silent version of the bug this whole flag exists for. Undoing it is a hand edit.
+        # the silent version of the bug these flags exist for. Undoing it is a hand edit.
         return 0
     fi
 
     if [ ! -f "$BT_CONF" ]; then
         warn "no ${BT_CONF}; skipping the gamepad Bluetooth settings"
+        return 0
+    fi
+
+    # The marker alone, for a board that pairs under `off` once `btd` is out of the way. Returns
+    # before touching `Privacy`, which is the whole point of the flag: on such a board `device` is
+    # what breaks it.
+    if [ -z "$WEIRD_BLE" ]; then
+        write_pause_marker
+        say "left Privacy alone (--pause-btd-on-pair without --weird-ble)"
         return 0
     fi
 
@@ -468,23 +517,36 @@ configure_bluetooth() {
     fi
 
     # Written after the setting, so the marker never claims a board is configured that is not.
+    write_pause_marker
+}
+
+# The marker `robotctl` reads to decide whether to pause `btd` for a pairing.
+#
+# Its own function because both flags write it and only one of them touches `Privacy` — which is the
+# distinction this whole section exists to make.
+write_pause_marker() {
     if [ -f "$WEIRD_BLE_MARKER" ]; then
-        say "weird-ble marker already at ${WEIRD_BLE_MARKER}"
-    else
-        mkdir -p "$(dirname "$WEIRD_BLE_MARKER")"
-        cat > "$WEIRD_BLE_MARKER" <<'MARKER'
-# This board was provisioned with --weird-ble.
-#
-# Its Bluetooth cannot bond a gamepad under BlueZ's default Privacy = off, so
-# /etc/bluetooth/main.conf sets Privacy = device. Under that setting a pad cannot form a new bond
-# while btd advertises, so `robotctl pad pair` stops btd for the pairing window and starts it again.
-#
-# Both are workarounds for the aic8800 radio. Delete this file, unset Privacy, and drop BtdPaused
-# from robotctl when the radio changes.
-MARKER
-        chmod 644 "$WEIRD_BLE_MARKER"
-        say "wrote ${WEIRD_BLE_MARKER} so robotctl pauses btd while a pad bonds"
+        say "btd-pause marker already at ${WEIRD_BLE_MARKER}"
+        return 0
     fi
+    mkdir -p "$(dirname "$WEIRD_BLE_MARKER")"
+    cat > "$WEIRD_BLE_MARKER" <<'MARKER'
+# This board needs btd paused while a gamepad bonds.
+#
+# On the aic8800 radio a pad cannot form a NEW bond while btd advertises, so `robotctl pad pair`
+# stops btd for the pairing window, power-cycles the adapter, and starts btd again afterwards. An
+# existing bond is unaffected: a bonded pad connects and drives with the whole stack up.
+#
+# This says nothing about Privacy. A board provisioned with --pause-btd-on-pair keeps BlueZ's
+# default (off); one provisioned with --weird-ble also has Privacy = device because it cannot bond
+# under off at all. Setting device on a board that did not need it makes a bond flap with
+# `PIN or Key Missing` instead, so the two are deliberately separate.
+#
+# A workaround for a radio that is not what ships. Delete this file and drop BtdPaused from
+# robotctl when the radio changes.
+MARKER
+    chmod 644 "$WEIRD_BLE_MARKER"
+    say "wrote ${WEIRD_BLE_MARKER} so robotctl pauses btd while a pad bonds"
 }
 
 # What the board looks like now. Printed whether or not anything was changed, because "is
@@ -504,17 +566,28 @@ report() {
   will not drive anything."
     fi
 
-    # Gamepad readiness. This board's part of it is one setting; who may read the pad is
+    # Gamepad readiness. This board's part of it is two independent settings; who may read the pad is
     # `padd.service`'s business now, and pairing one is `sudo robotctl pad pair`.
+    #
+    # Both are reported, because the pair of them is what says which of the three configurations a
+    # board is in — and the advice for a pad that will not bond depends on which one is missing.
+    if [ -f "$WEIRD_BLE_MARKER" ]; then
+        printf '  %-22s %s\n' "btd on pairing" "paused — the marker is set"
+    else
+        printf '  %-22s %s\n' "btd on pairing" \
+            "not paused — a pad that will not bond wants --pause-btd-on-pair"
+    fi
+
     if [ -f "$BT_CONF" ] && grep -Eq '^[[:space:]]*Privacy[[:space:]]*=[[:space:]]*device' "$BT_CONF"; then
-        # Worth naming the consequence every time: this is the board where `robotctl pad pair` stops
-        # btd for the pairing window, and someone reading this should know that is expected.
-        printf '  %-22s %s\n' "bluetooth privacy" "device — pad pair pauses btd"
+        # Worth naming the consequence every time: `device` is what makes a bond flap on a board
+        # that only needed the pause, and that failure looks like success at first.
+        printf '  %-22s %s\n' "bluetooth privacy" \
+            "device — drop --weird-ble if a bond flaps with PIN or Key Missing"
     else
         # Covers both `off` and absent, which behave the same. Named as a possible cause rather than
-        # a fault: most boards bond a pad exactly like this.
+        # a fault: with btd paused, most boards bond a pad exactly like this.
         printf '  %-22s %s\n' "bluetooth privacy" \
-            "off — if a pad will not bond, re-provision with --weird-ble"
+            "off — if a pad will not bond even with btd paused, try --weird-ble"
     fi
 
     # The device node is what gilrs opens, so this is the only claim that matters.


### PR DESCRIPTION
`--weird-ble` does two things at once, and on 50:37:CD:16:1D:90 that combination cannot be made to work. Measured there on 2026-08-19, one variable at a time, daemon 0.6.0 throughout:

    Privacy   btd paused   result
    off       no           pairing dies ~800us after Encryption Change,
                           Remote User Terminated (0x13)
    off       YES          bonds, held 45/45 samples, real input, driving
    device    yes          bonds, then flaps: 46x PIN or Key Missing (0x06)

So the two halves fix different faults and are not a package:

  - btd advertising breaks a NEW bond. Pausing it for the pairing window fixes that — and it is what makes the aic8800 driver build irrelevant. Every earlier failure blamed on the driver had btd advertising, which was the uncontrolled variable; the same board bonds and holds on the stock 5.0 build once btd is paused.
  - Privacy = device breaks RECONNECTION on a board that does not need it. A clean bond then flaps with PIN or Key Missing, on either driver build, whether or not the bond was made under device. On such a board the flag is not merely unnecessary but harmful, and it fails in a worse way than not pairing at all, because it looks like it worked.

Hence `--pause-btd-on-pair` for the first half alone. `--weird-ble` still implies it, so nothing provisioned before this behaves differently.

The marker is now written by `write_pause_marker`, called from both paths, because only one of them touches Privacy — which is the whole distinction. Its path is unchanged: robotctl reads that exact string, and renaming it would make every board already carrying one stop pausing btd with nothing to say why. The name is now narrower than its meaning, and says so.

`report` names both settings rather than only Privacy, because the pair of them is what says which of the three configurations a board is in — and the advice for a pad that will not bond depends on which half is missing. The old line sent everyone to --weird-ble, which is the wrong answer for a board that flaps.

install-dev.md drops `--weird-ble` from the recommended command in favour of the pause, and gains a table mapping the failure you actually see to the flag that board wants — including the flapping row, which is the one that sends people chasing the wrong thing. pair-a-gamepad.md now leads with the pause too.

Verified: the two functions exercised against fixtures over six cases (neither flag, pause alone, pause over an existing Privacy = off, weird-ble from unset, weird-ble correcting off, weird-ble with no [General]) — 14 assertions, and in particular that the pause never rewrites Privacy. Then on hardware: with the marker removed first so the write path ran, `DUCK_PAUSE_BTD=1` wrote the marker mode 644, printed "left Privacy alone", and left main.conf byte-identical to a pre-run backup. board-test.sh gains the pause-only case; note CI lints that script but does not run it.