### PR TITLE
Audio review fixes: the ride's two exits, and a mic that backs off

### DIFF
--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -207,7 +207,8 @@ robotctl quack
 
 The loudest way to tell ducks apart: every robot's voice bank is generated from its SoC
 serial (`sounds ensure-bank`, run by every release install), so the robot that answers — in
-a voice that is only its own — is the one you're SSH'd into. The robot also greets when
+a voice that is only its own — is the one you're SSH'd into. A robot with no voice — audio
+off, or no bank — says so instead of printing 🦆, so silence always means the wrong duck. The robot also greets when
 `robotd` comes up, pecks goodbye before powering off, and coos when the mic hears its head
 being scratched (walk mode; the classifier ships in the release). Audio hardware bring-up —
 codec driver, overlays, mixer — is `setup-board.sh`'s audio section, once per board.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -293,7 +293,14 @@ pub mod method {
     pub const ROBOT_MOUTH: &str = "robot.mouth";
     /// Play one of the robot's voice-bank sounds — chirp, greet, coo... `wheee` is the
     /// held ride: `hold: true` starts it and must keep arriving (a notification per tick,
-    /// like the mouth) or the ride ends; `hold: false` releases it deliberately.
+    /// like the mouth) or the ride ends; `hold: false` releases it deliberately. The two
+    /// endings differ: a deliberate release cuts the ride, a hold that stops arriving plays
+    /// it out through its end segment.
+    ///
+    /// Refused, with a reason, by a robot that has no voice — audio disabled, or no bank
+    /// rendered. Sounds are never refused for circumstance (a chirp out of a fallen robot
+    /// is diagnostics, not danger), but "accepted" from a robot that cannot make a sound
+    /// would make `robotctl quack` lie about which duck answered.
     pub const ROBOT_SOUND: &str = "robot.sound";
     /// Sit down gracefully, then power the machine off. The prototype's Select long-press.
     pub const ROBOT_SHUTDOWN: &str = "robot.shutdown";

--- a/pet-detect/src/worker.rs
+++ b/pet-detect/src/worker.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
@@ -236,6 +237,23 @@ impl PetHandle {
     }
 }
 
+/// Backoff between restarts of a capture that will not stay up: doubling from 250 ms to a
+/// cap. A board where `arecord` exists but the codec does not — `configure_audio` fails soft
+/// at every step, so a failed DKMS build leaves exactly that — makes `arecord` exit
+/// immediately on every spawn. Without a backoff on *that* path (the original only slept
+/// when the `arecord` binary itself was missing) the worker fork/execs as fast as the CPU
+/// allows for the life of the daemon, with a `warn!` per iteration into the journal.
+const RESTART_BACKOFF_MIN: Duration = Duration::from_millis(250);
+const RESTART_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// A capture that ran this long is not the failure this backoff is for; the delay resets.
+const RESTART_HEALTHY: Duration = Duration::from_secs(5);
+
+/// After this many consecutive immediate failures the per-restart line drops to `debug`.
+/// The backoff is at its cap by then and the warning has been said — the worker keeps
+/// trying (a codec that comes back should be heard) but stops narrating it.
+const RESTART_QUIET_AFTER: u32 = 5;
+
 fn worker_loop(
     alsa_device: &str,
     mut detector: PettingDetector,
@@ -244,21 +262,61 @@ fn worker_loop(
     shutdown: &Arc<AtomicBool>,
 ) {
     let mut sentry = SoundSentry::new();
+    let mut failures: u32 = 0;
     while !shutdown.load(Ordering::Acquire) {
+        let started = Instant::now();
         match spawn_arecord(alsa_device) {
             Ok(mut c) => {
                 if let Err(e) = pump(&mut c, &mut detector, &mut sentry, tx, tx_sound, shutdown) {
-                    tracing::warn!(error = %e, "pet worker: restarting arecord");
+                    log_restart(failures, &e.to_string());
                 }
                 let _ = c.kill();
                 let _ = c.wait();
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "pet worker: cannot start arecord — retrying in 1s");
-                thread::sleep(std::time::Duration::from_secs(1));
-            }
+            Err(e) => log_restart(failures, &e.to_string()),
+        }
+        if started.elapsed() >= RESTART_HEALTHY {
+            failures = 0;
+            continue;
+        }
+        failures = failures.saturating_add(1);
+        let backoff = RESTART_BACKOFF_MIN
+            .saturating_mul(1u32 << (failures - 1).min(8))
+            .min(RESTART_BACKOFF_MAX);
+        if failures == RESTART_QUIET_AFTER {
+            tracing::warn!(
+                device = alsa_device,
+                ?backoff,
+                "pet worker: the mic will not stay up — retrying quietly from here"
+            );
+        }
+        // Sliced, because `shutdown()` joins this thread: a 30 s sleep would be 30 s of
+        // robotd not exiting.
+        if !sleep_unless_shutdown(backoff, shutdown) {
+            return;
         }
     }
+}
+
+fn log_restart(failures: u32, error: &str) {
+    if failures < RESTART_QUIET_AFTER {
+        tracing::warn!(error, "pet worker: restarting arecord");
+    } else {
+        tracing::debug!(error, "pet worker: restarting arecord");
+    }
+}
+
+/// Sleep, waking early if shutdown is asked for. `false` means "stop".
+fn sleep_unless_shutdown(total: Duration, shutdown: &Arc<AtomicBool>) -> bool {
+    const SLICE: Duration = Duration::from_millis(100);
+    let deadline = Instant::now() + total;
+    while Instant::now() < deadline {
+        if shutdown.load(Ordering::Acquire) {
+            return false;
+        }
+        thread::sleep(SLICE.min(deadline.saturating_duration_since(Instant::now())));
+    }
+    !shutdown.load(Ordering::Acquire)
 }
 
 fn spawn_arecord(device: &str) -> Result<Child> {
@@ -285,9 +343,6 @@ fn pump(
         .ok_or_else(|| anyhow::anyhow!("arecord stdout missing"))?;
     let mut buf = [0u8; 4096];
     let mut i16_buf: Vec<i16> = Vec::with_capacity(2048);
-    // Persistent petting state (Start..End spans many seconds between events); the sentry
-    // suppresses sound events for the whole session.
-    let mut petting = false;
 
     while !shutdown.load(Ordering::Acquire) {
         let n = stdout.read(&mut buf)?;
@@ -304,16 +359,20 @@ fn pump(
         let samples = i16_to_f32(&i16_buf);
         let (events, _p) = detector.push_samples(&samples)?;
         for ev in events {
-            petting = matches!(ev, PettingEvent::Start);
             if tx.send(ev).is_err() {
                 // Receiver dropped — the daemon is shutting down.
                 return Ok(());
             }
         }
         // Ambient sound events off the same stream, muted while petting (head scratches
-        // are LOUD on this mic) + a short hangover.
+        // are LOUD on this mic) + a short hangover. Read off the detector rather than
+        // tracked here: a Start..End session spans many seconds, and `arecord` can flap
+        // inside one. The detector survives a restart (it is owned by `worker_loop`), so a
+        // local copy would come back `false` mid-session — and no second `Start` would ever
+        // re-arm it, leaving the sentry emitting head-scratch noise as `Voice` events until
+        // the probability finally fell below the exit threshold.
         let mut sounds = Vec::new();
-        sentry.push(&samples, petting, &mut sounds);
+        sentry.push(&samples, detector.is_petting(), &mut sounds);
         for sev in sounds {
             let _ = tx_sound.send(sev);
         }

--- a/robotd/src/intents.rs
+++ b/robotd/src/intents.rs
@@ -83,8 +83,24 @@ const SKILL_ROULADE: u32 = 1 << 4;
 
 /// How fresh a wheee hold must be to still count as held. `padd` re-notifies every tick
 /// (20 ms) while the trigger is down, so anything much older means the client stopped
-/// holding — or stopped existing. Either way the ride lands instead of looping forever.
+/// holding — or stopped existing. The stale hold lands the ride instead of looping forever.
 pub const WHEEE_HOLD_FRESH: Duration = Duration::from_millis(300);
+
+/// What the wheee level says, as the loop consumes it. Three states rather than a bool
+/// because the two ways of *not* being held are different sounds: a client that spells out
+/// `hold: false` wants the ride cut where it stands (the prototype's release), while a hold
+/// that simply stopped arriving wants the ride played out through its end segment — nobody
+/// asked for a cut there, the client just went away. Collapsing them loses the end segment
+/// entirely, since a cut ride's writer only ever sees a broken pipe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WheeeHold {
+    /// A `hold: true` fresh enough to trust.
+    Held,
+    /// A client that is still there and said to stop.
+    Released,
+    /// A hold that went stale — the client stopped re-notifying, or stopped existing.
+    Decayed,
+}
 
 pub struct Intents {
     /// Epoch for every stamp. `Instant` so the clock cannot run backwards under us.
@@ -271,12 +287,18 @@ impl Intents {
         .collect()
     }
 
-    /// The wheee hold as the loop consumes it: held, and only recently enough to trust —
-    /// see [`WHEEE_HOLD_FRESH`].
-    pub fn wheee_held(&self) -> bool {
+    /// The wheee hold as the loop consumes it — see [`WheeeHold`] for why "not held" is
+    /// two answers and not one.
+    pub fn wheee_hold(&self) -> WheeeHold {
         let stamp = self.wheee.load();
-        stamp.value
-            && Duration::from_micros(self.now_us().saturating_sub(stamp.at_us)) < WHEEE_HOLD_FRESH
+        if !stamp.value {
+            return WheeeHold::Released;
+        }
+        if Duration::from_micros(self.now_us().saturating_sub(stamp.at_us)) < WHEEE_HOLD_FRESH {
+            WheeeHold::Held
+        } else {
+            WheeeHold::Decayed
+        }
     }
 
     /// Ask for the sit-then-power-off sequence.
@@ -351,6 +373,39 @@ impl Intents {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The hold's three states, which the ride's two different exits depend on. A `false`
+    /// from a live client and a `true` that went stale must not read the same: one cuts the
+    /// ride, the other plays it out.
+    #[test]
+    fn a_stale_hold_reads_as_decayed_not_released() {
+        use duck_ipc_proto::{SoundParams, SoundTag};
+        let intents = Intents::new();
+        assert_eq!(
+            intents.wheee_hold(),
+            WheeeHold::Released,
+            "nothing has ever held it"
+        );
+
+        intents.request_sound(SoundParams {
+            tag: SoundTag::Wheee,
+            hold: Some(true),
+        });
+        assert_eq!(intents.wheee_hold(), WheeeHold::Held);
+
+        std::thread::sleep(WHEEE_HOLD_FRESH + Duration::from_millis(50));
+        assert_eq!(
+            intents.wheee_hold(),
+            WheeeHold::Decayed,
+            "a client that stopped re-notifying is not a client that released"
+        );
+
+        intents.request_sound(SoundParams {
+            tag: SoundTag::Wheee,
+            hold: Some(false),
+        });
+        assert_eq!(intents.wheee_hold(), WheeeHold::Released);
+    }
 
     /// Before any client has spoken, the twist must already look stale. A robot that comes
     /// up believing it has a live driver would run its deadman timer down from `now`,

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -258,6 +258,12 @@ struct RobotState {
     policy_kick_left: Option<String>,
     policy_kick_right: Option<String>,
     policy_roulade: Option<String>,
+    /// Whether this robot can make a sound at all: audio enabled, and a bank with wavs in
+    /// it. Same job as the `policy_*` fields above — false is "this robot cannot do that",
+    /// which is what lets `dispatch` refuse a `robot.sound` with a reason instead of
+    /// accepting it into silence. Read once at startup, like the policies: the postinstall
+    /// renders the bank and restarts robotd, so a bank cannot appear under a running one.
+    has_voice: bool,
     /// `walk` or `roller` — constant for the life of the process; `robot.mode` reports it.
     mode: &'static str,
     /// Whether a fall preempts anything (`fall_limp` or `fall_recover`). When false —
@@ -314,6 +320,7 @@ impl RobotState {
             policy_kick_left: named_policy(params, |p| p.kick_left.clone()),
             policy_kick_right: named_policy(params, |p| p.kick_right.clone()),
             policy_roulade: named_policy(params, |p| p.roulade.clone()),
+            has_voice: params.audio.enabled && has_any_wav(&params.audio.bank),
             mode: params.policy.mode.as_str(),
             fall_gate: params.safety.fall_limp || params.safety.fall_recover,
             fallen: AtomicBool::new(false),
@@ -1067,7 +1074,7 @@ async fn control_loop<T: RobotIo>(
         && model.exists()
     {
         match pet_detect::worker::PetHandle::spawn(pet_detect::worker::PetConfig {
-            alsa_device: format!("{},0", params.audio.device),
+            alsa_device: params.audio.capture_device(),
             model_path: model.clone(),
             enter_threshold: params.audio.pet_enter_threshold,
             exit_threshold: params.audio.pet_exit_threshold,
@@ -1233,14 +1240,21 @@ async fn control_loop<T: RobotIo>(
             }
         }
 
-        // Sounds: one-shot tags queued by clients, and the wheee hold as a level — held
-        // only while `padd`'s re-notifications stay fresh, so a client that dies mid-ride
-        // leaves a ride that lands instead of looping forever.
+        // Sounds: the wheee hold as a level, then the one-shot tags queued by clients. In
+        // that order, because the ride owns the PCM while it lasts — the one-shots have to
+        // see the ride this tick started (they wait) or the release this tick did (they
+        // play). The hold is held only while `padd`'s re-notifications stay fresh; a client
+        // that dies mid-ride leaves a ride that lands rather than one that loops forever.
         if let Some(voice) = voice.as_mut() {
+            let hold = if powered_off {
+                intents::WheeeHold::Released
+            } else {
+                intents.wheee_hold()
+            };
+            voice.wheee(hold);
             for tag in intents.take_sounds() {
                 voice.play(tag.as_str(), false);
             }
-            voice.wheee(intents.wheee_held() && !powered_off);
 
             // Petting: coo, exactly when the prototype coos — not fallen, no scripted move
             // in flight. The verdict is used bare here (not the armed fall gate): this is a
@@ -1683,6 +1697,21 @@ fn named_policy(
     pick(&policy).as_deref().and_then(file_name)
 }
 
+/// Whether a voice bank has anything to play. One directory walk at startup: the bank is a
+/// tree of per-tag directories, and an empty one (postinstall's `ensure-bank` failed, which
+/// the hook deliberately downgrades to a warning) is exactly the case a `robot.sound` must
+/// not answer "accepted" to.
+fn has_any_wav(bank: &std::path::Path) -> bool {
+    let Ok(tags) = std::fs::read_dir(bank) else {
+        return false;
+    };
+    tags.filter_map(Result::ok).any(|tag| {
+        std::fs::read_dir(tag.path()).is_ok_and(|mut wavs| {
+            wavs.any(|w| w.is_ok_and(|w| w.path().extension().is_some_and(|ext| ext == "wav")))
+        })
+    })
+}
+
 fn limit_name(limit: duck_control::safety::Limit) -> &'static str {
     use duck_control::safety::Limit;
     match limit {
@@ -1983,12 +2012,25 @@ fn dispatch(
             proto::Response::ok(Some(id), &result)
         }
 
-        // A sound is queued for the loop's next tick, and never refused: unlike a skill it
-        // moves nothing, and a chirp out of a fallen robot is diagnostics, not danger. A
-        // robot with audio disabled just stays quiet.
+        // A sound is queued for the loop's next tick. Never refused for *circumstance* —
+        // unlike a skill it moves nothing, and a chirp out of a fallen robot is
+        // diagnostics, not danger — but refused when this robot has no voice at all, the
+        // same way `robot.do` refuses a skill that was never configured.
+        //
+        // That refusal is the whole value of `robotctl quack`: its job is to tell you which
+        // duck you are talking to, and an accepted-then-silent quack inverts the answer —
+        // you hear nothing, conclude you are on the wrong duck, and go looking.
         proto::Call::RobotSound(p) => {
-            intents.request_sound(*p);
-            proto::Response::ok(Some(id), &proto::IntentResult::accepted())
+            let result = if state.has_voice {
+                intents.request_sound(*p);
+                proto::IntentResult::accepted()
+            } else {
+                proto::IntentResult::refused(
+                    "this robot has no voice: audio is disabled, or its bank is empty \
+                     (run `sounds ensure-bank`)",
+                )
+            };
+            proto::Response::ok(Some(id), &result)
         }
 
         // Sit, then power the machine off. Never refused for being inconvenient — a robot
@@ -2355,6 +2397,56 @@ mod tests {
             .result_as()
             .expect("robot.mode must deserialize as ModeResult");
         assert_eq!(mode.mode, "walk");
+    }
+
+    /// `robotctl quack` exists to answer "which duck am I talking to", and it answers by
+    /// making a noise. A robot that cannot make one must say so — accepting the call and
+    /// staying silent inverts the answer, sending whoever asked off to look for a duck they
+    /// were already connected to.
+    #[test]
+    fn robot_sound_is_refused_by_a_robot_with_no_voice() {
+        let intents = Intents::new();
+        let id = || proto::Id::Number(1);
+        let quack = || {
+            proto::Call::RobotSound(proto::SoundParams {
+                tag: proto::SoundTag::Chirp,
+                hold: None,
+            })
+        };
+
+        // Audio off: the robot is quiet by configuration, and says so.
+        let mut params = Params::default();
+        params.audio.enabled = false;
+        let mute = RobotState::new(&params, false, false);
+        let refused: proto::IntentResult = dispatch(&mute, &intents, id(), &quack())
+            .result_as()
+            .unwrap();
+        assert!(!refused.accepted);
+        assert!(refused.reason.is_some(), "a refusal must say why");
+        assert!(intents.take_sounds().is_empty(), "a refusal must not queue");
+
+        // Audio on, but the bank never rendered (`ensure-bank` failed, which the
+        // postinstall downgrades to a warning): same silence, so the same answer.
+        let empty = std::env::temp_dir().join(format!("bank-empty-{}", std::process::id()));
+        std::fs::create_dir_all(&empty).unwrap();
+        let mut params = Params::default();
+        params.audio.bank = empty.clone();
+        let bankless = RobotState::new(&params, false, false);
+        let refused: proto::IntentResult = dispatch(&bankless, &intents, id(), &quack())
+            .result_as()
+            .unwrap();
+        assert!(!refused.accepted, "an empty bank is a robot with no voice");
+
+        // A rendered bank: accepted, and actually queued for the loop to play.
+        std::fs::create_dir_all(empty.join("chirp")).unwrap();
+        std::fs::write(empty.join("chirp/chirp_a.wav"), b"RIFF").unwrap();
+        let voiced = RobotState::new(&params, false, false);
+        let accepted: proto::IntentResult = dispatch(&voiced, &intents, id(), &quack())
+            .result_as()
+            .unwrap();
+        assert!(accepted.accepted);
+        assert_eq!(intents.take_sounds(), vec![proto::SoundTag::Chirp]);
+        std::fs::remove_dir_all(&empty).ok();
     }
 
     /// A skill whose network was never configured is refused at the door with a reason —

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -74,6 +74,19 @@ impl AudioParams {
         self.pet_detect.unwrap_or(mode == Mode::Walk)
     }
 
+    /// The capture PCM for the mic worker: the playback device with subdevice 0. Only
+    /// appended when the operator has not already spelled a subdevice out — `plughw:aic3104`
+    /// in `robotd.toml` is the default and needs it, but the equally natural full spec
+    /// `plughw:aic3104,0` would otherwise become `plughw:aic3104,0,0`, which no card
+    /// answers to. That lands the worker in its restart loop for the life of the daemon.
+    pub fn capture_device(&self) -> String {
+        if self.device.contains(',') {
+            self.device.clone()
+        } else {
+            format!("{},0", self.device)
+        }
+    }
+
     /// The classifier path, or `None` when disabled with the `"none"` sentinel.
     pub fn pet_model_resolved(&self) -> Option<PathBuf> {
         match &self.pet_model {
@@ -518,6 +531,24 @@ mod tests {
         let path = dir.join("robotd.toml");
         std::fs::write(&path, body).unwrap();
         path
+    }
+
+    /// The capture device is derived from the playback one, and the derivation must be
+    /// idempotent: an operator who writes the full ALSA spec gets the device they wrote,
+    /// not one with a second subdevice glued on that no card answers to.
+    #[test]
+    fn the_capture_device_does_not_double_its_subdevice() {
+        let plain = AudioParams {
+            device: "plughw:aic3104".to_owned(),
+            ..AudioParams::default()
+        };
+        assert_eq!(plain.capture_device(), "plughw:aic3104,0");
+
+        let spelled_out = AudioParams {
+            device: "plughw:aic3104,0".to_owned(),
+            ..AudioParams::default()
+        };
+        assert_eq!(spelled_out.capture_device(), "plughw:aic3104,0");
     }
 
     /// An unprovisioned board must still come up. A daemon that refuses to start because a

--- a/robotd/src/sound.rs
+++ b/robotd/src/sound.rs
@@ -8,17 +8,40 @@
 //!    that plays goes through this one struct, owned by the control loop.
 //!  - **The wheee ride streams into a single `aplay`**: start → loop (repeating while held)
 //!    → end, written by a paced thread so the pipe never queues more than ~250 ms — else
-//!    the release would land that late. Cutting the ride kills the child and the writer
-//!    exits on the broken pipe.
+//!    the release would land that late. The ride has *two* exits, and they are not the
+//!    same: a client that says "released" cuts it (kill the child, the writer exits on the
+//!    broken pipe), while a hold that merely went stale lands it — the writer is let out of
+//!    its loop and writes the end segment into a pipe that is still open. Only the second
+//!    one ever plays `wheee_end_*`, which is why [`Ride`] is a state and not a bool.
 //!
 //! Playing is spawning: nothing here blocks the 50 Hz tick except the deliberately blocking
-//! goodbye peck right before power-off, when there is no tick left to miss.
+//! goodbye peck right before power-off, when there is no tick left to miss — and that one is
+//! bounded, because a wedged PCM must not be able to hold up the power-off.
 
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+
+use crate::intents::WheeeHold;
+
+/// How long the blocking goodbye peck may hold up the power-off. The longest bank sound is
+/// well under a second; this is a ceiling on a wedged PCM, not a playback budget.
+const BLOCKING_PLAY_MAX: Duration = Duration::from_millis(1500);
+
+/// What the wheee ride is doing. `Landing` exists because the end segment takes real time
+/// to play and the trigger keeps asking during it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ride {
+    /// No ride. The PCM is free for one-shots.
+    Off,
+    /// The writer thread is streaming start → loop into an open pipe.
+    Riding,
+    /// The writer is on the end segment, or `aplay` is draining it. Reaped when the child
+    /// exits; a fresh press supersedes it.
+    Landing,
+}
 
 /// The player. Constructed once by the control loop; `None`-like when the bank is missing —
 /// every play degrades to a debug line, so a robot without a generated bank (or a codec)
@@ -27,10 +50,13 @@ pub struct Sound {
     bank: PathBuf,
     device: String,
     child: Option<Child>,
-    /// The wheee rider loops while this is true. Shared with the writer thread.
+    /// The wheee rider loops while this is true. Shared with the writer thread; clearing
+    /// it *without* killing the child is what makes the end segment play.
     wheee_held: Arc<AtomicBool>,
-    /// Whether the current child is a wheee ride (a plain sound must not flip the flag).
-    wheee_riding: bool,
+    /// What the ride is doing. Not a bool: a plain sound must not flip it, and "landing"
+    /// (the end segment is being written) has to be told apart from both "riding" and
+    /// "off", or the trigger restarts a ride that is still finishing.
+    ride: Ride,
     /// Bank missing is logged once, not per press.
     warned_missing: bool,
 }
@@ -42,7 +68,7 @@ impl Sound {
             device,
             child: None,
             wheee_held: Arc::new(AtomicBool::new(false)),
-            wheee_riding: false,
+            ride: Ride::Off,
             warned_missing: false,
         }
     }
@@ -67,9 +93,11 @@ impl Sound {
         Some(files.swap_remove(nanos % files.len()))
     }
 
-    fn kill_current(&mut self) {
+    /// Stop whatever is on the PCM, now. The ride's abrupt exit, and what every one-shot
+    /// does to its predecessor.
+    fn stop_child(&mut self) {
         self.wheee_held.store(false, Ordering::Relaxed);
-        self.wheee_riding = false;
+        self.ride = Ride::Off;
         if let Some(mut child) = self.child.take()
             && let Ok(None) = child.try_wait()
         {
@@ -78,10 +106,47 @@ impl Sound {
         }
     }
 
+    /// The ride's *other* exit: let the writer out of its loop but leave the pipe open, so
+    /// it writes the end segment and `aplay` drains it. The child stays parented here and
+    /// is reaped by [`Self::reap_landing`] on a later tick.
+    fn land_ride(&mut self) {
+        self.wheee_held.store(false, Ordering::Relaxed);
+        self.ride = Ride::Landing;
+        if self.child.is_none() {
+            // Nothing to land (the degraded path's one-shot already finished, or never
+            // spawned): the PCM is free again straight away.
+            self.ride = Ride::Off;
+        }
+    }
+
+    /// Free the PCM once a landing ride has actually finished. Called per tick while
+    /// landing, which is the only cadence available — nothing here waits.
+    fn reap_landing(&mut self) {
+        match self.child.as_mut().map(|c| c.try_wait()) {
+            None | Some(Ok(Some(_))) | Some(Err(_)) => {
+                self.child = None;
+                self.ride = Ride::Off;
+            }
+            Some(Ok(None)) => {}
+        }
+    }
+
     /// Play a voice-bank sound, cutting off any still-playing one. `blocking` waits for
     /// playback — used right before poweroff so the goodbye peck is heard.
     pub fn play(&mut self, tag: &str, blocking: bool) {
-        self.kill_current();
+        // A ride owns the single-client PCM for as long as it lasts. Cutting it for a
+        // 200 ms chirp would restart the wheee from its start segment on every press of the
+        // other trigger — and holding both triggers is the expected way to use them, since
+        // either one opens the mouth. The one-shot is dropped, not queued: it is an event,
+        // and an event that arrives during a ride is stale by the time the ride ends.
+        //
+        // The blocking goodbye peck is the exception, and the only one: it is the last
+        // sound this process makes, so it takes the PCM off whatever holds it.
+        if self.ride != Ride::Off && !blocking {
+            tracing::debug!(tag, "sound skipped: the wheee ride has the PCM");
+            return;
+        }
+        self.stop_child();
         let Some(wav) = self.pick(tag) else {
             if !self.warned_missing {
                 self.warned_missing = true;
@@ -100,29 +165,44 @@ impl Sound {
             .stderr(Stdio::null())
             .spawn();
         match child {
-            Ok(mut c) if blocking => {
-                let _ = c.wait();
-            }
+            Ok(mut c) if blocking => wait_bounded(&mut c, BLOCKING_PLAY_MAX),
             Ok(c) => self.child = Some(c),
             Err(e) => tracing::debug!(error = %e, tag, "aplay failed"),
         }
     }
 
-    /// The held ride, level-driven: the loop calls this every tick with "is the trigger
-    /// (freshly) held". The rising edge starts the ride, the falling edge cuts it — the
-    /// prototype's release kills the streaming aplay outright, and the writer thread exits
-    /// on the broken pipe.
-    pub fn wheee(&mut self, held: bool) {
-        if held && !self.wheee_riding {
-            self.start_wheee();
-        } else if !held && self.wheee_riding {
-            self.kill_current();
+    /// The ride, level-driven: the loop calls this every tick with what the wheee hold
+    /// currently says. The rising edge starts it; the two ways of stopping are different
+    /// sounds, which is the whole point of [`WheeeHold`] carrying three states.
+    pub fn wheee(&mut self, hold: WheeeHold) {
+        match hold {
+            // A press during a landing ride supersedes it — `start_wheee` takes the PCM.
+            WheeeHold::Held if self.ride != Ride::Riding => self.start_wheee(),
+            WheeeHold::Held => {}
+            // The client said "released": cut it, as the prototype does.
+            WheeeHold::Released if self.ride != Ride::Off => self.stop_child(),
+            // The hold went stale — the client stopped re-notifying, or stopped existing.
+            // Land the ride rather than chopping it: nobody asked for a cut.
+            WheeeHold::Decayed if self.ride == Ride::Riding => self.land_ride(),
+            WheeeHold::Decayed if self.ride == Ride::Landing => self.reap_landing(),
+            WheeeHold::Released | WheeeHold::Decayed => {}
         }
+    }
+
+    /// A bank with no wheee triads — a half-rendered `ensure-bank`, or a bank from before
+    /// the wheee was segmented. Fall back to the plain one-shot, and *latch the ride
+    /// anyway*: the trigger asks every 20 ms, and without a latch this path would fork,
+    /// exec and kill `aplay` fifty times a second (plus a `read_dir` and three ~110 KB
+    /// reads per tick) for as long as the trigger is down, with nothing audible to show
+    /// for it. Landing it is a no-op — there is no end segment to write.
+    fn degraded_wheee(&mut self) {
+        self.play("wheee", false);
+        self.ride = Ride::Riding;
     }
 
     /// Stream start → loop (while held) → end into one `aplay`, so the loop wraps gap-free.
     fn start_wheee(&mut self) {
-        self.kill_current();
+        self.stop_child();
         let dir = self.bank.join("wheee");
         let mut letters: Vec<String> = std::fs::read_dir(&dir)
             .map(|rd| {
@@ -139,7 +219,7 @@ impl Sound {
             .unwrap_or_default();
         if letters.is_empty() {
             // A bank without triads (or no bank): the one-shot path says what's wrong.
-            self.play("wheee", false);
+            self.degraded_wheee();
             return;
         }
         letters.sort();
@@ -152,7 +232,7 @@ impl Sound {
         let (Some((rate, start_pcm)), Some((_, loop_pcm)), Some((_, end_pcm))) =
             (seg("start"), seg("loop"), seg("end"))
         else {
-            self.play("wheee", false);
+            self.degraded_wheee();
             return;
         };
         let child = Command::new("aplay")
@@ -180,7 +260,7 @@ impl Sound {
             return;
         };
         self.child = Some(child);
-        self.wheee_riding = true;
+        self.ride = Ride::Riding;
         self.wheee_held.store(true, Ordering::Relaxed);
         let held = self.wheee_held.clone();
 
@@ -224,7 +304,8 @@ impl Sound {
                         }
                     }
                 }
-                // Released without being killed (the hold decayed): land the ride.
+                // Out of the loop with the pipe still open: the hold decayed and
+                // `land_ride` cleared the flag without killing us. Play the ride out.
                 for chunk in end_pcm.chunks(CHUNK) {
                     if !send(&mut stdin, chunk) {
                         return;
@@ -233,6 +314,28 @@ impl Sound {
             })
             .ok();
     }
+}
+
+/// Wait for a child, but not forever. The goodbye peck runs with `poweroff()` on the next
+/// line: if the PCM wedges — it is single-client, and the ride this just killed does not
+/// release the device synchronously — an unbounded `wait()` leaves the robot powered on with
+/// its intents already disabled, which is worse than a clipped goodbye.
+fn wait_bounded(child: &mut Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Err(_) => return,
+            Ok(None) if Instant::now() >= deadline => break,
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+    tracing::warn!(
+        ?timeout,
+        "aplay did not finish in time; going on without it"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// Read a PCM wav: (sample_rate, raw S16LE payload). A minimal RIFF chunk walk — enough for
@@ -286,8 +389,55 @@ mod tests {
     fn a_missing_bank_is_silent_not_fatal() {
         let mut sound = Sound::new(PathBuf::from("/nonexistent/bank"), "default".into());
         sound.play("chirp", false);
-        sound.wheee(true);
-        sound.wheee(false);
+        sound.wheee(WheeeHold::Held);
+        sound.wheee(WheeeHold::Released);
         assert!(sound.child.is_none());
+        assert_eq!(sound.ride, Ride::Off);
+    }
+
+    /// A bank whose `wheee/` holds no triads (a half-rendered `ensure-bank`, or a bank from
+    /// before the wheee was segmented) must latch the ride on the fallback. Without the
+    /// latch the trigger re-enters `start_wheee` every 20 ms for as long as it is held —
+    /// a `read_dir` and an `aplay` spawn/kill pair, fifty times a second, silently.
+    #[test]
+    fn a_bank_without_wheee_triads_latches_instead_of_respawning() {
+        let dir = std::env::temp_dir().join(format!("sound-triads-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("wheee")).unwrap();
+        let mut sound = Sound::new(dir.clone(), "null".into());
+
+        sound.wheee(WheeeHold::Held);
+        assert_eq!(sound.ride, Ride::Riding, "the fallback must latch");
+        sound.wheee(WheeeHold::Held);
+        assert_eq!(sound.ride, Ride::Riding, "a held trigger must not re-enter");
+        sound.wheee(WheeeHold::Released);
+        assert_eq!(sound.ride, Ride::Off);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The two exits are different sounds, and only one of them plays `wheee_end_*`: a
+    /// client that says "released" gets the cut, a hold that goes stale gets the landing.
+    /// Both must end at `Off` — a ride that cannot leave `Landing` blocks every one-shot.
+    #[test]
+    fn a_decayed_hold_lands_and_a_release_cuts() {
+        let dir = std::env::temp_dir().join(format!("sound-exits-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("wheee")).unwrap();
+        let mut sound = Sound::new(dir.clone(), "null".into());
+
+        // Decay: land, then reap. No child ever spawned here, so the reap is immediate —
+        // on a real ride it takes as many ticks as the end segment lasts.
+        sound.wheee(WheeeHold::Held);
+        sound.wheee(WheeeHold::Decayed);
+        assert_eq!(
+            sound.ride,
+            Ride::Off,
+            "a landing ride with no child frees the PCM"
+        );
+
+        // Release: cut, straight to Off, and the writer's loop flag is down either way.
+        sound.wheee(WheeeHold::Held);
+        sound.wheee(WheeeHold::Released);
+        assert_eq!(sound.ride, Ride::Off);
+        assert!(!sound.wheee_held.load(Ordering::Relaxed));
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -510,6 +510,15 @@ fetch_repo_file() {
 # Add one word to armbianEnv's overlays= line, preserving order (the codec overlay must
 # come after its bus overlay — it grafts the codec node onto the bus that overlay enables).
 ensure_overlay_word() {
+    # Same guard `configure_overlay` has, for the same reason — and here it matters more:
+    # without it the `echo >>` below *creates* an armbianEnv.txt that never existed, on a
+    # board that boots from something else entirely, and asks for a reboot to load it.
+    if [ ! -f "$ENV_TXT" ]; then
+        warn "no ${ENV_TXT}; not an Armbian image?
+  Load the ${1} overlay by whatever means this image provides, then re-run.
+  Everything else here will still be done."
+        return 0
+    fi
     if ! grep -Eq '^overlays=' "$ENV_TXT"; then
         echo "overlays=$1" >> "$ENV_TXT"
         needs_reboot=1


### PR DESCRIPTION
Review fixes for #121, targeting `audio` rather than `main`. Eight findings, three clusters. `cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean; `cargo test -p robotd -p pet-detect` passes with five new tests. **Not run on hardware** — the ride's landing path and the mic backoff both want a board.

## The wheee ride (3 findings, one root cause)

`kill_current` conflated *stop the child* with *clear the ride state*. It was the only writer of `wheee_held = false`, and it always killed the aplay in the same breath — so the writer thread could only exit on a broken pipe, the `end_pcm` write always hit EPIPE, and the `wheee_end_*.wav` files the bank renders were dead assets. The comment at `sound.rs:227`, the `WHEEE_HOLD_FRESH` doc, and "a dead client leaves a ride that lands" all described something unreachable.

The distinction existed one layer up and was thrown away: `padd` sends an explicit `hold: false` on release, and a client that dies just stops sending. `Intents` collapsed both into one bool. It now answers with `WheeeHold` — `Held` / `Released` / `Decayed` — and `Sound` carries a matching three-state `Ride`:

- **Released** cuts the ride where it stands — the prototype's behaviour, which padd's own comment already claimed.
- **Decayed** clears the writer's flag *without* killing the child, so the end segment goes into a pipe that is still open and the ride plays out. `Landing` is reaped per tick; a fresh press supersedes it.

Two more fell out of the same split:

- **A one-shot mid-ride was inaudible.** `play` killed the ride, the same tick's `wheee` restarted it, and `start_wheee` killed the chirp spawned microseconds earlier. Holding LT and tapping RT — the expected way to use triggers that both open the mouth — gave no quack and a wheee restarting from its start segment on every press. The ride now owns the single-client PCM while it lasts; one-shots are dropped with a debug line (they are events, stale by the time a ride ends), except the blocking goodbye peck.
- **The two `start_wheee` fallbacks returned without latching.** A bank missing one of the three triad files turned a held LT into fifty aplay spawn/kill pairs a second, plus a `read_dir` and three ~110 KB reads per tick, with nothing audible. They latch now.

## The mic (2 findings)

`worker_loop` slept only when `arecord` itself was missing. When it *spawned* and exited immediately — the normal outcome when the capture device does not exist or is busy — `pump` returned EOF and the loop respawned with no delay at all.

That state is reachable on a stock board: audio defaults to enabled, pet-detect resolves to on in walk mode, and the release now ships the model. Any robot that installs this before running `setup-board.sh --ref audio`, or after a soft-failed DKMS build (`configure_audio` explicitly tolerates one), fork/execs arecord as fast as the CPU allows, forever, with one `warn!` per iteration into journald.

Now a capped exponential backoff (250 ms → 30 s) that resets on a capture that stayed up ≥ 5 s, going quiet after five consecutive failures. I did **not** make it give up permanently, as the review suggested: a codec that comes back should be heard, and the flood and the fork storm are both gone with the backoff alone. The sleep is sliced, because `shutdown()` joins this thread.

`pump` also kept its own `petting` bool, re-initialised on every restart while the detector's own state persists. An arecord flap mid-petting left the sentry emitting head-scratch noise as `Voice` events with no second `Start` ever coming to re-arm it. It reads `detector.is_petting()` now.

Related: `format!("{},0", device)` is now `capture_device()`, appending only when no subdevice was spelled out. `plughw:aic3104,0` in robotd.toml became `plughw:aic3104,0,0`, which no card answers to — and which landed straight in the restart loop above.

## The rest (3 findings)

- **The goodbye peck's `wait()` was unbounded**, on the line before `poweroff()`, with intents already disabled. A wedged PCM — single-client, and the ride just killed does not release the device synchronously — meant a robot that never powered off. Bounded to 1.5 s.
- **`robot.sound` answered "accepted" unconditionally**, including from a robot with audio off or an empty bank (postinstall downgrades a failed `ensure-bank` to a warning). That is the one answer `robotctl quack` cannot afford to get wrong: its whole job is telling you which duck you are on, and silence then reads as "wrong duck". It now refuses with a reason when the robot has no voice, the way `robot.do` refuses an unconfigured skill. `robotctl` needed no change — it already handles refusals.
- **`ensure_overlay_word` wrote `$ENV_TXT` without the existence guard its sibling has**, creating a bogus `armbianEnv.txt` containing only `overlays=i2c3-pihat` on any non-Armbian board, and asking for a reboot to load it. Same guard, same wording as `configure_overlay`.

## Not changed

No `API_VERSION` bump — `accepted: false` with a reason was always in the shape of `IntentResult`. Left as noted-only from the review: `Sound::play` reaping the previous child on the next play (bounded at one zombie), and `ensure-bank`'s `remove_dir_all` before `rename` (a narrower window than the half-render it prevents).