### PR TITLE
docs: the WebRTC design, scoped to local signalling

### DIFF
--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -1,27 +1,35 @@
-//! Which calls BLE may make, which socket answers them, and which connection carries them.
+//! Which calls BLE may make, and which of a service's connections carries them.
 //!
 //! BLE exposes a **subset** of the robot API (`architecture.md` §4.1): provisioning, status,
 //! and the update commands with their progress. It is too slow and too constrained for the full
 //! surface, and — more to the point — a radio anybody within a few metres can talk to is not
 //! the transport over which to offer "reset this robot to factory state".
 //!
-//! One table decides all three questions, because they are the same question asked about the
-//! same call: a call is permitted exactly when this file names the service that answers it, and
-//! the [`Lane`] it names is which of that service's connections it travels on.
+//! **Two questions, and only one of them is BLE's.** *Which service answers a call, and how long
+//! answering holds a connection* is a property of the call, and lives in
+//! [`proto::Call::destination`] where every transport reads the same answer. *Whether BLE may make
+//! it* is this file. They were one table until a second transport needed the first half and none
+//! of the second; `docs/design/remote-webrtc.md` §5 records the split.
 //!
-//! **The match is deliberately exhaustive.** Adding a variant to [`proto::Call`] makes this
-//! file fail to compile, so a new method cannot reach the radio because someone forgot this
-//! file existed. A `_ => None` wildcard would be the safe default in the moment and the wrong
-//! one over time: it would silently deny new methods, and the first symptom would be a phone
-//! app that cannot see a feature nobody remembered to route. The lane lives in the same table
-//! for the same reason — a new long-running method given the wrong lane is a session that
-//! stops answering, which is [`Lane`]'s whole subject.
+//! **The permission match is deliberately exhaustive.** Adding a variant to [`proto::Call`] makes
+//! this file fail to compile, so a new method cannot reach the radio because someone forgot this
+//! file existed. A `_ => false` wildcard would be the safe default in the moment and the wrong one
+//! over time: it would silently deny new methods, and the first symptom would be a phone app that
+//! cannot see a feature nobody remembered to route. Every transport needs its own such match for
+//! the same reason — a shared one with a wildcard would be the hole in all of them at once.
 
 use duck_ipc_proto as proto;
 
-/// The service that owns the answer to a call.
+/// How long a call holds a connection. Defined once, in the protocol crate.
+pub use proto::Lane;
+
+/// The service that owns the answer to a call, restricted to the three `btd` holds sockets to.
 ///
-/// One socket per service, connected directly — there is no broker (`architecture.md` §2.2).
+/// Narrower than [`proto::Service`] on purpose. `padd` and `tofd` answer calls too, and `btd` has
+/// no connection to either: `padd` is the unprivileged client whose whole value is having no
+/// special access, and giving the BLE transport a socket to it would be the first thing to make
+/// that untrue. The conversion below therefore *fails* for them, which turns a comment into
+/// something the compiler enforces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Upstream {
     /// `updaterd`, at `proto::DEFAULT_SOCKET`.
@@ -32,56 +40,20 @@ pub enum Upstream {
     Config,
 }
 
-/// Which connection to a service carries a call.
-///
-/// **Every daemon here serves one connection one request at a time**: `updaterd` and `configd`
-/// both read a line, await the whole call, and only then read the next
-/// (`updater/src/ipc.rs::handle_connection`, `configd/src/main.rs::handle`). A single connection
-/// per service would therefore put every call on one queue behind the slowest thing on it, and
-/// two orderings a phone app reaches for first are broken by that:
-///
-/// - `update.apply` then `update.status` — the status line waits in a socket `updaterd` will not
-///   read for minutes, so the client times out having heard nothing while the robot is fine.
-/// - `update.subscribe` then `update.apply` — worse. `stream_progress` owns its connection until
-///   the peer goes away and never reads another request, so the apply is written into a socket
-///   nobody reads: it never runs, never replies and never errors. An update the owner asked for
-///   that the robot silently did not perform.
-///
-/// So calls are grouped by *how long they hold a connection*, and each group gets its own. Four
-/// lanes is at most four sockets per service per session, which costs nothing and is bounded
-/// without any bookkeeping — the alternative, a connection per call, needs `btd` to know when a
-/// call ended, which needs it to parse replies. It deliberately never does (`session`).
-///
-/// Calls that share a lane are queued behind each other, and each grouping says why that is the
-/// right answer rather than a compromise.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Lane {
-    /// Answers as fast as the daemon can look something up. Reads from memory, and the writes
-    /// that only store a value.
-    ///
-    /// Queueing these behind each other is invisible, and keeping them off the other lanes is
-    /// the point: a status poll during an update must answer, and `updaterd` is built so it can
-    /// — `update.status` falls back to a cached snapshot rather than waiting for the engine
-    /// (`updater/src/ipc.rs`). That fallback is wasted if the request never gets read.
-    Prompt,
-    /// Seconds: a read that goes to the network or sweeps a radio.
-    ///
-    /// Two of them, and queueing them behind each other is fine. What matters is that neither
-    /// sits in front of a `Prompt` call nor behind an `Operation` one — `update.check` during an
-    /// update should come straight back `BUSY`, not resolve whenever the update finishes.
-    Slow,
-    /// As long as it takes, and it changes the robot: an update, joining a network, bonding a pad.
-    ///
-    /// Minutes, for a daemon update. Sharing one lane is correct rather than tolerated: `updaterd`
-    /// single-flights mutations behind a file lock and answers `BUSY` for a second one, and two
-    /// radio operations at once on `configd` is not a thing to want either. So a second
-    /// `Operation` waiting for the first is the behaviour to have.
-    Operation,
-    /// Never answers. The service writes notifications until the peer goes away.
-    ///
-    /// One call, `update.subscribe`, and it must be alone: a connection handed to a progress
-    /// stream reads no further requests at all.
-    Stream,
+impl TryFrom<proto::Service> for Upstream {
+    type Error = ();
+
+    fn try_from(service: proto::Service) -> Result<Self, Self::Error> {
+        match service {
+            proto::Service::Updater => Ok(Upstream::Updater),
+            proto::Service::Robot => Ok(Upstream::Robot),
+            proto::Service::Config => Ok(Upstream::Config),
+            // Not sockets `btd` holds. Unreachable in practice, because `permits` refuses every
+            // call these answer — and an error rather than a panic so that staying true is not
+            // something this file has to be careful about.
+            proto::Service::Pad | proto::Service::Tof => Err(()),
+        }
+    }
 }
 
 /// What happens to a call that arrives over BLE.
@@ -97,17 +69,19 @@ pub enum Route {
     Refused,
 }
 
-/// Where this call goes and on which connection, or `None` if BLE may not make it.
+/// May a call arriving over BLE be served at all?
 ///
-/// Read the `None` arms as the security boundary: each one is a deliberate decision that a
+/// Read the `false` arms as the security boundary: each one is a deliberate decision that a
 /// phone in the room does not get to do this.
-pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
-    use Lane::*;
-    use Upstream::*;
+fn permits(call: &proto::Call) -> bool {
     use proto::Call::*;
     match call {
         // The version handshake. Must be reachable or no client can establish anything.
-        Hello(_) => Some((Updater, Prompt)),
+        Hello(_) => true,
+
+        // Answered by `btd` itself rather than forwarded. Permitted because it is the one call a
+        // session must be able to make before it has made any other.
+        SystemAuthenticate(_) => true,
 
         // ── the update subset §4.1 names ────────────────────────────────────
         //
@@ -116,17 +90,14 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         // policy, and does — `deploy/updater.toml` names `btd` in `allow_users`, which is a
         // narrower claim than granting the robot group. Routing it here without that grant would
         // have produced a phone button that always returned PERMISSION_DENIED.
-        Apply(_) => Some((Updater, Operation)),
-        // Reaches the network, so `Slow` — and off the `Operation` lane deliberately, because
-        // "is there an update?" asked during one has an immediate answer (`BUSY`) and queueing
-        // it would turn that into a spinner that resolves minutes later.
-        Check(_) => Some((Updater, Slow)),
-        Status => Some((Updater, Prompt)),
-        Subscribe => Some((Updater, Stream)),
+        Apply(_) => true,
+        Check(_) => true,
+        Status => true,
+        Subscribe => true,
         // Read-only, and what support asks for first. `update.log` is the record that
         // survives a wiped journal (§8.2), so a phone able to read it is worth having.
-        Log(_) => Some((Updater, Prompt)),
-        ListInstalled(_) => Some((Updater, Prompt)),
+        Log(_) => true,
+        ListInstalled(_) => true,
 
         // Going back. Both are permitted, and both are less consequential than the `Apply`
         // above them: they move the robot to a release that has already run on this board,
@@ -144,44 +115,39 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         // same authority plus a version number, and it is what a list of installed releases is
         // *for*: `ListInstalled` is already routed above, so an app can show them, and being able
         // to show them without being able to choose one would be the odd half.
-        Rollback(_) => Some((Updater, Operation)),
-        Select(_) => Some((Updater, Operation)),
+        Rollback(_) => true,
+        Select(_) => true,
 
         // Is the robot alright? The one `robot.*` call an app has any use for.
-        RobotHealth => Some((Robot, Prompt)),
+        RobotHealth => true,
 
         // ── provisioning, which is what §4.1 puts BLE here for ──────────────
         //
         // This is the case the whole transport exists to serve: a robot that has never seen a
         // network cannot be configured over that network, so BLE is the only way in. All four
         // are permitted, including the two that change things.
-        NetStatus => Some((Config, Prompt)),
-        // `configd` re-sweeps the radio rather than returning the last scan, which takes seconds.
-        NetScan => Some((Config, Slow)),
+        NetStatus => true,
+        NetScan => true,
         // Carries a wifi passphrase, which §7 requires to travel over a paired, encrypted link.
         // It does: the characteristic sets `encrypt_authenticated_write` and the PIN agent makes
         // the bond an authenticated one (`crate::pairing`). Routing this before that existed
         // would have been the ordering mistake.
-        //
-        // `Operation` because `configd` polls NetworkManager for up to 45 seconds before calling
-        // a join failed, and a phone showing "connecting…" wants `net.status` to keep answering
-        // throughout — which is the same defect as the update one, on the path BLE exists for.
-        NetConnect(_) => Some((Config, Operation)),
-        NetForget(_) => Some((Config, Prompt)),
+        NetConnect(_) => true,
+        NetForget(_) => true,
 
         // Name and identity. Renaming from the app is the reason `system.setName` exists.
-        SystemInfo => Some((Config, Prompt)),
-        SystemSetName(_) => Some((Config, Prompt)),
+        SystemInfo => true,
+        SystemSetName(_) => true,
 
         // Which daemons are up and which release each is running. Routed because an app that can
         // trigger an update should be able to show whether it took — and because the one daemon it
         // cannot report on this way is `btd` itself, which answering at all proves is running.
-        SystemServices => Some((Config, Prompt)),
+        SystemServices => true,
 
         // Rebooting is drastic but recoverable, and it is what an app offers when a robot is
         // confused — the alternative being "unplug it", which for a walking robot is worse.
         // Unlike `resetToGolden` it discards nothing.
-        SystemReboot => Some((Config, Prompt)),
+        SystemReboot => true,
 
         // ── the gamepad ─────────────────────────────────────────────────────
         //
@@ -192,21 +158,17 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         //
         // `pad.pair` is the more consequential of the two, because a bonded pad can enable the
         // policy afterwards. That is deliberate: it is the same authority as standing next to the
-        // robot with a controller, and the PIN gate is what stands in front of it. It waits on a
-        // pad for its whole timeout, so it shares the `Operation` lane with the wifi join.
-        PadStatus => Some((Config, Prompt)),
-        PadPair(_) => Some((Config, Operation)),
-        PadForget(_) => Some((Config, Prompt)),
+        // robot with a controller, and the PIN gate is what stands in front of it.
+        PadStatus => true,
+        PadPair(_) => true,
+        PadForget(_) => true,
 
-        // Answered by `btd`, so it has no upstream. See `route_for`.
-        SystemAuthenticate(_) => None,
+        // ── refused ─────────────────────────────────────────────────────────
 
         // The pairing PIN, and the one refusal in this file that is load-bearing rather than
         // conservative: a PIN readable by an unpaired peer authorises nothing at all. `btd`
         // reads it over the unix socket to answer BlueZ's passkey request, and BLE never can.
-        SystemPairingPin | SystemSetPairingPin(_) => None,
-
-        // ── refused ─────────────────────────────────────────────────────────
+        SystemPairingPin | SystemSetPairingPin(_) => false,
 
         // Pinning, and it stays refused while `Select` above it does not. The difference is what
         // the mistake looks like afterwards: a wrong `select` is one release away from being
@@ -214,48 +176,47 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         // refuses every later update and reports itself as up to date. That is the one failure
         // here that looks exactly like correct behaviour, and it needs `robotctl` and a person
         // who meant it.
-        Pin(_) => None,
+        Pin(_) => false,
 
         // Factory reset in all but name: back to the golden image, discarding every release
         // since. Never over a radio — and note that `Rollback` and `Select` being routed does
         // not weaken this, because neither discards anything.
-        ResetToGolden(_) => None,
+        ResetToGolden(_) => false,
 
         // `updaterd`'s private questions to `robotd` — may I restart the control loop, which
         // model API is this, is a telepresence session live. Internal plumbing of the update
         // decision, of no use to a client and misleading if exposed: a phone reading
         // `safeToRestart` would learn nothing it could act on.
-        RobotSafeToRestart | RobotModelApi | RobotRemoteSessionActive => None,
+        RobotSafeToRestart | RobotModelApi | RobotRemoteSessionActive => false,
 
         // Motor control. **Never over BLE**, which is what §4.1 means by a subset: BLE is too
         // slow and too constrained for the full surface, and teleop belongs on WebRTC's
-        // unreliable `teleop` datachannel where a stale command is dropped rather than
-        // retransmitted (§5.2). A 20-byte notification budget and a link that does not exist for
-        // the first ~73s of a boot is not a control transport. The skills, the body pose and
-        // the mouth are motor control like the rest.
+        // datachannel (`docs/design/remote-webrtc.md` §2). A 20-byte notification budget and a
+        // link that does not exist for the first ~73s of a boot is not a control transport. The
+        // skills, the body pose and the mouth are motor control like the rest.
         RobotMove(_) | RobotHead(_) | RobotLook(_) | RobotEnable(_) | RobotDo(_) | RobotPose(_)
-        | RobotMouth(_) => None,
+        | RobotMouth(_) => false,
 
         // Harmless and rather charming from a phone — but it rides the same refusal as the
         // rest of robot.* until the app path exists to want it: opening one call to the
         // radio ahead of a client that can use it buys nothing and widens the surface.
-        RobotSound(_) => None,
+        RobotSound(_) => false,
 
         // Powering the machine off from a phone in the room is `system.reboot` without the
         // coming back. The sit-then-power-off flow wants whoever asked to be watching the
         // robot, and that is `robotctl` or the pad's long-press, deliberately.
-        RobotShutdown => None,
+        RobotShutdown => false,
 
         // Constant for the life of the process, and only a stick-mapping hint for local
         // clients like `padd`. An app gets the same answer through `system.info` territory
         // when it ever needs one; no reason to open another read to the radio today.
-        RobotMode => None,
+        RobotMode => false,
 
         // Power to the joints. A phone button that drops the robot on the floor is not one to
         // offer, and `robot.init` is its counterpart: standing a robot up moves every joint at once,
         // which wants the person doing it to be looking at the robot rather than at a screen. Both
         // are `robotctl` on the robot, deliberately.
-        RobotInit | RobotRelax => None,
+        RobotInit | RobotRelax => false,
 
         // `robot.stop` deserves its own line, because refusing it looks wrong. An emergency stop
         // in the app is exactly what someone reaches for, and §6 does say local should preempt
@@ -264,32 +225,41 @@ pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
         // deadman in `robotd` already stops the robot when intents stop arriving, which is the
         // mechanism that does not depend on a phone being in range. A real e-stop is physical.
         // Reconsider deliberately if the app ever needs it, with that caveat stated in the UI.
-        RobotStop => None,
+        RobotStop => false,
 
         // High-rate telemetry. `robot.subscribe` streams state at up to the control rate; over
         // BLE that is a firehose into a 20-byte pipe, and a client would get a decimated,
         // unpredictably-lagged view it could not reason about. `robot.health` is the question an
         // app actually has.
-        RobotSubscribe(_) => None,
+        RobotSubscribe(_) => false,
 
         // The same objection as `robot.subscribe`, only more so: this is every evdev event the pad
         // sends, over a hundred reports a second, and it exists to *measure the cadence of its own
         // delivery*. Carried over BLE the measurement would be of the phone's link rather than the
         // pad's, which is worse than refusing — it would be a number that looks like an answer.
         //
-        // It is also not `btd`'s to forward. Every route here goes to one of three sockets `btd`
-        // holds, and this one is served by `padd`, which is deliberately not among them: `padd` is
-        // the unprivileged client whose whole value is having no special access, and giving the BLE
-        // transport a connection to it would be the first thing to make that untrue.
-        PadInput => None,
+        // It is also not `btd`'s to forward: `padd` is deliberately not one of the sockets `btd`
+        // holds, which `Upstream`'s conversion now enforces rather than merely documents.
+        PadInput => false,
 
         // Depth frames, and the same two objections as the pad tap. A 64-zone frame
         // fifteen times a second is a firehose into a 20-byte pipe; and it is served by
-        // `tofd`, which is not one of the three sockets `btd` holds. When a phone has a
+        // `tofd`, which is not one of the sockets `btd` holds. When a phone has a
         // reason to see what the robot sees, it will be through `mediad`'s video path
         // (`architecture.md` §5.2), where depth belongs next to the frame it annotates.
-        TofStream => None,
+        TofStream => false,
     }
+}
+
+/// Where this call goes and on which connection, or `None` if BLE may not make it — or if no
+/// service answers it, which for `system.authenticate` is the same answer with a different reason.
+/// [`route_for`] tells those two apart.
+pub fn destination_for(call: &proto::Call) -> Option<(Upstream, Lane)> {
+    if !permits(call) {
+        return None;
+    }
+    let (service, lane) = call.destination()?;
+    Some((Upstream::try_from(service).ok()?, lane))
 }
 
 /// The service that answers a call, ignoring which connection carries it.
@@ -605,6 +575,59 @@ mod tests {
                 "{}",
                 call.method()
             );
+        }
+    }
+
+    /// A permitted call must be one `btd` can actually deliver.
+    ///
+    /// This is the test the split made necessary. Permission and destination are now decided in
+    /// two places, so it became possible to permit a call that `btd` holds no socket for —
+    /// `pad.input` and `tof.stream` are served by `padd` and `tofd`, and `btd` connects to
+    /// neither. Before, one table answered both questions and the mistake could not be written.
+    ///
+    /// `system.authenticate` is the deliberate exception: permitted, and answered by `btd` itself
+    /// rather than forwarded, which is exactly what `route_for` reports as `Local`.
+    #[test]
+    fn everything_permitted_is_deliverable() {
+        for call in every_call() {
+            if !permits(&call) {
+                continue;
+            }
+            if matches!(call, proto::Call::SystemAuthenticate(_)) {
+                assert_eq!(
+                    route_for(&call),
+                    Route::Local,
+                    "system.authenticate must be answered by btd itself"
+                );
+                continue;
+            }
+            assert!(
+                destination_for(&call).is_some(),
+                "{} is permitted over BLE but btd cannot deliver it — it is served by a socket \
+                 btd does not hold, so either permit it and give btd that socket, or refuse it",
+                call.method()
+            );
+        }
+    }
+
+    /// And the converse: a refused call must not be deliverable, whatever the shared table says.
+    ///
+    /// Cheap, and it pins the composition order. `destination_for` consulting the shared
+    /// destination *before* the permission check would pass every other test in this file and
+    /// quietly route the whole API to the radio.
+    #[test]
+    fn nothing_refused_is_deliverable() {
+        for call in every_call() {
+            if permits(&call) {
+                continue;
+            }
+            assert_eq!(
+                destination_for(&call),
+                None,
+                "{} is refused over BLE but destination_for offered a route",
+                call.method()
+            );
+            assert_eq!(route_for(&call), Route::Refused, "{}", call.method());
         }
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ own the mechanism is the bug.
 | [`updater-design.md`](design/updater-design.md) | The update engine: verification, atomic swap, health gate, rollback, release format. |
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
+| [`remote-webrtc.md`](design/remote-webrtc.md) | WebRTC sessions, signalling, and the control channel — how a peer drives and observes the robot. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
 
 ## `project/` — you are running the project

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -32,7 +32,10 @@ peer (browser / phone / server-side program)
 
 Two data channels rather than one, for the reason `architecture.md` §5.2 gives: a retransmitted
 80 ms-old joystick command is worse than useless, so teleop goes `maxRetransmits: 0` and always
-takes the newest. That choice has a consequence people miss, and §6 is about it.
+takes the newest.
+
+**The first version opens `control` only.** Teleop is not the near-term priority, and leaving it
+out is not merely deferral — §6 is about what it removes.
 
 **`webrtcsink` takes pre-encoded H.264 on its sink pad**, so the pipeline is
 `appsrc ! mpph264enc ! h264parse ! webrtcsink` and the encoder never reaches negotiation. Verified
@@ -161,24 +164,42 @@ connection hangs — the exact bug `app-path-design.md` §7 records. One datacha
 stream with the same hazard, and `btd`'s answer works unchanged: route by method to a per-lane
 socket, pump each socket back, never correlate.
 
-## 6. Teleop needs sequence numbers, and this is not optional
+## 6. Why `control`-only comes first, and what `teleop` will cost when it lands
 
 `intents.rs` stores each intent in an `ArcSwap` and takes last-writer-wins. That is correct today
 because every writer reaches it through a unix socket, where a later message cannot arrive before an
 earlier one.
 
+**A reliable, ordered datachannel keeps that true.** SCTP in that mode delivers in order by
+definition, so intents arriving over `control` preserve the property `intents.rs` already depends
+on. Starting with one channel is therefore not a compromise that stores up work — it means there is
+no ordering problem to solve in the first version at all.
+
+### What it costs instead, so nobody is surprised
+
+Head-of-line blocking. On a reliable channel a lost packet stalls everything behind it, including
+the control RPCs, so a bad link shows up as *everything* pausing rather than as a stale joystick.
+Driving over `control` is fine at a modest rate and gets worse with rate and loss — which is
+precisely why `architecture.md` §5.2 specifies a second channel, and why the answer to "the robot
+feels laggy over a poor link" is teleop rather than tuning.
+
+### And when teleop lands, it needs sequence numbers
+
 **SCTP with `maxRetransmits: 0` reorders.** A twist from 80 ms ago can land after a fresher one and
-win, and the robot then drives on a stale command with nothing anywhere reporting a problem. It is
-not a rare race: it is the normal behaviour of the channel we chose on purpose.
+win last-writer-wins, and the robot then drives on a stale command with nothing anywhere reporting a
+problem. It is not a rare race: it is the normal behaviour of the channel, chosen deliberately.
 
-So teleop frames carry a **monotonic sequence number per stream**, and the writer drops anything
-not newer than what it last applied. This is a property of the *transport*, so it belongs in
-`mediad` rather than in `robotd` — `robotd` should keep receiving intents it can trust the ordering
-of, which is what makes `intents.rs` simple.
+So teleop frames carry a **monotonic sequence number per stream**, and the writer drops anything not
+newer than what it last applied. This is a property of the *transport*, so it belongs in `mediad`
+rather than in `robotd` — `robotd` should keep receiving intents whose ordering it can trust, which
+is what lets `intents.rs` stay as simple as it is.
 
-The deadman needs nothing: `safety.gate(command, twist_age)` is already age-based, so a partition
-stops the robot with no new code. Worth stating because it is the one thing about lossy links that
-is already handled.
+Worth writing down before the channel exists rather than after: the failure is silent, it looks like
+bad tuning rather than a bug, and the fix is trivial if it is designed in and awkward if a stale
+twist has to be diagnosed first.
+
+The deadman needs nothing either way: `safety.gate(command, twist_age)` is already age-based, so a
+partition stops the robot with no new code.
 
 ## 7. Reaching a robot that is not on your LAN
 
@@ -283,6 +304,8 @@ wrong one.
   media stack, `get_frame` returning a JPEG. It is a few dozen lines once §5's routing exists, and
   it is what makes "an LLM drives the robot" easy — but it is a second transport and the first one
   should work.
+- **The `teleop` datachannel.** Not the near-term priority; §6 covers what deferring it removes,
+  what it costs in the meantime, and the sequence numbers it will need.
 - **Multi-peer video.** One media session at a time, plus control-only clients. Simulcast and
   encode-once-send-many are a real project.
 - **Consent and the streaming indicator.** `architecture.md` §7 wants explicit per-session consent

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -298,7 +298,40 @@ What this section is *for* until then: knowing that two simultaneous drivers is 
 than a mystery, and that the first symptom is a robot ignoring both inputs rather than obeying the
 wrong one.
 
-## 10. Deferred, with reasons
+## 10. Building `mediad` at all
+
+The `gstreamer-rs` crates are pkg-config crates, so cross-compiling them needs the *target's*
+headers, `.pc` files and shared libraries on the developer's machine. `cargo board` cross-builds
+from macOS with `cargo-zigbuild`, and `scripts/ci-cross-deps.sh` says of the one C dependency it
+already has that it "is the cost of that one exception, and it is worth reading before adding
+another". This is the second, and much larger.
+
+**`scripts/cross-sysroot.sh` unpacks the robot's own Debian packages into a sysroot** — proven:
+the full workspace cross-builds against it, and `gstreamer`, `gstreamer-app` and
+`gstreamer-webrtc` all resolve at 1.26.2, the same version the board runs.
+
+Three things about it worth knowing before touching it:
+
+- **It serves the whole workspace, not just `mediad`.** `PKG_CONFIG_LIBDIR` *replaces*
+  pkg-config's search path rather than adding to it, so a sysroot carrying only GStreamer breaks
+  `padd` — whose `gilrs` needs libudev — and does it inside `libudev-sys`, nowhere near anything
+  about media. Replacing is still right: `PKG_CONFIG_PATH` is additive to the *host's*, which is
+  how pkg-config comes to answer with a macOS library and produce a binary that cannot run on the
+  robot.
+- **The package list is explicit, not resolved.** Walking Debian `Depends` from the obvious roots
+  pulls 543 packages, because `libgstreamer-plugins-bad1.0-dev` declares every optional backend's
+  dev package and the closure reaches Qt, Vulkan and OpenEXR. Nineteen packages satisfy what is
+  actually needed.
+- **A `-dev` package alone is not enough for anything actually linked.** It ships `libfoo.so` as a
+  symlink onto the `libfoo.so.N` in the runtime package, so `-lfoo` needs both. Libraries that
+  only appear in `Requires.private` need just the `-dev`.
+
+The alternative was building `mediad` on an arm64 runner like the plugins in
+[`media-bringup.md`](../project/media-bringup.md). Rejected because it splits the daemon build in
+two and leaves nobody able to build `mediad` on a laptop — which for the crate that will need the
+most iteration against real hardware is the wrong trade.
+
+## 11. Deferred, with reasons
 
 - **A WebSocket surface for server-side programs** (`architecture.md` §5.3). Same JSON-RPC, no
   media stack, `get_frame` returning a JPEG. It is a few dozen lines once §5's routing exists, and

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -54,7 +54,7 @@ started. A LAN client connects to the same server directly.
 at all and every session goes through a bridge, which defeats the point of a local mode. So it
 binds on all interfaces, and §4 is what that implies for who may drive.
 
-## 4. Authorisation: open on the LAN, and the bridge is where that stops
+## 4. Authorisation: none on the robot, and why that holds both locally and remotely
 
 **No gate in the first version.** A peer that reaches the signalling server can start a session,
 drive the robot, and see through its camera. That is a decision, not an oversight.
@@ -68,30 +68,46 @@ What it costs, stated plainly so nobody has to discover it: anyone on the same n
 robot and its camera. Fine on a bench and in an office. **Not fine in a home**, which is the thing
 to revisit before one ships to one.
 
-### The bridge is the line, not the LAN
+### Where authorisation actually lives: the bridge, and it is already there
 
-"On the LAN" is a boundary only while the LAN is the boundary. §7's bridge deletes it: a robot
-reachable through a rendezvous service is reachable by whoever can address it there, and "open to
-anyone who can connect" stops meaning "open to people in the building".
+The remote path does not need a gate on the robot either, because it is authenticated **before it
+reaches one** — on both sides:
 
-So the rule is: **LAN-only may be unauthenticated; bridged may not.** That is a cheaper commitment
-than it sounds, because the bridge has to solve identity anyway — something has to decide which
-robots a given user may see — and whatever answers that question is also what authorises the
-session. Deferring auth is therefore not deferring work; it is declining to invent a second answer
-before the first one exists.
+- **The client** authenticates to the rendezvous service with OAuth, and the service shows it only
+  the robots its account owns. Reaching the part of the bridge that routes to a given robot *is*
+  the proof.
+- **The robot** authenticates outward: its relay holds an account token and connects to the service
+  with it (§7). So the robot proves it belongs to the account too.
 
-### The hook, when it is wanted
+The service is therefore matching two already-authenticated parties, and a session arriving through
+it has been authorised twice over. A `system.authenticate` on top would be a second answer to a
+question already answered — and a worse one, since the shared `000000` PIN proves less than an
+account token does.
+
+**What this means is that the trust moved rather than vanished**, and it is worth naming where it
+went: the robot has no independent check, so the binding between a robot and an account is now the
+thing that must be right, and it lives in the service rather than here. That is an acceptable place
+for it — it is the only component that can know the answer — but it is a dependency, not an absence
+of one.
+
+The one arrangement none of this covers is a robot whose signalling port is exposed to the internet
+directly, by a port forward rather than through the bridge. Then there is no bridge to have
+authenticated anything, and §4's LAN reasoning does not apply either, because the population that
+can reach it is no longer the people in the building. That is a deployment mistake rather than a
+design decision, and worth saying out loud precisely because nothing in the robot would notice.
+
+### The hook, if it is ever wanted
 
 `system.authenticate` — the method BLE already uses, added in `API_VERSION` v4. A control channel
-would serve that one method and refuse the rest by name until it passes, exactly as a BLE session
-does, with the PIN read from `configd` over its unix socket rather than over the channel being
-authenticated.
+would serve that one method and refuse the rest by name until it passes, with the PIN read from
+`configd` over its unix socket rather than over the channel being authenticated.
 
-Cheap to add later precisely because §5's routing table already needs a notion of *which methods a
-transport may reach*. "Which methods before authentication" is the same table with a smaller
-subset, not a new mechanism. Using BLE's mechanism rather than inventing a second one is the point:
-two authorisation schemes for two transports is how one of them ends up weaker, and it is usually
-the newer one.
+It is named here so the answer exists, not because it is planned. The case for it is narrow: it
+adds nothing to the bridged path, which is better authenticated already, and on the LAN it costs a
+step per connection while proving only that the peer read a number printed on every robot. If it is
+ever wanted, it is cheap — §5's routing table already needs a notion of which methods a transport
+may reach, and "which methods before authentication" is the same table with a smaller subset rather
+than a new mechanism.
 
 ## 5. The control channel is a pipe to the existing API
 
@@ -180,10 +196,13 @@ Two properties follow, and both are the reason for this shape:
   a LAN client speaks. That is the concrete payoff for using `webrtcsink` rather than `webrtcbin`:
   the protocol already exists, so the bridge is a relay rather than a translator.
 
-**And the bridge is where §4's open door closes.** A LAN-only robot may be unauthenticated; a
-bridged one may not, because "whoever can reach it" stops meaning "whoever is in the building". The
-bridge already has to answer which robots a given user may see, and whatever answers that is what
-authorises the session — so this is not extra work, it is the same work not done twice.
+- **The bridge authenticates, so the robot does not have to.** The relay connects *outward* holding
+  an account token, and the service shows a client only the robots its account owns — so a bridged
+  session is authorised on both sides before it arrives. §4 covers where that leaves the trust.
+
+  A useful consequence: because the relay is a robot-side process connecting to loopback, the robot
+  *can* tell a bridged peer from a LAN one by source address, even though it does not currently act
+  on the difference. Nothing is foreclosed if that stops being true.
 
 `reachy_mini` runs exactly this arrangement against a Hugging Face Space, with the robot
 registering as a `producer` and the Space keeping a TTL lease refreshed by a heartbeat. Whether we

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -1,0 +1,227 @@
+# WebRTC: sessions, signalling, and the control channel
+
+How a phone, a browser or a server-side program drives and observes the robot over WebRTC.
+[`architecture.md`](architecture.md) §5 states the requirement; this owns the mechanism.
+
+Scoped to **local signalling**: everything below runs on the robot and works on a LAN with no
+backend at all. Reaching a robot from outside the LAN is the same design with a proxy in front of
+it (§7) — deliberately not the first thing built, because the local case is the one every other
+case is defined in terms of.
+
+## 1. What this is not
+
+`webrtcbin` is not used. `mediad` uses **`webrtcsink`** from `gst-plugins-rs`, and the difference
+is the whole reason this document is short: `webrtcsink` brings a signalling protocol, a session
+model, and per-consumer encoder management, so what is left to design is the *control* surface
+rather than the media plumbing.
+
+`webrtcbin` would mean writing all three. It is in Debian and `webrtcsink` is not
+([`media-bringup.md`](../project/media-bringup.md) covers how that plugin is built and shipped),
+which is the one argument for it — and it is outweighed by the protocol coming for free, because
+that protocol is what a remote bridge proxies (§7).
+
+## 2. One session, four streams
+
+```
+peer (browser / phone / server-side program)
+   ├── video track      camera, hardware H.264 (mpph264enc, constrained-baseline)
+   ├── audio track      mic; two-way for telepresence
+   ├── datachannel "control"   reliable, ordered      → the robot API (§5)
+   └── datachannel "teleop"    unreliable, unordered  → input and high-rate telemetry
+```
+
+Two data channels rather than one, for the reason `architecture.md` §5.2 gives: a retransmitted
+80 ms-old joystick command is worse than useless, so teleop goes `maxRetransmits: 0` and always
+takes the newest. That choice has a consequence people miss, and §6 is about it.
+
+**`webrtcsink` takes pre-encoded H.264 on its sink pad**, so the pipeline is
+`appsrc ! mpph264enc ! h264parse ! webrtcsink` and the encoder never reaches negotiation. Verified
+on hardware; the four encoder properties that are decisions rather than defaults are in
+[`media-bringup.md`](../project/media-bringup.md).
+
+## 3. `mediad` runs the signalling server itself
+
+`webrtcsink` has `run-signalling-server`, with `signalling-server-host` and
+`signalling-server-port` (gst-plugins-rs 0.15.3). So the server runs **in `mediad`'s own process**
+and there is no second binary to build, ship or supervise — which matters, because the plugin we
+ship is a `.so` while `gst-webrtc-signalling-server` is a separate Rust binary from the same
+upstream crate. Not shipping it is a real simplification, not a shortcut.
+
+`webrtcsink`'s own signaller defaults to `ws://127.0.0.1:8443` and connects to the server it just
+started. A LAN client connects to the same server directly.
+
+**Bind address is a decision, not a default.** Loopback only would mean a LAN peer cannot reach it
+at all and every session goes through a bridge, which defeats the point of a local mode. So it
+binds on all interfaces — and that makes §4 load-bearing rather than optional.
+
+## 4. Authorisation, because the signalling port is open on the LAN
+
+A peer that reaches the signalling server can start a session, and a session carries the control
+channel, which carries the robot API. So the question is not "who may signal" but "who may drive".
+
+**Reuse `system.authenticate`.** It already exists — `API_VERSION` v4 added it — and it already
+solves this problem once, for BLE: a client proves knowledge of the robot's pairing PIN before
+anything else is served. `app-path-design.md` §5 explains why the check lives at the protocol layer
+rather than the link layer, and that reasoning transfers unchanged: *we* define the rules here too.
+
+So the control channel is **unauthorised until `system.authenticate` succeeds on it**, exactly as a
+BLE session is. Concretely:
+
+- A fresh `control` channel serves `system.authenticate` and nothing else. Every other method is
+  refused, by name, with the same error a BLE session gives.
+- Media tracks do not flow before that either. A camera in someone's home must not stream to
+  whoever found port 8443.
+- The PIN comes from `configd` over its unix socket, never over the channel being authenticated —
+  the same rule that makes `system.pairingPin` unroutable to BLE.
+
+This is deliberately the *same* mechanism rather than a second one. Two authorisation schemes for
+two transports is how one of them ends up weaker, and it is usually the newer one.
+
+## 5. The control channel is a pipe to the existing API
+
+Frames on `control` are **JSON-RPC 2.0, one object per line**, which is what
+[`duck-ipc-proto`](../../duck-ipc-proto/src/lib.rs) already defines and what `robotctl` and `btd`
+already speak. Nothing new is invented: `mediad` routes a call to the unix socket of the service
+that owns it and pumps replies back.
+
+`btd` is the working precedent and should become the shared one:
+
+| `btd` today | what `mediad` needs |
+|---|---|
+| `route.rs` — which calls may travel, which socket answers, which lane carries them | the same table, with a *different permitted subset* |
+| `session.rs` — the `system.authenticate` gate | the same gate |
+| `upstream.rs` — dial the sockets, timeout everything | the same |
+| `framing.rs` — BLE MTU chunking | **not needed**; SCTP frames itself |
+
+So three of the four files are transport-independent and one is not. **Lift the routing table into
+something both transports use**, parameterised by which subset a transport may reach.
+
+The property worth preserving is not the code, it is the exhaustive match. `route.rs` says it
+plainly: adding a variant to `proto::Call` makes the file fail to compile, so a new method cannot
+reach the radio because somebody forgot this file existed. A `_ => None` wildcard would deny new
+methods silently, and the first symptom would be an app that cannot see a feature nobody remembered
+to route. That guarantee has to hold **per transport**, or WebRTC becomes the hole in it.
+
+### What WebRTC may reach, and why it is not BLE's subset
+
+BLE's subset is narrow because the radio is slow and anyone within a few metres can talk to it.
+Neither applies here, so WebRTC gets more — but "more" is not "everything", and two categories stay
+out:
+
+- **`system.pairingPin` and `system.setPairingPin`.** A PIN readable over the channel it authorises
+  makes the authorisation theatre. Same reasoning as BLE, same answer.
+- **`update.*` mutations.** Not on security grounds — on honesty grounds. §8 explains.
+
+### Replies are not correlated, deliberately
+
+`btd` forwards whatever a socket emits without parsing it, and has a test pinning that: a
+subscription is a stream of notifications on an open connection, and every one has to reach the
+client. Correlating replies to requests would break exactly that. `mediad` inherits the same rule,
+which also means **no per-method work in `mediad` when a method is added** — the pipe stays dumb,
+and `duck-ipc-proto` stays the only place a method is defined.
+
+The lane concept transfers too, and it is easy to assume it will not. Every daemon serves one
+request at a time per connection, so `update.subscribe` followed by anything else on the same
+connection hangs — the exact bug `app-path-design.md` §7 records. One datachannel is one ordered
+stream with the same hazard, and `btd`'s answer works unchanged: route by method to a per-lane
+socket, pump each socket back, never correlate.
+
+## 6. Teleop needs sequence numbers, and this is not optional
+
+`intents.rs` stores each intent in an `ArcSwap` and takes last-writer-wins. That is correct today
+because every writer reaches it through a unix socket, where a later message cannot arrive before an
+earlier one.
+
+**SCTP with `maxRetransmits: 0` reorders.** A twist from 80 ms ago can land after a fresher one and
+win, and the robot then drives on a stale command with nothing anywhere reporting a problem. It is
+not a rare race: it is the normal behaviour of the channel we chose on purpose.
+
+So teleop frames carry a **monotonic sequence number per stream**, and the writer drops anything
+not newer than what it last applied. This is a property of the *transport*, so it belongs in
+`mediad` rather than in `robotd` — `robotd` should keep receiving intents it can trust the ordering
+of, which is what makes `intents.rs` simple.
+
+The deadman needs nothing: `safety.gate(command, twist_age)` is already age-based, so a partition
+stops the robot with no new code. Worth stating because it is the one thing about lossy links that
+is already handled.
+
+## 7. Reaching a robot that is not on your LAN
+
+**The remote path is a bridge to the local signalling server, not a second design.** A relay
+process connects outward to a rendezvous service and proxies the same protocol to
+`ws://127.0.0.1:8443`. The robot's signalling server, session model, authorisation and control
+channel are unchanged; DTLS-SRTP keeps media encrypted end to end even through a relay, which is
+worth stating to clients plainly.
+
+Two properties follow, and both are the reason for this shape:
+
+- **Local mode never depends on the bridge.** If the rendezvous service is down, a LAN client still
+  connects. Invariant 1 in `architecture.md` — local recovery stays independent — extends to media.
+- **The bridge parses nothing.** It proxies the gst signalling protocol, which is the same protocol
+  a LAN client speaks. That is the concrete payoff for using `webrtcsink` rather than `webrtcbin`:
+  the protocol already exists, so the bridge is a relay rather than a translator.
+
+`reachy_mini` runs exactly this arrangement against a Hugging Face Space, with the robot
+registering as a `producer` and the Space keeping a TTL lease refreshed by a heartbeat. Whether we
+adopt that service, and how a robot is bound to an account, is out of scope here and stays out
+until local mode works.
+
+### The signalling protocol, for whoever writes the bridge
+
+From `gst-plugins-rs` 0.15.3, `net/webrtc/protocol` — the wire is JSON with a `type` tag,
+camelCase:
+
+| peer → server | server → peer |
+|---|---|
+| `setPeerStatus` (`roles`, `meta`, `peerId`) | `welcome` (`peerId`) |
+| `startSession` (`peerId`, optional `offer`) | `sessionStarted` (`peerId`, `sessionId`) |
+| `endSession` (`sessionId`) | `startSession`, `endSession` |
+| `peer` (SDP `offer`/`answer`, or `ice`) | `peer`, `error` (`details`) |
+| `list`, `listConsumers` | `list` (`producers`), `listConsumers` (`consumers`) |
+
+Roles are `producer`, `listener`, `consumer`. The robot is a `producer`; `meta` is free-form JSON
+and is where a robot's identity goes.
+
+## 8. Updating the robot over WebRTC: refused, and say so
+
+`RobotRemoteSessionActive` already exists in `duck-ipc-proto`, and
+`updater/src/preflight.rs::check_no_remote_session` already refuses an update while a remote session
+is up. Nothing sets it true yet, because nothing creates remote sessions.
+
+Once `mediad` reports honestly, **an update requested over WebRTC refuses itself.** That is not a
+bug to work around. Restarting `mediad` mid-session drops the session, so the client that asked
+would lose the connection it was watching progress on — and `update-over-ble.md` records what
+"start an update and watch it" failing silently already cost once.
+
+So: `update.*` mutations are not in WebRTC's permitted subset, and the refusal names the reason and
+points at BLE, which is the transport that survives the restart. Read-only `update.*` calls stay
+available, because seeing the version and history over a remote session is useful and harmless.
+
+## 9. Authority: the thing this feature breaks
+
+`intents.rs` says its slots are "single-writer in practice, so last-writer-wins means what it
+says". That premise is true with one gamepad. **It is false the moment a pad and a remote peer both
+drive**, and the failure is not a contest — it is two writers at 50 Hz interleaving into one slot,
+producing a robot that obeys neither.
+
+`architecture.md` §6 already calls for defined priority and handoff rather than last-writer-wins,
+with local physical able to preempt remote, and the roadmap defers it to M6. **WebRTC is what makes
+it due**, so it lands with this rather than after it: an intent carries its source, the loop
+resolves by priority, and a remote peer cannot quietly take the robot from someone holding a pad.
+
+This is the one part of this document that changes a file `robotd` owns, and it is the part most
+worth arguing about before it is written.
+
+## 10. Deferred, with reasons
+
+- **A WebSocket surface for server-side programs** (`architecture.md` §5.3). Same JSON-RPC, no
+  media stack, `get_frame` returning a JPEG. It is a few dozen lines once §5's routing exists, and
+  it is what makes "an LLM drives the robot" easy — but it is a second transport and the first one
+  should work.
+- **Multi-peer video.** One media session at a time, plus control-only clients. Simulcast and
+  encode-once-send-many are a real project.
+- **Consent and the streaming indicator.** `architecture.md` §7 wants explicit per-session consent
+  and a visible indicator, and is right that they are cheap now and expensive later. They need
+  hardware that exists — an LED under software control — which is not yet established.
+- **TURN.** LAN-only needs none. A bridge does, and it costs real bandwidth; that decision belongs
+  with the rendezvous service, not here.

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -52,30 +52,46 @@ started. A LAN client connects to the same server directly.
 
 **Bind address is a decision, not a default.** Loopback only would mean a LAN peer cannot reach it
 at all and every session goes through a bridge, which defeats the point of a local mode. So it
-binds on all interfaces — and that makes §4 load-bearing rather than optional.
+binds on all interfaces, and §4 is what that implies for who may drive.
 
-## 4. Authorisation, because the signalling port is open on the LAN
+## 4. Authorisation: open on the LAN, and the bridge is where that stops
 
-A peer that reaches the signalling server can start a session, and a session carries the control
-channel, which carries the robot API. So the question is not "who may signal" but "who may drive".
+**No gate in the first version.** A peer that reaches the signalling server can start a session,
+drive the robot, and see through its camera. That is a decision, not an oversight.
 
-**Reuse `system.authenticate`.** It already exists — `API_VERSION` v4 added it — and it already
-solves this problem once, for BLE: a client proves knowledge of the robot's pairing PIN before
-anything else is served. `app-path-design.md` §5 explains why the check lives at the protocol layer
-rather than the link layer, and that reasoning transfers unchanged: *we* define the rules here too.
+Usability outranks hardening at this stage, and here the trade is not even close. The robot's
+pairing PIN is a shared `000000` — a PIN that is the same on every robot authenticates nobody — so
+requiring it over WebRTC would add a step to every first connection and buy no safety at all. An
+awkward first connect is a real cost; this particular gate is a real cost with no benefit.
 
-So the control channel is **unauthorised until `system.authenticate` succeeds on it**, exactly as a
-BLE session is. Concretely:
+What it costs, stated plainly so nobody has to discover it: anyone on the same network has the
+robot and its camera. Fine on a bench and in an office. **Not fine in a home**, which is the thing
+to revisit before one ships to one.
 
-- A fresh `control` channel serves `system.authenticate` and nothing else. Every other method is
-  refused, by name, with the same error a BLE session gives.
-- Media tracks do not flow before that either. A camera in someone's home must not stream to
-  whoever found port 8443.
-- The PIN comes from `configd` over its unix socket, never over the channel being authenticated —
-  the same rule that makes `system.pairingPin` unroutable to BLE.
+### The bridge is the line, not the LAN
 
-This is deliberately the *same* mechanism rather than a second one. Two authorisation schemes for
-two transports is how one of them ends up weaker, and it is usually the newer one.
+"On the LAN" is a boundary only while the LAN is the boundary. §7's bridge deletes it: a robot
+reachable through a rendezvous service is reachable by whoever can address it there, and "open to
+anyone who can connect" stops meaning "open to people in the building".
+
+So the rule is: **LAN-only may be unauthenticated; bridged may not.** That is a cheaper commitment
+than it sounds, because the bridge has to solve identity anyway — something has to decide which
+robots a given user may see — and whatever answers that question is also what authorises the
+session. Deferring auth is therefore not deferring work; it is declining to invent a second answer
+before the first one exists.
+
+### The hook, when it is wanted
+
+`system.authenticate` — the method BLE already uses, added in `API_VERSION` v4. A control channel
+would serve that one method and refuse the rest by name until it passes, exactly as a BLE session
+does, with the PIN read from `configd` over its unix socket rather than over the channel being
+authenticated.
+
+Cheap to add later precisely because §5's routing table already needs a notion of *which methods a
+transport may reach*. "Which methods before authentication" is the same table with a smaller
+subset, not a new mechanism. Using BLE's mechanism rather than inventing a second one is the point:
+two authorisation schemes for two transports is how one of them ends up weaker, and it is usually
+the newer one.
 
 ## 5. The control channel is a pipe to the existing API
 
@@ -108,8 +124,10 @@ BLE's subset is narrow because the radio is slow and anyone within a few metres 
 Neither applies here, so WebRTC gets more — but "more" is not "everything", and two categories stay
 out:
 
-- **`system.pairingPin` and `system.setPairingPin`.** A PIN readable over the channel it authorises
-  makes the authorisation theatre. Same reasoning as BLE, same answer.
+- **`system.pairingPin` and `system.setPairingPin`.** Not because they would compromise *this*
+  transport — §4 leaves it open anyway — but because they authorise a **different** one. A LAN peer
+  that can rewrite the pairing PIN can lock a phone out of BLE, which is the recovery path. Keeping
+  the PIN off every network transport is the same rule that makes it unroutable to BLE itself.
 - **`update.*` mutations.** For now only, and for a different reason than the PIN: applying an
   update restarts `mediad` and drops the session. Wanted later; §8 is what it will take.
 
@@ -161,6 +179,11 @@ Two properties follow, and both are the reason for this shape:
 - **The bridge parses nothing.** It proxies the gst signalling protocol, which is the same protocol
   a LAN client speaks. That is the concrete payoff for using `webrtcsink` rather than `webrtcbin`:
   the protocol already exists, so the bridge is a relay rather than a translator.
+
+**And the bridge is where §4's open door closes.** A LAN-only robot may be unauthenticated; a
+bridged one may not, because "whoever can reach it" stops meaning "whoever is in the building". The
+bridge already has to answer which robots a given user may see, and whatever answers that is what
+authorises the session — so this is not extra work, it is the same work not done twice.
 
 `reachy_mini` runs exactly this arrangement against a Hugging Face Space, with the robot
 registering as a `producer` and the Space keeping a TTL lease refreshed by a heartbeat. Whether we

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -110,7 +110,8 @@ out:
 
 - **`system.pairingPin` and `system.setPairingPin`.** A PIN readable over the channel it authorises
   makes the authorisation theatre. Same reasoning as BLE, same answer.
-- **`update.*` mutations.** Not on security grounds — on honesty grounds. §8 explains.
+- **`update.*` mutations.** For now only, and for a different reason than the PIN: applying an
+  update restarts `mediad` and drops the session. Wanted later; §8 is what it will take.
 
 ### Replies are not correlated, deliberately
 
@@ -182,35 +183,57 @@ camelCase:
 Roles are `producer`, `listener`, `consumer`. The robot is a `producer`; `meta` is free-form JSON
 and is where a robot's identity goes.
 
-## 8. Updating the robot over WebRTC: refused, and say so
+## 8. Updating the robot over WebRTC: not yet, and what it will take
 
-`RobotRemoteSessionActive` already exists in `duck-ipc-proto`, and
-`updater/src/preflight.rs::check_no_remote_session` already refuses an update while a remote session
-is up. Nothing sets it true yet, because nothing creates remote sessions.
+Not in the first permitted subset, and **that is a deferral rather than a principle** — a phone
+updating a robot over WebRTC is wanted later, so this section is about what has to be true first
+rather than why it must not be.
 
-Once `mediad` reports honestly, **an update requested over WebRTC refuses itself.** That is not a
-bug to work around. Restarting `mediad` mid-session drops the session, so the client that asked
-would lose the connection it was watching progress on — and `update-over-ble.md` records what
-"start an update and watch it" failing silently already cost once.
+What makes it awkward today: applying an update restarts `mediad`, which drops the session the
+client is watching progress on. `update-over-ble.md` records what "start an update and watch it"
+failing silently already cost once, and a session that vanishes mid-update is the same shape of
+problem. So the first subset leaves `update.*` mutations out and BLE stays the transport that
+survives the restart. Read-only `update.*` calls are in from the start — seeing version and history
+over a remote session is useful and costs nothing.
 
-So: `update.*` mutations are not in WebRTC's permitted subset, and the refusal names the reason and
-points at BLE, which is the transport that survives the restart. Read-only `update.*` calls stay
-available, because seeing the version and history over a remote session is useful and harmless.
+Two things have to change for the mutations, and both are small and specific:
 
-## 9. Authority: the thing this feature breaks
+- **The client has to survive the restart.** The protocol already supports it: progress is pushed
+  as a JSON-RPC *notification*, which `duck-ipc-proto` documents precisely so a client that
+  reconnects mid-update can resubscribe and keep receiving them. So the work is a client that
+  reconnects and re-subscribes, not a change to the wire format.
+- **`RobotRemoteSessionActive` has to get more specific.**
+  `updater/src/preflight.rs::check_no_remote_session` refuses an update while a remote session is
+  up, which is right when the session is a *bystander* — someone is on a telepresence call and
+  should not have the robot restarted under them. It is wrong when the session is the *requester*.
+  Nothing sets that flag true yet, so the distinction can be designed in rather than retrofitted:
+  the check needs to know whether this update was asked for over the session it is about to drop.
+
+Worth writing down now precisely because nothing sets the flag yet. The moment `mediad` reports
+honestly, an update requested over WebRTC would refuse itself, and that would look like a bug in
+the update path rather than a missing distinction here.
+
+## 9. Authority: the premise this feature breaks, noted and not acted on
 
 `intents.rs` says its slots are "single-writer in practice, so last-writer-wins means what it
-says". That premise is true with one gamepad. **It is false the moment a pad and a remote peer both
+says". That is true with one gamepad. **It stops being true the moment a pad and a remote peer both
 drive**, and the failure is not a contest — it is two writers at 50 Hz interleaving into one slot,
 producing a robot that obeys neither.
 
-`architecture.md` §6 already calls for defined priority and handoff rather than last-writer-wins,
-with local physical able to preempt remote, and the roadmap defers it to M6. **WebRTC is what makes
-it due**, so it lands with this rather than after it: an intent carries its source, the loop
-resolves by priority, and a remote peer cannot quietly take the robot from someone holding a pad.
+**Deliberately not solved here.** It is recorded so that a confusing robot has an explanation
+waiting, and because the flag that eventually resolves it is cheaper to design before there are two
+transports than after. `architecture.md` §6 owns the requirement — defined priority and handoff,
+local physical able to preempt remote — and the roadmap has it in M6.
 
-This is the one part of this document that changes a file `robotd` owns, and it is the part most
-worth arguing about before it is written.
+When it is time, the cheap answer is a **single-writer token**: one peer holds the right to write
+intents, others are observers, and handing it over is explicit. That is much less than §6's full
+arbitration and it removes the interleaving, which is the part that produces nonsense rather than
+merely the wrong winner. Priority ordering — physical preempting remote without asking — can come
+after, on top of the same token.
+
+What this section is *for* until then: knowing that two simultaneous drivers is a known gap rather
+than a mystery, and that the first symptom is a robot ignoring both inputs rather than obeying the
+wrong one.
 
 ## 10. Deferred, with reasons
 

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -570,6 +570,55 @@ pub enum Call {
     TofStream,
 }
 
+/// The service that owns the answer to a call.
+///
+/// One socket per service, connected directly — there is no broker (`architecture.md` §2.2). A
+/// transport adapter holds connections to the services whose calls it carries, and to no others:
+/// `btd` holds three, and `padd` being absent from them is deliberate rather than incidental —
+/// `padd` is the unprivileged client whose whole value is having no special access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Service {
+    /// `updaterd`, at [`DEFAULT_SOCKET`].
+    Updater,
+    /// `robotd` — the control loop.
+    Robot,
+    /// `configd` — wifi, identity, the pairing PIN, gamepad bonding.
+    Config,
+    /// `padd` — the raw gamepad input stream.
+    Pad,
+    /// `tofd` — the depth stream.
+    Tof,
+}
+
+/// How long answering a call holds a connection, and therefore which connection carries it.
+///
+/// **Every service here serves one connection one request at a time.** So a single connection per
+/// service would put every call on one queue behind the slowest thing on it, and two orderings a
+/// client reaches for first are broken by that:
+///
+/// - `update.apply` then `update.status` — the status line waits in a socket `updaterd` will not
+///   read for minutes, so the client times out having heard nothing while the robot is fine.
+/// - `update.subscribe` then `update.apply` — worse. The subscription owns its connection until
+///   the peer goes away and never reads another request, so the apply is written into a socket
+///   nobody reads: it never runs, never replies and never errors. An update the owner asked for
+///   that the robot silently did not perform.
+///
+/// Grouping by *how long a call holds a connection* and giving each group its own is what fixes
+/// both. It is at most four sockets per service per session, which costs nothing and is bounded
+/// without bookkeeping — the alternative, a connection per call, needs the adapter to know when a
+/// call ended, which needs it to parse replies. It deliberately never does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Lane {
+    /// Answers as fast as the daemon can look something up.
+    Prompt,
+    /// Seconds: a read that goes to the network or sweeps a radio.
+    Slow,
+    /// As long as it takes, and it changes the robot: an update, joining a network, bonding a pad.
+    Operation,
+    /// Never answers. The service writes notifications until the peer goes away.
+    Stream,
+}
+
 impl Call {
     /// The wire method name.
     pub fn method(&self) -> &'static str {
@@ -649,6 +698,105 @@ impl Call {
                 | Call::PadPair(_)
                 | Call::PadForget(_)
         )
+    }
+
+    /// The service that owns the answer to this call, and how long answering it holds a
+    /// connection. `None` for a call no service answers.
+    ///
+    /// **This is a property of the call, not of a transport.** Who owns `net.connect` does not
+    /// change depending on whether a phone asked over Bluetooth or a browser asked over a
+    /// datachannel, and neither does the fact that `configd` will sit on the connection for the
+    /// better part of a minute while it waits for NetworkManager. Whether a given transport may
+    /// *make* the call is the separate question, and it stays with the transport — see
+    /// `btd::route` for the one that exists, and `docs/design/remote-webrtc.md` §5 for why the two
+    /// were split.
+    ///
+    /// It lives here, beside [`Call::mutates`], because it is the same kind of fact: something
+    /// every adapter needs and none should decide for itself.
+    pub fn destination(&self) -> Option<(Service, Lane)> {
+        use Lane::*;
+        use Service::*;
+        Some(match self {
+            // The version handshake. `updaterd` answers it because it is the service on the
+            // recovery path — the one that must reply when the rest of the robot does not.
+            Call::Hello(_) => (Updater, Prompt),
+
+            // ── updaterd ────────────────────────────────────────────────────
+            //
+            // `Apply`, `Rollback` and `ResetToGolden` all move `current`, and `updaterd`
+            // single-flights mutations behind a file lock and answers `BUSY` for a second one —
+            // so sharing one lane is the behaviour to have rather than a compromise.
+            Call::Apply(_) | Call::Rollback(_) | Call::Select(_) | Call::ResetToGolden(_) => {
+                (Updater, Operation)
+            }
+            // Reaches the network to ask a mirror what exists, so seconds. Deliberately off
+            // `Operation`: "is there an update?" asked during one has an immediate answer
+            // (`BUSY`), and queueing it behind the update would turn that into a spinner that
+            // resolves minutes later.
+            Call::Check(_) => (Updater, Slow),
+            // `update.status` falls back to a cached snapshot rather than waiting for the engine,
+            // so it answers during an apply — which is wasted if the request is queued behind one.
+            Call::Status => (Updater, Prompt),
+            Call::Pin(_) | Call::Log(_) | Call::ListInstalled(_) => (Updater, Prompt),
+            // Owns its connection until the peer goes away and never reads another request.
+            Call::Subscribe => (Updater, Stream),
+
+            // ── robotd ──────────────────────────────────────────────────────
+            Call::RobotSafeToRestart
+            | Call::RobotHealth
+            | Call::RobotModelApi
+            | Call::RobotRemoteSessionActive
+            | Call::RobotMode => (Robot, Prompt),
+            // Intents and one-shot skills. All fast: they store a value the control loop reads on
+            // its next tick, and none of them waits for the robot to finish anything.
+            Call::RobotMove(_)
+            | Call::RobotHead(_)
+            | Call::RobotLook(_)
+            | Call::RobotStop
+            | Call::RobotEnable(_)
+            | Call::RobotInit
+            | Call::RobotRelax
+            | Call::RobotDo(_)
+            | Call::RobotPose(_)
+            | Call::RobotMouth(_)
+            | Call::RobotSound(_)
+            | Call::RobotShutdown => (Robot, Prompt),
+            Call::RobotSubscribe(_) => (Robot, Stream),
+
+            // ── configd ─────────────────────────────────────────────────────
+            Call::NetStatus
+            | Call::NetForget(_)
+            | Call::SystemInfo
+            | Call::SystemServices
+            | Call::SystemSetName(_)
+            | Call::SystemReboot
+            | Call::SystemPairingPin
+            | Call::SystemSetPairingPin(_)
+            | Call::PadStatus
+            | Call::PadForget(_) => (Config, Prompt),
+            // Re-sweeps the radio rather than returning the last scan.
+            Call::NetScan => (Config, Slow),
+            // `configd` polls NetworkManager for up to 45 seconds before calling a join failed,
+            // and `pad.pair` waits on a gamepad for its whole timeout. Both hold the connection
+            // for that long, which is what `Operation` is for — and why `net.status` must not be
+            // queued behind them.
+            Call::NetConnect(_) | Call::PadPair(_) => (Config, Operation),
+
+            // ── padd and tofd ───────────────────────────────────────────────
+            //
+            // Both are streams, and both are named here even though the only transport that
+            // exists today reaches neither: what a call *is* does not depend on who may ask it.
+            Call::PadInput => (Pad, Stream),
+            Call::TofStream => (Tof, Stream),
+
+            // ── answered by no service ──────────────────────────────────────
+            //
+            // The PIN check belongs to the transport, which is the whole point of it: BLE cannot
+            // express a fixed passkey printed on a robot, so the check moved up a layer to where
+            // we define the rules (`docs/design/app-path-design.md` §5). A transport that does not
+            // gate anything simply never sees this call.
+            Call::SystemAuthenticate(_) => return None,
+        })
     }
 
     /// The component this call is about, where it names one.
@@ -2945,6 +3093,51 @@ mod tests {
     /// someone remembers to add it. Pin the count: adding a `Call` without extending the
     /// list fails here, which is the only thing standing between a new method and it never
     /// being round-tripped at all.
+    /// `destination` answers for every call but the one the transport answers itself.
+    ///
+    /// The `None` arm is a single deliberate case — `system.authenticate`, whose check belongs to
+    /// the transport rather than to any service. A second `None` appearing here would mean a call
+    /// no service owns, which is a call nobody can serve.
+    #[test]
+    fn only_authenticate_has_no_service() {
+        for call in every_call() {
+            let has = call.destination().is_some();
+            let expected = !matches!(call, Call::SystemAuthenticate(_));
+            assert_eq!(
+                has,
+                expected,
+                "{} destination() = {:?}",
+                call.method(),
+                call.destination()
+            );
+        }
+    }
+
+    /// A stream holds its connection forever, so it must never share a lane with a call that
+    /// expects an answer.
+    ///
+    /// Pinned because the failure is silent and specific: `update.subscribe` owns its connection
+    /// and never reads another request, so anything queued behind it is written into a socket
+    /// nobody reads — it never runs, never replies and never errors.
+    #[test]
+    fn subscriptions_are_the_only_thing_on_the_stream_lane() {
+        for call in every_call() {
+            if let Some((_, Lane::Stream)) = call.destination() {
+                assert!(
+                    matches!(
+                        call,
+                        Call::Subscribe
+                            | Call::RobotSubscribe(_)
+                            | Call::PadInput
+                            | Call::TofStream
+                    ),
+                    "{} is on the Stream lane but is not a subscription",
+                    call.method()
+                );
+            }
+        }
+    }
+
     #[test]
     fn every_call_covers_every_variant() {
         assert_eq!(

--- a/scripts/cross-sysroot.sh
+++ b/scripts/cross-sysroot.sh
@@ -1,0 +1,204 @@
+#!/bin/sh
+# Build the aarch64 sysroot that `mediad` cross-compiles against.
+#
+# `cargo board` links one C dependency today — libudev, for `gilrs` in `padd` — and
+# `scripts/ci-cross-deps.sh` says plainly that it "is the cost of that one exception, and it is
+# worth reading before adding another". GStreamer is the second, and it is much larger: the
+# `gstreamer-rs` crates are pkg-config crates, so cross-compiling them needs the *target's* headers,
+# `.pc` files and shared libraries on this machine.
+#
+# The route CI takes for libudev — Ubuntu multiarch plus ports.ubuntu.com — is not the route here,
+# for one reason worth stating: it would link against *Ubuntu's* GStreamer while the robot runs
+# Debian trixie's. This unpacks the robot's own packages instead, so what the compiler sees is what
+# the board has, at the same version.
+#
+#   sh scripts/cross-sysroot.sh            build it, then print what to export
+#   sh scripts/cross-sysroot.sh --check    verify an existing one and print nothing else
+#
+# Runs on macOS and Linux. Needs curl, ar, tar, awk and pkg-config — no dpkg, because a `.deb` is
+# an `ar` archive containing a tarball and both hosts have those.
+#
+# It downloads and unpacks; it never installs anything, and everything lives under one directory
+# you can delete.
+set -eu
+
+SYSROOT="${DUCK_SYSROOT:-${TMPDIR:-/tmp}/duck-aarch64-sysroot}"
+CACHE="${SYSROOT}/.cache"
+
+# Debian 13. The robot runs Armbian on a trixie userland and takes GStreamer from the Debian
+# archive — `apt-cache policy` on a provisioned board shows deb.debian.org and security.debian.org
+# with no Armbian multimedia overlay — so this is the same archive the board installs from.
+MIRROR="${DUCK_DEBIAN_MIRROR:-http://deb.debian.org/debian}"
+SUITE="${DUCK_DEBIAN_SUITE:-trixie}"
+ARCH=arm64
+TRIPLE=aarch64-linux-gnu
+
+# The pkg-config modules `mediad` needs. `--check` verifies exactly these, so a package list that
+# goes stale fails here rather than inside a build.
+#
+# `gstreamer-webrtc-1.0` and `gstreamer-sdp-1.0` come from plugins-bad. `mediad` drives
+# `webrtcsink` mostly by setting properties and connecting signals, which is core GStreamer and
+# GLib — but a data channel is a `GstWebRTCDataChannel`, so the typed bindings are wanted rather
+# than reaching for untyped `glib::Object` calls.
+#
+# **`libudev` is here because it has to be, and the reason is worth knowing.**
+# `PKG_CONFIG_LIBDIR` *replaces* pkg-config's search path rather than adding to it, so a sysroot
+# that carries only GStreamer breaks `padd`, whose `gilrs` needs libudev — `cargo board` then fails
+# in `libudev-sys`, nowhere near anything about media. Replacing is nonetheless the right choice:
+# `PKG_CONFIG_PATH` is additive to the host's, and `ci-cross-deps.sh` records what that costs —
+# pkg-config answering with the *host's* library and producing a binary that cannot run on the
+# robot. So this sysroot serves the whole workspace rather than one crate of it.
+MODULES="gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 gstreamer-audio-1.0
+gstreamer-webrtc-1.0 gstreamer-sdp-1.0 libudev"
+
+# The packages that satisfy those modules, and nothing more.
+#
+# **Explicit, not resolved.** Walking Debian `Depends` from these roots pulls 543 packages —
+# `libgstreamer-plugins-bad1.0-dev` declares every optional backend's dev package, so the closure
+# reaches Qt, Vulkan and OpenEXR. None of that is needed to compile against one `.pc` file.
+#
+# Derived by unpacking the four obvious roots and then asking `pkg-config` what was missing, one
+# round at a time, mapping each answer back to a package through the archive's `Contents` index:
+# libpcre2-8, libffi, orc-0.4, zlib, mount, blkid, libselinux, libsepol — eight rounds, in that
+# order. Re-derive the same way if `--check` starts failing; the map is
+# `Contents-arm64.gz`, whose lines are `path  section/package`.
+#
+# Note `libglib2.0-0t64` and not `libglib2.0-0`: trixie's 64-bit `time_t` transition renamed it.
+# And `libgio-2.0-dev` rather than `libglib2.0-dev`, which is a 55 KiB metapackage — GLib's headers
+# and `.pc` files moved out of it.
+#
+# **A `-dev` package alone is not enough for anything actually linked**, and the split is not
+# obvious. A `-dev` ships `libfoo.so` as a *symlink* onto the `libfoo.so.N` that lives in the
+# runtime package, so `-lfoo` on the link line needs both. That is why the GStreamer, GLib and
+# udev runtime packages are here.
+#
+# The rest are `-dev` only, and correctly so: pcre2, ffi, orc, zlib, mount, blkid, selinux and
+# sepol appear in `Requires.private`, which pkg-config needs to *resolve* but which never reaches
+# the link line of a dynamically linked binary. If one of them ever does, the symptom is
+# `unable to find dynamic system library` and the fix is its runtime package.
+PACKAGES="libgstreamer1.0-dev libgstreamer1.0-0
+libgstreamer-plugins-base1.0-dev libgstreamer-plugins-base1.0-0
+libgstreamer-plugins-bad1.0-dev libgstreamer-plugins-bad1.0-0
+libgio-2.0-dev libglib2.0-dev libglib2.0-dev-bin libglib2.0-0t64
+libsysprof-capture-4-dev libpcre2-dev libffi-dev liborc-0.4-dev
+zlib1g-dev libmount-dev libblkid-dev libselinux1-dev libsepol-dev
+libudev-dev libudev1"
+
+say()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+CHECK_ONLY=0
+[ "${1:-}" = "--check" ] && CHECK_ONLY=1
+
+check_tools() {
+    for t in curl ar tar awk pkg-config; do
+        command -v "$t" >/dev/null 2>&1 || die "${t} is required"
+    done
+}
+
+# The environment a cross build needs. Printed rather than exported, because a script cannot
+# export into its caller's shell — and `eval` on this is one line the caller can read first.
+print_env() {
+    cat <<EOF
+export PKG_CONFIG_SYSROOT_DIR="${SYSROOT}"
+export PKG_CONFIG_LIBDIR="${SYSROOT}/usr/lib/${TRIPLE}/pkgconfig:${SYSROOT}/usr/share/pkgconfig"
+export PKG_CONFIG_ALLOW_CROSS=1
+export RUSTFLAGS="\${RUSTFLAGS:+\$RUSTFLAGS }-L ${SYSROOT}/usr/lib/${TRIPLE}"
+EOF
+}
+
+# Are all of MODULES resolvable against the sysroot?
+verify() {
+    PKG_CONFIG_SYSROOT_DIR="$SYSROOT"
+    PKG_CONFIG_LIBDIR="${SYSROOT}/usr/lib/${TRIPLE}/pkgconfig:${SYSROOT}/usr/share/pkgconfig"
+    PKG_CONFIG_ALLOW_CROSS=1
+    export PKG_CONFIG_SYSROOT_DIR PKG_CONFIG_LIBDIR PKG_CONFIG_ALLOW_CROSS
+
+    bad=0
+    for mod in $MODULES; do
+        if version="$(pkg-config --modversion "$mod" 2>/dev/null)"; then
+            printf '  %-24s %s\n' "$mod" "$version"
+        else
+            # The first line names the module pkg-config could not find, which is usually a
+            # transitive one rather than $mod itself — that is the package to add above.
+            printf '  %-24s MISSING: %s\n' "$mod" \
+                "$(pkg-config --print-errors --exists "$mod" 2>&1 | head -1)"
+            bad=1
+        fi
+    done
+    return "$bad"
+}
+
+fetch() {
+    install -d "$CACHE"
+    index="${CACHE}/Packages"
+    if [ ! -s "$index" ]; then
+        say "fetching the ${SUITE}/${ARCH} package index"
+        curl -fsSL -o "${index}.gz" \
+            "${MIRROR}/dists/${SUITE}/main/binary-${ARCH}/Packages.gz" \
+            || die "cannot fetch the package index from ${MIRROR}"
+        gunzip -f "${index}.gz" || die "cannot gunzip the package index"
+    fi
+
+    for pkg in $PACKAGES; do
+        # `Filename:` for this exact package, from its own stanza. Matched on a whole-line
+        # `Package:` so `libgstreamer1.0-0` cannot be answered by `libgstreamer1.0-0-dbgsym`.
+        rel="$(awk -v want="$pkg" '
+            /^Package: /   { cur = ($2 == want) }
+            cur && /^Filename: / { print $2; exit }
+        ' "$index")"
+        [ -n "$rel" ] || die "no ${pkg} in ${SUITE}/${ARCH}.
+  Debian renames packages between releases — trixie moved GLib's headers out of libglib2.0-dev
+  and renamed libglib2.0-0 to libglib2.0-0t64. If this is a rename, fix PACKAGES above."
+
+        deb="${CACHE}/$(basename "$rel")"
+        [ -s "$deb" ] || curl -fsSL -o "$deb" "${MIRROR}/${rel}" \
+            || die "cannot download ${MIRROR}/${rel}"
+
+        # `ar x` writes into the working directory, so each unpack gets its own.
+        tmp="$(mktemp -d)"
+        ( cd "$tmp" && ar x "$deb" ) || { rm -rf "$tmp"; die "cannot unpack ${deb}"; }
+        data="$(find "$tmp" -maxdepth 1 -name 'data.tar*' | head -1)"
+        [ -n "$data" ] || { rm -rf "$tmp"; die "no data.tar in ${deb}"; }
+        tar -xf "$data" -C "$SYSROOT" || { rm -rf "$tmp"; die "cannot extract ${data}"; }
+        rm -rf "$tmp"
+        printf '  %s\n' "$pkg"
+    done
+}
+
+main() {
+    check_tools
+
+    if [ "$CHECK_ONLY" = 1 ]; then
+        [ -d "$SYSROOT" ] || die "no sysroot at ${SYSROOT}; run this without --check first"
+        say "verifying ${SYSROOT}"
+        verify || die "the sysroot does not satisfy every module above.
+  The MISSING line names the module pkg-config could not find — look it up in the archive's
+  Contents-arm64 index and add the package that ships it to PACKAGES in this script."
+        exit 0
+    fi
+
+    install -d "$SYSROOT"
+    say "unpacking into ${SYSROOT}"
+    fetch
+
+    printf '\n'
+    say "pkg-config against the sysroot"
+    verify || die "built the sysroot and it still does not satisfy every module above."
+
+    printf '\n'
+    say "ready — export these, or: eval \"\$(sh scripts/cross-sysroot.sh --check >/dev/null && \
+sh scripts/cross-sysroot.sh 2>/dev/null | grep ^export)\""
+    printf '\n'
+    print_env
+    cat <<EOF
+
+Then \`cargo board\` links against the robot's own libraries. Delete ${SYSROOT} to start over;
+the downloaded .debs are cached under it, so a rebuild costs nothing.
+EOF
+}
+
+# Called on the last line so a truncated download defines functions and then does nothing, rather
+# than running half a build.
+main "$@"


### PR DESCRIPTION
`architecture.md` §5 states the requirement for remote access; nothing owned the mechanism. This
does — [`docs/design/remote-webrtc.md`](docs/design/remote-webrtc.md).

Docs only. No code, and it does not depend on #131 — separate files, either order.

**Scoped to local signalling.** Everything in it runs on the robot and works on a LAN with no
backend at all. Reaching a robot from outside is the same design with a proxy in front of the local
signalling server, which is how `reachy_mini` already does it against a Hugging Face Space — so
the remote case is defined in terms of the local one rather than beside it, and local mode never
depends on the bridge being up.

## The choice everything else follows from

**`webrtcsink`, not `webrtcbin`.** `webrtcsink` brings a signalling protocol, a session model and
per-consumer encoder management, so what is left to design is the *control* surface rather than the
media plumbing. And that protocol is what a remote bridge proxies — which is why the bridge is a
relay rather than a translator.

`run-signalling-server` (verified present in gst-plugins-rs 0.15.3, with `signalling-server-host`
and `-port`) means `mediad` runs the server in its **own process**, so the separate
`gst-webrtc-signalling-server` binary never has to be built or shipped — worth knowing, since what
we ship from that upstream is a `.so` and the server is a Rust binary beside it.

## Four things it decides

**No authorisation on the robot at all**, and it holds for both paths for different reasons.

*Locally*: anyone on the same network can drive the robot and see its camera. The pairing PIN is a
shared `000000`, so requiring it would add a step to every first connection and prove only that the
peer read a number printed on every robot. Usability outranks hardening here and this gate is cost
with no benefit. What it costs is stated plainly — fine on a bench and in an office, not fine in a
home.

*Remotely*: the bridge already authenticates, **on both sides**. The client authenticates to the
rendezvous service with OAuth and sees only the robots its account owns, so reaching the part of the
bridge that routes to a given robot *is* the proof; and the robot's relay connects outward holding
an account token, so the robot proves it belongs to the account too. The service matches two
already-authenticated parties, and a `system.authenticate` on top would be a second answer to a
question already answered.

So the trust moved rather than vanished, and the doc names where: the robot has no independent
check, so the robot↔account binding must be right and lives in the service. The one case neither
argument covers is a signalling port exposed to the internet by a port forward rather than through
the bridge — a deployment mistake, worth stating because nothing in the robot would notice.

**The control channel is a pipe to the JSON-RPC that already exists.** `btd` is the precedent, and
three of its four files are transport-independent — only `framing.rs` is BLE-specific, since SCTP
frames itself. So the routing table should be **lifted and parameterised by transport**. The
property worth preserving is not the code but the exhaustive match: adding a `proto::Call` variant
must keep failing to compile, or WebRTC becomes the hole in a guarantee `route.rs` currently holds
for BLE. Replies stay uncorrelated, which is what keeps the pipe free of per-method work.

**Teleop carries sequence numbers.** `intents.rs` takes last-writer-wins, which is correct over a
unix socket and wrong over SCTP with `maxRetransmits: 0` — a twist from 80 ms ago can land after a
fresher one and win, with nothing reporting a problem. That is the normal behaviour of the channel
we chose on purpose, so it is a transport property and belongs in `mediad`. The deadman needs
nothing: `safety.gate` is already age-based.

**`update.*` mutations wait, and the doc says what they need rather than why they must not be.**
Applying an update restarts `mediad` and drops the session the client is watching progress on, so
BLE stays the transport that survives it. Two specific things unblock it later: a client that
reconnects and re-subscribes — which the protocol already supports, since progress is a
notification precisely so a reconnecting client keeps receiving it — and `RobotRemoteSessionActive`
learning to tell a *bystander* session from the one that *requested* the update. Worth designing
now because nothing sets that flag yet; the moment `mediad` reports honestly, an update over
WebRTC would refuse itself and look like a bug in the update path.

## The premise this feature breaks — noted, not solved

`intents.rs` says its slots are "single-writer in practice, so last-writer-wins means what it
says". True with one gamepad. **It stops being true the moment a pad and a remote peer both
drive** — and the result is not a contest but two writers at 50 Hz interleaving into one slot,
producing a robot that obeys neither.

**Deliberately not fixed here**, and the doc no longer asks for it to be. `architecture.md` §6 owns
the requirement and the roadmap has it in M6. The section exists so that a confusing robot has an
explanation waiting, and it records the cheap answer for when it is time: a **single-writer token**
— one peer holds the right to write intents, others observe, handover is explicit. That removes the
interleaving, which is the part that produces nonsense rather than merely the wrong winner, and
priority ordering can be layered on the same token later.

Nothing in this PR touches a file `robotd` owns.

## Also in there

- The exact signalling protocol from `net/webrtc/protocol` at 0.15.3 — message set, roles, field
  names — for whoever writes the bridge, read off the source rather than inferred from another
  implementation's log lines.
- Which `Call` variants stay out of WebRTC's subset, and that the two reasons are different:
  `system.pairingPin` on security grounds, `update.*` on honesty grounds.
- What is deferred and why: the WebSocket surface for server-side programs, multi-peer video,
  consent plus the streaming indicator (which needs an LED that is not yet established), and TURN.

## Review focus

§5 and §6. §5's routing-table lift is the decision that constrains future code — the exhaustive
match over `proto::Call` has to keep holding *per transport* or WebRTC becomes the hole in it. §6 is
the one place the doc says something is not optional, and it is the claim I would least like to be
wrong about: SCTP with `maxRetransmits: 0` reorders, so a stale twist can win last-writer-wins in
`intents.rs`, which a unix socket cannot produce.

§4 (LAN-open) and §9 (authority noted, not solved) reflect review decisions already taken.

