### PR TITLE
Limp fall

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -232,13 +232,14 @@ mode = "walk"
 # held in someone's hands does not stay limp forever.
 #
 # The pose ramp then travels the joints back to standing. Its gain is not the limp gain:
-# they have to actually move across the floor. 160 is the softened standing gain. 0.3 s is
-# measured on the robot — anything slower is dead time before the stand-up, since the joints
-# are travelling unloaded rather than lifting the robot.
+# they have to actually move across the floor. 160 is the softened standing gain. 0.6 s was
+# settled on at the robot: a full second is mostly dead time before the stand-up, since the
+# joints travel unloaded rather than lifting the robot, and 0.3 also worked — this keeps
+# some margin over it.
 # limp_fall_still_rate = 1.0
 # limp_fall_still_ms = 200
 # limp_fall_max_ms = 1500
-# limp_fall_pose_ms = 300
+# limp_fall_pose_ms = 600
 # limp_fall_pose_gain = 160
 
 # Sit down gracefully and power the machine off when the battery EMA reaches the empty

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -191,6 +191,60 @@ mode = "walk"
 # `--fall-detect` flag.
 # fall_recover = false
 
+# Land soft, then stand up from a still robot instead of a thrashing one.
+#
+# The standing policy is a good stand-up-er and a bad faller: from a still robot, face down
+# or face up, it gets back on its feet cleanly; out of a dynamic fall it tries and fails and
+# tries again, at walking gain, against the floor, and the motors pay for every attempt.
+#
+# With this on, a fall is taken away from the policy entirely. The moment the robot is seen
+# to be going down — before it lands — the gains drop to `gain_limp` and the joints follow
+# wherever they are pushed, so the robot arrives limp. Once it has stopped moving it is
+# ramped back to the standing pose over `limp_fall_pose_ms`, and only then handed back: what
+# the standing policy sees is a still robot in a known posture, which is the case it is good
+# at. (With `fall_recover` also on, the landed robot goes straight to the recovery rise —
+# its own 0.3 s settle is exactly what just happened, at length.)
+#
+# Independent of `fall_limp`/`fall_recover`, which act on a robot that is already down.
+# This one acts in the second before it gets there. Off by default: it is new, and its
+# failure mode is causing the fall it predicted.
+# limp_fall = false
+
+# When a fall counts as started. This is the whole feature, and both ways of getting it
+# wrong are real: too early and the robot limps out of leans it would have walked off —
+# every false positive is a fall the robot *caused*, strictly worse than a stiff landing —
+# and too late and it lands stiff anyway and the mode bought nothing.
+#
+# The test is not a position, because by the time gravity reaches the `fall_gravity_z`
+# above, the robot is on the floor. It is a projection: projected gravity rotates with the
+# trunk, so its rate is exactly `-(w x g)` from the gyro in the same 12-byte IMU block, and
+# extrapolating that says where gravity will be `limp_fall_lookahead_ms` from now. Trigger
+# when the robot is *already* tilted past `limp_fall_tilt_z` (about 26° — ordinary walking
+# does not reach it, which is what keeps footfalls and shoves out), is still tipping over
+# rather than recovering, and the extrapolation lands past `limp_fall_predict_z`.
+#
+# The debounce is three ticks at 50 Hz: longer than a footfall impulse, short enough to
+# leave most of the fall to limp through. `robotctl monitor` shows gravity live, and the
+# state stream's `safety.limp` and the `limp_fall` / `limp_pose` policy labels are what
+# tuning is read from.
+# limp_fall_tilt_z = -0.90
+# limp_fall_predict_z = -0.5
+# limp_fall_lookahead_ms = 300
+# limp_fall_debounce_ms = 60
+
+# The landing, and what happens after it. The limp ends when the robot has gone still —
+# read from the gyro rather than timed, because a stumble and a fall off a table take very
+# different times to finish — or at `limp_fall_max_ms` whatever the gyro says, so a robot
+# held in someone's hands does not stay limp forever.
+#
+# The pose ramp then travels the joints back to standing. Its gain is not the limp gain:
+# they have to actually move across the floor. 160 is the softened standing gain.
+# limp_fall_still_rate = 1.0
+# limp_fall_still_ms = 200
+# limp_fall_max_ms = 1500
+# limp_fall_pose_ms = 1000
+# limp_fall_pose_gain = 160
+
 # Sit down gracefully and power the machine off when the battery EMA reaches the empty
 # floor (6.6 V — the same value the battery percentage maps to 0%). The EMA moves over
 # ~10 s, so a load sag cannot trip it; reaching 6.6 requires a genuinely spent pack.

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -162,9 +162,14 @@ mode = "walk"
 # nominal_voltage = 7.4
 
 [safety]
-# Fall detection, on projected gravity in the trunk frame. Upright reads about -1.0 on z;
-# a robot on its side reads near 0. Debounced, because the impulse from a firm footfall
-# would otherwise read as a fall — and dropping the robot mid-stride is how you cause one.
+# The fall verdict: is the robot down? On projected gravity in the trunk frame — upright
+# reads about -1.0 on z, a robot on its side reads near 0. Debounced, because the impulse
+# from a firm footfall would otherwise read as a fall.
+#
+# It is a REPORT and nothing else. It shows in `robotctl monitor` and the state stream, and
+# it refuses nothing: a fallen robot can still be enabled, init'd, driven and sent skills,
+# because being down is exactly when someone needs to do those things. What the daemon
+# *does* about a fall is limp_fall, further down, and that runs off its own detector.
 # fall_gravity_z = -0.5
 # fall_debounce_ms = 200
 
@@ -174,22 +179,8 @@ mode = "walk"
 # standing is its safe state. Losing balance is the other event, and it goes limp instead.
 # deadman_ms = 500
 
-# Whether a detected fall preempts anything: hold at gain_limp, refuse init/enable/skills
-# until upright. OFF by default, as the prototype is — a fallen robot keeps being driven
-# and the humans stay in charge; the fall verdict still shows in robotctl monitor either
-# way. fall_recover = true implies this (recovery starts with the limp settle).
-# fall_limp = false
-
-# Gain once fallen (only used when fall_limp/fall_recover arms the gate) — low enough to
-# yield rather than fight the floor.
+# The gain limp-fall yields at — low enough to give way rather than fight the floor.
 # gain_limp = 50
-
-# Stand back up after a fall, on its own: limp 0.3 s so the robot settles, then the
-# standing network drives until the robot has been solidly upright (gravity z < -0.85) for
-# a full second. While this is on, the standing network is RESERVED for recovery and body
-# pose — command magnitude no longer selects it. Off by default, matching the prototype's
-# `--fall-detect` flag.
-# fall_recover = false
 
 # Land soft, then stand up from a still robot instead of a thrashing one.
 #
@@ -202,12 +193,13 @@ mode = "walk"
 # wherever they are pushed, so the robot arrives limp. Once it has stopped moving it is
 # ramped back to the standing pose over `limp_fall_pose_ms`, and only then handed back: what
 # the standing policy sees is a still robot in a known posture, which is the case it is good
-# at. (With `fall_recover` also on, the landed robot goes straight to the recovery rise —
-# its own 0.3 s settle is exactly what just happened, at length.)
+# at. The hand-back is a hand-back and nothing more — with nobody driving, command magnitude
+# selects the standing network, and that is the stand-up.
 #
-# Independent of `fall_limp`/`fall_recover`, which act on a robot that is already down.
-# This one acts in the second before it gets there. Off by default: it is new, and its
-# failure mode is causing the fall it predicted.
+# The only thing the daemon does about a fall. With it off, a fall changes nothing: the
+# policy keeps driving and the humans stay in charge, which is the prototype's behaviour
+# and the default here. Off by default: it is new, and its failure mode is causing the
+# fall it predicted.
 # limp_fall = false
 
 # When a fall counts as started. This is the whole feature, and both ways of getting it

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -176,7 +176,8 @@ mode = "walk"
 # How long the robot goes without a velocity intent before it stops.
 #
 # Stop, not limp: losing contact with a client should leave a biped standing, because
-# standing is its safe state. Losing balance is the other event, and it goes limp instead.
+# standing is its safe state. Losing balance is the other event, and limp_fall below is
+# what answers it — this one only ever zeroes the velocity.
 # deadman_ms = 500
 
 # The gain limp-fall yields at — low enough to give way rather than fight the floor.

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -199,9 +199,10 @@ mode = "walk"
 #
 # The only thing the daemon does about a fall. With it off, a fall changes nothing: the
 # policy keeps driving and the humans stay in charge, which is the prototype's behaviour
-# and the default here. Off by default: it is new, and its failure mode is causing the
-# fall it predicted.
-# limp_fall = false
+# and the default here. ON by default since it was validated on a robot: the whole point is
+# that the fleet lands soft, and a mode every board has to opt into individually is a mode
+# most boards do not have. Set it to false on a robot that needs the old behaviour.
+# limp_fall = true
 
 # When a fall counts as started. This is the whole feature, and both ways of getting it
 # wrong are real: too early and the robot limps out of leans it would have walked off —
@@ -231,11 +232,13 @@ mode = "walk"
 # held in someone's hands does not stay limp forever.
 #
 # The pose ramp then travels the joints back to standing. Its gain is not the limp gain:
-# they have to actually move across the floor. 160 is the softened standing gain.
+# they have to actually move across the floor. 160 is the softened standing gain. 0.3 s is
+# measured on the robot — anything slower is dead time before the stand-up, since the joints
+# are travelling unloaded rather than lifting the robot.
 # limp_fall_still_rate = 1.0
 # limp_fall_still_ms = 200
 # limp_fall_max_ms = 1500
-# limp_fall_pose_ms = 1000
+# limp_fall_pose_ms = 300
 # limp_fall_pose_gain = 160
 
 # Sit down gracefully and power the machine off when the battery EMA reaches the empty

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -363,6 +363,33 @@ still*, because standing is the safe state for a biped. Losing balance makes it 
 events, two responses, written down rather than inferred from whichever got implemented
 first.
 
+#### 5.4.1 Falling is a third event
+
+The fall verdict above answers "is the robot down". That is the right question for
+refusing to enable a robot lying on its side, and the wrong one for softening a landing:
+gravity past `fall_gravity_z` held for 200 ms *is* the robot on the floor, and the window
+worth acting in has closed by then.
+
+So `limp_fall` (off by default) runs a second, separate detector — `duck_control::fall` —
+on the rate rather than the position. Projected gravity rotates with the trunk, so
+`ġ = −ω × g` is exact and comes straight from the gyro in the same 12-byte IMU block;
+extrapolating it over ~0.3 s says where gravity is heading. It fires when the robot is
+already tilted (≈26°), still tipping over rather than recovering, and predicted past the
+fall threshold — debounced three ticks. Differentiating the SFLP quaternion instead would
+add the filter's lag to the one number whose whole value is being early.
+
+What it buys is not the landing itself but the stand-up after it. The standing policy gets
+a still robot in a known posture up cleanly and a thrashing one up only after several
+attempts at walking gain against the floor, which is where the load on the motors comes
+from. So the sequence takes the fall away from the policy: limp at `gain_limp` following
+the joints down, wait for the gyro to go quiet, ramp back to the standing pose over ~1 s,
+hand over. With `fall_recover` also on, that hands straight to its rise — its 0.3 s settle
+is what just happened, at length.
+
+The tuning is the feature, and it is asymmetric: a false positive is a fall the robot
+*caused*, which is worse than the stiff landing it was trying to avoid. The defaults sit
+deliberately on the late side.
+
 ### 5.5 Intents
 
 Two vocabularies — intents in, state out — and JSON-RPC's two message families map onto

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -353,15 +353,19 @@ above it *can* command a motor — the invariant is structural rather than remem
 Three rules, unconditional:
 
 - **Joint clamp** — targets clipped to the model's range every tick, whatever the policy asked.
-- **Fall → limp** — projected gravity in the body frame, debounced (0.2 s in the runtime).
-  In the runtime this is `--fall-detect`, a flag, evaluated inline among the gamepad handling
-  and *skipped while a scripted skill is active*. Here it is always on and preempts anything.
 - **Intent deadman** — if intents stop arriving, velocity goes to zero.
 
 **Stop is not limp**, and the distinction matters: losing comms makes the robot *stand
-still*, because standing is the safe state for a biped. Losing balance makes it limp. Two
-events, two responses, written down rather than inferred from whichever got implemented
-first.
+still*, because standing is the safe state for a biped. Losing balance is a different event
+and this layer does not answer it.
+
+The fall verdict (projected gravity, debounced 0.2 s) lives here and is published, but it
+**gates nothing**: a fallen robot is enabled, init'd, driven and sent skills exactly like an
+upright one. That is deliberate — being on the floor is precisely when someone needs those
+calls to work — and it is what lets the answer to a fall live above this layer with no
+exemption to special-case. Earlier revisions had a `fall_limp` gate and a `fall_recover`
+auto-stand-up here; both were removed, because a safety rule that recovery has to bypass in
+order to work is not one.
 
 #### 5.4.1 Falling is a third event
 
@@ -383,8 +387,8 @@ a still robot in a known posture up cleanly and a thrashing one up only after se
 attempts at walking gain against the floor, which is where the load on the motors comes
 from. So the sequence takes the fall away from the policy: limp at `gain_limp` following
 the joints down, wait for the gyro to go quiet, ramp back to the standing pose over ~1 s,
-hand over. With `fall_recover` also on, that hands straight to its rise — its 0.3 s settle
-is what just happened, at length.
+hand over. The hand-back is nothing more than that — the twist has been held at zero
+throughout, so command magnitude selects the standing network, and that is the stand-up.
 
 The tuning is the feature, and it is asymmetric: a false positive is a fall the robot
 *caused*, which is worse than the stiff landing it was trying to avoid. The defaults sit

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -374,7 +374,8 @@ refusing to enable a robot lying on its side, and the wrong one for softening a 
 gravity past `fall_gravity_z` held for 200 ms *is* the robot on the floor, and the window
 worth acting in has closed by then.
 
-So `limp_fall` (off by default) runs a second, separate detector — `duck_control::fall` —
+So `limp_fall` (on by default since it was validated on a robot) runs a second, separate
+detector — `duck_control::fall` —
 on the rate rather than the position. Projected gravity rotates with the trunk, so
 `ġ = −ω × g` is exact and comes straight from the gyro in the same 12-byte IMU block;
 extrapolating it over ~0.3 s says where gravity is heading. It fires when the robot is

--- a/duck-control/src/fall.rs
+++ b/duck-control/src/fall.rs
@@ -1,0 +1,272 @@
+//! Seeing a fall *start*, rather than confirming one that already finished.
+//!
+//! [`crate::safety::Safety`] has a fall verdict already, and it is the right one for what
+//! it does: projected gravity past `fall_gravity_z` (about 60° from upright) held for
+//! `fall_debounce` (200 ms). By the time that latches the robot is on the floor, or a few
+//! tens of milliseconds from it. That is fine for "refuse to enable a robot lying on its
+//! side" and useless for "drop the gains before it lands" — the whole value of limping is
+//! spent in the window this predictor exists to find.
+//!
+//! So this is a second, deliberately separate detector. It answers a different question —
+//! *is the robot on its way down right now* — and it answers it early enough to act on,
+//! which means it answers on a rate rather than on a position.
+//!
+//! # How
+//!
+//! Projected gravity in the trunk frame rotates with the trunk, so its derivative is
+//! exactly `ġ = −ω × g` for body-frame angular velocity `ω`. Only the z component matters
+//! (that is what the fall threshold reads), which is one multiply-subtract:
+//!
+//! ```text
+//! ġz = −(ωx·gy − ωy·gx)
+//! ```
+//!
+//! No filtering, no differentiation of the quaternion: the gyro is a direct measurement
+//! arriving in the same 12-byte block, and differentiating the SFLP quaternion instead
+//! would add the filter's own lag to the very number whose whole point is to be early.
+//!
+//! Extrapolate that linearly over [`FallPredictor`]'s lookahead and the test is "where
+//! will gravity be a quarter-second from now" — trigger when *that* is past the point of
+//! no return. Three conditions, all required:
+//!
+//!  - **Already tilted** past `tilt_z`. A gyro spike on an upright robot is a footfall, a
+//!    shove that it will absorb, or somebody picking it up. None of those is a fall, and
+//!    a predictor with no position gate calls all three one.
+//!  - **Still tipping over** (`ġz > 0`) — going *down*, not recovering from a lean.
+//!  - **Predicted past `predicted_z`** at the lookahead horizon.
+//!
+//! and then debounced for a few ticks, because one noisy sample must not cost the robot
+//! its gains mid-stride.
+//!
+//! # The tuning is the whole feature
+//!
+//! Too early and the robot limps out of leans it would have walked off — every false
+//! positive is a fall the robot *caused*, which is strictly worse than the fall being
+//! dampened. Too late and it lands stiff and the mode has bought nothing. The defaults sit
+//! deliberately on the late side of that: `tilt_z = -0.90` is about 26° from upright,
+//! which ordinary walking does not reach, and 60 ms of debounce is three ticks at 50 Hz —
+//! longer than any footfall impulse, short enough to leave most of the fall to limp
+//! through.
+
+use std::time::Duration;
+
+use crate::imu::ImuData;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FallPredictorConfig {
+    /// Projected-gravity z the robot must *already* be past before a prediction counts.
+    /// Upright is -1.0; -0.90 is about 26° of tilt.
+    pub tilt_z: f64,
+    /// Where the extrapolation has to reach to count as a fall in progress. The same sense
+    /// as `SafetyConfig::fall_gravity_z`, and by default the same number: "it will be
+    /// what safety calls fallen, in `lookahead`".
+    pub predicted_z: f64,
+    /// How far ahead to extrapolate.
+    pub lookahead: Duration,
+    /// How long the verdict must hold before it fires.
+    pub debounce: Duration,
+}
+
+impl Default for FallPredictorConfig {
+    fn default() -> Self {
+        Self {
+            tilt_z: -0.90,
+            predicted_z: -0.5,
+            lookahead: Duration::from_millis(300),
+            debounce: Duration::from_millis(60),
+        }
+    }
+}
+
+/// Watches the IMU for a fall that has started but not landed.
+///
+/// Edge-triggered: [`Self::observe`] returns `true` on the tick the debounce completes and
+/// then stays `false` until the robot stops looking like it is falling. The caller owns
+/// what to do about it and how long to keep doing it — this only reports the moment.
+#[derive(Debug, Clone)]
+pub struct FallPredictor {
+    config: FallPredictorConfig,
+    /// How long the three conditions have held together. Any tick that fails one resets it.
+    falling_for: Duration,
+    /// Whether the trigger has already been handed out for this fall, so a caller polling
+    /// every tick gets one edge rather than a stream of them.
+    fired: bool,
+}
+
+impl FallPredictor {
+    pub fn new(config: FallPredictorConfig) -> Self {
+        Self {
+            config,
+            falling_for: Duration::ZERO,
+            fired: false,
+        }
+    }
+
+    /// Rate of change of projected-gravity z, per second, from `ġ = −ω × g`.
+    ///
+    /// Positive means the trunk is tipping *away* from upright — gravity z climbing from
+    /// -1 towards 0. Public because it is the number to look at when tuning the
+    /// thresholds against a recording, and it is not otherwise recoverable from outside.
+    pub fn gravity_z_rate(imu: &ImuData) -> f64 {
+        -(imu.gyro[0] * imu.gravity[1] - imu.gyro[1] * imu.gravity[0])
+    }
+
+    /// Where gravity z is heading, `lookahead` from now, at the current rate.
+    pub fn predicted_z(&self, imu: &ImuData) -> f64 {
+        imu.gravity[2] + Self::gravity_z_rate(imu) * self.config.lookahead.as_secs_f64()
+    }
+
+    /// One tick. `true` exactly once per fall, when the debounce completes.
+    pub fn observe(&mut self, imu: &ImuData, dt: Duration) -> bool {
+        let rate = Self::gravity_z_rate(imu);
+        let going_down = imu.gravity[2] > self.config.tilt_z
+            && rate > 0.0
+            && self.predicted_z(imu) > self.config.predicted_z;
+
+        if !going_down {
+            self.falling_for = Duration::ZERO;
+            // Re-arm only once the robot stops looking like it is falling, so the caller
+            // that limped is not handed a second trigger while the first one is still
+            // playing out on the way down.
+            self.fired = false;
+            return false;
+        }
+
+        self.falling_for = self.falling_for.saturating_add(dt);
+        if self.falling_for >= self.config.debounce && !self.fired {
+            self.fired = true;
+            return true;
+        }
+        false
+    }
+
+    /// Forget the accumulated verdict — the caller has taken charge (it is limping, or the
+    /// policy stopped driving), so the next fall must be detected from scratch.
+    pub fn reset(&mut self) {
+        self.falling_for = Duration::ZERO;
+        self.fired = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DT: Duration = Duration::from_millis(20);
+
+    /// Gravity for a trunk pitched `tilt` radians forward, and a pitch rate about y.
+    fn tipping(tilt: f64, pitch_rate: f64) -> ImuData {
+        ImuData {
+            gyro: [0.0, pitch_rate, 0.0],
+            gravity: [tilt.sin(), 0.0, -tilt.cos()],
+            ..ImuData::default()
+        }
+    }
+
+    /// The derivative has to be the real one, or every threshold above it is guesswork.
+    /// Pitching forward at 1 rad/s from 30° must raise gravity z at sin(30°) = 0.5 per
+    /// second — the analytic value, not something close to it.
+    #[test]
+    fn the_rate_is_the_analytic_derivative() {
+        let imu = tipping(std::f64::consts::FRAC_PI_6, 1.0);
+        assert!((FallPredictor::gravity_z_rate(&imu) - 0.5).abs() < 1e-12);
+    }
+
+    /// Tipping the other way reads negative — recovering from a lean must never look like
+    /// a fall, whatever the magnitude of the rate.
+    #[test]
+    fn recovering_from_a_lean_never_fires() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        // Well past the tilt gate, rotating back towards upright, fast.
+        for _ in 0..50 {
+            assert!(!p.observe(&tipping(0.9, -4.0), DT));
+        }
+    }
+
+    /// An upright robot taking a hard footfall: a big gyro transient with no tilt behind
+    /// it. This is the false positive that matters — it happens every step.
+    #[test]
+    fn a_footfall_on_an_upright_robot_never_fires() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        for _ in 0..10 {
+            // 8° of lean, 3 rad/s of impulse. The tilt gate is what refuses this.
+            assert!(!p.observe(&tipping(0.14, 3.0), DT));
+        }
+    }
+
+    /// A real fall: tilted past the gate and rotating over at a rate that puts it on the
+    /// floor. It must fire, and it must fire *once*.
+    #[test]
+    fn a_fall_fires_once_after_the_debounce() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        let falling = tipping(0.6, 3.0);
+        // 34° of tilt clears the -0.90 gate; the extrapolation clears -0.5.
+        assert!(falling.gravity[2] > -0.90);
+        assert!(p.predicted_z(&falling) > -0.5);
+
+        // Debounce is 60 ms — three ticks. The first two must stay quiet.
+        assert!(!p.observe(&falling, DT));
+        assert!(!p.observe(&falling, DT));
+        assert!(p.observe(&falling, DT), "the debounce completes on tick 3");
+        for _ in 0..20 {
+            assert!(!p.observe(&falling, DT), "one edge per fall, not a stream");
+        }
+    }
+
+    /// A tilt that is not going anywhere — the robot held at an angle by hand — is not a
+    /// fall however far it is tipped. Position alone must not trigger this; that verdict
+    /// belongs to `Safety`, on its own thresholds.
+    #[test]
+    fn a_static_tilt_is_not_a_fall() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        for _ in 0..50 {
+            assert!(!p.observe(&tipping(1.2, 0.0), DT));
+        }
+    }
+
+    /// A slow topple that has not committed yet — tilted, tipping, but slowly enough that
+    /// the standing policy has a quarter-second to catch it. Waiting is the right answer:
+    /// limping here would *cause* the fall it is predicting.
+    #[test]
+    fn a_slow_lean_waits() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        // 26° and 0.3 rad/s: predicted z is about -0.86, nowhere near the -0.5 floor.
+        let leaning = tipping(0.46, 0.3);
+        assert!(leaning.gravity[2] > -0.90, "past the tilt gate");
+        for _ in 0..50 {
+            assert!(!p.observe(&leaning, DT));
+        }
+    }
+
+    /// The trigger re-arms only after the robot stops looking like it is falling, so a
+    /// second fall is caught but the tail of the first one is not re-reported.
+    #[test]
+    fn it_rearms_when_the_fall_stops() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        let falling = tipping(0.6, 3.0);
+        for _ in 0..3 {
+            p.observe(&falling, DT);
+        }
+        assert!(!p.observe(&falling, DT), "already fired");
+        // Upright and still: the verdict clears.
+        assert!(!p.observe(&tipping(0.0, 0.0), DT));
+        // And a fresh fall fires again, after its own debounce.
+        assert!(!p.observe(&falling, DT));
+        assert!(!p.observe(&falling, DT));
+        assert!(p.observe(&falling, DT));
+    }
+
+    /// `reset` drops a debounce in progress: the caller took charge, so the next fall is
+    /// detected from scratch rather than completing a count from before.
+    #[test]
+    fn reset_drops_a_debounce_in_progress() {
+        let mut p = FallPredictor::new(FallPredictorConfig::default());
+        let falling = tipping(0.6, 3.0);
+        p.observe(&falling, DT);
+        p.observe(&falling, DT);
+        p.reset();
+        assert!(!p.observe(&falling, DT), "the count restarted");
+        assert!(!p.observe(&falling, DT));
+        assert!(p.observe(&falling, DT));
+    }
+}

--- a/duck-control/src/lib.rs
+++ b/duck-control/src/lib.rs
@@ -8,6 +8,7 @@
 //! seam. Observations, the policy runner and the safety layer arrive with slice 2.
 
 pub mod bus;
+pub mod fall;
 pub mod imu;
 pub mod io;
 pub mod model;

--- a/duck-control/src/safety.rs
+++ b/duck-control/src/safety.rs
@@ -16,15 +16,20 @@
 //!
 //! Plus a deadman on the command itself: if intents stop arriving, the velocity goes to
 //! zero. **Stop is not limp** — losing comms makes the robot *stand still*, because standing
-//! is the safe state for a biped; losing balance makes it yield. Two events, two responses.
+//! is the safe state for a biped; losing balance is a different event, and it is not this
+//! layer's to answer.
 //!
-//! **Fall → limp is a mode, not a rule** ([`SafetyConfig::fall_limp`]), and it ships OFF.
-//! The prototype never limps on a fall — its `--fall-detect` defaults off and doubles as
-//! auto-recovery when on — and a robot that yields the moment gravity misreads a lean is a
-//! robot that keeps sitting down while someone handles it. The fall *verdict* is always
-//! tracked and reported; what changes with the flag is only whether it preempts the
-//! policy. Fall recovery requires the limp (its settle phase), so `robotd` turns this on
-//! whenever `fall_recover` is on.
+//! **The fall verdict is a report, not a rule.** [`Safety::fallen`] is tracked every tick
+//! and published, and it preempts nothing: a fallen robot keeps being driven and the
+//! humans stay in charge. That is the prototype's behaviour, and it is the only one — a
+//! robot that yields the moment gravity misreads a lean is a robot that keeps sitting down
+//! while someone handles it.
+//!
+//! What to *do* about a fall is a control decision, and it lives above this layer:
+//! `robotd`'s limp-fall mode drops the gain and rides the robot down, on
+//! [`crate::fall::FallPredictor`] rather than on this verdict. It commands through `apply`
+//! like anything else, with no exemption and no back door — which is the point of the
+//! write handle living here.
 
 use std::time::Duration;
 
@@ -54,11 +59,10 @@ pub struct SafetyConfig {
     pub deadman: Duration,
     /// Gain while running.
     pub gain_running: u16,
-    /// Gain once fallen. Low enough to yield rather than fight the floor.
+    /// Gain to yield at rather than fight the floor. Nothing here applies it — `robotd`
+    /// commands it during limp-fall — but it lives with the other safety numbers because
+    /// it is one: the gain at which the robot stops pushing back.
     pub gain_limp: u16,
-    /// Whether a fall preempts the policy: hold at `gain_limp` until upright. Off matches
-    /// the prototype, whose `--fall-detect` ships off; the fall verdict reports either way.
-    pub fall_limp: bool,
 }
 
 impl Default for SafetyConfig {
@@ -70,7 +74,6 @@ impl Default for SafetyConfig {
             deadman: Duration::from_millis(500),
             gain_running: 200,
             gain_limp: 50,
-            fall_limp: false,
         }
     }
 }
@@ -85,8 +88,6 @@ pub enum Limit {
     Range,
     /// A target was `NaN` or infinite.
     NotFinite,
-    /// The robot is down; the policy is not driving.
-    Fallen,
 }
 
 /// What safety did with a tick's worth of targets.
@@ -107,10 +108,6 @@ pub struct Safety<T: RobotIo> {
     /// How long gravity has been past the threshold. Reset by any upright sample.
     falling_for: Duration,
     fallen: bool,
-    /// Fall recovery in progress: the caller is deliberately driving a robot that gravity
-    /// still calls fallen — the stand-up policy getting it back on its feet. See
-    /// [`Self::set_recovery`].
-    recovering: bool,
     /// Tracks the last gain written so an unchanged one is not rewritten every tick — that
     /// would be fifteen bus writes per tick for no reason.
     gain: Option<u16>,
@@ -123,7 +120,6 @@ impl<T: RobotIo> Safety<T> {
             config,
             falling_for: Duration::ZERO,
             fallen: false,
-            recovering: false,
             gain: None,
         }
     }
@@ -152,24 +148,6 @@ impl<T: RobotIo> Safety<T> {
 
     pub fn fallen(&self) -> bool {
         self.fallen
-    }
-
-    /// Let the caller drive a robot that gravity still calls fallen — fall recovery.
-    ///
-    /// This is the one deliberate exception to "fall → limp preempts everything", and it is
-    /// part of the safety policy rather than a bypass of it: in fall-recovery mode the loop
-    /// goes limp for the prototype's 0.3 s (this flag off — the ordinary fallen branch),
-    /// then engages the stand-up network with this flag on. While set, [`Self::apply`]
-    /// writes the caller's targets at the caller's gain instead of holding at limp gain.
-    ///
-    /// The caller clears it once the robot has been solidly upright again — and `fallen`
-    /// itself still tracks gravity throughout, so nothing else changes meaning.
-    pub fn set_recovery(&mut self, on: bool) {
-        self.recovering = on;
-    }
-
-    pub fn recovering(&self) -> bool {
-        self.recovering
     }
 
     /// Power the joints, so the positions this writes can actually be held.
@@ -250,9 +228,9 @@ impl<T: RobotIo> Safety<T> {
     ///
     /// `hold` is what to command when the policy must not drive — normally the pose the
     /// robot is already in.
-    /// `running_gain` is what the caller wants while upright — the standing policy runs
-    /// softer than the walking one, and that is a control decision, not a safety one. The
-    /// limp gain is not negotiable and overrides it whenever the robot is down.
+    /// `running_gain` is what the caller wants — the standing policy runs softer than the
+    /// walking one, and limp-fall softer still. All of those are control decisions, not
+    /// safety ones, so they are passed in rather than second-guessed here.
     pub fn apply(
         &mut self,
         targets: [f64; NUM_JOINTS],
@@ -261,18 +239,10 @@ impl<T: RobotIo> Safety<T> {
     ) -> Result<Applied, IoError> {
         let mut applied = Applied::default();
 
-        // A fallen robot yields — when the fall gate is on. It precedes everything else:
-        // whatever the policy computed for a robot it believes is upright is not something
-        // to send to one that is on its side. Two exceptions: the gate itself off (the
-        // prototype's default — the policy keeps driving and the humans stay in charge),
-        // and an active recovery ([`Self::set_recovery`]), where the stand-up network is
-        // deliberately driving a robot gravity still calls fallen.
-        if self.fallen && self.config.fall_limp && !self.recovering {
-            applied.limits.push(Limit::Fallen);
-            self.set_gain(self.config.gain_limp)?;
-            self.io.write(&JointTargets::new(hold))?;
-            return Ok(applied);
-        }
+        // Note what is *not* here: a fall gate. Being down does not stop the caller
+        // driving, because the verdict is a report (see the module docs). What a fall is
+        // worth doing about is decided above, and arrives as ordinary targets and an
+        // ordinary gain.
         self.set_gain(running_gain)?;
 
         // Non-finite is refused, not clamped. Clamping `NaN` silently produces a boundary
@@ -339,18 +309,6 @@ mod tests {
 
     fn safety() -> Safety<FakeIo> {
         Safety::new(FakeIo::at(DEFAULT_POSITION), SafetyConfig::default())
-    }
-
-    /// A safety with the fall gate ON — what `robotd` builds when `fall_limp` or
-    /// `fall_recover` is configured.
-    fn gated() -> Safety<FakeIo> {
-        Safety::new(
-            FakeIo::at(DEFAULT_POSITION),
-            SafetyConfig {
-                fall_limp: true,
-                ..SafetyConfig::default()
-            },
-        )
     }
 
     /// A hard footfall spikes gravity briefly. Treating that as a fall would drop the robot
@@ -455,15 +413,24 @@ mod tests {
         assert_eq!(s.io().last_gain, Some(SafetyConfig::default().gain_running));
     }
 
+    /// **The fall verdict preempts nothing.** It is tracked, it is published, and it does
+    /// not touch the motors: a fallen robot is driven exactly like an upright one, at the
+    /// gain the caller asked for.
+    ///
+    /// This is the contract that lets limp-fall live entirely above this layer — it drops
+    /// the gain by *asking*, through the same `apply` as everything else, with no exemption
+    /// to special-case. A gate here would have to be bypassed for the pose ramp to move a
+    /// robot lying on the floor, and a safety rule with a bypass is not one.
     #[test]
-    fn falling_goes_limp_rather_than_freezing() {
-        let mut s = gated();
+    fn a_fall_does_not_preempt_the_caller() {
+        let mut s = safety();
         for _ in 0..11 {
             s.observe(&on_its_side(), Duration::from_millis(20));
         }
+        assert!(s.fallen(), "the verdict is still tracked");
+
         let mut wanted = DEFAULT_POSITION;
         wanted[0] = 0.9;
-
         let applied = s
             .apply(
                 wanted,
@@ -471,16 +438,30 @@ mod tests {
                 SafetyConfig::default().gain_running,
             )
             .unwrap();
-        assert!(applied.limited_by(Limit::Fallen));
-        assert_eq!(
-            s.io().last_gain,
-            Some(SafetyConfig::default().gain_limp),
-            "a fallen robot must go soft"
-        );
+
+        assert!(applied.limits.is_empty(), "{:?}", applied.limits);
         assert_eq!(
             s.io().last_written.unwrap().positions,
-            DEFAULT_POSITION,
-            "the policy must not drive a fallen robot"
+            wanted,
+            "the caller keeps driving a robot that is down"
+        );
+        assert_eq!(s.io().last_gain, Some(SafetyConfig::default().gain_running));
+    }
+
+    /// The other half: a caller that *wants* to go soft says so, and it goes straight
+    /// through. This is exactly what `robotd` does during limp-fall.
+    #[test]
+    fn a_caller_that_asks_for_the_limp_gain_gets_it() {
+        let mut s = safety();
+        s.observe(&upright(), Duration::from_millis(20));
+        let limp = SafetyConfig::default().gain_limp;
+
+        s.apply(DEFAULT_POSITION, DEFAULT_POSITION, limp).unwrap();
+        assert_eq!(s.io().last_gain, Some(limp));
+        assert_eq!(
+            s.gain(),
+            Some(limp),
+            "and it is reported as what is running"
         );
     }
 
@@ -564,46 +545,6 @@ mod tests {
         assert_eq!(stale.twist, [0.0; 3], "velocity must stop");
         assert_eq!(stale.head, command.head, "head is harmless when stale");
         assert_eq!(limit, Some(Limit::Deadman));
-    }
-
-    /// Recovery is the one sanctioned way to drive a fallen robot: with the flag on, the
-    /// caller's targets and gain go through; with it off, the same tick would have been
-    /// held at limp gain. Both directions matter — the flag must also *stop* working when
-    /// cleared, or fall → limp would be silently dead after the first recovery.
-    #[test]
-    fn recovery_lets_the_caller_drive_a_fallen_robot() {
-        let mut s = gated();
-        for _ in 0..11 {
-            s.observe(&on_its_side(), Duration::from_millis(20));
-        }
-        assert!(s.fallen());
-
-        let mut wanted = DEFAULT_POSITION;
-        wanted[0] = 0.5;
-
-        s.set_recovery(true);
-        let applied = s.apply(wanted, DEFAULT_POSITION, 160).unwrap();
-        assert!(applied.limits.is_empty(), "{:?}", applied.limits);
-        assert_eq!(s.io().last_written.unwrap().positions, wanted);
-        assert_eq!(
-            s.io().last_gain,
-            Some(160),
-            "recovery runs at the caller's gain"
-        );
-
-        s.set_recovery(false);
-        let applied = s
-            .apply(
-                wanted,
-                DEFAULT_POSITION,
-                SafetyConfig::default().gain_running,
-            )
-            .unwrap();
-        assert!(
-            applied.limited_by(Limit::Fallen),
-            "cleared flag must restore limp"
-        );
-        assert_eq!(s.io().last_gain, Some(SafetyConfig::default().gain_limp));
     }
 
     /// The gain is written once per transition, not once per tick. At 50 Hz the naive

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -572,7 +572,7 @@ fn notify(stream: &mut UnixStream, call: &proto::Call) -> std::io::Result<()> {
 /// Send a discrete intent and read its answer.
 ///
 /// Answered, unlike the continuous ones, because "refused, and here is why" is a real
-/// outcome — safety declines to enable a policy on a fallen robot — and a client that
+/// outcome — a skill with no policy loaded, a sound with no bank — and a client that
 /// ignored it would leave the operator wondering why nothing happened.
 fn request(
     stream: &mut UnixStream,

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -303,8 +303,8 @@ enum RobotCommand {
     /// robot with no walking network can still stand — and it is what the gamepad's Start does on
     /// its way to driving, so running this by hand is for the bench rather than the everyday path.
     ///
-    /// Refused on a fallen robot only when `[safety] fall_limp` or `fall_recover` arms the
-    /// fall gate — by default it works whatever gravity says, as the prototype does.
+    /// Works whatever gravity says — a robot lying on the floor is exactly the one that
+    /// needs it, and being down never refuses anything.
     Init {
         #[arg(long)]
         json: bool,

--- a/robotd/src/control.rs
+++ b/robotd/src/control.rs
@@ -9,7 +9,7 @@
 //! ```text
 //! skill windows ← advance / expire (roulade window, kick timer, ground-pick phase, sit↔stand rise)
 //! command      ← the caller's smoothed command, re-encoded for the active skill
-//! net          ← roulade > kick > ground pick > sit/rise > stand-by-magnitude (or forced) > walk
+//! net          ← roulade > kick > ground pick > sit/rise > stand-by-magnitude > walk
 //! action       ← ONNX
 //! targets      ← home pose + action_scale × action
 //! filters      ← optional first-order low-pass on head and legs
@@ -122,7 +122,7 @@ pub struct Step {
     /// Which network drove, as the wire label: `walk`, `stand`, `ground_pick`, `kick_left`,
     /// `kick_right`, `sit`, `rise`.
     pub label: &'static str,
-    /// What the gain should be while upright. Safety still overrides it on a fall.
+    /// What the gain should be for this tick.
     pub gain: u16,
     /// A scripted move is mid-flight — the robot is moving regardless of the twist, so
     /// restarting the daemon now would put it on the floor.
@@ -164,8 +164,6 @@ pub struct Controller {
     /// end of a roll, positive means chain another.
     roulade_chain: f64,
     sit: Sit,
-    /// Drive the standing network regardless of command magnitude — fall recovery.
-    pub force_standing: bool,
 }
 
 impl Controller {
@@ -181,7 +179,6 @@ impl Controller {
             roulade: None,
             roulade_chain: 0.0,
             sit: Sit::Up,
-            force_standing: false,
         }
     }
 
@@ -376,7 +373,7 @@ impl Controller {
                         c.twist = [0.0; 3];
                     }
                     let standing = self.policy.will_stand(c.twist_magnitude())
-                        || ((self.force_standing || body_active) && self.policy.has_standing());
+                        || (body_active && self.policy.has_standing());
                     if standing {
                         (Net::Stand, c, "stand")
                     } else {

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -117,41 +117,17 @@ const COAST_TICKS: u32 = 3;
 /// the very jolt it exists to prevent.
 const RESET_AFTER_PAUSE: Duration = Duration::from_millis(200);
 
-/// Fall recovery (`[safety] fall_recover`): the limp settle before the standing network
-/// engages, the stricter gravity threshold that counts as solidly upright, and how long it
-/// must hold. All three are the prototype's numbers.
-const RECOVERY_LIMP: Duration = Duration::from_millis(300);
-const RECOVERY_UPRIGHT_Z: f64 = -0.85;
-const RECOVERY_UPRIGHT_HOLD: Duration = Duration::from_secs(1);
-
 /// Mean leg-joint deviation from the home pose above which a boot counts as seated —
 /// hips and knees folded far from standing. The prototype's threshold.
 const SEATED_BOOT_RAD: f64 = 0.30;
 
-/// Where fall recovery is in its limp-then-stand sequence.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum Recovery {
-    Idle,
-    /// Settling at limp gain before the stand-up engages.
-    Limp {
-        since: Instant,
-    },
-    /// The standing network is driving a robot gravity may still call fallen.
-    Rising {
-        upright_for: Duration,
-    },
-}
-
 /// Where the limp-fall sequence is (`[safety] limp_fall`).
 ///
-/// A different animal from [`Recovery`], and the two must not be confused. `Recovery` runs
-/// *after* the fall, on the `fallen` verdict, and its 300 ms limp is a settle. This runs
-/// *during* the fall, on [`duck_control::fall::FallPredictor`], and its limp is the point:
-/// the robot has to be soft before it lands, not after.
+/// The daemon's only answer to a fall, and it runs *during* one rather than after it: the
+/// trigger is [`duck_control::fall::FallPredictor`], not the `fallen` verdict, because a
+/// verdict that waits for the robot to be down cannot make it soft before it lands.
 ///
-/// They compose. With both on, this sequence owns the fall and hands a landed, posed robot
-/// straight to `Recovery::Rising` — skipping the settle it has already done at length,
-/// rather than dropping the robot again the moment it was put back into shape.
+/// The verdict is still tracked and published throughout — it just does not gate anything.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum LimpFall {
     Idle,
@@ -365,10 +341,6 @@ struct RobotState {
     has_voice: bool,
     /// `walk` or `roller` — constant for the life of the process; `robot.mode` reports it.
     mode: &'static str,
-    /// Whether a fall preempts anything (`fall_limp` or `fall_recover`). When false —
-    /// the default, the prototype's behaviour — `fallen` is a report, not a wall, and
-    /// none of the `robot.*` calls refuse for it.
-    fall_gate: bool,
     /// Published by the loop so the IPC side can answer without consulting it.
     fallen: AtomicBool,
     /// The policy is driving and has been asked for a non-zero velocity.
@@ -421,7 +393,6 @@ impl RobotState {
             policy_roulade: named_policy(params, |p| p.roulade.clone()),
             has_voice: params.audio.enabled && has_any_wav(&params.audio.bank),
             mode: params.policy.mode.as_str(),
-            fall_gate: params.safety.fall_limp || params.safety.fall_recover,
             fallen: AtomicBool::new(false),
             moving: AtomicBool::new(false),
             homed: AtomicBool::new(false),
@@ -1014,9 +985,6 @@ async fn control_loop<T: RobotIo>(
     poweroff: PowerOff,
 ) {
     let policy_cfg = params.policy.resolved();
-    // Whether a fall preempts anything. Mirrors `RobotState::fall_gate` for the loop's own
-    // gates — with it off, `fallen` is a report in the state stream and nothing more.
-    let fall_gate = params.safety.fall_limp || params.safety.fall_recover;
     let mut safety = Safety::new(
         io,
         SafetyConfig {
@@ -1025,8 +993,6 @@ async fn control_loop<T: RobotIo>(
             deadman: Duration::from_millis(params.safety.deadman_ms),
             gain_running: policy_cfg.gain,
             gain_limp: params.safety.gain_limp,
-            // Recovery cannot work without the limp settle, so it implies the gate.
-            fall_limp: params.safety.fall_limp || params.safety.fall_recover,
         },
     );
 
@@ -1087,10 +1053,10 @@ async fn control_loop<T: RobotIo>(
         };
         match Policy::load(&paths, DEFAULT_STANDING_THRESHOLD) {
             Ok(mut policy) => {
-                // Roller mode has no standing network; fall recovery reserves it for
-                // getting up (and body pose). Either way, command magnitude stops
-                // selecting it.
-                if policy_cfg.mode == Mode::Roller || params.safety.fall_recover {
+                // Roller mode has no standing network — command magnitude stops selecting
+                // it. Nothing else reserves it: limp-fall hands back by *letting* the
+                // standing network be selected, which is what stands the robot up.
+                if policy_cfg.mode == Mode::Roller {
                     policy.set_standing_disabled(true);
                 }
                 tracing::warn!(
@@ -1101,7 +1067,7 @@ async fn control_loop<T: RobotIo>(
                     ground_pick = ?policy_cfg.ground_pick.as_ref().map(|p| p.display().to_string()),
                     kicks = policy_cfg.kick_left.is_some() || policy_cfg.kick_right.is_some(),
                     roulade = ?policy_cfg.roulade.as_ref().map(|p| p.display().to_string()),
-                    fall_recover = params.safety.fall_recover,
+                    limp_fall = params.safety.limp_fall,
                     "policy loaded"
                 );
                 Some(Controller::new(policy, tuning, skills))
@@ -1169,10 +1135,9 @@ async fn control_loop<T: RobotIo>(
     // bus pressure the spasms investigation taught this loop not to add.
     let mut odometry = odometry::Odometry::alpha();
 
-    // The sit-then-power-off sequence, and fall recovery.
+    // The sit-then-power-off sequence.
     let mut shutdown_sit: Option<Instant> = None;
     let mut powered_off = false;
-    let mut recovery = Recovery::Idle;
     let mut warned_imu_warming = false;
 
     // Limp-fall (`[safety] limp_fall`): the predictor that sees a fall start, and where the
@@ -1344,10 +1309,7 @@ async fn control_loop<T: RobotIo>(
         if requests.any() {
             match controller.as_mut() {
                 Some(controller)
-                    if snapshot.enabled
-                        && bringup == Bringup::Ready
-                        && !(fall_gate && safety.fallen())
-                        && shutdown_sit.is_none() =>
+                    if snapshot.enabled && bringup == Bringup::Ready && shutdown_sit.is_none() =>
                 {
                     let outcome = |what: &str, result: Result<(), &'static str>| match result {
                         Ok(()) => tracing::warn!(skill = what, "skill started"),
@@ -1490,9 +1452,8 @@ async fn control_loop<T: RobotIo>(
         //
         // Everything here is off the policy's path by construction: `driving` is false for
         // the whole sequence, so the controller is not stepped and the targets below come
-        // from this block. Recovery is marked in `safety` throughout, because the landing
-        // will latch `fallen` mid-sequence and the armed fall gate would otherwise hold the
-        // robot at limp gain and refuse to let the pose ramp move it.
+        // from this block. Nothing in `safety` needs telling: the fall verdict gates
+        // nothing, so the pose ramp moves a robot lying on the floor like any other tick.
         if params.safety.limp_fall {
             // Abandoned mid-sequence: someone cut the torque, disabled the policy, or the
             // shutdown sit started. Whatever took over owns the robot now — drop out rather
@@ -1507,7 +1468,6 @@ async fn control_loop<T: RobotIo>(
                 tracing::warn!("limp-fall abandoned — something else took the robot");
                 limp_fall = LimpFall::Idle;
                 falling.reset();
-                safety.set_recovery(false);
                 hold = coast.known_positions(hold);
             }
             match limp_fall {
@@ -1515,6 +1475,10 @@ async fn control_loop<T: RobotIo>(
                     // Only on a fresh sample: a coasted one is the same reading twice, and
                     // feeding it to a debounce would let one bad tick count three times.
                     let eligible = was_driving
+                        // Already down. There is no fall left to catch, and this is what
+                        // stops the sequence firing at a robot on the floor working its way
+                        // upright: a stand-up rocks, and a rock is a tilt with a rate on it.
+                        // Limping through that would be an endless limp-pose-retry loop.
                         && !safety.fallen()
                         && shutdown_sit.is_none()
                         && !powered_off
@@ -1534,7 +1498,6 @@ async fn control_loop<T: RobotIo>(
                                     gain = params.safety.gain_limp,
                                     "falling — going limp to land soft"
                                 );
-                                safety.set_recovery(true);
                                 limp_fall = LimpFall::Limp {
                                     since: tick_start,
                                     landing: Landing::default(),
@@ -1585,23 +1548,13 @@ async fn control_loop<T: RobotIo>(
                         limp_fall = LimpFall::Idle;
                         falling.reset();
                         hold = DEFAULT_POSITION;
-                        // Hand a landed, posed robot straight to the recovery rise. Its own
-                        // limp settle is exactly what just happened, at length; running it
-                        // again would drop the robot back out of the pose this phase spent
-                        // a second building.
-                        if params.safety.fall_recover && safety.fallen() {
-                            if let Some(controller) = controller.as_mut() {
-                                controller.force_standing = true;
-                                controller.reset();
-                            }
-                            recovery = Recovery::Rising {
-                                upright_for: Duration::ZERO,
-                            };
-                        } else {
-                            safety.set_recovery(false);
-                            if let Some(controller) = controller.as_mut() {
-                                controller.reset();
-                            }
+                        // Hand back to the policy, and let it choose. The twist has been
+                        // held at zero through the whole sequence, so with nobody driving
+                        // the standing network is what command magnitude selects — which
+                        // is the stand-up. A client that *is* driving gets its walk back;
+                        // the humans stay in charge, here as everywhere else.
+                        if let Some(controller) = controller.as_mut() {
+                            controller.reset();
                         }
                     }
                 }
@@ -1609,77 +1562,11 @@ async fn control_loop<T: RobotIo>(
         }
         let in_limp_fall = limp_fall != LimpFall::Idle;
 
-        // Fall recovery (`[safety] fall_recover`): limp so the robot settles, then the
-        // standing network gets it up, then back to whatever was driving. The prototype's
-        // `--fall-detect`, minus its scripted-move opt-outs — a fall during a kick here
-        // waits for the kick window to lapse (they are half a second) rather than being
-        // ignored outright.
-        if params.safety.fall_recover && controller.is_some() && !powered_off && !in_limp_fall {
-            match recovery {
-                Recovery::Idle => {
-                    if safety.fallen()
-                        && snapshot.enabled
-                        && bringup == Bringup::Ready
-                        && shutdown_sit.is_none()
-                        && controller
-                            .as_ref()
-                            .is_some_and(|c| !c.busy() && !c.is_sitting())
-                    {
-                        tracing::warn!("fallen — limp for 300 ms, then standing recovery");
-                        recovery = Recovery::Limp { since: tick_start };
-                    }
-                }
-                Recovery::Limp { since } => {
-                    if !safety.fallen() {
-                        // Someone righted it during the settle; nothing to recover from.
-                        recovery = Recovery::Idle;
-                    } else if tick_start.duration_since(since) >= RECOVERY_LIMP {
-                        tracing::warn!("limp done — standing policy engaged for recovery");
-                        safety.set_recovery(true);
-                        if let Some(controller) = controller.as_mut() {
-                            controller.force_standing = true;
-                            controller.reset();
-                        }
-                        recovery = Recovery::Rising {
-                            upright_for: Duration::ZERO,
-                        };
-                    }
-                }
-                Recovery::Rising { upright_for } => {
-                    // Hysteresis: solidly upright, stricter than the fall threshold, held
-                    // for a full second — so it does not bounce back to walking mid-standup.
-                    let upright = sensors
-                        .as_ref()
-                        .is_some_and(|s| s.imu.gravity[2] < RECOVERY_UPRIGHT_Z);
-                    let held = if upright {
-                        upright_for + period
-                    } else {
-                        Duration::ZERO
-                    };
-                    if held >= RECOVERY_UPRIGHT_HOLD {
-                        tracing::warn!("upright again — returning to the walking policy");
-                        safety.set_recovery(false);
-                        if let Some(controller) = controller.as_mut() {
-                            controller.force_standing = false;
-                        }
-                        recovery = Recovery::Idle;
-                    } else {
-                        recovery = Recovery::Rising { upright_for: held };
-                    }
-                }
-            }
-        }
-        let in_recovery = matches!(recovery, Recovery::Limp { .. } | Recovery::Rising { .. });
-
-        // Smooth the command. The recovery sequence holds the twist at zero outright — the
-        // prototype does the same — and leaving body-pose mode snaps the body back to
-        // nominal rather than gliding, which is its B-button exit.
-        let twist_target = if in_recovery || in_limp_fall {
-            [0.0; 3]
-        } else {
-            gated.twist
-        };
-        if in_recovery || in_limp_fall {
+        // Smooth the command. The limp-fall sequence holds the twist at zero outright, so
+        // the robot is not handed back mid-command; and leaving body-pose mode snaps the
+        // body back to nominal rather than gliding, which is its B-button exit.
+        let twist_target = if in_limp_fall { [0.0; 3] } else { gated.twist };
+        if in_limp_fall {
             twist_ema = [0.0; 3];
         }
         for (ema, target) in twist_ema.iter_mut().zip(twist_target) {
@@ -1707,10 +1594,8 @@ async fn control_loop<T: RobotIo>(
 
         // Bring the robot up when someone asks it to drive and it has no torque yet.
         //
-        // Gated on the fall only when the fall gate is armed, and there it is not
-        // belt-and-braces: a robot `apply` holds at limp gain is one a ramp cannot stand
-        // up. With the gate off (the default) a fallen robot ramps like any other, which
-        // is the prototype's behaviour.
+        // Not gated on the fall: a fallen robot ramps like any other, as the prototype
+        // does. Being down is a report, and the humans stay in charge.
         //
         // Needs a sample: `from` is where the joints actually are, and starting a ramp from a
         // position nobody read would be the lurch this exists to avoid.
@@ -1718,11 +1603,10 @@ async fn control_loop<T: RobotIo>(
         // joints to run a policy that is disabled or would not load is work towards nothing, and it
         // would make a release whose bundle is broken stand the robot up and then hold. A robot that
         // should stand without a policy is what `robotd init` is for.
-        if let (Bringup::Limp, true, true, false, Some(sensors)) = (
+        if let (Bringup::Limp, true, true, Some(sensors)) = (
             bringup,
             snapshot.enabled,
             controller.is_some(),
-            fall_gate && safety.fallen(),
             sensors.as_ref(),
         ) {
             match safety.set_torque(true) {
@@ -1782,15 +1666,11 @@ async fn control_loop<T: RobotIo>(
         // observation to build, and inventing one would feed the policy a stale robot.
         //
         // And only once the ramp is done, or the policy's first step would come from wherever the
-        // robot was slumped. A fall stops the driving only when the fall gate is armed
-        // (`fall_limp`/`fall_recover`) — by default it does not, as the prototype does not:
-        // the policy keeps driving and the humans stay in charge. Recovery is the armed
-        // gate's one sanctioned exception, marked inside safety itself.
+        // robot was slumped. A fall does not stop the driving, as the prototype does not
+        // stop it: the policy keeps going and the humans stay in charge.
         let driving = snapshot.enabled
             && bringup == Bringup::Ready
             && controller.is_some()
-            && (!(fall_gate && safety.fallen()) || safety.recovering())
-            && !matches!(recovery, Recovery::Limp { .. })
             // The limp-fall sequence owns the robot for its duration: the whole point is
             // that the policy is *not* driving while the robot falls, lands and is posed.
             && !in_limp_fall
@@ -1936,11 +1816,10 @@ async fn control_loop<T: RobotIo>(
                 policy: policy_label.to_owned(),
                 safety: proto::SafetyState {
                     fallen: safety.fallen(),
-                    // Limp means "the robot is actually at limp gain": the armed fall gate
-                    // holding a fallen robot, or the limp-fall sequence riding one down. A
+                    // Limp means "the robot is actually at limp gain" — which now happens
+                    // in exactly one place, the limp-fall sequence riding a fall down. A
                     // bare fall verdict is a report, not a state.
-                    limp: (fall_gate && safety.fallen() && !safety.recovering())
-                        || matches!(limp_fall, LimpFall::Limp { .. }),
+                    limp: matches!(limp_fall, LimpFall::Limp { .. }),
                     gravity: sensors.imu.gravity,
                     gain: safety.gain(),
                 },
@@ -2102,7 +1981,6 @@ fn limit_name(limit: duck_control::safety::Limit) -> &'static str {
         Limit::Deadman => "deadman",
         Limit::Range => "joint_range",
         Limit::NotFinite => "not_finite",
-        Limit::Fallen => "fallen",
     }
 }
 
@@ -2410,10 +2288,11 @@ fn dispatch(
                 proto::Skill::SitToggle => state.policy_sitstand.is_some(),
                 proto::Skill::Roulade => state.policy_roulade.is_some(),
             };
+            // Not refused for being down. A skill on a fallen robot is the human's call,
+            // and refusing it is how a robot ends up unable to do the thing that would
+            // have righted it.
             let result = if !configured {
                 proto::IntentResult::refused("no policy configured for that skill")
-            } else if state.fall_gate && state.fallen.load(Ordering::Relaxed) {
-                proto::IntentResult::refused("the robot is down; stand it up first")
             } else {
                 intents.request_skill(p.skill);
                 proto::IntentResult::accepted()
@@ -2490,16 +2369,18 @@ fn dispatch(
             proto::Response::ok(Some(id), &proto::IntentResult::accepted())
         }
 
-        // Refusing to enable a fallen robot is a normal answer with a reason, not an
-        // error: the client asked something reasonable and safety declined.
+        // A refusal here is a normal answer with a reason, not an error: the client asked
+        // something reasonable and the daemon declined. Gravity is never one of those
+        // reasons — see below.
         proto::Call::RobotEnable(p) => {
             // `toggle` flips the robot's own state — the pad's Start. Evaluated here, not
             // in the client, because a client-side belief drifts (relax, shutdown, either
             // side restarting) and a stale one turns Start into a no-op every other press.
             let on = if p.toggle { !intents.enabled() } else { p.on };
-            let result = if on && state.fall_gate && state.fallen.load(Ordering::Relaxed) {
-                proto::IntentResult::refused("the robot is down; stand it up first")
-            } else {
+            // Never refused for being down. Start on a robot lying on the floor is exactly
+            // how someone asks it to stand back up, and it brings the robot up and hands it
+            // to the standing policy like any other enable.
+            let result = {
                 intents.set_enabled(on);
                 // No init here: stopping is what returns the robot to its home pose (the
                 // loop commands it directly on the disable — the prototype's "returning
@@ -2526,16 +2407,9 @@ fn dispatch(
         // Both only *ask*. The control loop owns the only `RobotIo` handle, so nothing here touches
         // the bus — which is also why `robotd init` needs the daemon stopped and these do not.
         proto::Call::RobotInit => {
-            // Refused only when the fall gate is armed (`fall_limp`/`fall_recover`): there,
-            // `Safety::apply` commands a fallen robot at limp gain and holds it, so a ramp
-            // would be writing a stand-up that cannot happen. With the gate off — the
-            // default — init works whatever gravity says, which is the prototype's
-            // behaviour and what a bench actually needs.
-            let result = if state.fall_gate && state.fallen.load(Ordering::Relaxed) {
-                proto::IntentResult::refused(
-                    "the robot is down and the fall gate is armed. Stand it up first, or drop `fall_limp`/`fall_recover` from robotd.toml",
-                )
-            } else {
+            // Never refused for gravity: init works whatever the robot is lying on, which
+            // is the prototype's behaviour and what a bench actually needs.
+            let result = {
                 intents.request_init();
                 proto::IntentResult::accepted()
             };
@@ -2708,18 +2582,42 @@ mod tests {
         );
     }
 
-    /// Limp-fall ships off, and it is independent of the fall gate: turning it on must not
-    /// silently arm `fall_limp`, which would leave a fallen robot refusing `robot.enable`.
+    /// Limp-fall ships off, and turning it on must not make a fallen robot refuse anything.
+    ///
+    /// This is the contract that answers "I booted it face-down and pressed Start": enable
+    /// and init are never refused for gravity, whatever the mode is set to.
     #[test]
-    fn limp_fall_ships_off_and_arms_nothing_else() {
+    fn limp_fall_ships_off_and_refuses_nothing_when_on() {
         let mut params = Params::default();
         assert!(!params.safety.limp_fall);
         params.safety.limp_fall = true;
+
         let s = RobotState::new(&params, false, false);
+        let intents = Arc::new(Intents::new());
+        let id = || proto::Id::Number(1);
+        s.fallen.store(true, Ordering::Relaxed);
+
+        let enabled: proto::IntentResult = dispatch(
+            &s,
+            &intents,
+            id(),
+            &proto::Call::RobotEnable(proto::EnableParams {
+                on: true,
+                toggle: false,
+            }),
+        )
+        .result_as()
+        .unwrap();
         assert!(
-            !s.fall_gate,
-            "limp_fall is about the fall, not about what happens once the robot is down"
+            enabled.accepted,
+            "Start on a robot lying on the floor is how someone asks it to stand up"
         );
+        assert!(intents.enabled());
+
+        let init: proto::IntentResult = dispatch(&s, &intents, id(), &proto::Call::RobotInit)
+            .result_as()
+            .unwrap();
+        assert!(init.accepted, "nor may init refuse for gravity");
     }
 
     fn state() -> RobotState {
@@ -3045,8 +2943,8 @@ mod tests {
         assert!(!refused.accepted);
         assert!(!intents.take_skills().kick_left, "a refusal must not queue");
 
-        // A fall refuses a skill only when the fall gate is armed. By default it is not —
-        // the prototype never limps on a fall — so `fallen` is a report, not a wall.
+        // A fall never refuses a skill: `fallen` is a report, not a wall. Refusing here is
+        // how a robot ends up unable to do the thing that would have righted it.
         s.fallen.store(true, Ordering::Relaxed);
         let down: proto::IntentResult = dispatch(
             &s,
@@ -3058,29 +2956,8 @@ mod tests {
         )
         .result_as()
         .unwrap();
-        assert!(down.accepted, "with the gate off, fallen must not refuse");
+        assert!(down.accepted, "fallen must not refuse a skill");
         assert!(intents.take_skills().sit_toggle);
-
-        // With `fall_limp` armed, the same call hits the wall — same as robot.enable.
-        let mut params = Params::default();
-        params.safety.fall_limp = true;
-        let gated = RobotState::new(&params, false, false);
-        gated.fallen.store(true, Ordering::Relaxed);
-        let down: proto::IntentResult = dispatch(
-            &gated,
-            &intents,
-            id(),
-            &proto::Call::RobotDo(proto::DoParams {
-                skill: proto::Skill::SitToggle,
-            }),
-        )
-        .result_as()
-        .unwrap();
-        assert!(!down.accepted);
-        assert!(
-            !intents.take_skills().sit_toggle,
-            "a refusal must not queue"
-        );
     }
 
     /// The pose and mouth intents land in their slots like move and head do — including via

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -2582,15 +2582,15 @@ mod tests {
         );
     }
 
-    /// Limp-fall ships off, and turning it on must not make a fallen robot refuse anything.
+    /// Limp-fall ships ON, and it must refuse a fallen robot nothing.
     ///
     /// This is the contract that answers "I booted it face-down and pressed Start": enable
-    /// and init are never refused for gravity, whatever the mode is set to.
+    /// and init are never refused for gravity, whatever the mode is set to. It matters more
+    /// now the mode is a default than it did when it was opt-in — every robot has it.
     #[test]
-    fn limp_fall_ships_off_and_refuses_nothing_when_on() {
-        let mut params = Params::default();
-        assert!(!params.safety.limp_fall);
-        params.safety.limp_fall = true;
+    fn limp_fall_ships_on_and_refuses_nothing() {
+        let params = Params::default();
+        assert!(params.safety.limp_fall, "on by default, fleet-wide");
 
         let s = RobotState::new(&params, false, false);
         let intents = Arc::new(Intents::new());

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -33,6 +33,7 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
 use clap::{Parser, Subcommand};
+use duck_control::fall::{FallPredictor, FallPredictorConfig};
 use duck_control::io::RobotIo;
 use duck_control::obs::{BodyPose, Command as PolicyCommand};
 use duck_control::policy::{DEFAULT_STANDING_THRESHOLD, Policy, PolicyPaths};
@@ -139,6 +140,82 @@ enum Recovery {
     Rising {
         upright_for: Duration,
     },
+}
+
+/// Where the limp-fall sequence is (`[safety] limp_fall`).
+///
+/// A different animal from [`Recovery`], and the two must not be confused. `Recovery` runs
+/// *after* the fall, on the `fallen` verdict, and its 300 ms limp is a settle. This runs
+/// *during* the fall, on [`duck_control::fall::FallPredictor`], and its limp is the point:
+/// the robot has to be soft before it lands, not after.
+///
+/// They compose. With both on, this sequence owns the fall and hands a landed, posed robot
+/// straight to `Recovery::Rising` — skipping the settle it has already done at length,
+/// rather than dropping the robot again the moment it was put back into shape.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum LimpFall {
+    Idle,
+    /// Gains at `gain_limp`, joints commanded to wherever they already are — the softest
+    /// thing the servos can do short of cutting torque, which would drop the head on the
+    /// floor and lose the pose the next phase ramps from.
+    Limp {
+        since: Instant,
+        landing: Landing,
+    },
+    /// Ramping from where the robot landed back to the standing pose, so the standing
+    /// policy starts from the still, known posture it stands up from cleanly.
+    Posing {
+        from: [f64; NUM_JOINTS],
+        since: Instant,
+    },
+}
+
+/// Watching a limping robot for the moment it stops moving.
+///
+/// The end of the limp is read from the gyro rather than timed, because the falls are not
+/// all the same length: a stumble is over in a few hundred milliseconds and a topple off a
+/// table takes most of a second, and ending the limp early is landing stiff after all.
+/// Debounced, because a tumbling robot passes through instants of near-zero rate on its
+/// way over — one quiet sample is not a landing.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+struct Landing {
+    still_for: Duration,
+}
+
+impl Landing {
+    /// One tick. `rate` is the gyro magnitude in rad/s, or `None` for a tick with no fresh
+    /// sample — which resets rather than accumulates: a robot nobody can read is not a
+    /// robot anybody has seen go still.
+    fn observe(&mut self, rate: Option<f64>, period: Duration, below: f64, held: Duration) -> bool {
+        self.still_for = match rate {
+            Some(rate) if rate < below => self.still_for.saturating_add(period),
+            _ => Duration::ZERO,
+        };
+        self.still_for >= held
+    }
+}
+
+impl LimpFall {
+    /// The interpolated pose target for this tick, or `None` once the ramp is done.
+    ///
+    /// The same linear shape as [`Bringup::homing_target`], and separate from it on
+    /// purpose: that ramp is bring-up from limp at the policy gain over a fixed two
+    /// seconds, this one is a landed robot being put back into shape, and both its
+    /// duration and its gain are tunable because both depend on how the robot lands.
+    fn pose_target(&self, now: Instant, over: Duration) -> Option<[f64; NUM_JOINTS]> {
+        let LimpFall::Posing { from, since } = self else {
+            return None;
+        };
+        let t = now.duration_since(*since).as_secs_f64() / over.as_secs_f64();
+        if t >= 1.0 {
+            return None;
+        }
+        let mut target = [0.0; NUM_JOINTS];
+        for (i, slot) in target.iter_mut().enumerate() {
+            *slot = from[i] + (DEFAULT_POSITION[i] - from[i]) * t;
+        }
+        Some(target)
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -1098,6 +1175,22 @@ async fn control_loop<T: RobotIo>(
     let mut recovery = Recovery::Idle;
     let mut warned_imu_warming = false;
 
+    // Limp-fall (`[safety] limp_fall`): the predictor that sees a fall start, and where the
+    // sequence it drives has got to. Built whether or not the mode is on — it costs a
+    // multiply-subtract per tick, and having the numbers computed on every robot is what
+    // makes the thresholds tunable against a recording from a robot that was not running
+    // the mode.
+    let mut falling = FallPredictor::new(FallPredictorConfig {
+        tilt_z: params.safety.limp_fall_tilt_z,
+        predicted_z: params.safety.limp_fall_predict_z,
+        lookahead: Duration::from_millis(params.safety.limp_fall_lookahead_ms),
+        debounce: Duration::from_millis(params.safety.limp_fall_debounce_ms),
+    });
+    let limp_fall_still = Duration::from_millis(params.safety.limp_fall_still_ms);
+    let limp_fall_max = Duration::from_millis(params.safety.limp_fall_max_ms);
+    let limp_fall_pose = Duration::from_millis(params.safety.limp_fall_pose_ms);
+    let mut limp_fall = LimpFall::Idle;
+
     // The voice, and the ear. Both optional equipment: a robot without a codec or a bank
     // walks identically — the player degrades to a debug line, and the mic worker is only
     // spawned when configured, with its own retry loop when arecord flaps.
@@ -1386,12 +1479,142 @@ async fn control_loop<T: RobotIo>(
             poweroff();
         }
 
+        // Limp-fall (`[safety] limp_fall`): catch the fall on the way down.
+        //
+        // The standing policy is a good stand-up-er and a bad faller. It stands a still
+        // robot up cleanly from face-down or face-up; asked to do it out of a dynamic fall
+        // it tries, fails, tries again — at walking gain, against the floor — and the
+        // motors pay for every attempt. So take the fall away from it: go soft before the
+        // landing, let the robot arrive limp, put it back into the standing pose, and only
+        // then hand it over. What the policy then sees is the case it is good at.
+        //
+        // Everything here is off the policy's path by construction: `driving` is false for
+        // the whole sequence, so the controller is not stepped and the targets below come
+        // from this block. Recovery is marked in `safety` throughout, because the landing
+        // will latch `fallen` mid-sequence and the armed fall gate would otherwise hold the
+        // robot at limp gain and refuse to let the pose ramp move it.
+        if params.safety.limp_fall {
+            // Abandoned mid-sequence: someone cut the torque, disabled the policy, or the
+            // shutdown sit started. Whatever took over owns the robot now — drop out rather
+            // than finishing a pose ramp nobody asked for, and hold where the robot is
+            // rather than snapping back to a pose it collapsed out of a second ago.
+            if limp_fall != LimpFall::Idle
+                && !(snapshot.enabled
+                    && bringup == Bringup::Ready
+                    && shutdown_sit.is_none()
+                    && !powered_off)
+            {
+                tracing::warn!("limp-fall abandoned — something else took the robot");
+                limp_fall = LimpFall::Idle;
+                falling.reset();
+                safety.set_recovery(false);
+                hold = coast.known_positions(hold);
+            }
+            match limp_fall {
+                LimpFall::Idle => {
+                    // Only on a fresh sample: a coasted one is the same reading twice, and
+                    // feeding it to a debounce would let one bad tick count three times.
+                    let eligible = was_driving
+                        && !safety.fallen()
+                        && shutdown_sit.is_none()
+                        && !powered_off
+                        // A roulade tips the robot over on purpose, a ground pick pitches it
+                        // forward, and a sit is not a fall. Limping through any of them would
+                        // break a move that was working.
+                        && controller
+                            .as_ref()
+                            .is_some_and(|c| !c.busy() && !c.is_sitting());
+                    match fresh.as_ref() {
+                        Some(fresh) if eligible && safety.imu_ready() => {
+                            if falling.observe(&fresh.imu, period) {
+                                tracing::warn!(
+                                    gravity_z = format!("{:.2}", fresh.imu.gravity[2]),
+                                    rate =
+                                        format!("{:.2}", FallPredictor::gravity_z_rate(&fresh.imu)),
+                                    gain = params.safety.gain_limp,
+                                    "falling — going limp to land soft"
+                                );
+                                safety.set_recovery(true);
+                                limp_fall = LimpFall::Limp {
+                                    since: tick_start,
+                                    landing: Landing::default(),
+                                };
+                            }
+                        }
+                        // Not eligible, or blind for this tick. Drop any debounce in
+                        // progress rather than resuming it later against a robot that has
+                        // moved on.
+                        _ => falling.reset(),
+                    }
+                }
+                LimpFall::Limp { since, mut landing } => {
+                    let rate = fresh
+                        .as_ref()
+                        .map(|s| s.imu.gyro.iter().map(|w| w * w).sum::<f64>().sqrt());
+                    let landed = landing.observe(
+                        rate,
+                        period,
+                        params.safety.limp_fall_still_rate,
+                        limp_fall_still,
+                    );
+                    // Whatever the gyro says: a robot held in someone's hands, or resting
+                    // against something that keeps nudging it, must not stay limp forever.
+                    let timed_out = tick_start.duration_since(since) >= limp_fall_max;
+                    if landed || timed_out {
+                        // From where the robot actually is. `hold` is where it was when
+                        // driving stopped, which is a pose it has since collapsed out of —
+                        // ramping from that would start with a jump.
+                        let from = coast.known_positions(hold);
+                        tracing::warn!(
+                            limp_ms = tick_start.duration_since(since).as_millis(),
+                            timed_out,
+                            pose_ms = limp_fall_pose.as_millis(),
+                            "landed — posing back to standing"
+                        );
+                        limp_fall = LimpFall::Posing {
+                            from,
+                            since: tick_start,
+                        };
+                    } else {
+                        limp_fall = LimpFall::Limp { since, landing };
+                    }
+                }
+                LimpFall::Posing { since, .. } => {
+                    if tick_start.duration_since(since) >= limp_fall_pose {
+                        tracing::warn!("posed — handing back to the standing policy");
+                        limp_fall = LimpFall::Idle;
+                        falling.reset();
+                        hold = DEFAULT_POSITION;
+                        // Hand a landed, posed robot straight to the recovery rise. Its own
+                        // limp settle is exactly what just happened, at length; running it
+                        // again would drop the robot back out of the pose this phase spent
+                        // a second building.
+                        if params.safety.fall_recover && safety.fallen() {
+                            if let Some(controller) = controller.as_mut() {
+                                controller.force_standing = true;
+                                controller.reset();
+                            }
+                            recovery = Recovery::Rising {
+                                upright_for: Duration::ZERO,
+                            };
+                        } else {
+                            safety.set_recovery(false);
+                            if let Some(controller) = controller.as_mut() {
+                                controller.reset();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let in_limp_fall = limp_fall != LimpFall::Idle;
+
         // Fall recovery (`[safety] fall_recover`): limp so the robot settles, then the
         // standing network gets it up, then back to whatever was driving. The prototype's
         // `--fall-detect`, minus its scripted-move opt-outs — a fall during a kick here
         // waits for the kick window to lapse (they are half a second) rather than being
         // ignored outright.
-        if params.safety.fall_recover && controller.is_some() && !powered_off {
+        if params.safety.fall_recover && controller.is_some() && !powered_off && !in_limp_fall {
             match recovery {
                 Recovery::Idle => {
                     if safety.fallen()
@@ -1451,8 +1674,12 @@ async fn control_loop<T: RobotIo>(
         // Smooth the command. The recovery sequence holds the twist at zero outright — the
         // prototype does the same — and leaving body-pose mode snaps the body back to
         // nominal rather than gliding, which is its B-button exit.
-        let twist_target = if in_recovery { [0.0; 3] } else { gated.twist };
-        if in_recovery {
+        let twist_target = if in_recovery || in_limp_fall {
+            [0.0; 3]
+        } else {
+            gated.twist
+        };
+        if in_recovery || in_limp_fall {
             twist_ema = [0.0; 3];
         }
         for (ema, target) in twist_ema.iter_mut().zip(twist_target) {
@@ -1564,6 +1791,9 @@ async fn control_loop<T: RobotIo>(
             && controller.is_some()
             && (!(fall_gate && safety.fallen()) || safety.recovering())
             && !matches!(recovery, Recovery::Limp { .. })
+            // The limp-fall sequence owns the robot for its duration: the whole point is
+            // that the policy is *not* driving while the robot falls, lands and is posed.
+            && !in_limp_fall
             && sensors.is_some()
             && imu_warm
             && !powered_off;
@@ -1614,6 +1844,38 @@ async fn control_loop<T: RobotIo>(
         };
 
         let (mut targets, gain, moving, policy_label) = match (driving, sensors.as_ref()) {
+            // The limp-fall sequence, before anything else — `driving` is false throughout,
+            // so without this it would fall through to the hold branch and the robot would
+            // be commanded its pre-fall pose at walking gain, which is precisely the thing
+            // the mode exists to stop.
+            //
+            // `moving` stays true for the whole sequence: the joints are travelling (down,
+            // then back to the pose), and `safeToRestart` must not say yes in the middle of
+            // a fall.
+            _ if in_limp_fall => match limp_fall {
+                // Command the joints where they already are, at limp gain. Following the
+                // measurement rather than holding a fixed pose is what makes it soft: a
+                // fixed target grows an error as the robot collapses, and an error at any
+                // gain is a motor pushing back against the floor.
+                LimpFall::Limp { .. } => (
+                    coast.known_positions(hold),
+                    params.safety.gain_limp,
+                    true,
+                    "limp_fall",
+                ),
+                LimpFall::Posing { .. } => (
+                    // Past the end of the ramp the target is the pose itself — the state
+                    // machine above clears `Posing` on the same tick, so this is the one
+                    // frame where the two can disagree.
+                    limp_fall
+                        .pose_target(tick_start, limp_fall_pose)
+                        .unwrap_or(DEFAULT_POSITION),
+                    params.safety.limp_fall_pose_gain,
+                    true,
+                    "limp_pose",
+                ),
+                LimpFall::Idle => unreachable!("in_limp_fall excludes Idle"),
+            },
             (true, Some(sensors)) => {
                 let controller = controller.as_mut().expect("driving implies a controller");
                 match controller.step(sensors, &command, snapshot.pose.active, dt, scale_mult) {
@@ -1674,9 +1936,11 @@ async fn control_loop<T: RobotIo>(
                 policy: policy_label.to_owned(),
                 safety: proto::SafetyState {
                     fallen: safety.fallen(),
-                    // Limp means "safety is actually holding it at limp gain", which needs
-                    // the fall gate armed — a bare fall verdict is a report, not a state.
-                    limp: fall_gate && safety.fallen() && !safety.recovering(),
+                    // Limp means "the robot is actually at limp gain": the armed fall gate
+                    // holding a fallen robot, or the limp-fall sequence riding one down. A
+                    // bare fall verdict is a report, not a state.
+                    limp: (fall_gate && safety.fallen() && !safety.recovering())
+                        || matches!(limp_fall, LimpFall::Limp { .. }),
                     gravity: sensors.imu.gravity,
                     gain: safety.gain(),
                 },
@@ -2353,6 +2617,110 @@ async fn shutdown() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The limp-fall pose ramp: starts where the robot landed, ends at the standing pose,
+    /// and reports itself finished rather than pinning at the end — the state machine reads
+    /// `None` as "hand back to the policy".
+    #[test]
+    fn the_limp_fall_pose_ramp_ends_at_the_standing_pose() {
+        let landed = [0.7; NUM_JOINTS];
+        let over = Duration::from_secs(1);
+        let since = Instant::now();
+        let posing = LimpFall::Posing {
+            from: landed,
+            since,
+        };
+
+        let start = posing.pose_target(since, over).expect("t = 0");
+        assert_eq!(start, landed, "the ramp starts from where the robot landed");
+
+        let half = posing
+            .pose_target(since + over / 2, over)
+            .expect("mid-ramp");
+        for (i, value) in half.iter().enumerate() {
+            let expected = landed[i] + (DEFAULT_POSITION[i] - landed[i]) * 0.5;
+            assert!((value - expected).abs() < 1e-9);
+        }
+
+        assert!(
+            posing.pose_target(since + over, over).is_none(),
+            "a finished ramp is None, not the endpoint held forever"
+        );
+    }
+
+    /// Only the posing phase has a ramp. Asking the limp phase for one must not hand back
+    /// a target — that phase follows the joints down, it does not drive them anywhere.
+    #[test]
+    fn only_the_posing_phase_ramps() {
+        let over = Duration::from_secs(1);
+        let now = Instant::now();
+        assert!(LimpFall::Idle.pose_target(now, over).is_none());
+        assert!(
+            LimpFall::Limp {
+                since: now,
+                landing: Landing::default(),
+            }
+            .pose_target(now, over)
+            .is_none()
+        );
+    }
+
+    /// The landing detector. The limp ends when the robot has been still for the full hold,
+    /// not on the first quiet sample — a robot tumbling over passes through instants of
+    /// near-zero rate on the way, and ending the limp on one of those is landing stiff
+    /// after all.
+    #[test]
+    fn the_landing_needs_the_robot_to_stay_still() {
+        let period = Duration::from_millis(20);
+        let held = Duration::from_millis(60);
+        let mut landing = Landing::default();
+
+        // Still, but not for long enough yet.
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        // One tumbling sample restarts the count from zero.
+        assert!(!landing.observe(Some(4.0), period, 1.0, held));
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        assert!(
+            landing.observe(Some(0.1), period, 1.0, held),
+            "three ticks still"
+        );
+    }
+
+    /// A tick with no fresh sample is not evidence of stillness. A robot nobody can read is
+    /// not a robot anybody has seen stop moving, and a bad bus must not end the limp.
+    #[test]
+    fn a_blind_tick_is_not_a_landing() {
+        let period = Duration::from_millis(20);
+        let held = Duration::from_millis(60);
+        let mut landing = Landing::default();
+
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        assert!(!landing.observe(Some(0.1), period, 1.0, held));
+        assert!(
+            !landing.observe(None, period, 1.0, held),
+            "blind, not still"
+        );
+        assert!(
+            !landing.observe(Some(0.1), period, 1.0, held),
+            "counting again"
+        );
+    }
+
+    /// Limp-fall ships off, and it is independent of the fall gate: turning it on must not
+    /// silently arm `fall_limp`, which would leave a fallen robot refusing `robot.enable`.
+    #[test]
+    fn limp_fall_ships_off_and_arms_nothing_else() {
+        let mut params = Params::default();
+        assert!(!params.safety.limp_fall);
+        params.safety.limp_fall = true;
+        let s = RobotState::new(&params, false, false);
+        assert!(
+            !s.fall_gate,
+            "limp_fall is about the fall, not about what happens once the robot is down"
+        );
+    }
 
     fn state() -> RobotState {
         RobotState::new(&Params::default(), false, false)

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -343,8 +343,9 @@ pub struct SafetyParams {
     /// must not stay limp forever.
     pub limp_fall_max_ms: u64,
     /// How long the ramp back to the standing pose takes, once the robot has landed.
-    /// 0.3 s — measured on the robot, where a slower ramp was just dead time before the
-    /// stand-up: the joints are travelling across the floor unloaded, not lifting anything.
+    /// 0.6 s — settled on at the robot. The joints travel across the floor unloaded rather
+    /// than lifting anything, so a full second was mostly dead time before the stand-up;
+    /// 0.6 keeps some margin over the 0.3 that also worked.
     pub limp_fall_pose_ms: u64,
     /// Gain for that ramp. The joints have to actually travel across the floor, so it is
     /// not the limp gain; it is the softened standing gain rather than the walking one.
@@ -399,7 +400,7 @@ impl Default for SafetyParams {
             limp_fall_still_rate: 1.0,
             limp_fall_still_ms: 200,
             limp_fall_max_ms: 1500,
-            limp_fall_pose_ms: 300,
+            limp_fall_pose_ms: 600,
             limp_fall_pose_gain: 160,
         }
     }

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -304,20 +304,8 @@ pub struct SafetyParams {
     pub fall_debounce_ms: u64,
     /// Intent age past which the velocity is zeroed. Stop, not limp.
     pub deadman_ms: u64,
-    /// Gain once fallen — low enough to yield rather than fight the floor.
+    /// The gain limp-fall yields at — low enough to give way rather than fight the floor.
     pub gain_limp: u16,
-    /// Whether a detected fall preempts the policy: hold at `gain_limp`, refuse
-    /// `robot.init`/`robot.enable`/skills until the robot is upright again. Off by
-    /// default, as the prototype is — its `--fall-detect` ships off, so a fallen robot
-    /// keeps being driven and the humans stay in charge. The fall verdict is reported in
-    /// the state stream either way. `fall_recover = true` implies this: recovery starts
-    /// with the limp settle.
-    pub fall_limp: bool,
-    /// Stand back up after a fall, on its own: limp 0.3 s, then the standing network drives
-    /// until the robot has been solidly upright for a second. Reserves the standing network
-    /// for recovery, so command magnitude stops selecting it. Off by default, as the
-    /// prototype ships `--fall-detect`.
-    pub fall_recover: bool,
     /// Sit down and power the machine off when the battery EMA reaches the empty floor
     /// (6.6 V — `duck_control::model::BATTERY_EMPTY_V`). The EMA moves over ~10 s, so a
     /// load sag cannot trip it.
@@ -327,11 +315,11 @@ pub struct SafetyParams {
     /// down. Off by default: it is a new behaviour, and one whose failure mode is causing
     /// the fall it predicted.
     ///
-    /// Independent of `fall_limp`/`fall_recover` — those act on a robot that is already
-    /// down. This acts in the second before it gets there: drop to `gain_limp`, let the
-    /// robot collapse, then pose it back to standing and hand it to the standing policy,
-    /// which stands up far more cleanly from a still robot than from one that has been
-    /// thrashing since the fall began.
+    /// The only thing the daemon does about a fall. Drop to `gain_limp`, let the robot
+    /// collapse, pose it back to standing once it has landed, then hand it to the standing
+    /// policy — which stands up far more cleanly from a still robot than from one that has
+    /// been thrashing since the fall began. With it off, a fall changes nothing: the policy
+    /// keeps driving and the humans stay in charge.
     pub limp_fall: bool,
     /// Projected-gravity z the robot must already be past before a fall prediction counts
     /// — about 26° of tilt, which ordinary walking does not reach.
@@ -399,8 +387,6 @@ impl Default for SafetyParams {
             fall_debounce_ms: 200,
             deadman_ms: 500,
             gain_limp: 50,
-            fall_limp: false,
-            fall_recover: false,
             battery_empty_shutdown: true,
             limp_fall: false,
             limp_fall_tilt_z: -0.90,
@@ -640,7 +626,7 @@ mod tests {
         assert_eq!(from_file.control.cmd_alpha, built_in.control.cmd_alpha);
         assert_eq!(from_file.control.head_alpha, built_in.control.head_alpha);
         assert_eq!(from_file.policy.resolved(), built_in.policy.resolved());
-        assert_eq!(from_file.safety.fall_recover, built_in.safety.fall_recover);
+        assert_eq!(from_file.safety.limp_fall, built_in.safety.limp_fall);
         assert_eq!(
             from_file.safety.battery_empty_shutdown,
             built_in.safety.battery_empty_shutdown

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -312,8 +312,9 @@ pub struct SafetyParams {
     pub battery_empty_shutdown: bool,
 
     /// Go limp *while falling*, to land soft instead of fighting the floor all the way
-    /// down. Off by default: it is a new behaviour, and one whose failure mode is causing
-    /// the fall it predicted.
+    /// down. **On by default** since it was validated on a robot — the whole point is that
+    /// the fleet lands soft, and a mode every board has to opt into individually is a mode
+    /// most boards do not have.
     ///
     /// The only thing the daemon does about a fall. Drop to `gain_limp`, let the robot
     /// collapse, pose it back to standing once it has landed, then hand it to the standing
@@ -342,6 +343,8 @@ pub struct SafetyParams {
     /// must not stay limp forever.
     pub limp_fall_max_ms: u64,
     /// How long the ramp back to the standing pose takes, once the robot has landed.
+    /// 0.3 s — measured on the robot, where a slower ramp was just dead time before the
+    /// stand-up: the joints are travelling across the floor unloaded, not lifting anything.
     pub limp_fall_pose_ms: u64,
     /// Gain for that ramp. The joints have to actually travel across the floor, so it is
     /// not the limp gain; it is the softened standing gain rather than the walking one.
@@ -388,7 +391,7 @@ impl Default for SafetyParams {
             deadman_ms: 500,
             gain_limp: 50,
             battery_empty_shutdown: true,
-            limp_fall: false,
+            limp_fall: true,
             limp_fall_tilt_z: -0.90,
             limp_fall_predict_z: -0.5,
             limp_fall_lookahead_ms: 300,
@@ -396,7 +399,7 @@ impl Default for SafetyParams {
             limp_fall_still_rate: 1.0,
             limp_fall_still_ms: 200,
             limp_fall_max_ms: 1500,
-            limp_fall_pose_ms: 1000,
+            limp_fall_pose_ms: 300,
             limp_fall_pose_gain: 160,
         }
     }

--- a/robotd/src/params.rs
+++ b/robotd/src/params.rs
@@ -322,6 +322,42 @@ pub struct SafetyParams {
     /// (6.6 V — `duck_control::model::BATTERY_EMPTY_V`). The EMA moves over ~10 s, so a
     /// load sag cannot trip it.
     pub battery_empty_shutdown: bool,
+
+    /// Go limp *while falling*, to land soft instead of fighting the floor all the way
+    /// down. Off by default: it is a new behaviour, and one whose failure mode is causing
+    /// the fall it predicted.
+    ///
+    /// Independent of `fall_limp`/`fall_recover` — those act on a robot that is already
+    /// down. This acts in the second before it gets there: drop to `gain_limp`, let the
+    /// robot collapse, then pose it back to standing and hand it to the standing policy,
+    /// which stands up far more cleanly from a still robot than from one that has been
+    /// thrashing since the fall began.
+    pub limp_fall: bool,
+    /// Projected-gravity z the robot must already be past before a fall prediction counts
+    /// — about 26° of tilt, which ordinary walking does not reach.
+    pub limp_fall_tilt_z: f64,
+    /// Where the extrapolation must reach to count as falling. Same sense as
+    /// `fall_gravity_z`, and by default the same number.
+    pub limp_fall_predict_z: f64,
+    /// How far ahead the tilt rate is extrapolated.
+    pub limp_fall_lookahead_ms: u64,
+    /// How long the fall verdict must hold before the gains drop. Three ticks at 50 Hz —
+    /// longer than a footfall impulse, short enough to leave most of the fall to limp
+    /// through.
+    pub limp_fall_debounce_ms: u64,
+    /// Angular-rate magnitude below which the robot counts as having landed, rad/s.
+    pub limp_fall_still_rate: f64,
+    /// How long it has to stay that still before the limp ends.
+    pub limp_fall_still_ms: u64,
+    /// Hard cap on the limp, however the landing reads. A robot that never goes still —
+    /// held in someone's hands, or resting against something that keeps nudging it —
+    /// must not stay limp forever.
+    pub limp_fall_max_ms: u64,
+    /// How long the ramp back to the standing pose takes, once the robot has landed.
+    pub limp_fall_pose_ms: u64,
+    /// Gain for that ramp. The joints have to actually travel across the floor, so it is
+    /// not the limp gain; it is the softened standing gain rather than the walking one.
+    pub limp_fall_pose_gain: u16,
 }
 
 impl Default for PolicyParams {
@@ -366,6 +402,16 @@ impl Default for SafetyParams {
             fall_limp: false,
             fall_recover: false,
             battery_empty_shutdown: true,
+            limp_fall: false,
+            limp_fall_tilt_z: -0.90,
+            limp_fall_predict_z: -0.5,
+            limp_fall_lookahead_ms: 300,
+            limp_fall_debounce_ms: 60,
+            limp_fall_still_rate: 1.0,
+            limp_fall_still_ms: 200,
+            limp_fall_max_ms: 1500,
+            limp_fall_pose_ms: 1000,
+            limp_fall_pose_gain: 160,
         }
     }
 }


### PR DESCRIPTION
The robot goes limp when falling, gently goes back to init position then tries to standup. 

This should reduce the stress on the motors and improve the likelyhood of standing up correctly without falling in the violent fail loop. 