### PR TITLE
robotd: give the startup greet its own switch

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -261,6 +261,11 @@ mode = "walk"
 # Where the voice bank lives.
 # bank = "/var/lib/robot/sounds"
 
+# Quack once as the control loop comes up — on a headless board that greet is the audible
+# "robotd is running". Turn it off (and keep the triggers, and the mic) if you restart the
+# daemon often enough to be tired of it.
+# greet = true
+
 # Listen for petting on the onboard mic and coo about it. Unset resolves per mode, as the
 # prototype's launcher did: on for walking, off for the roller. The model ships in the
 # release (models/pet_detect.onnx); "none" disables it outright; thresholds are the

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -238,10 +238,19 @@ robotctl quack
 The loudest way to tell ducks apart: every robot's voice bank is generated from its SoC
 serial (`sounds ensure-bank`, run by every release install), so the robot that answers — in
 a voice that is only its own — is the one you're SSH'd into. A robot with no voice — audio
-off, or no bank — says so instead of printing 🦆, so silence always means the wrong duck. The robot also greets when
-`robotd` comes up, pecks goodbye before powering off, and coos when the mic hears its head
-being scratched (walk mode; the classifier ships in the release). Audio hardware bring-up —
-codec driver, overlays, mixer — is `setup-board.sh`'s audio section, once per board.
+off, or no bank — says so instead of printing 🦆, so silence always means the wrong duck.
+The robot also greets when `robotd` comes up, pecks goodbye before powering off, and coos
+when the mic hears its head being scratched (walk mode; the classifier ships in the
+release). The startup greet has its own switch, for anyone restarting the daemon all day:
+
+```
+sudo robotctl configure
+```
+
+Set `audio.greet = false` and take the restart it offers on save. That silences the one
+quack and leaves the triggers and the mic alone, which `audio.enabled = false` does not.
+Audio hardware bring-up — codec driver, overlays, mixer — is `setup-board.sh`'s audio
+section, once per board.
 
 To audition a voice or regenerate the bank by hand, the release carries the generator:
 

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -53,6 +53,10 @@ pub struct AudioParams {
     /// Where the per-robot voice bank lives. The release's postinstall renders it there
     /// (`sounds ensure-bank`), seeded from the SoC serial.
     pub bank: PathBuf,
+    /// Quack once as the control loop comes up. On by default because on a headless board
+    /// it is the audible "robotd is running"; off for anyone who restarts the daemon all
+    /// day and would rather it did so quietly.
+    pub greet: bool,
     /// Listen for petting on the onboard mic. Absent resolves per mode, as the prototype's
     /// launcher does: on for walking, off for the roller (its launch line dropped
     /// `--pet-detect`).
@@ -71,6 +75,7 @@ impl Default for AudioParams {
             enabled: true,
             device: "plughw:aic3104".to_owned(),
             bank: PathBuf::from("/var/lib/robot/sounds"),
+            greet: true,
             pet_detect: None,
             pet_model: None,
             pet_enter_threshold: 0.95,

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -291,6 +291,11 @@ pub const REGISTRY: &[Entry] = &[
     entry("audio.device", Kind::Text, "ALSA playback device"),
     entry("audio.bank", Kind::Text, "Voice bank directory"),
     feature(
+        "audio.greet",
+        Kind::Bool,
+        "Quack once at startup — the audible \"robotd is running\"",
+    ),
+    feature(
         "audio.pet_detect",
         Kind::TriBool,
         "Coo when petted; unset resolves per mode (walk on, roller off)",
@@ -463,6 +468,7 @@ mod tests {
                 "safety.battery_empty_shutdown",
                 "safety.limp_fall",
                 "audio.enabled",
+                "audio.greet",
                 "audio.pet_detect",
             ]
         );

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -1191,8 +1191,13 @@ async fn control_loop<T: RobotIo>(
     };
 
     // Say hello in this robot's own voice as the control loop comes up, as the prototype
-    // does — the greet is also the audible "robotd is running" on a headless board.
-    if let Some(voice) = voice.as_mut() {
+    // does — the greet is also the audible "robotd is running" on a headless board. Its
+    // own switch, because the reason to want it gone (restarting the daemon all day) is
+    // not a reason to give up the triggers and the mic that `audio.enabled = false` takes
+    // with it.
+    if let Some(voice) = voice.as_mut()
+        && params.audio.greet
+    {
         voice.play("greet", false);
     }
 


### PR DESCRIPTION
The greet fires unconditionally whenever the voice exists, so the only way to stop it was `audio.enabled = false` — which also takes the chirp, the wheee and the petting mic with it. Restarting the daemon all day is not a reason to give up the rest of the robot's voice.

## The key

```toml
[audio]
greet = false
```

Default `true`: on a headless board that quack is still the audible "robotd is running", so a robot nobody has told otherwise behaves exactly as before.

It is a `feature()` entry in the registry, not a plain one — this is a key someone opens the editor to flip, so it belongs on `robotctl configure`'s front page next to `audio.enabled`. That means the pinned feature-switch set moves by one line, deliberately.

Config is read once at startup, so `sudo robotctl configure` offers the restart on save — turning the greet off costs exactly one more greet.

## Checks

`cargo test -p robotd-params` green, `cargo check -p robotd -p robotctl`, clippy and `cargo fmt --check` clean.