### PR TITLE
The WebRTC client, from a test page to the robot's console

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -165,6 +165,7 @@ jobs:
             --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
+            --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -153,6 +153,7 @@ jobs:
             --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
+            --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ name = "mediad"
 version = "0.9.1"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "duck-ipc-proto",
  "glib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -475,9 +475,9 @@ dependencies = [
  "jni 0.19.0",
  "jni-utils",
  "log",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-bluetooth",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "once_cell",
  "static_assertions",
  "thiserror 2.0.19",
@@ -1007,6 +1007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1071,7 @@ dependencies = [
  "futures",
  "serde_json",
  "tokio",
+ "webbrowser",
 ]
 
 [[package]]
@@ -2463,6 +2474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,14 +2625,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-bluetooth"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
 dependencies = [
  "bitflags 2.13.1",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2625,6 +2662,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2642,7 +2681,18 @@ dependencies = [
  "bitflags 2.13.1",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4605,6 +4655,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
+dependencies = [
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -112,8 +112,8 @@ manifest_asset = "manifest.json"
 # `updaterd` restarts neither itself nor `btd`, both of which ship in this same artifact:
 # restarting itself would kill the executor mid-update, and restarting `btd` would drop
 # the connection reporting progress to the app. Both pick up the new binary at the next
-# boot. `mediad` joins this list in the change that first installs it — naming a unit
-# that does not exist makes `systemctl restart` fail, which rolls the update back.
+# boot. `mediad` needs no entry: the restart set is derived from the units the release ships,
+# and `mediad.service` has an `[Install]` section, so an apply restarts it like the rest.
 [component.daemon.on_apply]
 action = "restart"
 # The daemons whose binaries an update replaces and which are safe to interrupt while it runs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ own the mechanism is the bug.
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 | [`remote-webrtc.md`](design/remote-webrtc.md) | WebRTC sessions, signalling, and the control channel — how a peer drives and observes the robot. |
+| [`webrtc-console.md`](design/webrtc-console.md) | The WebRTC client: serving it from the robot, finding the robot, and what the page should be. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
 
 ## `project/` — you are running the project

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -153,6 +153,8 @@ upstream crate. Not shipping it is a real simplification, not a shortcut.
 started. A LAN client connects to the same server directly — `mediad/webclient/index.html` is one,
 in a single file with no build step, which speaks this protocol by hand rather than through
 `gst-plugins-rs`'s JS library so that trying it needs nothing installed.
+[`webrtc-console.md`](webrtc-console.md) owns what becomes of that page — the robot serving it,
+finding the robot, and the control surface it should reach.
 
 **Bind address is a decision, not a default.** Loopback only would mean a LAN peer cannot reach it
 at all and every session goes through a bridge, which defeats the point of a local mode. So it

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -103,6 +103,14 @@ live path.
 | 5 | verify sha256, then verify the artifact signature | no |
 | 6 | extract to `releases/.staging-<ver>/root/`, write `.updater-manifest.json` | no |
 | 7 | **`hooks/preinstall`** (cwd = the staged tree) — installs ONNX Runtime if below the floor, then runs the release's `scripts/setup-gstreamer.sh` for `mediad`'s stack | no |
+
+**The hook script comes from the incoming release; the code that runs it does not.** `updaterd`
+never restarts itself mid-update (§1), so every step in this table is executed by the `updaterd`
+that was already running — the *previous* release's. A change to how hooks are run, logged or
+bounded therefore takes effect one apply later, on the first apply after `updaterd` has restarted
+onto the release carrying it. This cost a confused round of "the hook ran and logged nothing" once;
+`cat /run/updaterd/identity.json` is what tells you which build is about to run your hook.
+
 | 8 | `rename` the staged tree to `releases/<ver>/` | no |
 | 9 | arm the boot counter (`pending.json`), *before* the swap | no |
 | 10 | swap `current` → `releases/<ver>` | no |

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -102,7 +102,7 @@ live path.
 | 4 | download to `releases/.staging-<ver>/dl/` | no |
 | 5 | verify sha256, then verify the artifact signature | no |
 | 6 | extract to `releases/.staging-<ver>/root/`, write `.updater-manifest.json` | no |
-| 7 | **`hooks/preinstall`** (cwd = the staged tree) — installs ONNX Runtime if below the floor | no |
+| 7 | **`hooks/preinstall`** (cwd = the staged tree) — installs ONNX Runtime if below the floor, then runs the release's `scripts/setup-gstreamer.sh` for `mediad`'s stack | no |
 | 8 | `rename` the staged tree to `releases/<ver>/` | no |
 | 9 | arm the boot counter (`pending.json`), *before* the swap | no |
 | 10 | swap `current` → `releases/<ver>` | no |

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -832,6 +832,12 @@ so no unsigned code ever runs. Rust binary or shell script — the engine just
 **Contract**
 - Runs *after* the symlink swap, *before* `apply`. (A `pre_install` hook, if
   present, runs before the swap.)
+- The pre-install hook gets a longer ceiling than the post-install one — ten minutes
+  against two. It is the hook that installs what the release needs and the board may not
+  have (ONNX Runtime; the GStreamer stack for `mediad`, which is around 100 MB of apt on a
+  board that has never had it), and it can afford the minutes precisely because nothing has
+  been swapped: the old release is still live and serving, so a long pre-install is a slow
+  update rather than a robot in an unclear state.
 - Non-zero exit ⇒ failed update ⇒ rollback.
 - Environment provided (absent values are **omitted**, not set empty, so a hook can
   tell "first install" from "unknown"):

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -1207,12 +1207,14 @@ gate against. Both are now live:
 
 | | was | now | still pending |
 |---|---|---|---|
-| `on_apply` | `none` | `restart` with `["robotd"]` | `mediad` joins the list when it exists |
+| `on_apply` | `none` | `restart` with `["robotd", "configd"]` | — |
 | `health` | `none` | `socket`, 30s | timeout is a guess until M4 measures a real boot |
 
-`mediad` stays out for the original reason: naming a unit that is not installed makes
-`systemctl restart` fail, which fails the update, which rolls it back — so listing it
-today would revert every update.
+`mediad` needed an entry under the old authoritative list and needs none now: the restart
+set is derived from the units a release ships, skipping any without an `[Install]`
+section, and `mediad.service` has one. So an apply restarts it, and a robot that has
+never run it enables it on the next install — the rule is the unit file, not a name
+anybody maintains.
 
 **`health = none` was the weakest the design gets**: it commits as soon as the swap
 succeeds, so there was no auto-rollback at all, and the boot counter was the only

--- a/docs/design/webrtc-console.md
+++ b/docs/design/webrtc-console.md
@@ -85,7 +85,7 @@ it this way first.
 Three things keep it there, and they are requirements on the change rather than hopes:
 
 - **One address is typed.** `http://<robot>:8080`. The 8443 is reached by the page's own
-  JavaScript and never by a human. `duck-btctl open` (§2) removes even that one.
+  JavaScript and never by a human. `duckctl open` (§2) removes even that one.
 - **`mediad` fills the signalling URL in as it serves the page**, rather than the page carrying a
   constant. It knows the host the request arrived on and it knows its own `--port`, so the page
   gets the real answer — one `str::replace` over the embedded string at startup. This is what
@@ -112,18 +112,18 @@ Worth writing down now rather than discovering it while wiring a microphone.
 
 ## 2. Finding the robot: two commands, and one of them is already hand-rolled
 
-`btd` files the robot's IPv4 in its advertisement under company id `0xFFFF`, and `duck-btctl`
+`btd` files the robot's IPv4 in its advertisement under company id `0xFFFF`, and `duckctl`
 already parses it — `Address::At`, `Unassigned`, `Unsaid`, three answers rather than two, and
 `scan` prints it today. So the work is a command, not a mechanism.
 
-### 2.1 `duck-btctl ip`
+### 2.1 `duckctl ip`
 
-The robot's address on stdout and nothing else, so `ssh radxa@$(duck-btctl ip)` works — the split
+The robot's address on stdout and nothing else, so `ssh radxa@$(duckctl ip)` works — the split
 the tool already keeps, diagnostics on stderr and data on stdout.
 
 **This is not a new idea in this repo; it is one that has already been written badly once.**
 `scripts/dev-push.sh` needs exactly this and hand-rolls it: `resolve_board()` calls
-`duck-btctl wifi status` and pipes the JSON through a six-line Python program embedded in the
+`duckctl wifi status` and pipes the JSON through a six-line Python program embedded in the
 shell script to pull `result.ip4`. That is the command, minus a home.
 
 Reading the advertisement rather than calling `net.status` is better on three counts, all of them
@@ -134,21 +134,21 @@ visible in what `dev-push.sh` had to write around:
   refused, so that branch stops existing.
 - **Seconds rather than tens of seconds.** `dev-push.sh` caches the address per robot precisely
   because "BLE discovery costs ten to twenty seconds"; a scan that stops at the first matching
-  advertisement is about a second, because `duck-btctl` already polls until something appears
+  advertisement is about a second, because `duckctl` already polls until something appears
   rather than sleeping out `SCAN_TIME`.
 - **It is not stale.** `btd`'s `reconcile_advertisement` re-reads `net.status` every `ADV_POLL`
   (5s) and re-advertises when the answer moves, so the advertisement *is* `net.status` with a
   five-second lag — well inside the window in which a new lease has already broken ssh.
 
 **With one fallback, which is not optional.** A robot bonded to this Mac often stops advertising
-the service to it — `duck-btctl`'s own scan tiers exist for that — so when no advertisement is
+the service to it — `duckctl`'s own scan tiers exist for that — so when no advertisement is
 seen, `ip` connects and asks `net.status`, which is what `dev-push.sh` does today. Cheap read
 first, call second. Without the fallback this command would fail on exactly the laptops that use
 it most.
 
 The three-way `Address` already carries the right failure text and this is where it pays:
 
-- `Unassigned` — the robot has no network. The fix is `duck-btctl wifi connect`, and it has to be
+- `Unassigned` — the robot has no network. The fix is `duckctl wifi connect`, and it has to be
   over BLE, because `net.connect` is refused over WebRTC by design ("a robot that has never seen a
   network cannot be configured over that network").
 - `Unsaid` — a release from before `btd` advertised an address. The fallback answers anyway;
@@ -157,19 +157,19 @@ The three-way `Address` already carries the right failure text and this is where
 Its third caller is neither of the two above: `install-dev.md` opens by asking for "the board's
 **IP address**", with the note that mDNS on this image is unreliable, and offers no way to get it.
 
-### 2.2 `duck-btctl open`
+### 2.2 `duckctl open`
 
 Resolve, then open `http://<address>:8080/` in the browser. `--print` prints the URL instead, for
 a machine with no browser or a script; `--port` for a robot started with a non-default
 `--web-port`.
 
 A command rather than a documented shell substitution, for one reason: **the port default should
-live in exactly one place that a person never has to read.** `open "http://$(duck-btctl ip):8080"`
+live in exactly one place that a person never has to read.** `open "http://$(duckctl ip):8080"`
 works, and it is the kind of line someone writes once and then looks up forever.
 
 ### 2.3 Not these
 
-- **`duck-btctl url`.** That is `open --print`. A third command whose entire content is a port
+- **`duckctl url`.** That is `open --print`. A third command whose entire content is a port
   number.
 - **A URL column on `scan`.** `scan` lists earbuds too, and the robot lines already carry the
   address. One note under the list pointing at `open` is enough.
@@ -184,23 +184,23 @@ alternatives and become a sequence — which is worth saying because `route.rs` 
 over WebRTC deliberately, and this is the other half of that refusal.
 
 The follow-on, in its own change rather than these four: `dev-push.sh`'s `resolve_board` becomes
-`btctl --name "$1" ip`, deleting the embedded Python and the wrong-PIN branch. Separate because it
+`client --name "$1" ip`, deleting the embedded Python and the wrong-PIN branch. Separate because it
 touches the push path, and because it should land after `ip` has been used by hand a few times.
 
-Both commands are written here under today's name; §3 is the argument that it should be
-`duckctl` by the time they land.
-
-`duck-btctl` is a stopgap for the phone app, so this stays at two commands and no new mechanism.
+`duckctl` is a stopgap for the phone app, so this stays at two commands and no new mechanism.
 The durable halves are the ones that outlive it: `btd` broadcasting the address, and `mediad`
 serving on a known port. The app will do the same two steps natively.
 
 ## 3. The tool is named after a transport it is about to stop being
 
-`open` launches a browser at an http URL, and the name of the tool that does it says `bt`. Worth
-pulling on, because it turns out to point at something larger than one command.
+**Decided and landed** — `duck-btctl` is `duckctl`, in its own crate. The rest of this section is
+the reasoning, kept because the alternatives are the part worth being able to re-read.
+
+`open` launches a browser at an http URL, and the name of the tool that does it said `bt`. Worth
+pulling on, because it turned out to point at something larger than one command.
 
 **`open` itself is not misplaced.** Its substance *is* Bluetooth: it scans for an advertisement to
-learn where the robot is, and the `xdg-open` on the end is one line. `duck-btctl open` reads as
+learn where the robot is, and the `xdg-open` on the end is one line. `duckctl open` reads as
 "use the radio to find the robot, then show me its console", which is exactly what it does — the
 same way `wifi connect` is a wifi command whose whole mechanism is BLE.
 
@@ -241,23 +241,32 @@ without an alias.
 plausible on a Mac. `microduck` is the repository and too long for a command someone runs twenty
 times an hour.
 
-### 3.3 What not to rewrite
+### 3.3 What was not rewritten
 
-196 references across about twenty files, and most are prose. **`docs/project/` is not among them.**
-Those are dated records that describe a moment — an update session in August, four install-path
-bugs and what closed them — and rewriting a tool name into an account of something that happened
-before the tool had that name makes the record slightly false. They keep saying `duck-btctl`.
-`docs/robot/`, `docs/design/`, the scripts and the code are the rename.
+196 references across about twenty files, most of them prose. **The dated records keep the old
+name.** `update-over-ble.md` and `install-path-gap.md` describe a moment — an update session, four
+install-path bugs and what closed them — and rewriting a tool name into an account of something
+that happened before the tool had it makes the record slightly false. Their *links* are repointed
+so they still resolve; their prose is not.
+
+`roadmap.md` sits in the same directory and is the exception, because it is not a record of a
+moment: it describes the repo as it is now, down to a crate-by-crate layout table. A layout table
+naming a directory that does not exist is simply wrong.
 
 **No compatibility shim, no alias.** One user and one robot: a `duck-btctl` that still works is a
 second name to keep in step and a reason for the old one to survive in someone's shell history for
 a year.
 
-### 3.4 When
+### 3.4 What keeps it off the board
 
-Before the console work adds commands under the old name, and ideally before `ip` and `open` are
-documented — otherwise `docs/robot/duck-btctl.md` gets those two entries written twice. It blocks
-nothing and nothing blocks it, so it is cheapest first and merely tidy later.
+`cargo board --bins` — in `dev-push.sh` and in the release workflow — builds every default member
+for aarch64. As an example it was excluded for free; as a crate it would be cross-compiled, which
+means building a Bluetooth stack for a board that must never see one, on the release path.
+
+**`default-members` in the workspace root, everything except `duckctl`.** One list, rather than
+naming binaries at each of the two `--bins` call sites and keeping the two in step by hand — which
+is the failure this repo keeps writing down. `--workspace` is unaffected, so CI lints and tests it
+exactly as before.
 
 ## 4. The page becomes a console
 
@@ -319,12 +328,12 @@ Four changes, each of which stands alone and lands separately:
 1. **Serve the page, with the signalling URL filled in as it is served.** Deletes the python
    instruction and the warning block. Small, and everything else is nicer on top of it.
 2. **Producer `meta`.** Smaller still, and independent.
-3. **The tool becomes `duckctl` (§3),** then gains **`ip` and `open`.** Client-side only, touches
-   no daemon. The move first so the two commands are documented once; `ip` before `open`, since
-   `ip` stands on its own for ssh and `open` is a port number on top of it.
+3. **`duckctl` gains `ip` and `open`.** Client-side only, touches no daemon. The rename it needed
+   first (§3) is done. `ip` before `open`, since `ip` stands on its own for ssh and `open` is a
+   port number on top of it.
 4. **The console.** The large one, done last, on a page that is already reachable.
 
-Then, separately, `dev-push.sh` switching to `duck-btctl ip` (§2.4).
+Then, separately, `dev-push.sh` switching to `duckctl ip` (§2.4).
 
 ## 8. Not doing
 
@@ -335,4 +344,4 @@ Then, separately, `dev-push.sh` switching to `duck-btctl ip` (§2.4).
   a client that needs npm is a client nobody runs. Still true at four times the size.
 - **Serving over TLS in this change.** §1.3 says when, and why it is not now.
 - **Teaching the advertisement a port.** Four bytes of IPv4 is what it carries; a robot on a
-  non-default `--web-port` is a `--port` on `duck-btctl open`, not a wire-format change.
+  non-default `--web-port` is a `--port` on `duckctl open`, not a wire-format change.

--- a/docs/design/webrtc-console.md
+++ b/docs/design/webrtc-console.md
@@ -49,14 +49,13 @@ This deletes four problems at once rather than one:
 
 ### 1.1 Which HTTP server
 
-**`axum`.** It is already in `Cargo.lock` — `updater` uses it as a dev-dependency for its test
-mirror — so the crate is known-good against this toolchain and the cross build.
+**`axum`. Decided.** It is already in `Cargo.lock` — `updater` uses it as a dev-dependency for its
+test mirror — so the crate is known-good against this toolchain and the cross build.
 
-The alternative is a hand-rolled HTTP/1.1 responder: this serves one file over one method, so it
-is perhaps sixty lines. Rejected. Sixty lines of hand-written request parsing bound to
-`0.0.0.0` is a parser exposed to everyone on the network, written to avoid a dependency that the
-build already resolves — and `hyper` underneath `axum` is the most-read implementation of that
-parser in the language. The dependency count is not the thing to optimise here.
+The alternative was a hand-rolled HTTP/1.1 responder: this serves one file over one method, so it
+is perhaps sixty lines. Sixty lines of hand-written request parsing bound to `0.0.0.0` is a parser
+exposed to everyone on the network, written to avoid a dependency the build already resolves —
+and `hyper` underneath `axum` is the most-read implementation of that parser in the language.
 
 `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` in `mediad.service` already permits the
 listener; nothing in the unit changes.
@@ -75,20 +74,33 @@ question with two answers.
 Embedding costs a rebuild to change a stylesheet. That is the right trade for a page that is part
 of the daemon's interface.
 
-### 1.3 Two ports now, one port later — and why the later matters
+### 1.3 Two ports, and nobody has to know there are two
 
 `webrtcsink` owns the listener on 8443 (`run-signalling-server`, with only `-host` and `-port` to
 say about it), so the page cannot be a route on it. Two ports: 8080 serves the page, 8443 stays
-the signalling server. Nothing about the media path changes, which is the entire argument for
-doing it this way first.
+the signalling server. Nothing about the media path changes, which is the whole argument for doing
+it this way first.
+
+**Two ports is a fact about the implementation, and it must not become a step for a person.**
+Three things keep it there, and they are requirements on the change rather than hopes:
+
+- **One address is typed.** `http://<robot>:8080`. The 8443 is reached by the page's own
+  JavaScript and never by a human. `duck-btctl open` (§2) removes even that one.
+- **`mediad` fills the signalling URL in as it serves the page**, rather than the page carrying a
+  constant. It knows the host the request arrived on and it knows its own `--port`, so the page
+  gets the real answer — one `str::replace` over the embedded string at startup. This is what
+  makes `--port` safe to change: there is no second place holding a stale copy of it.
+- **The one failure two ports can produce is named in words.** If 8080 answers and 8443 does not
+  — a firewall between, most plausibly — the page must say *the page came from this robot, but its
+  signalling port did not answer*, not `websocket error`. That is the only route by which the
+  second port can ever reach a person, and it should reach them as a diagnosis.
 
 The one-port variant is to run the signalling server ourselves — upstream publishes it as a
-library alongside the plugin — and point `webrtcsink`'s signaller at
-`ws://127.0.0.1:8080/ws`. Then one `axum` server serves the page and the protocol on one origin.
-That is more work and a second copy of the protocol version to keep in step with the `.so` we
-ship, and it should not be in the first change.
+library alongside the plugin — and point `webrtcsink`'s signaller at `ws://127.0.0.1:8080/ws`.
+Then one `axum` server serves the page and the protocol on one origin. More work, and a second
+copy of the protocol version to keep in step with the `.so` we ship, so not in the first change.
 
-**But it is where this ends up, and §3.4 is why.** A browser gives a page served over plain http
+**But it is where this ends up, and here is why.** A browser gives a page served over plain http
 to a private address no microphone, and depending on the browser no gamepad either — those are
 secure-context APIs, and `http://192.168.1.42` is not a secure context (`http://localhost` is,
 which is precisely why nobody has hit this yet). Two-way audio is in `remote-webrtc.md` §2. The
@@ -98,32 +110,84 @@ our own signalling server when audio or a browser gamepad is wanted, TLS on the 
 
 Worth writing down now rather than discovering it while wiring a microphone.
 
-## 2. Finding the robot: `btd` already broadcasts the answer
+## 2. Finding the robot: two commands, and one of them is already hand-rolled
 
-The last mile is nearly built. `btd` files the robot's IPv4 in its advertisement under company id
-`0xFFFF`, and `duck-btctl` already parses it — `Address::At`, `Unassigned`, `Unsaid`, three
-answers rather than two, and `scan` prints it today.
+`btd` files the robot's IPv4 in its advertisement under company id `0xFFFF`, and `duck-btctl`
+already parses it — `Address::At`, `Unassigned`, `Unsaid`, three answers rather than two, and
+`scan` prints it today. So the work is a command, not a mechanism.
 
-So: **`duck-btctl ip`**, which resolves a robot by name (or `DUCK_ROBOT`) and prints the address
-on stdout and nothing else — matching the split the tool already keeps, diagnostics on stderr and
-data on stdout, so `open "http://$(duck-btctl ip):8080"` works. And **`duck-btctl open`**, which
-does that for you.
+### 2.1 `duck-btctl ip`
 
-Neither connects, bonds, or authenticates. It is an advertisement read, so it works on a robot
-this laptop has never paired with, and it costs a scan.
+The robot's address on stdout and nothing else, so `ssh radxa@$(duck-btctl ip)` works — the split
+the tool already keeps, diagnostics on stderr and data on stdout.
 
-The three-way `Address` already carries the right failure text, and this is where it pays:
+**This is not a new idea in this repo; it is one that has already been written badly once.**
+`scripts/dev-push.sh` needs exactly this and hand-rolls it: `resolve_board()` calls
+`duck-btctl wifi status` and pipes the JSON through a six-line Python program embedded in the
+shell script to pull `result.ip4`. That is the command, minus a home.
+
+Reading the advertisement rather than calling `net.status` is better on three counts, all of them
+visible in what `dev-push.sh` had to write around:
+
+- **No connection, so no bond and no PIN.** `resolve_board` carries a whole failure branch for
+  "the robot refused `net.status` — a wrong PIN, most often". An advertisement read cannot be
+  refused, so that branch stops existing.
+- **Seconds rather than tens of seconds.** `dev-push.sh` caches the address per robot precisely
+  because "BLE discovery costs ten to twenty seconds"; a scan that stops at the first matching
+  advertisement is about a second, because `duck-btctl` already polls until something appears
+  rather than sleeping out `SCAN_TIME`.
+- **It is not stale.** `btd`'s `reconcile_advertisement` re-reads `net.status` every `ADV_POLL`
+  (5s) and re-advertises when the answer moves, so the advertisement *is* `net.status` with a
+  five-second lag — well inside the window in which a new lease has already broken ssh.
+
+**With one fallback, which is not optional.** A robot bonded to this Mac often stops advertising
+the service to it — `duck-btctl`'s own scan tiers exist for that — so when no advertisement is
+seen, `ip` connects and asks `net.status`, which is what `dev-push.sh` does today. Cheap read
+first, call second. Without the fallback this command would fail on exactly the laptops that use
+it most.
+
+The three-way `Address` already carries the right failure text and this is where it pays:
 
 - `Unassigned` — the robot has no network. The fix is `duck-btctl wifi connect`, and it has to be
-  over BLE, because `net.connect` is refused over WebRTC by design (`route.rs`: "a robot that has
-  never seen a network cannot be configured over that network").
-- `Unsaid` — a release from before `btd` advertised an address. `duck-btctl wifi status` still
-  reports it; updating puts it in the list.
+  over BLE, because `net.connect` is refused over WebRTC by design ("a robot that has never seen a
+  network cannot be configured over that network").
+- `Unsaid` — a release from before `btd` advertised an address. The fallback answers anyway;
+  updating makes it fast.
 
-That closes a loop worth naming: **BLE provisions the network and then hands you the URL for it.**
-The two transports stop being alternatives and become a sequence.
+Its third caller is neither of the two above: `install-dev.md` opens by asking for "the board's
+**IP address**", with the note that mDNS on this image is unreliable, and offers no way to get it.
 
-`duck-btctl` is a stopgap for the phone app, so this stays thin — two commands, no new mechanism.
+### 2.2 `duck-btctl open`
+
+Resolve, then open `http://<address>:8080/` in the browser. `--print` prints the URL instead, for
+a machine with no browser or a script; `--port` for a robot started with a non-default
+`--web-port`.
+
+A command rather than a documented shell substitution, for one reason: **the port default should
+live in exactly one place that a person never has to read.** `open "http://$(duck-btctl ip):8080"`
+works, and it is the kind of line someone writes once and then looks up forever.
+
+### 2.3 Not these
+
+- **`duck-btctl url`.** That is `open --print`. A third command whose entire content is a port
+  number.
+- **A URL column on `scan`.** `scan` lists earbuds too, and the robot lines already carry the
+  address. One note under the list pointing at `open` is enough.
+- **Anything that has to connect.** Both commands are advertisement reads with a fallback. A
+  command here that *required* a bond would be a different kind of command, and it would belong
+  with `wifi` and `update` rather than with finding a robot.
+
+### 2.4 The loop this closes, and the one follow-on
+
+BLE provisions the network and then hands you the URL for it. The two transports stop being
+alternatives and become a sequence — which is worth saying because `route.rs` refuses `net.connect`
+over WebRTC deliberately, and this is the other half of that refusal.
+
+The follow-on, in its own change rather than these four: `dev-push.sh`'s `resolve_board` becomes
+`btctl --name "$1" ip`, deleting the embedded Python and the wrong-PIN branch. Separate because it
+touches the push path, and because it should land after `ip` has been used by hand a few times.
+
+`duck-btctl` is a stopgap for the phone app, so this stays at two commands and no new mechanism.
 The durable halves are the ones that outlive it: `btd` broadcasting the address, and `mediad`
 serving on a known port. The app will do the same two steps natively.
 
@@ -184,11 +248,14 @@ should be good.
 
 Four changes, each of which stands alone and lands separately:
 
-1. **Serve the page, default the URL to `location.hostname`.** Deletes the python instruction and
-   the warning block. Small, and everything else is nicer on top of it.
+1. **Serve the page, with the signalling URL filled in as it is served.** Deletes the python
+   instruction and the warning block. Small, and everything else is nicer on top of it.
 2. **Producer `meta`.** Smaller still, and independent.
-3. **`duck-btctl ip` / `open`.** Client-side only, touches no daemon.
+3. **`duck-btctl ip` and `open`.** Client-side only, touches no daemon. `ip` first: it stands on
+   its own for ssh, and `open` is a port number on top of it.
 4. **The console.** The large one, done last, on a page that is already reachable.
+
+Then, separately, `dev-push.sh` switching to `duck-btctl ip` (§2.4).
 
 ## 7. Not doing
 
@@ -198,3 +265,5 @@ Four changes, each of which stands alone and lands separately:
 - **A JS framework, a bundler, or `gstwebrtc-api`.** The page speaks the protocol by hand because
   a client that needs npm is a client nobody runs. Still true at four times the size.
 - **Serving over TLS in this change.** §1.3 says when, and why it is not now.
+- **Teaching the advertisement a port.** Four bytes of IPv4 is what it carries; a robot on a
+  non-default `--web-port` is a `--port` on `duck-btctl open`, not a wire-format change.

--- a/docs/design/webrtc-console.md
+++ b/docs/design/webrtc-console.md
@@ -1,6 +1,6 @@
 # The WebRTC client: from a test page to the robot's console
 
-Status: proposal · Date: 2026-08-25 · Owner: pierre
+Status: landed · Date: 2026-08-25 · Owner: pierre
 
 `mediad/webclient/index.html` proved the transport. This is what turns it into something a person
 uses: served by the robot rather than by `python3`, found through the address `btd` already
@@ -10,10 +10,13 @@ Companion to [`remote-webrtc.md`](remote-webrtc.md), which owns the transport �
 the session model, authorisation, and what a peer may call. Where the two touch, that page is the
 owner and this one points at it.
 
-**Nothing here is built.** The approach, written down before the first line, so the decisions are
-arguable rather than implied by a diff.
+**All four changes are in.** This page was written before the first line of them, so the decisions
+are arguable rather than implied by a diff; it is kept because the alternatives are the part worth
+being able to re-read. Where the code and this page could drift, the code is the answer:
+`mediad/src/web.rs` serves the page, `mediad/src/producer.rs` fills in `meta`, `duckctl`'s `ip` and
+`open` find the robot, and `mediad/webclient/index.html` is the console. §7 says what is left.
 
-## 0. What is wrong with it today
+## 0. What was wrong with it
 
 Not much, for what it was for. It answered "does a browser get video and a datachannel", and the
 answer was yes. Six things are wrong with it as *a client*:
@@ -31,6 +34,8 @@ Every one of those is a step between a person and a working robot, and none of t
 WebRTC.
 
 ## 1. `mediad` serves the page
+
+**Landed** — `mediad/src/web.rs`, `--web-port`, default 8080.
 
 An HTTP listener in `mediad`, one route, returning the page. `http://<robot>:8080/` and there is
 nothing else to run.
@@ -111,6 +116,8 @@ our own signalling server when audio or a browser gamepad is wanted, TLS on the 
 Worth writing down now rather than discovering it while wiring a microphone.
 
 ## 2. Finding the robot: two commands, and one of them is already hand-rolled
+
+**Landed** — `duckctl ip` and `duckctl open`, advertisement first and `net.status` behind it.
 
 `btd` files the robot's IPv4 in its advertisement under company id `0xFFFF`, and `duckctl`
 already parses it — `Address::At`, `Unassigned`, `Unsaid`, three answers rather than two, and
@@ -270,6 +277,8 @@ exactly as before.
 
 ## 4. The page becomes a console
 
+**Landed** — `mediad/webclient/index.html`, still one file and still no build step.
+
 The permitted subset is large and almost none of it is reachable from the page. Reorganised
 around what a person came to do:
 
@@ -302,6 +311,8 @@ believe and expensive to be wrong about.
 
 ## 5. The robot names itself before the session starts
 
+**Landed** — `mediad/src/producer.rs`.
+
 `webrtcsink` takes a `meta` structure and the signalling server hands it to every peer in `list`
 — the page already logs it and it is empty. Fill it from `configd`: name, serial, release,
 `API_VERSION`.
@@ -321,19 +332,23 @@ nothing reads it yet.
 Named so the shape is visible, not proposed here. It is a second transport and the first one
 should be good.
 
-## 7. Order
+## 7. Order, and what is left
 
-Four changes, each of which stands alone and lands separately:
+Four changes, each of which stood alone and landed separately, in this order:
 
-1. **Serve the page, with the signalling URL filled in as it is served.** Deletes the python
-   instruction and the warning block. Small, and everything else is nicer on top of it.
+1. **Serve the page, with the signalling URL filled in as it is served.** Deleted the python
+   instruction and the warning block. Small, and everything else was nicer on top of it. The API
+   version is substituted the same way, for §4's banner — a literal in the page would be a second
+   copy of `API_VERSION`, wrong on the day it is bumped and wrong in the direction that reports
+   agreement.
 2. **Producer `meta`.** Smaller still, and independent.
-3. **`duckctl` gains `ip` and `open`.** Client-side only, touches no daemon. The rename it needed
-   first (§3) is done. `ip` before `open`, since `ip` stands on its own for ssh and `open` is a
-   port number on top of it.
-4. **The console.** The large one, done last, on a page that is already reachable.
+3. **`duckctl` gains `ip` and `open`.** Client-side only, touched no daemon.
+4. **The console.** The large one, done last, on a page that was already reachable.
 
-Then, separately, `dev-push.sh` switching to `duckctl ip` (§2.4).
+**Not done, and deliberately separate:** `dev-push.sh`'s `resolve_board` still hand-rolls this with
+`duckctl wifi status` and six lines of embedded Python (§2.4). It becomes `duckctl ip`, which deletes
+the Python and the wrong-PIN branch — separate because it touches the push path, and because it
+should land after `ip` has been used by hand a few times.
 
 ## 8. Not doing
 
@@ -342,6 +357,6 @@ Then, separately, `dev-push.sh` switching to `duckctl ip` (§2.4).
   flags — one flag, not a mechanism.
 - **A JS framework, a bundler, or `gstwebrtc-api`.** The page speaks the protocol by hand because
   a client that needs npm is a client nobody runs. Still true at four times the size.
-- **Serving over TLS in this change.** §1.3 says when, and why it is not now.
+- **Serving over TLS.** §1.3 says when, and why it was not now.
 - **Teaching the advertisement a port.** Four bytes of IPv4 is what it carries; a robot on a
   non-default `--web-port` is a `--port` on `duckctl open`, not a wire-format change.

--- a/docs/design/webrtc-console.md
+++ b/docs/design/webrtc-console.md
@@ -187,11 +187,79 @@ The follow-on, in its own change rather than these four: `dev-push.sh`'s `resolv
 `btctl --name "$1" ip`, deleting the embedded Python and the wrong-PIN branch. Separate because it
 touches the push path, and because it should land after `ip` has been used by hand a few times.
 
+Both commands are written here under today's name; §3 is the argument that it should be
+`duckctl` by the time they land.
+
 `duck-btctl` is a stopgap for the phone app, so this stays at two commands and no new mechanism.
 The durable halves are the ones that outlive it: `btd` broadcasting the address, and `mediad`
 serving on a known port. The app will do the same two steps natively.
 
-## 3. The page becomes a console
+## 3. The tool is named after a transport it is about to stop being
+
+`open` launches a browser at an http URL, and the name of the tool that does it says `bt`. Worth
+pulling on, because it turns out to point at something larger than one command.
+
+**`open` itself is not misplaced.** Its substance *is* Bluetooth: it scans for an advertisement to
+learn where the robot is, and the `xdg-open` on the end is one line. `duck-btctl open` reads as
+"use the radio to find the robot, then show me its console", which is exactly what it does — the
+same way `wifi connect` is a wifi command whose whole mechanism is BLE.
+
+**The name is still wrong, for a reason that arrives with `mediad` rather than with `open`.** There
+is about to be a second transport to this robot, and the two reach *different* method sets by
+design: `robot.move` is refused over BLE and permitted over WebRTC; `net.connect` is the other way
+round. So a person will need both, and the thing they actually want is not a choice of binary —
+it is a tool that knows which transport can serve a call and says so when neither can:
+
+> `wifi connect` is Bluetooth-only, and this robot is not advertising.
+
+That tool cannot be called `btctl`. And a tool called `btctl` quietly teaches everyone that
+Bluetooth is the way to reach a robot, at exactly the moment it stops being the only one.
+
+### 3.1 It is a move, not a rename, and that fixes two existing warts
+
+A transport-agnostic client cannot stay `btd/examples/duck-btctl.rs`. It would need `btleplug`
+*and* a WebSocket client, and `btd` is the BLE daemon — an example of it is the wrong home for
+half of that. So the honest shape is its own workspace member, and two things that are awkward
+today stop being awkward on the way:
+
+- **The install line.** `cargo install --path btd --example duck-btctl` is odd enough that
+  `dev-push.sh` carries a fallback for clones that never ran it — it shells out to
+  `cargo run -q -p btd --example duck-btctl` instead. `cargo install --path duckctl` needs no
+  fallback.
+- **The example-that-is-really-a-product.** The reason it is an example is to keep `btleplug` off
+  the robot, since an example's dev-dependencies never reach the shipped artifact. Its own crate
+  keeps that for free, by not being a dependency of any daemon — the same guarantee, stated
+  directly rather than as a side effect of where the file sits.
+
+### 3.2 `duckctl`
+
+It pairs with `robotctl` the way the two are actually used: `robotctl` on the robot, `duckctl` at
+it. It keeps the `duck-` family the repo is already named for, and it is short enough to type
+without an alias.
+
+`duck` alone is better to type and is taken: Cyberduck ships a CLI by that name, which is
+plausible on a Mac. `microduck` is the repository and too long for a command someone runs twenty
+times an hour.
+
+### 3.3 What not to rewrite
+
+196 references across about twenty files, and most are prose. **`docs/project/` is not among them.**
+Those are dated records that describe a moment — an update session in August, four install-path
+bugs and what closed them — and rewriting a tool name into an account of something that happened
+before the tool had that name makes the record slightly false. They keep saying `duck-btctl`.
+`docs/robot/`, `docs/design/`, the scripts and the code are the rename.
+
+**No compatibility shim, no alias.** One user and one robot: a `duck-btctl` that still works is a
+second name to keep in step and a reason for the old one to survive in someone's shell history for
+a year.
+
+### 3.4 When
+
+Before the console work adds commands under the old name, and ideally before `ip` and `open` are
+documented — otherwise `docs/robot/duck-btctl.md` gets those two entries written twice. It blocks
+nothing and nothing blocks it, so it is cheapest first and merely tidy later.
+
+## 4. The page becomes a console
 
 The permitted subset is large and almost none of it is reachable from the page. Reorganised
 around what a person came to do:
@@ -223,7 +291,7 @@ nothing has exercised: that the deadman stops the robot when a session drops (§
 ordering over `control` is enough to keep `intents.rs` honest (§6 again). Both are cheap to
 believe and expensive to be wrong about.
 
-## 4. The robot names itself before the session starts
+## 5. The robot names itself before the session starts
 
 `webrtcsink` takes a `meta` structure and the signalling server hands it to every peer in `list`
 — the page already logs it and it is empty. Fill it from `configd`: name, serial, release,
@@ -233,7 +301,7 @@ Small, and it pays three times: the page can name the robot before starting a se
 that finds two producers can say which is which, and the rendezvous service in §7 needs exactly
 this field to route on. Cheapest item here.
 
-## 5. What it opens, but is not
+## 6. What it opens, but is not
 
 `remote-webrtc.md` §11 defers "a WebSocket surface for server-side programs — same JSON-RPC, no
 media stack, `get_frame` returning a JPEG", and calls it a few dozen lines once §5's routing
@@ -244,20 +312,21 @@ nothing reads it yet.
 Named so the shape is visible, not proposed here. It is a second transport and the first one
 should be good.
 
-## 6. Order
+## 7. Order
 
 Four changes, each of which stands alone and lands separately:
 
 1. **Serve the page, with the signalling URL filled in as it is served.** Deletes the python
    instruction and the warning block. Small, and everything else is nicer on top of it.
 2. **Producer `meta`.** Smaller still, and independent.
-3. **`duck-btctl ip` and `open`.** Client-side only, touches no daemon. `ip` first: it stands on
-   its own for ssh, and `open` is a port number on top of it.
+3. **The tool becomes `duckctl` (§3),** then gains **`ip` and `open`.** Client-side only, touches
+   no daemon. The move first so the two commands are documented once; `ip` before `open`, since
+   `ip` stands on its own for ssh and `open` is a port number on top of it.
 4. **The console.** The large one, done last, on a page that is already reachable.
 
 Then, separately, `dev-push.sh` switching to `duck-btctl ip` (§2.4).
 
-## 7. Not doing
+## 8. Not doing
 
 - **A gate on the console.** §4 of `remote-webrtc.md` owns that decision and nothing here changes
   its terms. A `--no-web` flag to turn the page off is worth having for the home case that section

--- a/docs/design/webrtc-console.md
+++ b/docs/design/webrtc-console.md
@@ -1,0 +1,200 @@
+# The WebRTC client: from a test page to the robot's console
+
+Status: proposal · Date: 2026-08-25 · Owner: pierre
+
+`mediad/webclient/index.html` proved the transport. This is what turns it into something a person
+uses: served by the robot rather than by `python3`, found through the address `btd` already
+broadcasts, and exercising the control surface `route.rs` actually permits.
+
+Companion to [`remote-webrtc.md`](remote-webrtc.md), which owns the transport — signalling,
+the session model, authorisation, and what a peer may call. Where the two touch, that page is the
+owner and this one points at it.
+
+**Nothing here is built.** The approach, written down before the first line, so the decisions are
+arguable rather than implied by a diff.
+
+## 0. What is wrong with it today
+
+Not much, for what it was for. It answered "does a browser get video and a datachannel", and the
+answer was yes. Six things are wrong with it as *a client*:
+
+| | |
+|---|---|
+| it needs `python3 -m http.server` | a second tool and a second terminal, and the page is served from the laptop to talk to the robot |
+| the URL is typed by hand | `ws://radxa-zero3.local:8443` — and `radxa-zero3` is the hostname on **every** board flashed from one image (`configd/src/main.rs` says so where it falls back to it), so two robots on one network collide |
+| its comment block is mostly warnings | `file://` and Private Network Access, http not https — a header that had to be corrected twice already (`7f52a34`) |
+| it exercises the protocol, not the robot | `route.rs` permits move, head, look, pose, mouth, do, sound, enable, init, relax, stop, subscribe, `tof.stream`, `pad.input`. The page offers `robot.health` and a JSON textbox |
+| it is shipped nowhere | no `--include` names it, so a robot in the field has no client |
+| it cannot say which robot it reached | the producer's `meta` is unset, so `list` returns an id and nothing else |
+
+Every one of those is a step between a person and a working robot, and none of them is about
+WebRTC.
+
+## 1. `mediad` serves the page
+
+An HTTP listener in `mediad`, one route, returning the page. `http://<robot>:8080/` and there is
+nothing else to run.
+
+This deletes four problems at once rather than one:
+
+- **No `python3`.** The instruction becomes an address.
+- **No URL to type.** The page defaults its signalling target to `ws://${location.hostname}:8443`
+  — it was served by the robot, so it knows which robot it is talking to.
+- **Private Network Access stops applying.** Chrome blocks a request from a *public or opaque*
+  origin to a private address. A page served from `192.168.x` has a private origin, so the check
+  that broke `file://` is not reached at all. The warning block in the header goes away because
+  the failure it warns about cannot happen.
+- **One version.** The page and the binary ship together (§1.2), so a client from a checkout can
+  no longer be pointed at a robot from a release.
+
+### 1.1 Which HTTP server
+
+**`axum`.** It is already in `Cargo.lock` — `updater` uses it as a dev-dependency for its test
+mirror — so the crate is known-good against this toolchain and the cross build.
+
+The alternative is a hand-rolled HTTP/1.1 responder: this serves one file over one method, so it
+is perhaps sixty lines. Rejected. Sixty lines of hand-written request parsing bound to
+`0.0.0.0` is a parser exposed to everyone on the network, written to avoid a dependency that the
+build already resolves — and `hyper` underneath `axum` is the most-read implementation of that
+parser in the language. The dependency count is not the thing to optimise here.
+
+`RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` in `mediad.service` already permits the
+listener; nothing in the unit changes.
+
+### 1.2 The page is embedded, not installed
+
+`include_str!("../webclient/index.html")`, served from memory.
+
+The alternative — install it under `/opt/robot/daemon/current/webclient/` and read it at
+request time — costs an `--include` line in *three* places (`_build-release.yml`, `dev.yml`,
+`scripts/dev-push.sh`), which `xtask`'s packaging tripwires exist to keep in step and which is
+exactly the list that has drifted before. It also puts a filesystem read behind a network request
+in a unit running `ProtectSystem=strict`, and it makes "which page is this robot serving" a
+question with two answers.
+
+Embedding costs a rebuild to change a stylesheet. That is the right trade for a page that is part
+of the daemon's interface.
+
+### 1.3 Two ports now, one port later — and why the later matters
+
+`webrtcsink` owns the listener on 8443 (`run-signalling-server`, with only `-host` and `-port` to
+say about it), so the page cannot be a route on it. Two ports: 8080 serves the page, 8443 stays
+the signalling server. Nothing about the media path changes, which is the entire argument for
+doing it this way first.
+
+The one-port variant is to run the signalling server ourselves — upstream publishes it as a
+library alongside the plugin — and point `webrtcsink`'s signaller at
+`ws://127.0.0.1:8080/ws`. Then one `axum` server serves the page and the protocol on one origin.
+That is more work and a second copy of the protocol version to keep in step with the `.so` we
+ship, and it should not be in the first change.
+
+**But it is where this ends up, and §3.4 is why.** A browser gives a page served over plain http
+to a private address no microphone, and depending on the browser no gamepad either — those are
+secure-context APIs, and `http://192.168.1.42` is not a secure context (`http://localhost` is,
+which is precisely why nobody has hit this yet). Two-way audio is in `remote-webrtc.md` §2. The
+robot will need to serve TLS, and `webrtcsink`'s built-in server offers no way to configure a
+certificate, while an `axum` server offers the ordinary one. So the sequence is: two ports now,
+our own signalling server when audio or a browser gamepad is wanted, TLS on the same day.
+
+Worth writing down now rather than discovering it while wiring a microphone.
+
+## 2. Finding the robot: `btd` already broadcasts the answer
+
+The last mile is nearly built. `btd` files the robot's IPv4 in its advertisement under company id
+`0xFFFF`, and `duck-btctl` already parses it — `Address::At`, `Unassigned`, `Unsaid`, three
+answers rather than two, and `scan` prints it today.
+
+So: **`duck-btctl ip`**, which resolves a robot by name (or `DUCK_ROBOT`) and prints the address
+on stdout and nothing else — matching the split the tool already keeps, diagnostics on stderr and
+data on stdout, so `open "http://$(duck-btctl ip):8080"` works. And **`duck-btctl open`**, which
+does that for you.
+
+Neither connects, bonds, or authenticates. It is an advertisement read, so it works on a robot
+this laptop has never paired with, and it costs a scan.
+
+The three-way `Address` already carries the right failure text, and this is where it pays:
+
+- `Unassigned` — the robot has no network. The fix is `duck-btctl wifi connect`, and it has to be
+  over BLE, because `net.connect` is refused over WebRTC by design (`route.rs`: "a robot that has
+  never seen a network cannot be configured over that network").
+- `Unsaid` — a release from before `btd` advertised an address. `duck-btctl wifi status` still
+  reports it; updating puts it in the list.
+
+That closes a loop worth naming: **BLE provisions the network and then hands you the URL for it.**
+The two transports stop being alternatives and become a sequence.
+
+`duck-btctl` is a stopgap for the phone app, so this stays thin — two commands, no new mechanism.
+The durable halves are the ones that outlive it: `btd` broadcasting the address, and `mediad`
+serving on a known port. The app will do the same two steps natively.
+
+## 3. The page becomes a console
+
+The permitted subset is large and almost none of it is reachable from the page. Reorganised
+around what a person came to do:
+
+| | |
+|---|---|
+| **header** | robot name, release, API version — from `hello` and `system.info`, sent automatically when the channel opens, not clicked |
+| **video** | plus link quality from `getStats()`: bitrate, fps, loss, RTT. Today a stream that degrades is a picture that looks worse and a log that says nothing |
+| **drive** | keys and an on-screen stick → `robot.move` at a fixed rate; drag on the video → `robot.look` |
+| **posture** | `robot.enable`, `init`, `relax`, `stop`, `shutdown` — confirm on the last two |
+| **do / sound** | the `Do` and `Sound` enums as menus |
+| **telemetry** | `robot.subscribe` at 2 Hz into a live panel: mode, health |
+| **console** | the raw JSON box, the log, and the two refusal buttons — collapsed, because they prove the route table rather than drive the robot |
+
+Three constraints on it:
+
+- **The stop button must not read as an e-stop.** `route.rs` permits `robot.stop` on the grounds
+  that this channel is reliable and the deadman already stops the robot when intents stop
+  arriving, and then says in as many words that the UI should not imply it is a physical e-stop.
+  A label, not a big red circle.
+- **A version difference is a banner, not a locked door.** `hello` reporting skew says so and the
+  page keeps working — same rule `duck-btctl` settled on in #102.
+- **Still one file, still no build step.** That constraint is why the client is runnable at all
+  and it survives. If it outgrows one file it becomes three — `index.html`, `app.js`, `app.css`,
+  three `include_str!`s, still no build step, still no npm.
+
+Driving from the page is also the first real test of two claims `remote-webrtc.md` makes and
+nothing has exercised: that the deadman stops the robot when a session drops (§6), and that
+ordering over `control` is enough to keep `intents.rs` honest (§6 again). Both are cheap to
+believe and expensive to be wrong about.
+
+## 4. The robot names itself before the session starts
+
+`webrtcsink` takes a `meta` structure and the signalling server hands it to every peer in `list`
+— the page already logs it and it is empty. Fill it from `configd`: name, serial, release,
+`API_VERSION`.
+
+Small, and it pays three times: the page can name the robot before starting a session, a client
+that finds two producers can say which is which, and the rendezvous service in §7 needs exactly
+this field to route on. Cheapest item here.
+
+## 5. What it opens, but is not
+
+`remote-webrtc.md` §11 defers "a WebSocket surface for server-side programs — same JSON-RPC, no
+media stack, `get_frame` returning a JPEG", and calls it a few dozen lines once §5's routing
+exists. Once there is an `axum` server in `mediad`, it is a route on a server that already runs,
+and the frame is already there: `_frames` in `main.rs` is the raw NV12 tap off the tee, and
+nothing reads it yet.
+
+Named so the shape is visible, not proposed here. It is a second transport and the first one
+should be good.
+
+## 6. Order
+
+Four changes, each of which stands alone and lands separately:
+
+1. **Serve the page, default the URL to `location.hostname`.** Deletes the python instruction and
+   the warning block. Small, and everything else is nicer on top of it.
+2. **Producer `meta`.** Smaller still, and independent.
+3. **`duck-btctl ip` / `open`.** Client-side only, touches no daemon.
+4. **The console.** The large one, done last, on a page that is already reachable.
+
+## 7. Not doing
+
+- **A gate on the console.** §4 of `remote-webrtc.md` owns that decision and nothing here changes
+  its terms. A `--no-web` flag to turn the page off is worth having for the home case that section
+  flags — one flag, not a mechanism.
+- **A JS framework, a bundler, or `gstwebrtc-api`.** The page speaks the protocol by hand because
+  a client that needs npm is a client nobody runs. Still true at four times the size.
+- **Serving over TLS in this change.** §1.3 says when, and why it is not now.

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -88,6 +88,25 @@ itself and use the new name:
 robotctl system set-name ducky
 ```
 
+## The console
+
+The robot serves a page that streams its camera and drives it:
+
+```
+http://192.168.1.42:8080/
+```
+
+The address is the one `duckctl scan` printed. Nothing to install and nothing to serve — `mediad`
+embeds the page, so a robot running that daemon is a robot with a console.
+
+Two ports are involved and only this one is typed: the page reaches the signalling server on 8443
+itself, using the host it was served from. If the page loads and then says its signalling port did
+not answer, the robot is up and something between you and 8443 is not — a firewall, most often.
+
+The camera and the drive controls are on WebRTC and nothing else, so a robot with no network address
+has no console. Join it to one over the radio first — `duckctl wifi connect` below needs no network
+of its own.
+
 ## Always the same robot
 
 Put the name in the environment instead of on every command line:

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -64,6 +64,23 @@ network; a line with no address at all means a release from before robots broadc
 The SSID is not in the listing — it does not fit in an advertisement. `duckctl wifi status` has
 it, along with the signal and both addresses.
 
+For the address on its own:
+
+```bash
+ssh radxa@$(duckctl ip)
+```
+
+`ip` prints the address and nothing else, so it substitutes. It reads the advertisement, so it
+connects to nothing, needs no PIN, and takes about a second — and the answer is not stale: `btd`
+re-reads the address every five seconds and re-advertises when it moves.
+
+A robot bonded to this machine often stops advertising the service to it, and then `ip` connects and
+asks `net.status` instead. That is slower and needs the PIN, and it always answers. `--verbose` says
+which of the two happened.
+
+A robot with no network address is told what to do about it rather than reported as empty, because
+the fix is over the radio and has to be — `net.connect` is refused over WebRTC by design.
+
 A robot that has never been renamed calls itself `duck-` plus four characters derived from its
 serial, so `duck-c51b`. Either half of a robot reported under two names at once — macOS shows
 `radxa-zero3 [duck-c51b]` — works as `--name`.
@@ -92,12 +109,16 @@ robotctl system set-name ducky
 
 The robot serves a page that streams its camera and drives it:
 
-```
-http://192.168.1.42:8080/
+```bash
+duckctl open
 ```
 
-The address is the one `duckctl scan` printed. Nothing to install and nothing to serve — `mediad`
-embeds the page, so a robot running that daemon is a robot with a console.
+Finds the robot, then opens `http://<address>:8080/` in a browser. `--print` gives the URL instead,
+for a machine with no browser or for a script; `--port` for a robot started with a non-default
+`mediad --web-port`.
+
+Nothing to install and nothing to serve — `mediad` embeds the page, so a robot running that daemon
+is a robot with a console.
 
 Two ports are involved and only this one is typed: the page reaches the signalling server on 8443
 itself, using the host it was served from. If the page loads and then says its signalling port did

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -120,6 +120,18 @@ for a machine with no browser or for a script; `--port` for a robot started with
 Nothing to install and nothing to serve — `mediad` embeds the page, so a robot running that daemon
 is a robot with a console.
 
+What is on it: the camera with the link's bitrate, frame rate, loss and round trip beside it; two
+pads and the keys `W`/`A`/`S`/`D` and `Q`/`E` to drive, at a gamepad's 0.3 m/s and 1.5 rad/s; a drag
+on the picture to look at a point; enable, init, relax, stop and shutdown; the skills and the voice
+bank as menus; and the state stream at 2 Hz beside `robot.health`, which is where a hot servo, a flat
+pack or a loop running slow gets named.
+
+`stop` zeroes the intents the page is sending. **It is not an emergency stop** — nothing in this
+system cuts servo power from a browser — and the button is a plain one for that reason.
+
+The raw JSON box, the log, and the two calls a WebRTC peer is refused are in the drawer at the
+bottom. They prove the route table is being consulted rather than drive the robot.
+
 Two ports are involved and only this one is typed: the page reaches the signalling server on 8443
 itself, using the host it was served from. If the page loads and then says its signalling port did
 not answer, the robot is up and something between you and 8443 is not — a firewall, most often.

--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -30,7 +30,9 @@ ssh-copy-id radxa@192.168.1.42
 ## What you need
 
 - The board's **IP address**. mDNS on this image is unreliable, so a `.local` name resolves when
-  it feels like it — use the address from your router's DHCP lease.
+  it feels like it. `duckctl ip` asks the robot over Bluetooth, which needs no network of your own
+  and no DHCP lease to read; your router's lease table is the fallback if the board is not
+  advertising yet.
 - **ssh key access**, from the step above. Provisioning reboots the board and reconnects by
   itself, and a password prompt cannot survive that.
 - A **GitHub token**. This repository is private, so its release assets are unreachable without

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -130,6 +130,20 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// and this is the second one — the daemon runs the IK and answers with the joints it chose.
 pub const API_VERSION: u32 = 12;
 
+/// The longest an update may legitimately go quiet, in seconds — the pre-install hook's ceiling.
+///
+/// **Here rather than in `updater`, because it is a contract with every client.** The phase
+/// notification for a hook arrives *before* the hook runs, so a client watching an apply sees
+/// nothing at all while the hook works — and that hook installs what a release needs and the board
+/// may not have: ONNX Runtime, and around 100 MB of apt for `mediad`'s GStreamer stack on a board
+/// that has never had it. A client whose idle budget is shorter than this reports a working update
+/// as a robot that stopped answering, which is exactly what `duckctl` did the first time this
+/// ceiling moved.
+///
+/// `updaterd` enforces it and every client sizes its own budget above it. Both read this constant,
+/// so the two cannot disagree.
+pub const UPDATE_MAX_SILENCE_SECONDS: u64 = 600;
+
 pub const DEFAULT_SOCKET: &str = "/run/updaterd.sock";
 
 /// Where each service listens by default.

--- a/duckctl/Cargo.toml
+++ b/duckctl/Cargo.toml
@@ -39,6 +39,11 @@ duck-ipc-proto = { path = "../duck-ipc-proto" }
 btleplug = "0.11"
 clap = { workspace = true, features = ["derive"] }
 futures = "0.3"
+# `open` launches a browser, and which command does that is per-platform: `open` on macOS,
+# `xdg-open` or one of five fallbacks on Linux, `cmd /c start` on Windows. A crate rather than a
+# match on `target_os`, for the same reason `btleplug` is one — this tool runs on whatever the
+# developer sits at, and the interesting part of `open` is finding the robot, not spawning a process.
+webbrowser = "1.2.4"
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -401,6 +401,60 @@ fn choose<T>(found: Vec<(T, String)>, target: &Target) -> Result<(T, String), St
     })
 }
 
+/// Deliver a resolved address the way the command asked for it.
+///
+/// **`ip` prints the address and nothing else**, because the tool's split is diagnostics on stderr
+/// and data on stdout: `ssh radxa@$(duckctl ip)` only works if that is the whole of what stdout
+/// carries. Every note this command emits goes to stderr for the same reason.
+fn deliver(command: &Command, address: &str) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        Command::Ip => {
+            println!("{address}");
+            Ok(())
+        }
+        Command::Open { print, port } => {
+            let url = console_url(address, *port);
+            if *print {
+                println!("{url}");
+                return Ok(());
+            }
+            eprintln!("opening {url}");
+            webbrowser::open(&url).map_err(|e| {
+                format!(
+                    "could not open a browser: {e}\nThe robot is at {url} — `duckctl open --print` \
+                     gives the URL without launching anything."
+                )
+                .into()
+            })
+        }
+        // `run` only calls this for the two above; every other command's answer is its JSON.
+        _ => Err("this command does not resolve an address".into()),
+    }
+}
+
+/// Where the console is, given where the robot is.
+///
+/// Plain `http`, because a robot on a LAN has no certificate to offer and `ws://` from an `https`
+/// page is blocked outright as mixed content. `webrtc-console.md` §1.3 says what that costs — a
+/// microphone, and on some browsers a gamepad, both being secure-context APIs — and when it changes.
+fn console_url(address: &str, port: u16) -> String {
+    format!("http://{address}:{port}/")
+}
+
+/// What to say when the robot is right there and has no address.
+///
+/// Two ways to arrive here and they are the same situation: an advertisement that carried `0.0.0.0`,
+/// and a `net.status` with no `ip4`. The fix is over the radio in both cases, and it has to be —
+/// `net.connect` is refused over WebRTC by design, because a robot that has never seen a network
+/// cannot be configured over that network.
+fn no_address(name: &str) -> String {
+    format!(
+        "{name} is in range and has no network address. Join it to a network over the same radio, \
+         which needs no network of its own:\n  duckctl --name '{name}' wifi connect <ssid> --psk \
+         <passphrase>\nThen `duckctl ip` again. `duckctl wifi status` says what the wifi is doing."
+    )
+}
+
 /// Has discovery found what it came for, or should it keep listening until the deadline?
 ///
 /// **Without a name, the first candidate wins**, and stopping there is the point: a bonded robot may
@@ -677,8 +731,8 @@ async fn step<T>(
     version,
     about = "Talk to a robot over BLE — the phone app's stand-in",
     long_about = "Finds a robot advertising the duck GATT service and speaks the same JSON-RPC \
-                  lines every other transport uses. This is a development tool: it is an example \
-                  rather than a binary, so it never ships to a robot."
+                  lines every other transport uses. This is a development tool, and nothing on a \
+                  robot depends on it, so it never ships to one."
 )]
 struct Cli {
     /// Connect to this robot by advertised name. Without it, `DUCK_ROBOT`; without that, the first
@@ -723,6 +777,30 @@ struct Cli {
 enum Command {
     /// List robots in range with the address each one broadcast, and stop.
     Scan,
+    /// The robot's IPv4 address on stdout, and nothing else.
+    ///
+    /// `ssh radxa@$(duckctl ip)`. Read from the advertisement `btd` already broadcasts, so no
+    /// connection is made, no bond is needed and no PIN can be wrong — and it costs about a second
+    /// rather than the tens `wifi status` does. A robot that is bonded to this machine and has
+    /// stopped advertising the service to it is asked over BLE instead, which is slower and always
+    /// answers.
+    Ip,
+    /// Open the robot's console in a browser.
+    ///
+    /// The page `mediad` serves: the camera, and the controls a WebRTC peer is allowed to drive.
+    /// Finds the robot the way `ip` above does.
+    Open {
+        /// Print the URL instead of opening it — for a machine with no browser, or a script.
+        #[arg(long)]
+        print: bool,
+        /// The console's port, for a robot started with a non-default `--web-port`.
+        //
+        // The same default as `mediad --web-port`, and the reason this command exists rather than a
+        // documented `open "http://$(duckctl ip):8080"`: the port belongs in one place that nobody
+        // has to read.
+        #[arg(long, default_value_t = 8080)]
+        port: u16,
+    },
     /// Version handshake plus update status.
     Status,
     /// What the robot is running: the API version, the release, and the revision it was built from.
@@ -884,6 +962,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // what makes it the safe command to reach for when a robot cannot be reached, and it is also why
     // it can only report what an advertisement carries.
     let list_only = matches!(cli.command, Command::Scan);
+    // `ip` and `open` want one field out of an advertisement, so they read it the way `scan` does —
+    // and unlike `scan` they connect after all when no advertisement carried one. Cheap read first,
+    // call second: without the fallback these two commands would fail on exactly the laptops that
+    // use them most, because a robot bonded to this Mac often stops advertising the service to it.
+    let resolving = matches!(cli.command, Command::Ip | Command::Open { .. });
 
     let manager = Manager::new().await?;
     let adapter = manager
@@ -917,6 +1000,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // the latter broke as soon as the Mac bonded with the robot. The authoritative test is whether
     // it serves our characteristic, which is only knowable after connecting.
     let mut advertised: Vec<(Peripheral, String)> = Vec::new();
+    // What each robot said about its address, beside the name it said it under — the two fields
+    // `choose` needs, so `ip` inherits the collision rule every other command follows rather than
+    // picking whichever robot the radio reported first.
+    let mut addresses: Vec<(Address, String)> = Vec::new();
     let mut named: Vec<(Peripheral, String)> = Vec::new();
     let mut connected: Vec<(Peripheral, String)> = Vec::new();
     // Everything the Mac reported, kept only so a failure can say what was in range. `configd`
@@ -927,6 +1014,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         advertised.clear();
+        addresses.clear();
         named.clear();
         connected.clear();
         // Cleared with the tiers, and rebuilt from the same sweep: `peripherals()` reports
@@ -944,13 +1032,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap_or_else(|| properties.address.to_string());
 
             let duck = properties.services.contains(&SERVICE_UUID);
+            let address = Address::read(&properties, duck);
+            if duck {
+                addresses.push((address, name.clone()));
+            }
             seen.push(Seen {
                 peripheral: peripheral.clone(),
                 identity: identity(&peripheral, properties.address),
                 local_name: properties.local_name.clone(),
                 services: properties.services.len(),
                 duck,
-                address: Address::read(&properties, duck),
+                address,
             });
 
             if list_only {
@@ -993,6 +1085,38 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         println!("{}", listing(&seen, cli.verbose, &target).await);
         return Ok(());
+    }
+
+    // The advertisement, before anything connects. An address here costs no bond, no PIN and about a
+    // second — and it is not stale: `btd` re-reads `net.status` every five seconds and re-advertises
+    // when the answer moves, so this is that call with a five-second lag, well inside the window in
+    // which a new lease has already broken ssh.
+    if resolving {
+        match choose(std::mem::take(&mut addresses), &target) {
+            Ok((Address::At(address), _)) => return deliver(&cli.command, &address.to_string()),
+            // The robot broadcast `0.0.0.0`, which is a robot with no network rather than a robot
+            // that did not say. Asking `net.status` over a connection would return the same nothing
+            // more slowly, so this answers now.
+            Ok((Address::Unassigned, name)) => return Err(no_address(&name).into()),
+            // A release from before `btd` advertised an address. The fallback answers anyway;
+            // updating makes it fast.
+            Ok((Address::Unsaid, name)) => eprintln!(
+                "{name} advertises no address — a release from before robots broadcast one. Asking \
+                 it over Bluetooth instead, which takes longer; `duckctl update apply` makes this \
+                 fast."
+            ),
+            // Nothing advertised the service, or nothing answering to the name did. Both are the
+            // fallback's case, and the tiers below have their own answer for each: this is the
+            // bonded-Mac situation the fallback exists for, and its failure message is better than
+            // anything that could be said here.
+            Err(_) => {
+                if cli.verbose {
+                    eprintln!(
+                        "no advertisement carried an address; connecting to ask net.status instead"
+                    );
+                }
+            }
+        }
     }
 
     let mut found = advertised;
@@ -1180,6 +1304,24 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     eprintln!("· {}", serde_json::to_string(&value)?);
                 }
                 continue;
+            }
+
+            // `ip` and `open` asked `net.status` for one field, so the reply is not the answer:
+            // stdout carries an address or a URL, or nothing at all. Before the JSON is printed,
+            // because printing it would be the bug — `$(duckctl ip)` would carry the whole object.
+            if resolving {
+                let _ = peripheral.disconnect().await;
+                if let Some(error) = value.get("error") {
+                    return Err(format!(
+                        "the robot answered and refused net.status: {error}\nA wrong PIN is the \
+                         usual cause — `robotctl system pin` on the robot says what it is."
+                    )
+                    .into());
+                }
+                return match value["result"]["ip4"].as_str().filter(|ip| !ip.is_empty()) {
+                    Some(address) => deliver(&cli.command, address),
+                    None => Err(no_address(&name).into()),
+                };
             }
 
             println!("{}", serde_json::to_string_pretty(&value)?);
@@ -1405,6 +1547,10 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         // request: there is no method to send, and connecting is the thing it exists not to do.
         Command::Scan => unreachable!("scan returns before anything connects"),
         Command::Status => ("update.status", serde_json::json!({}), REPLY_TIMEOUT),
+        // The fallback, reached only when no advertisement carried an address. `net.status` is what
+        // the advertisement is made of — `btd` re-reads it every five seconds — so this asks the
+        // same question over a connection that costs a bond and a PIN.
+        Command::Ip | Command::Open { .. } => ("net.status", serde_json::json!({}), REPLY_TIMEOUT),
         Command::Version => (
             "hello",
             serde_json::json!({ "api_version": duck_ipc_proto::API_VERSION }),
@@ -1943,6 +2089,72 @@ mod tests {
     }
 
     /// The whole point of the change: a listing says where to reach the robot, with no connection.
+    /// The one thing `open` adds over `ip`, and the reason it is a command rather than a documented
+    /// `open "http://$(duckctl ip):8080"`: the port has one home.
+    #[test]
+    fn the_console_url_is_the_address_and_the_port() {
+        assert_eq!(
+            console_url("192.168.1.42", 8080),
+            "http://192.168.1.42:8080/"
+        );
+        assert_eq!(
+            console_url("192.168.1.42", 9000),
+            "http://192.168.1.42:9000/"
+        );
+    }
+
+    /// `ip` picks a robot the same way every other command does. Two robots on one bench, one of
+    /// them named — the address that comes back has to be that robot's, not whichever advertisement
+    /// arrived first.
+    #[test]
+    fn an_advertised_address_is_chosen_by_name() {
+        let found = vec![
+            (
+                Address::At("192.168.1.7".parse().unwrap()),
+                "duck-aaaa".to_owned(),
+            ),
+            (
+                Address::At("192.168.1.42".parse().unwrap()),
+                "duck-c51b".to_owned(),
+            ),
+        ];
+        let (address, name) = choose(found, &asked_for("duck-c51b")).expect("one robot answers");
+        assert_eq!(name, "duck-c51b");
+        assert_eq!(address, Address::At("192.168.1.42".parse().unwrap()));
+    }
+
+    /// A robot that broadcast `0.0.0.0` is a robot with no network, and the fix is over the radio —
+    /// so the message names the command that does it rather than the field that was empty.
+    #[test]
+    fn a_robot_with_no_network_is_told_how_to_get_one() {
+        let message = no_address("duck-c51b");
+        assert!(message.contains("duck-c51b"));
+        assert!(message.contains("wifi connect"));
+    }
+
+    /// `--print` and `--port` are the two things `open` takes, and neither is positional.
+    #[test]
+    fn open_takes_a_port_and_can_print_instead() {
+        let cli = Cli::try_parse_from(["duckctl", "open", "--print", "--port", "9000"])
+            .expect("open --print --port parses");
+        assert!(matches!(
+            cli.command,
+            Command::Open {
+                print: true,
+                port: 9000
+            }
+        ));
+
+        let cli = Cli::try_parse_from(["duckctl", "open"]).expect("open parses on its own");
+        assert!(matches!(
+            cli.command,
+            Command::Open {
+                print: false,
+                port: 8080
+            }
+        ));
+    }
+
     #[test]
     fn a_robot_broadcasts_where_it_is() {
         let (properties, duck) = advertised(

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -72,10 +72,20 @@ const SCAN_POLL: Duration = Duration::from_millis(250);
 /// so gets its own budget below.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(15);
 const SLOW_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
-/// An update's silences are longer than any other call's: a post-install hook may take two
-/// minutes, and the phase notification arrives before it rather than during it. So the budget is
-/// the longest gap an update can legitimately have, not the longest an update can take.
-const UPDATE_IDLE_TIMEOUT: Duration = Duration::from_secs(180);
+/// An update's silences are longer than any other call's: a hook's phase notification arrives
+/// *before* the hook rather than during it, so the budget is the longest gap an update can
+/// legitimately have, not the longest an update can take.
+///
+/// **The gap is the pre-install hook's ceiling**, which is why this is derived from
+/// [`duck_ipc_proto::UPDATE_MAX_SILENCE_SECONDS`] rather than being a number here. That hook
+/// installs what a release needs and a board may not have — ONNX Runtime, and around 100 MB of apt
+/// for `mediad`'s GStreamer stack on a board that never had it — and this was 180 seconds when that
+/// ceiling was two minutes. A budget below the ceiling reports a working update as a robot that
+/// stopped answering, and the operator's next move is to interrupt an update that was fine.
+///
+/// A minute of margin over it, for the reply that follows the hook.
+const UPDATE_IDLE_TIMEOUT: Duration =
+    Duration::from_secs(duck_ipc_proto::UPDATE_MAX_SILENCE_SECONDS + 60);
 /// `update watch` follows progress until interrupted, so it has no deadline worth naming. A day
 /// is an arbitrary bound that keeps the reply loop one shape instead of two.
 const FOLLOW_TIMEOUT: Duration = Duration::from_secs(24 * 3600);

--- a/hooks/preinstall.in
+++ b/hooks/preinstall.in
@@ -13,7 +13,18 @@
 # and `control loop has not completed a cycle yet` as the only explanation.
 #
 # The environment is cleared by the updater apart from PATH and the hook context, so there is
-# no token here. That is fine: ONNX Runtime comes from microsoft/onnxruntime, which is public.
+# no token here. That is fine, and it is why both things this hook fetches are public:
+# ONNX Runtime from microsoft/onnxruntime, and the GStreamer plugins from
+# pollen-robotics/microduck-gst-plugins.
+#
+# Two dependencies, and they fail the update differently on purpose:
+#
+#   ONNX Runtime is fatal. A release that cannot load a policy is a robot that cannot stand,
+#   and aborting here leaves the old release live with no rollback and no boot-counter churn.
+#
+#   The GStreamer stack is not. A board with no camera stack loses `mediad` — video and the
+#   WebRTC console — and still walks, still pairs, still updates. Refusing the update over it
+#   would mean a board that cannot be fixed by the mechanism that fixes boards.
 set -eu
 
 ONNX_FLOOR="@ONNX_FLOOR@"
@@ -111,21 +122,55 @@ install_onnx() {
     fi
 }
 
+# The GStreamer stack `mediad` needs, by running the release's own copy of the script that
+# installs it.
+#
+# **The script, not a copy of what it does.** It owns the pinned plugins version, the Debian
+# package list, the Rockchip MPP and RGA debs, the udev rule for `/dev/mpp_service`, and the
+# encoder report — six things that would otherwise exist twice and drift, which is the class of
+# bug this repo keeps writing down. It is idempotent by design: a provisioned board pays a stamp
+# file comparison and two `dpkg -s` calls, and a board that has never had the stack gets it here.
+#
+# This is what the split between provisioning and updating is for. `provision.sh` installs the
+# stack on a new board; every board provisioned before that existed, and every board whose
+# plugins are older than the version this release was built against, is fixed by an ordinary
+# update instead of by somebody remembering a command.
+#
+# Never fatal, for the reason in the header. Its report goes to the update log either way, which
+# is where "this board cannot encode H.264 in hardware" belongs.
+install_gstreamer() {
+    script=scripts/setup-gstreamer.sh
+    if [ ! -f "$script" ]; then
+        say "no ${script} in this release; skipping the camera stack"
+        return 0
+    fi
+
+    say "checking the GStreamer stack"
+    if sh "$script"; then
+        say "GStreamer stack ready"
+    else
+        say "the GStreamer stack did not finish installing — this release will run without a
+  camera or a WebRTC console, and everything else is unaffected. To retry by hand:
+    sudo /usr/local/sbin/robot-setup-gstreamer"
+    fi
+}
+
 have="$(installed_onnx)"
 
 if at_least "$have" "$ONNX_FLOOR"; then
     say "ONNX Runtime ${have} satisfies >= ${ONNX_FLOOR}"
-    exit 0
+else
+    say "ONNX Runtime ${have:-absent} is below ${ONNX_FLOOR}, which this release requires"
+    install_onnx
+
+    # Verified rather than assumed: an install that reported success but left the symlink wrong
+    # would otherwise be discovered by robotd's control thread panicking, which is the failure
+    # mode this hook was written to remove.
+    have="$(installed_onnx)"
+    at_least "$have" "$ONNX_FLOOR" \
+        || die "installed ONNX Runtime ${have:-none}, still below ${ONNX_FLOOR}"
+
+    say "ONNX Runtime now ${have}"
 fi
 
-say "ONNX Runtime ${have:-absent} is below ${ONNX_FLOOR}, which this release requires"
-install_onnx
-
-# Verified rather than assumed: an install that reported success but left the symlink wrong
-# would otherwise be discovered by robotd's control thread panicking, which is the failure
-# mode this hook was written to remove.
-have="$(installed_onnx)"
-at_least "$have" "$ONNX_FLOOR" \
-    || die "installed ONNX Runtime ${have:-none}, still below ${ONNX_FLOOR}"
-
-say "ONNX Runtime now ${have}"
+install_gstreamer

--- a/mediad/Cargo.toml
+++ b/mediad/Cargo.toml
@@ -18,6 +18,15 @@ description = "Camera, mic, WebRTC — and the remote gateway"
 [dependencies]
 duck-ipc-proto = { path = "../duck-ipc-proto" }
 anyhow = "1"
+# The console's one route. Already in `Cargo.lock` — `updater` uses it for its test mirror — so it
+# is known-good against this toolchain and the cross build. The alternative was a hand-rolled
+# HTTP/1.1 responder: about sixty lines of hand-written request parsing bound to 0.0.0.0, written to
+# avoid a dependency the build already resolves, where `hyper` underneath this is the most-read
+# implementation of that parser in the language. `webrtc-console.md` §1.1.
+#
+# Default features off: this serves one file over GET, and JSON extractors, multipart, forms and
+# tracing middleware are all weight for routes that do not exist.
+axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net", "io-util", "sync", "time", "macros"] }

--- a/mediad/src/lib.rs
+++ b/mediad/src/lib.rs
@@ -10,11 +10,13 @@
 //! testable without a WebRTC peer and would serve a WebSocket surface (§11) unchanged.
 //!
 //! - [`web`] — the console page, served by the daemon it drives. `webrtc-console.md` §1.
+//! - [`producer`] — who this robot says it is, before a peer negotiates anything. §5.
 //!
 //! [`pipeline`] is the rest, and the only part that is not portable: `webrtcsink` with the
 //! signalling server in this process, `mpph264enc` in front of it, and a `control` datachannel per
 //! peer wired to [`session::run`].
 
+pub mod producer;
 pub mod route;
 pub mod session;
 pub mod upstream;

--- a/mediad/src/lib.rs
+++ b/mediad/src/lib.rs
@@ -9,6 +9,8 @@
 //! [`session::run`] is transport-agnostic on purpose: it takes lines and gives lines, so it is
 //! testable without a WebRTC peer and would serve a WebSocket surface (§11) unchanged.
 //!
+//! - [`web`] — the console page, served by the daemon it drives. `webrtc-console.md` §1.
+//!
 //! [`pipeline`] is the rest, and the only part that is not portable: `webrtcsink` with the
 //! signalling server in this process, `mpph264enc` in front of it, and a `control` datachannel per
 //! peer wired to [`session::run`].
@@ -16,6 +18,7 @@
 pub mod route;
 pub mod session;
 pub mod upstream;
+pub mod web;
 
 /// The GStreamer pipeline and the datachannel. Linux only — see the crate manifest for why the
 /// gate is by target rather than by feature.

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -36,6 +36,15 @@ struct Args {
     #[arg(long, default_value_t = 8443)]
     port: u32,
 
+    /// Where the console is served. `http://<robot>:8080/`, and nothing else to run.
+    ///
+    /// **Two ports, and only this one is ever typed.** `webrtcsink` owns the listener on `--port`
+    /// and takes only a host and a port about it, so the page cannot be a route on it — see
+    /// `webrtc-console.md` §1.3, which also says where this ends up: one port, our own signalling
+    /// server, and a certificate, on the day a microphone or a browser gamepad is wanted.
+    #[arg(long, default_value_t = 8080)]
+    web_port: u16,
+
     /// Target video bitrate, bits per second.
     ///
     /// Explicit rather than the encoder's "auto calculate": `rc-mode` is already constant-bitrate,
@@ -101,6 +110,24 @@ fn main() -> ExitCode {
     };
 
     runtime.block_on(async move {
+        // The console, before the pipeline: it is the page that says a robot's pipeline would not
+        // start, so it should be up first — and it needs nothing from GStreamer.
+        //
+        // **A page that cannot be served does not cost the video.** A refused bind is almost always
+        // a port already in use, which `Restart=always` cannot fix by trying again; a robot that
+        // streams and answers control calls with no console is much better than one that does
+        // neither. So this is logged at error and the daemon carries on.
+        let page = mediad::web::page(args.port);
+        let (web_host, web_port) = (args.host.clone(), args.web_port);
+        tokio::spawn(async move {
+            if let Err(e) = mediad::web::serve(&web_host, web_port, page).await {
+                tracing::error!(
+                    error = %format!("{e:#}"),
+                    "the console is not being served; video and control are unaffected"
+                );
+            }
+        });
+
         let source = if args.camera {
             mediad::pipeline::Source::Camera(mediad::pipeline::Camera {
                 device: args.camera_device.clone(),

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -128,6 +128,20 @@ fn main() -> ExitCode {
             }
         });
 
+        // Before the pipeline, because `webrtcsink`'s `meta` is set as the element is built and a
+        // producer that registered without a name would keep it until this daemon restarts. Costs a
+        // unix-socket round trip on a boot where `configd` may not be up yet, which is why it is
+        // bounded and why a failure is a warning rather than an exit.
+        let producer =
+            mediad::producer::Producer::learn(Default::default(), duck_ipc_proto::build_info!())
+                .await;
+        tracing::info!(
+            name = producer.name.as_deref().unwrap_or("unknown"),
+            release = %producer.release,
+            api_version = producer.api_version,
+            "producing as"
+        );
+
         let source = if args.camera {
             mediad::pipeline::Source::Camera(mediad::pipeline::Camera {
                 device: args.camera_device.clone(),
@@ -142,24 +156,26 @@ fn main() -> ExitCode {
         // `get_frame` surface in `architecture.md` §5.3 are what it is for — but the branch runs
         // from the start rather than being added later, because a tee inserted into a live
         // pipeline is a different and much harder problem than a tee that was always there.
-        let (_pipeline, mut channels, _frames) = match mediad::pipeline::start(
-            source,
-            &args.host,
-            args.port,
-            args.bitrate,
-            args.width,
-            args.height,
-            args.fps,
-        ) {
-            Ok(started) => started,
-            Err(e) => {
-                // The message names which step failed and what usually causes it — a missing
-                // plugin, a missing library, or a device node nobody can open. Those look
-                // identical from a log line that only says "failed".
-                tracing::error!(error = %format!("{e:#}"), "mediad cannot start");
-                return ExitCode::FAILURE;
-            }
+        let settings = mediad::pipeline::Settings {
+            host: args.host.clone(),
+            port: args.port,
+            bitrate: args.bitrate,
+            width: args.width,
+            height: args.height,
+            fps: args.fps,
         };
+
+        let (_pipeline, mut channels, _frames) =
+            match mediad::pipeline::start(source, &producer, &settings) {
+                Ok(started) => started,
+                Err(e) => {
+                    // The message names which step failed and what usually causes it — a missing
+                    // plugin, a missing library, or a device node nobody can open. Those look
+                    // identical from a log line that only says "failed".
+                    tracing::error!(error = %format!("{e:#}"), "mediad cannot start");
+                    return ExitCode::FAILURE;
+                }
+            };
 
         // One session per peer, each with its own connections to the services it talks to. Per
         // peer rather than shared, so one peer's minutes-long update cannot silence another's

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -82,6 +82,25 @@ use gstreamer_video as gst_video;
 use gstreamer_webrtc as gst_webrtc;
 use tokio::sync::mpsc;
 
+/// Where the signalling server listens, and what the video is.
+///
+/// One value rather than six positional arguments. `start` had reached eight of them, and two of
+/// those are a `width` and a `height` of the same type: a call site that swapped them would compile
+/// and produce a portrait stream. Named fields make that unrepresentable, and a seventh setting
+/// stops changing the signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Settings {
+    /// Where the signalling server binds. All interfaces on the robot — `remote-webrtc.md` §3.
+    pub host: String,
+    /// The signalling server's port, which is *not* the console's: [`crate::web`] owns that one.
+    pub port: u32,
+    /// Starting video bitrate, bits per second. Congestion control moves it from here.
+    pub bitrate: u32,
+    pub width: u32,
+    pub height: u32,
+    pub fps: u32,
+}
+
 /// Where the video comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -147,13 +166,19 @@ pub struct Channel {
 /// stops the session, which is what a shutdown should do.
 pub fn start(
     source: Source,
-    host: &str,
-    port: u32,
-    bitrate: u32,
-    width: u32,
-    height: u32,
-    fps: u32,
+    producer: &crate::producer::Producer,
+    settings: &Settings,
 ) -> Result<(gst::Pipeline, mpsc::Receiver<Channel>, Frames)> {
+    let &Settings {
+        port,
+        bitrate,
+        width,
+        height,
+        fps,
+        ..
+    } = settings;
+    let host = settings.host.as_str();
+
     // `GST_DEBUG` has to be in the environment before `init`, which is when GStreamer parses it.
     set_gstreamer_log_threshold();
 
@@ -252,6 +277,16 @@ pub fn start(
     sink.set_property("run-signalling-server", true);
     sink.set_property("signalling-server-host", host);
     sink.set_property("signalling-server-port", port);
+
+    // Who this robot is, handed to every peer in the signalling server's `list` answer — so a
+    // client knows which robot it found before it negotiates anything. [`crate::producer`] is what
+    // goes in it and why. A structure name is required and is not what a peer reads; `meta` is
+    // webrtcsink's own word for the property.
+    let mut meta = gst::Structure::builder("meta");
+    for (field, value) in producer.fields() {
+        meta = meta.field(field, value);
+    }
+    sink.set_property("meta", meta.build());
 
     // Offer H.264 and nothing else. Left alone `webrtcsink` proposes everything it can encode:
     // `mppvp8enc`, `mpph265enc` and `mpph264enc` on the VPU, but `vp9enc` and `av1enc` in

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -282,11 +282,24 @@ pub fn start(
     // client knows which robot it found before it negotiates anything. [`crate::producer`] is what
     // goes in it and why. A structure name is required and is not what a peer reads; `meta` is
     // webrtcsink's own word for the property.
-    let mut meta = gst::Structure::builder("meta");
-    for (field, value) in producer.fields() {
-        meta = meta.field(field, value);
+    //
+    // **Checked before it is set, for the reason every signal in this file is checked**:
+    // `set_property` panics on a name the element does not have, and a panic here is a daemon that
+    // will not start — costing the video and the control channel to gain a producer's name. This is
+    // the newest thing this function touches, so it is the one most likely to be wrong about a
+    // spelling, and a producer that is merely anonymous is a far better failure.
+    if sink.has_property("meta") {
+        let mut meta = gst::Structure::builder("meta");
+        for (field, value) in producer.fields() {
+            meta = meta.field(field, value);
+        }
+        sink.set_property("meta", meta.build());
+    } else {
+        tracing::warn!(
+            "webrtcsink has no `meta` property on these plugins, so peers see a producer id and \
+             nothing else. Everything else is unaffected."
+        );
     }
-    sink.set_property("meta", meta.build());
 
     // Offer H.264 and nothing else. Left alone `webrtcsink` proposes everything it can encode:
     // `mppvp8enc`, `mpph265enc` and `mpph264enc` on the VPU, but `vp9enc` and `av1enc` in

--- a/mediad/src/producer.rs
+++ b/mediad/src/producer.rs
@@ -1,0 +1,213 @@
+//! Who this robot is, said before a session starts.
+//!
+//! `webrtcsink` takes a `meta` structure and the signalling server hands it to every peer in its
+//! `list` answer — so a client learns which robot it found *before* it negotiates anything. The page
+//! already logs that field and it has always been empty. `webrtc-console.md` §5.
+//!
+//! Four fields, and each has a caller:
+//!
+//! - **`name`** — so a page can title itself with the robot rather than with an id, and so a client
+//!   that finds two producers on one network can say which is which. This is the whole of the field's
+//!   value today.
+//! - **`serial`** — the durable handle. A name is renamed and a peer id is per-session; the serial
+//!   outlives both, which is what an app keying on a robot needs (`app-path-design.md` §8.6).
+//! - **`release`** — what is running, so a client that behaves oddly against one robot can be told
+//!   apart from a robot that is a release behind, without opening a session to ask.
+//! - **`api_version`** — the same skew a session's `hello` reports, one round trip earlier. A client
+//!   can put the banner up before it starts negotiating.
+//!
+//! ## The name comes from `configd`, and its absence is not a failure
+//!
+//! `system.info` owns the name and the serial, and `mediad` has a connection to `configd` for it
+//! already. But `mediad` starts alongside `configd` rather than after it, and the unit says so
+//! deliberately — `After=` and not `Requires=`, because a service being down must not keep this one
+//! from starting. So this asks, waits [`ASK_TIMEOUT`], and goes on with what it knows about itself
+//! either way: a producer with no name is a robot that streams, and a robot that will not stream
+//! because it could not learn its own name would be a much worse trade.
+//!
+//! Asked once at startup rather than per peer. A rename takes effect on the next restart of this
+//! daemon, which is what `configd` does to `btd`'s advertisement too — and a peer that wants the
+//! live answer can call `system.info` over its own control channel.
+
+use std::time::Duration;
+
+use duck_ipc_proto as proto;
+use tokio::sync::mpsc;
+
+use crate::upstream::{Pool, Sockets};
+
+/// How long `configd` gets to say who this robot is.
+///
+/// It is one unix-socket round trip against a daemon that answers `system.info` from memory, so this
+/// is generous. It is spent once, before the pipeline exists, on a boot where every daemon is
+/// starting at once — which is the only case where it is spent at all.
+const ASK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// What a peer learns about this robot from the producer list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Producer {
+    /// As `configd` has it, or `None` when it did not answer in time.
+    pub name: Option<String>,
+    /// The SoC serial. `None` on a board with none to read, as `system.info` reports it.
+    pub serial: Option<String>,
+    /// The release this process was installed as, or the build it was compiled from.
+    pub release: String,
+    pub api_version: u32,
+}
+
+impl Producer {
+    /// What this process knows about itself, with nothing else asked.
+    ///
+    /// **The release, from the path rather than from the version.** Every crate in this workspace
+    /// shares one version line, so `0.9.1` names two different builds on a dev channel and the
+    /// directory a release installs into is what tells them apart — the same reasoning
+    /// [`proto::Identity::release`] exists for. A hand-built binary run from a home directory has no
+    /// such path, and then the compiled-in build string is the honest answer rather than a version
+    /// that implies a release nobody installed.
+    pub fn local(build: proto::BuildInfo) -> Self {
+        let release = std::env::current_exe()
+            .ok()
+            .and_then(|exe| proto::release_from_path(&exe.display().to_string()))
+            .map(|version| version.to_string())
+            .unwrap_or_else(|| build.to_string());
+
+        Self {
+            name: None,
+            serial: None,
+            release,
+            api_version: proto::API_VERSION,
+        }
+    }
+
+    /// [`Producer::local`], plus whatever `configd` says about the name and the serial.
+    pub async fn learn(sockets: Sockets, build: proto::BuildInfo) -> Self {
+        let mut producer = Self::local(build);
+
+        match ask_configd(sockets).await {
+            Ok(info) => {
+                producer.name = Some(info.name);
+                producer.serial = info.serial;
+            }
+            // At `warn` rather than `error`: the pipeline still starts and still streams, and the
+            // only cost is a producer a client cannot name. The reason is in the message because
+            // "no socket" and "answered something unexpected" want different next moves.
+            Err(e) => tracing::warn!(
+                error = %e,
+                "configd did not say who this robot is; the producer will have no name"
+            ),
+        }
+        producer
+    }
+
+    /// The `meta` fields, as the pairs a `GstStructure` is built from.
+    ///
+    /// Absent fields are absent rather than empty strings: a client reading `serial: ""` has to know
+    /// that means "none", where a missing key needs no convention. Keys are snake_case, as every
+    /// other field on this wire is.
+    pub fn fields(&self) -> Vec<(&'static str, String)> {
+        let mut fields = Vec::new();
+        if let Some(name) = &self.name {
+            fields.push(("name", name.clone()));
+        }
+        if let Some(serial) = &self.serial {
+            fields.push(("serial", serial.clone()));
+        }
+        fields.push(("release", self.release.clone()));
+        fields.push(("api_version", self.api_version.to_string()));
+        fields
+    }
+}
+
+/// One `system.info` call, and the first line back.
+///
+/// A [`Pool`] rather than a socket opened here, so this shares the connect and write timeouts every
+/// other call to a service gets rather than growing a second set of them.
+async fn ask_configd(sockets: Sockets) -> Result<proto::SystemInfoResult, String> {
+    let (replies_tx, mut replies_rx) = mpsc::channel::<String>(4);
+    let mut pool = Pool::new(sockets, replies_tx);
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": proto::method::SYSTEM_INFO,
+        "params": {},
+    })
+    .to_string();
+
+    pool.send(proto::Service::Config, proto::Lane::Prompt, &request)
+        .await
+        .map_err(|e| format!("could not ask configd: {e}"))?;
+
+    let line = tokio::time::timeout(ASK_TIMEOUT, replies_rx.recv())
+        .await
+        .map_err(|_| format!("configd did not answer within {ASK_TIMEOUT:?}"))?
+        .ok_or_else(|| "configd closed the connection".to_owned())?;
+
+    let reply: serde_json::Value =
+        serde_json::from_str(&line).map_err(|e| format!("configd answered nonsense: {e}"))?;
+    if let Some(error) = reply.get("error") {
+        return Err(format!("configd refused system.info: {error}"));
+    }
+    serde_json::from_value(reply["result"].clone())
+        .map_err(|e| format!("configd's system.info does not fit: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build() -> proto::BuildInfo {
+        proto::BuildInfo {
+            version: "0.9.1",
+            revision: Some("abc1234"),
+            built_at: None,
+        }
+    }
+
+    /// The two fields that are always known, and the version this daemon actually speaks — not a
+    /// constant copied into a page.
+    #[test]
+    fn what_is_known_without_asking_anything() {
+        let producer = Producer::local(build());
+        assert_eq!(producer.api_version, proto::API_VERSION);
+        assert!(!producer.release.is_empty());
+        assert_eq!(producer.name, None);
+    }
+
+    /// A client keys on what is there. An unnamed robot publishes three fields, not four with two
+    /// of them empty.
+    #[test]
+    fn absent_fields_are_absent() {
+        let fields = Producer::local(build()).fields();
+        let keys: Vec<_> = fields.iter().map(|(key, _)| *key).collect();
+        assert_eq!(keys, ["release", "api_version"]);
+    }
+
+    #[test]
+    fn a_named_robot_publishes_the_lot() {
+        let producer = Producer {
+            name: Some("duck-c51b".to_owned()),
+            serial: Some("3fa1c51b".to_owned()),
+            ..Producer::local(build())
+        };
+        let fields = producer.fields();
+        assert_eq!(
+            fields.iter().map(|(key, _)| *key).collect::<Vec<_>>(),
+            ["name", "serial", "release", "api_version"]
+        );
+        assert_eq!(fields[0].1, "duck-c51b");
+    }
+
+    /// `configd` not answering costs the name and nothing else. This is the boot case: `mediad` is
+    /// `After=configd.service` and not `Requires=`, so it can and does start first.
+    #[tokio::test]
+    async fn a_silent_configd_still_yields_a_producer() {
+        let sockets = Sockets {
+            config: "/nonexistent/configd.sock".into(),
+            ..Default::default()
+        };
+        let producer = Producer::learn(sockets, build()).await;
+        assert_eq!(producer.name, None);
+        assert_eq!(producer.api_version, proto::API_VERSION);
+    }
+}

--- a/mediad/src/web.rs
+++ b/mediad/src/web.rs
@@ -1,0 +1,111 @@
+//! The page, served by the daemon it drives.
+//!
+//! One route, one file, no build step. `http://<robot>:8080/` and there is nothing else to run —
+//! which is the whole of it, and `webrtc-console.md` §1 is why it is worth a dependency and a
+//! second port.
+//!
+//! **It deletes four problems rather than one.** No `python3 -m http.server`, so the instruction is
+//! an address rather than two commands. No URL to type, because a page served by the robot knows
+//! which robot it came from and derives its signalling target from `location.hostname`. Chrome's
+//! Private Network Access check stops applying, because that check is on requests from a *public or
+//! opaque* origin to a private address — and a page served from `192.168.x` has a private one, so
+//! the failure that made `file://` unusable cannot happen. And page and binary ship together, so a
+//! client from a checkout can no longer be pointed at a robot from a release.
+//!
+//! ## The port is filled in here, not carried by the page
+//!
+//! [`page`] substitutes the signalling port into the embedded page once, at startup. That is what
+//! makes `--port` safe to change: nothing holds a second copy of it. The *host* is the browser's to
+//! fill — `location.hostname`, which is the robot that served the page — so this is one number and
+//! not a URL.
+//!
+//! A page opened straight from the source tree keeps the token, reads it as `NaN`, and falls back to
+//! `webrtcsink`'s own 8443. It also then knows it was *not* served by a robot, which is what lets it
+//! tell "wrong host" apart from "the robot served me but its signalling port did not answer" — the
+//! one failure two ports can produce, and §1.3's requirement that it reach a person as a diagnosis.
+//!
+//! ## Portable, unlike [`crate::pipeline`]
+//!
+//! Nothing here touches GStreamer, so it compiles and its tests run on a laptop. The substitution is
+//! the part worth a test: a page served with the token still in it would connect to the wrong port
+//! and say nothing about why.
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use axum::Router;
+use axum::response::Html;
+use axum::routing::get;
+
+/// The page as it sits in the source tree.
+///
+/// `include_str!` rather than a file read at request time, and that is a decision: installing it
+/// under `current/webclient/` would cost an `--include` line in three places that already drift
+/// (`_build-release.yml`, `dev.yml`, `scripts/dev-push.sh`), put a filesystem read behind a network
+/// request in a unit running `ProtectSystem=strict`, and make "which page is this robot serving" a
+/// question with two answers. The cost is a rebuild to change a stylesheet, which is the right trade
+/// for a page that is part of the daemon's interface.
+const PAGE: &str = include_str!("../webclient/index.html");
+
+/// Where the page carries its signalling port until this module fills one in.
+const PORT_TOKEN: &str = "{{SIGNALLING_PORT}}";
+
+/// The page, with the signalling port filled in.
+pub fn page(signalling_port: u32) -> String {
+    PAGE.replace(PORT_TOKEN, &signalling_port.to_string())
+}
+
+/// Serve `page` on `host:port` until the process ends.
+///
+/// Returns only on failure — a bind that was refused, or a listener that died. The caller decides
+/// what that costs; in `mediad` it costs the page and not the video, because a robot that streams
+/// and answers control calls with no console is a great deal better than one that does neither.
+pub async fn serve(host: &str, port: u16, page: String) -> Result<()> {
+    let router = Router::new().route("/", get(move || std::future::ready(Html(page))));
+
+    let address: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .with_context(|| format!("{host}:{port} is not an address to listen on"))?;
+    let listener = tokio::net::TcpListener::bind(address)
+        .await
+        .with_context(|| format!("could not listen on {address}"))?;
+
+    tracing::info!(%address, "serving the console");
+    axum::serve(listener, router)
+        .await
+        .context("the console's listener stopped")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole of what this module does to the page.
+    #[test]
+    fn the_signalling_port_is_filled_in() {
+        let served = page(8443);
+        assert!(
+            !served.contains(PORT_TOKEN),
+            "the page went out with its port token still in it"
+        );
+        assert!(served.contains("8443"));
+    }
+
+    /// A non-default `--port` reaches the page, which is the reason the substitution exists at all:
+    /// a page carrying a constant would still be dialling 8443.
+    #[test]
+    fn a_moved_port_reaches_the_page() {
+        assert!(page(9000).contains("9000"));
+    }
+
+    /// The token is in the page, spelled the way this module spells it. Without this, a rename on
+    /// either side leaves a page that silently falls back to 8443 — which works on every robot
+    /// until someone moves the port, and then fails with nothing to read.
+    #[test]
+    fn the_page_carries_the_token_this_module_replaces() {
+        assert!(
+            PAGE.contains(PORT_TOKEN),
+            "the page has no {PORT_TOKEN} for the signalling port"
+        );
+    }
+}

--- a/mediad/src/web.rs
+++ b/mediad/src/web.rs
@@ -12,12 +12,19 @@
 //! the failure that made `file://` unusable cannot happen. And page and binary ship together, so a
 //! client from a checkout can no longer be pointed at a robot from a release.
 //!
-//! ## The port is filled in here, not carried by the page
+//! ## The port and the API version are filled in here, not carried by the page
 //!
-//! [`page`] substitutes the signalling port into the embedded page once, at startup. That is what
-//! makes `--port` safe to change: nothing holds a second copy of it. The *host* is the browser's to
-//! fill — `location.hostname`, which is the robot that served the page — so this is one number and
-//! not a URL.
+//! [`page`] substitutes both into the embedded page once, at startup. That is what makes `--port`
+//! safe to change: nothing holds a second copy of it. The *host* is the browser's to fill —
+//! `location.hostname`, which is the robot that served the page — so this is one number and not a
+//! URL.
+//!
+//! The API version is the same idea applied to the skew banner. A page cannot compare versions
+//! without knowing which one it speaks, and a literal in the page would be the second copy of
+//! [`proto::API_VERSION`] — wrong on the day it is bumped, and wrong in the direction that reports
+//! agreement. Substituted, a page served by a robot is a page that speaks that robot's release, and
+//! the banner it shows is about a *checkout* page pointed at a robot, which is the case it exists
+//! for.
 //!
 //! A page opened straight from the source tree keeps the token, reads it as `NaN`, and falls back to
 //! `webrtcsink`'s own 8443. It also then knows it was *not* served by a robot, which is what lets it
@@ -36,6 +43,7 @@ use anyhow::{Context, Result};
 use axum::Router;
 use axum::response::Html;
 use axum::routing::get;
+use duck_ipc_proto as proto;
 
 /// The page as it sits in the source tree.
 ///
@@ -50,9 +58,13 @@ const PAGE: &str = include_str!("../webclient/index.html");
 /// Where the page carries its signalling port until this module fills one in.
 const PORT_TOKEN: &str = "{{SIGNALLING_PORT}}";
 
-/// The page, with the signalling port filled in.
+/// Where it carries the API version this release speaks.
+const API_TOKEN: &str = "{{API_VERSION}}";
+
+/// The page, with the signalling port and the API version filled in.
 pub fn page(signalling_port: u32) -> String {
     PAGE.replace(PORT_TOKEN, &signalling_port.to_string())
+        .replace(API_TOKEN, &proto::API_VERSION.to_string())
 }
 
 /// Serve `page` on `host:port` until the process ends.
@@ -61,8 +73,6 @@ pub fn page(signalling_port: u32) -> String {
 /// what that costs; in `mediad` it costs the page and not the video, because a robot that streams
 /// and answers control calls with no console is a great deal better than one that does neither.
 pub async fn serve(host: &str, port: u16, page: String) -> Result<()> {
-    let router = Router::new().route("/", get(move || std::future::ready(Html(page))));
-
     let address: SocketAddr = format!("{host}:{port}")
         .parse()
         .with_context(|| format!("{host}:{port} is not an address to listen on"))?;
@@ -71,9 +81,14 @@ pub async fn serve(host: &str, port: u16, page: String) -> Result<()> {
         .with_context(|| format!("could not listen on {address}"))?;
 
     tracing::info!(%address, "serving the console");
-    axum::serve(listener, router)
+    axum::serve(listener, router(page))
         .await
         .context("the console's listener stopped")
+}
+
+/// One route, returning `page`.
+fn router(page: String) -> Router {
+    Router::new().route("/", get(move || std::future::ready(Html(page))))
 }
 
 #[cfg(test)]
@@ -82,13 +97,28 @@ mod tests {
 
     /// The whole of what this module does to the page.
     #[test]
-    fn the_signalling_port_is_filled_in() {
+    fn both_tokens_are_filled_in() {
         let served = page(8443);
         assert!(
             !served.contains(PORT_TOKEN),
             "the page went out with its port token still in it"
         );
+        assert!(
+            !served.contains(API_TOKEN),
+            "the page went out with its API version token still in it"
+        );
         assert!(served.contains("8443"));
+        assert!(served.contains(&proto::API_VERSION.to_string()));
+    }
+
+    /// The banner exists to catch a page from a checkout against a robot from a release, so the
+    /// version it compares against has to be this release's rather than a literal in the page.
+    #[test]
+    fn the_page_carries_the_api_token_this_module_replaces() {
+        assert!(
+            PAGE.contains(API_TOKEN),
+            "the page has no {API_TOKEN} for the API version"
+        );
     }
 
     /// A non-default `--port` reaches the page, which is the reason the substitution exists at all:
@@ -96,6 +126,46 @@ mod tests {
     #[test]
     fn a_moved_port_reaches_the_page() {
         assert!(page(9000).contains("9000"));
+    }
+
+    /// The route, end to end, over a real socket: a `GET /` answers 200 with the page. Cheap, and
+    /// it is the whole of what a browser does — the alternative is discovering on a board that the
+    /// one route is mounted somewhere a browser does not ask.
+    #[tokio::test]
+    async fn the_route_answers_with_the_page() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("a loopback port");
+        let address = listener.local_addr().expect("the port it took");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router(page(8443))).await;
+        });
+
+        let mut stream = tokio::net::TcpStream::connect(address)
+            .await
+            .expect("the server is listening");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: robot\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("wrote the request");
+        let mut answer = String::new();
+        stream
+            .read_to_string(&mut answer)
+            .await
+            .expect("read the answer");
+
+        assert!(
+            answer.starts_with("HTTP/1.1 200"),
+            "the console did not answer 200: {}",
+            answer.lines().next().unwrap_or("nothing at all")
+        );
+        assert!(answer.contains("duck console"), "that was not the page");
+        assert!(
+            !answer.contains(PORT_TOKEN),
+            "the page went out over the wire with its port token still in it"
+        );
     }
 
     /// The token is in the page, spelled the way this module spells it. Without this, a rename on

--- a/mediad/systemd/mediad.service
+++ b/mediad/systemd/mediad.service
@@ -121,10 +121,11 @@ RuntimeDirectory=mediad
 # are visible in `robotctl health` as a unit that is not running, and neither touches the control
 # loop, BLE, the pad or an update:
 #
-#   * **A board with no GStreamer stack.** `setup-gstreamer.sh` installs it and provisioning has
-#     run it by default since before `mediad` shipped — so this is a board provisioned earlier than
-#     that. The pipeline cannot start, `Restart=always` retries every five seconds, and the fix is
-#     one command: `sudo /usr/local/sbin/robot-setup-gstreamer`.
+#   * **A board with no GStreamer stack.** Provisioning installs it, and so does the pre-install
+#     hook of every update — `hooks/preinstall` runs the release's own `setup-gstreamer.sh` — so a
+#     board reaching this state has had both fail, most likely for want of network. The pipeline
+#     cannot start, `Restart=always` retries every five seconds, and re-running it by hand is
+#     `sudo /usr/local/sbin/robot-setup-gstreamer`.
 #   * **A board with no camera**, because `ExecStart` carries `--camera`. Same shape, and the
 #     drop-in above is the fix.
 #

--- a/mediad/systemd/mediad.service
+++ b/mediad/systemd/mediad.service
@@ -30,8 +30,8 @@ Type=exec
 # **The consequence, stated because it is not obvious:** the control datachannel is bundled with
 # the video track, so a robot whose camera is absent — unplugged, or the device-tree overlay not
 # enabled — fails to start this service and loses its WebRTC control surface along with its video.
-# BLE and the local pad are unaffected, and there is no `[Install]` section here, so nothing
-# auto-enables this. `--camera` can be dropped through a drop-in for a board with no camera:
+# BLE and the local pad are unaffected. `--camera` can be dropped through a drop-in for a board
+# with no camera:
 #
 #     /etc/systemd/system/mediad.service.d/test-pattern.conf
 #     [Service]
@@ -107,22 +107,30 @@ StandardError=journal
 # identity claiming to be running.
 RuntimeDirectory=mediad
 
-# **No `[Install]` section, deliberately, and this is the line to add when there is one:**
+# **This section is what makes `mediad` a daemon rather than something to remember.**
 #
-#     [Install]
-#     WantedBy=multi-user.target
+# `hooks/postinstall` enables and starts every unit that ships with an `[Install]` section, and
+# `units_shipped` in `updater/src/engine.rs` restarts every such unit on an apply — one rule, read
+# off the unit files rather than a list anybody maintains. So this section is the whole of what
+# makes a release install a working camera and pick up the next one, and its absence was the whole
+# of why every push ended with somebody typing `systemctl restart mediad`.
 #
-# `hooks/postinstall` enables and starts every unit that ships *with* one, which is what makes a
-# newly added service arrive working. That is right for a daemon that has run somewhere, and wrong
-# for this one twice over: `mediad` has never started on a board, and it needs the GStreamer stack
-# `setup-gstreamer.sh` installs, which a board provisioned before that existed does not have. A
-# unit that fails and restarts every five seconds on every robot in the field is a worse outcome
-# than one somebody starts on purpose.
+# It was absent while `mediad` had never started on a board. It has, so it is here.
 #
-# So the release carries it — the binary, the unit and the account are all there — and starting it
-# is a decision:
+# **Two ways this unit can now fail on a robot nobody was looking at, and what each costs.** Both
+# are visible in `robotctl health` as a unit that is not running, and neither touches the control
+# loop, BLE, the pad or an update:
 #
-#     sudo systemctl enable --now mediad
+#   * **A board with no GStreamer stack.** `setup-gstreamer.sh` installs it and provisioning has
+#     run it by default since before `mediad` shipped — so this is a board provisioned earlier than
+#     that. The pipeline cannot start, `Restart=always` retries every five seconds, and the fix is
+#     one command: `sudo /usr/local/sbin/robot-setup-gstreamer`.
+#   * **A board with no camera**, because `ExecStart` carries `--camera`. Same shape, and the
+#     drop-in above is the fix.
 #
-# postinstall notices the missing section and says so rather than treating it as a failure; the
-# boot recovery net's oneshot ships the same way for its own reasons.
+# `WantedBy=multi-user.target` rather than a `.wants` symlink somebody adds: the release owns which
+# units exist and systemd owns whether they are enabled, and a robot whose enablement was done by
+# hand on one board is a robot nobody can reason about.
+
+[Install]
+WantedBy=multi-user.target

--- a/mediad/webclient/index.html
+++ b/mediad/webclient/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>duck console</title>
 <!--
-  The robot's console. One file, no build step, no dependencies — mediad embeds this page and
+  The robot's console. One file, no build step, no dependencies — `mediad` embeds this page and
   serves it, so reaching it is an address and not a command:
 
       http://<robot>:8080/          — or `duckctl open`, which finds the robot for you
@@ -10,17 +10,15 @@
   **The robot serves it, and that is what makes the signalling target derivable.** The page was
   served by the robot it is about to talk to, so the host is `location.hostname` and the port is
   filled in by mediad as it serves (see SERVED_PORT below). Nothing is typed, and nothing here
-  holds a second copy of the port.
+  holds a second copy of the port — or of the API version the skew banner compares against.
 
   It speaks gst-plugins-rs's signalling protocol directly rather than using its gstwebrtc-api
   JS library, for one reason: a client that needs npm is a client nobody runs. The protocol is
   small and the exact shapes are below, read off net/webrtc/protocol at 0.15.3.
 
-  What it exercises, which is everything mediad does today:
-
-    * the signalling server mediad runs in-process    (§3 of docs/design/remote-webrtc.md)
-    * the video track, hardware-encoded H.264         (constrained-baseline, so a browser takes it)
-    * the `control` datachannel, and the JSON-RPC on it, including a refusal   (§5)
+  **One file is a constraint, not an accident** — it is what makes this runnable at all. If it
+  outgrows one file it becomes three (index.html, app.js, app.css, three `include_str!`s), still
+  with no build step and still with no npm.
 
   Served over http, never https: ws:// from an https page is mixed content and blocked outright,
   and a robot on a LAN has no certificate to offer wss. docs/design/webrtc-console.md §1.3 says
@@ -30,65 +28,232 @@
   falls back to 8443, and the host comes from wherever it is served. A file:// page cannot reach
   a robot at all — Chrome's Private Network Access blocks requests from an opaque origin to a
   private address — so serve it, or let the robot serve it.
+
+  What it drives is what `mediad/src/route.rs` permits, and no more. The two calls it refuses are
+  in the console drawer at the bottom, because they prove the route table is consulted rather than
+  drive the robot.
 -->
 <style>
-  :root { color-scheme: light dark; }
+  :root {
+    color-scheme: light dark;
+    --line: color-mix(in srgb, currentColor 15%, transparent);
+    --fill: color-mix(in srgb, currentColor 8%, transparent);
+  }
+  * { box-sizing: border-box; }
   body { font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 1rem;
-         display: grid; gap: 1rem; grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr); }
-  header { grid-column: 1 / -1; display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
-  h1 { font-size: 1rem; margin: 0 1rem 0 0; font-weight: 600; }
-  input, button, select, textarea { font: inherit; padding: .3rem .5rem; }
-  input[type=text] { min-width: 18rem; }
-  video { width: 100%; background: #111; aspect-ratio: 16/9; border-radius: 4px; }
-  pre { margin: 0; padding: .5rem; background: color-mix(in srgb, currentColor 8%, transparent);
-        border-radius: 4px; height: 22rem; overflow: auto; white-space: pre-wrap;
-        font: 12px/1.45 ui-monospace, monospace; }
-  .row { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; margin-bottom: .5rem; }
-  .pill { padding: .1rem .5rem; border-radius: 99px; font-size: 12px;
-          background: color-mix(in srgb, currentColor 12%, transparent); }
-  .in  { color: #2a7; } .out { color: #59f; } .bad { color: #e55; } .dim { opacity: .6; }
-  section > h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em;
-                 opacity: .6; margin: 0 0 .4rem; }
+         display: grid; gap: 1rem; }
+  h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+  h2 { font-size: .75rem; text-transform: uppercase; letter-spacing: .05em; opacity: .55;
+       margin: 0 0 .5rem; }
+  button, select, input, textarea { font: inherit; padding: .3rem .55rem; border-radius: 4px;
+       border: 1px solid var(--line); background: var(--fill); color: inherit; }
+  button { cursor: pointer; }
+  button:hover:not(:disabled) { background: color-mix(in srgb, currentColor 16%, transparent); }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+
+  header { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+  header .grow { flex: 1; }
+  .pill { padding: .1rem .5rem; border-radius: 99px; font-size: 12px; background: var(--fill);
+          white-space: nowrap; }
+  .in { color: #2a7; } .out { color: #59f; } .bad { color: #e55; } .warn { color: #d90; }
+  .dim { opacity: .55; }
+
+  #banner { padding: .5rem .75rem; border-radius: 4px; border: 1px solid #d90;
+            background: color-mix(in srgb, #d90 12%, transparent); }
+
+  main { display: grid; gap: 1rem; grid-template-columns: minmax(340px, 1.3fr) minmax(300px, 1fr); }
+  @media (max-width: 800px) { main { grid-template-columns: 1fr; } }
+  section { border: 1px solid var(--line); border-radius: 6px; padding: .75rem; }
+  .row { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
+  .hint { margin: .5rem 0 0; font-size: 12px; opacity: .6; }
+
+  video { width: 100%; background: #111; aspect-ratio: 16/9; border-radius: 4px; display: block;
+          touch-action: none; cursor: crosshair; }
+  .stats { margin-top: .5rem; font: 12px/1.4 ui-monospace, monospace; gap: .75rem; }
+  .stats b { font-weight: 600; opacity: .55; font-size: 11px; text-transform: uppercase; }
+
+  .pads { display: flex; gap: 1rem; align-items: flex-end; flex-wrap: wrap; }
+  .pad { position: relative; background: var(--fill); border: 1px solid var(--line);
+         border-radius: 8px; touch-action: none; }
+  #pad-move { width: 150px; height: 150px; }
+  #pad-turn { width: 150px; height: 44px; }
+  .knob { position: absolute; width: 26px; height: 26px; margin: -13px 0 0 -13px; left: 50%;
+          top: 50%; border-radius: 50%; background: currentColor; opacity: .5;
+          pointer-events: none; }
+  .pad-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; opacity: .5;
+               margin-bottom: .25rem; }
+
+  table { border-collapse: collapse; width: 100%; font: 12px/1.6 ui-monospace, monospace; }
+  th { text-align: left; font-weight: 600; opacity: .55; text-transform: uppercase;
+       font-size: 11px; letter-spacing: .04em; padding-right: .75rem; white-space: nowrap; }
+  td { text-align: right; }
+
+  details { border: 1px solid var(--line); border-radius: 6px; padding: .5rem .75rem; }
+  summary { cursor: pointer; font-size: .75rem; text-transform: uppercase; letter-spacing: .05em;
+            opacity: .55; }
+  details > *:not(summary) { margin-top: .75rem; }
+  #raw { flex: 1; min-width: 18rem; font: 12px ui-monospace, monospace; }
+  pre { margin: 0; padding: .5rem; background: var(--fill); border-radius: 4px; height: 16rem;
+        overflow: auto; white-space: pre-wrap; font: 12px/1.45 ui-monospace, monospace; }
 </style>
 
 <header>
-  <h1>duck console</h1>
-  <button id="connect">connect</button>
+  <h1 id="robot">duck console</h1>
+  <span id="release" class="pill dim">release unknown</span>
+  <span id="api" class="pill dim">api unknown</span>
+  <span class="grow"></span>
   <span id="state" class="pill">idle</span>
   <span id="dcstate" class="pill dim">no control channel</span>
   <span id="signalling" class="pill dim"></span>
+  <button id="connect">connect</button>
 </header>
 
-<section>
-  <h2>video</h2>
-  <video id="video" autoplay muted playsinline></video>
-  <h2 style="margin-top:1rem">control · JSON-RPC over the datachannel</h2>
-  <div class="row">
-    <button data-call='{"jsonrpc":"2.0","id":1,"method":"robot.health"}'>robot.health</button>
-    <button data-call='{"jsonrpc":"2.0","id":2,"method":"system.info"}'>system.info</button>
-    <button data-call='{"jsonrpc":"2.0","id":3,"method":"update.status"}'>update.status</button>
-    <button data-call='{"jsonrpc":"2.0","id":4,"method":"hello","params":{"apiVersion":10}}'>hello</button>
-  </div>
+<div id="banner" hidden></div>
+
+<main>
+  <section>
+    <h2>video</h2>
+    <video id="video" autoplay muted playsinline></video>
+    <div class="row stats">
+      <span><b>bitrate</b> <span id="bitrate">–</span></span>
+      <span><b>fps</b> <span id="fps">–</span></span>
+      <span><b>loss</b> <span id="loss">–</span></span>
+      <span><b>rtt</b> <span id="rtt">–</span></span>
+      <span id="gaze" class="pill dim" hidden>gaze clamped</span>
+    </div>
+    <p class="hint">Drag on the picture to look at a point. The robot solves the IK and says when a
+      point is out of reach.</p>
+  </section>
+
+  <section>
+    <h2>drive</h2>
+    <div class="pads">
+      <div>
+        <div class="pad-label">forward · strafe</div>
+        <div class="pad" id="pad-move"><div class="knob" id="knob-move"></div></div>
+      </div>
+      <div>
+        <div class="pad-label">turn</div>
+        <div class="pad" id="pad-turn"><div class="knob" id="knob-turn"></div></div>
+      </div>
+    </div>
+    <p class="hint">
+      <b>W</b>/<b>S</b> forward and back, <b>A</b>/<b>D</b> strafe, <b>Q</b>/<b>E</b> turn — arrows
+      drive and turn. Full deflection is 0.3 m/s and 1.5 rad/s, the same as a gamepad's.
+      Intents are resent at 10 Hz while anything is held: the robot stops on its own 500 ms after
+      they stop arriving.
+    </p>
+  </section>
+
+  <section>
+    <h2>posture</h2>
+    <div class="row">
+      <button data-call="robot.enable" data-params='{"on":true,"toggle":true}'>enable ⇄</button>
+      <button data-call="robot.init">init</button>
+      <button data-call="robot.relax">relax</button>
+      <button data-call="robot.stop" data-confirm="Zero the robot's intents?">stop</button>
+      <button data-call="robot.shutdown" data-confirm="Power the robot off?">shutdown</button>
+    </div>
+    <p class="hint">
+      <b>stop</b> zeroes the intents this session is sending. It is not a physical emergency stop —
+      nothing here cuts power to the servos — and it is a plain button for that reason.
+      <b>enable</b> toggles, so it always means "the other one" and cannot go stale.
+    </p>
+  </section>
+
+  <section>
+    <h2>do · sound</h2>
+    <div class="row">
+      <select id="skill">
+        <option value="sit_toggle">sit ⇄ stand</option>
+        <option value="ground_pick">ground pick</option>
+        <option value="kick_left">kick left</option>
+        <option value="kick_right">kick right</option>
+        <option value="roulade">roulade</option>
+      </select>
+      <button id="do">do</button>
+      <span class="grow"></span>
+      <select id="sound">
+        <option value="chirp">chirp</option>
+        <option value="greet">greet</option>
+        <option value="inquire">inquire</option>
+        <option value="alarm">alarm</option>
+        <option value="peck">peck</option>
+        <option value="coo">coo</option>
+        <option value="wheee">wheee (hold)</option>
+      </select>
+      <button id="play">play</button>
+    </div>
+    <p class="hint">One request is one skill; holding <b>play</b> on <b>wheee</b> keeps the ride
+      going, and letting go releases it.</p>
+  </section>
+
+  <section>
+    <h2>telemetry</h2>
+    <table>
+      <tr><th>mode</th><td id="t-mode">–</td></tr>
+      <tr><th>policy</th><td id="t-policy">–</td></tr>
+      <tr><th>loop</th><td id="t-loop">–</td></tr>
+      <tr><th>safety</th><td id="t-safety">–</td></tr>
+      <tr><th>requested</th><td id="t-requested">–</td></tr>
+      <tr><th>applied</th><td id="t-applied">–</td></tr>
+      <tr><th>health</th><td id="t-health">–</td></tr>
+      <tr><th>battery</th><td id="t-battery">–</td></tr>
+      <tr><th>temperatures</th><td id="t-temps">–</td></tr>
+    </table>
+    <p class="hint">The frame is <code>robot.subscribe</code> at 2 Hz; the last three rows are
+      <code>robot.health</code>, polled, because none of it is on that stream.</p>
+  </section>
+</main>
+
+<details>
+  <summary>console — raw calls, refusals, and the log</summary>
+
   <div class="row">
     <!-- Permitted over BLE and refused here, because reconfiguring wifi would take this session
-         with it. The interesting button: it proves the route table is being consulted. -->
-    <button data-call='{"jsonrpc":"2.0","id":5,"method":"net.connect","params":{"ssid":"x","psk":"y"}}'>net.connect <span class="dim">(should refuse)</span></button>
-    <button data-call='{"jsonrpc":"2.0","id":6,"method":"system.pairingPin"}'>system.pairingPin <span class="dim">(should refuse)</span></button>
+         with it. The interesting buttons: they prove the route table is being consulted. -->
+    <button data-call="net.connect" data-params='{"ssid":"x","psk":"y"}'>net.connect
+      <span class="dim">(refused)</span></button>
+    <button data-call="system.pairingPin">system.pairingPin <span class="dim">(refused)</span></button>
   </div>
+
   <div class="row">
-    <input id="custom" type="text" spellcheck="false"
-           value='{"jsonrpc":"2.0","id":9,"method":"robot.subscribe","params":{"hz":2}}'>
+    <input id="raw" type="text" spellcheck="false"
+           value='{"jsonrpc":"2.0","id":99,"method":"robot.health"}'>
     <button id="send">send</button>
   </div>
-</section>
 
-<section>
-  <h2>log</h2>
   <pre id="log"></pre>
-</section>
+</details>
 
 <script>
 "use strict";
+
+// ── what the robot filled in ───────────────────────────────────────────────────
+//
+// mediad replaces both tokens as it serves this page (`web.rs`), so neither the port nor the API
+// version has a second home. NaN means nobody substituted them — this page was opened from a
+// checkout rather than served by a robot — and that fact is load-bearing twice below: it picks the
+// right diagnosis for a signalling port that does not answer, and it is the only case in which the
+// version banner can fire at all, since a page served by a robot ships with that robot's release.
+const SERVED_PORT = Number("{{SIGNALLING_PORT}}");
+const SERVED_API = Number("{{API_VERSION}}");
+const SERVED_BY_ROBOT = Number.isFinite(SERVED_PORT);
+const SIGNALLING_PORT = SERVED_BY_ROBOT ? SERVED_PORT : 8443;
+const SIGNALLING_URL = `ws://${location.hostname || "localhost"}:${SIGNALLING_PORT}`;
+
+// Full deflection, matching `padd`'s defaults rather than inventing a second set of numbers:
+// 0.3 m/s and 1.5 rad/s. The robot clamps what it must; these are what a stick at the stop means.
+const MAX_LINEAR = 0.3;
+const MAX_ANGULAR = 1.5;
+// Continuous intents are resent, not latched. `safety.deadman_ms` is 500, so 10 Hz has margin for
+// a link that hiccups without the robot deciding the client is gone.
+const INTENT_HZ = 10;
+// Where a drag on the picture aims: a point a metre in front of the trunk, moved within about a
+// half-metre box. The IK clamps and reports it, which is why this can be a generous guess rather
+// than a calibration.
+const LOOK = { x: 1.0, y: 0.7, z: 0.2, dz: 0.45 };
+
 const $ = (id) => document.getElementById(id);
 const logEl = $("log");
 
@@ -97,26 +262,18 @@ function log(cls, ...parts) {
   line.className = cls;
   line.textContent = parts.join(" ");
   logEl.append(line);
+  while (logEl.childElementCount > 400) logEl.firstElementChild.remove();
   logEl.scrollTop = logEl.scrollHeight;
 }
 
-// **The signalling target, derived rather than typed.**
-//
-// mediad replaces the token below with its own `--port` as it serves this page (`web.rs`), so the
-// port is in one place and `--port` is safe to move. NaN means nobody substituted it — this page
-// was opened from a checkout rather than served by a robot — and then webrtcsink's own default is
-// the right guess. That same fact is what makes the two failures distinguishable below: a page the
-// robot served reaching no signalling port is a firewall between two ports on one robot, and a page
-// opened by hand reaching nothing is a wrong host.
-const SERVED_PORT = Number("{{SIGNALLING_PORT}}");
-const SERVED_BY_ROBOT = Number.isFinite(SERVED_PORT);
-const SIGNALLING_PORT = SERVED_BY_ROBOT ? SERVED_PORT : 8443;
-const SIGNALLING_URL = `ws://${location.hostname || "localhost"}:${SIGNALLING_PORT}`;
-
-let ws = null, pc = null, sessionId = null, control = null;
-
 function setState(text, cls = "pill") { $("state").textContent = text; $("state").className = cls + " pill"; }
 function setDc(text, cls = "dim") { $("dcstate").textContent = text; $("dcstate").className = cls + " pill"; }
+
+function banner(html) { $("banner").innerHTML = html; $("banner").hidden = false; }
+
+// ── signalling ─────────────────────────────────────────────────────────────────
+
+let ws = null, pc = null, sessionId = null, control = null;
 
 function send(msg) {
   log("out", "→", JSON.stringify(msg));
@@ -145,6 +302,7 @@ $("connect").onclick = () => {
     setState("closed", "bad"); setDc("no control channel");
     $("connect").textContent = "connect";
     ws = null; sessionId = null; control = null;
+    stopTelemetry();
     if (pc) { pc.close(); pc = null; }
   };
 
@@ -167,7 +325,14 @@ $("connect").onclick = () => {
           setState("no producer", "bad");
           return;
         }
-        log("dim", "producer:", producer.id, JSON.stringify(producer.meta || {}));
+        // The producer's `meta` names the robot before a session exists — `mediad/src/producer.rs`
+        // is what puts it there. Shown straight away, so the header is filled in before the
+        // datachannel opens and re-filled from `system.info` and `hello` when it does.
+        const meta = producer.meta || {};
+        log("dim", "producer:", producer.id, JSON.stringify(meta));
+        if (meta.name) $("robot").textContent = meta.name;
+        if (meta.release) $("release").textContent = meta.release;
+        if (meta.api_version) $("api").textContent = `api v${meta.api_version}`;
         // No `offer`, so the producer offers and we answer. That is the direction webrtcsink
         // wants: it knows what it is sending.
         send({ type: "startSession", peerId: producer.id });
@@ -203,6 +368,7 @@ $("connect").onclick = () => {
         log("dim", "session ended by the robot");
         if (pc) { pc.close(); pc = null; }
         setState("signalling"); setDc("no control channel");
+        stopTelemetry();
         break;
 
       case "error":
@@ -246,23 +412,412 @@ function newPeerConnection() {
   pc.ondatachannel = (event) => {
     control = event.channel;
     log("dim", "datachannel:", control.label);
-    control.onopen = () => setDc("control open", "in");
-    control.onclose = () => setDc("control closed", "bad");
-    control.onmessage = (e) => log("in", "control ←", e.data);
+    control.onopen = () => { setDc("control open", "in"); startTelemetry(); };
+    control.onclose = () => { setDc("control closed", "bad"); stopTelemetry(); };
+    control.onmessage = (e) => onControl(e.data);
   };
 }
 
-function sendControl(text) {
-  if (!control || control.readyState !== "open") {
+// ── JSON-RPC over the control channel ──────────────────────────────────────────
+//
+// Ids are handed out here and answers are matched to them, which is what lets a caller `await` one.
+// A line with no id is a notification — `robot.state` is the only one that streams today — and it
+// goes to the telemetry panel rather than to a pending promise.
+
+let nextId = 1;
+const inflight = new Map();
+
+function open() { return control && control.readyState === "open"; }
+
+// **`quiet` is what keeps the log readable.** A twist at 10 Hz and a health poll every two seconds
+// are the page working, not something a person did — logging their requests and their answers would
+// bury the one line anybody opens this drawer to read. Errors are logged whatever `quiet` says.
+function call(method, params = {}, quiet = false) {
+  if (!open()) {
     log("bad", "!! no control channel yet");
-    return;
+    return Promise.reject(new Error("no control channel"));
   }
-  log("out", "control →", text);
-  control.send(text);
+  const id = nextId++;
+  const line = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+  if (!quiet) log("out", "control →", line);
+  control.send(line);
+  return new Promise((resolve, reject) => {
+    inflight.set(id, { resolve, reject, quiet });
+    // Not a budget on the robot's behalf — a promise nobody settles is a leak, and a method that
+    // never answers is worth seeing rather than a panel that quietly stopped updating.
+    setTimeout(() => {
+      if (inflight.delete(id)) reject(new Error(`${method} did not answer`));
+    }, 10_000);
+  });
 }
 
-for (const button of document.querySelectorAll("button[data-call]")) {
-  button.onclick = () => sendControl(button.dataset.call);
+// Fire-and-forget, for the continuous intents: a twist resent at 10 Hz does not want a promise per
+// frame, and its answer carries nothing a knob can show. The id is still registered, so the reply it
+// produces is recognised as this rather than logged as an answer to something nobody asked.
+function tell(method, params) {
+  if (!open()) return;
+  const id = nextId++;
+  inflight.set(id, { quiet: true });
+  setTimeout(() => inflight.delete(id), 10_000);
+  control.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
 }
-$("send").onclick = () => sendControl($("custom").value);
+
+function onControl(data) {
+  let msg;
+  try { msg = JSON.parse(data); } catch { log("bad", "control ← unparseable:", data); return; }
+
+  // No id is a notification, and `robot.state` is the only one that streams today. Anything else
+  // arriving this way is worth seeing in full rather than summarised.
+  if (msg.id === undefined || msg.id === null) {
+    if (msg.method === "robot.state") { onState(msg.params); return; }
+    log("in", "control ←", data.slice(0, 400));
+    return;
+  }
+
+  const waiting = inflight.get(msg.id);
+  if (!waiting) { log("in", "control ←", data.slice(0, 400)); return; }
+  inflight.delete(msg.id);
+
+  if (msg.error) {
+    log("bad", "control ←", data.slice(0, 400));
+    if (waiting.reject) waiting.reject(msg.error);
+    return;
+  }
+  if (!waiting.quiet) log("in", "control ←", data.slice(0, 400));
+  if (waiting.resolve) waiting.resolve(msg.result);
+}
+
+// ── who this robot is, and whether we agree about the API ──────────────────────
+//
+// Sent when the channel opens rather than clicked: a header that needs a button pressed to fill in
+// is a header nobody reads.
+
+async function identify() {
+  try {
+    // `0` when this page was not served by a robot: it genuinely does not know which version it
+    // speaks, and claiming the robot's own would make the comparison below meaningless. A
+    // difference is reported and served either way — a robot refuses a call it does not know, not a
+    // version it does not share.
+    const hello = await call("hello", { api_version: SERVED_API || 0 });
+    $("api").textContent = `api v${hello.api_version}`;
+    if (hello.daemon_version) {
+      $("release").textContent = hello.revision
+        ? `${hello.daemon_version} (${hello.revision.slice(0, 7)})`
+        : `${hello.daemon_version}`;
+    }
+    // **A version difference is a banner, not a locked door.** Everything below keeps working, and
+    // the calls that a difference actually breaks fail with a message naming the method. A page
+    // served by a robot ships with that robot's release, so this can only fire for a page opened
+    // from a checkout — which is exactly the case worth saying out loud.
+    if (SERVED_API && hello.api_version !== SERVED_API) {
+      banner(`This page speaks API v${SERVED_API} and the robot speaks v${hello.api_version}. `
+        + `Everything still works; a call this robot does not know will say so. `
+        + `<code>duckctl open</code> serves the page from the robot itself, which cannot differ.`);
+    } else if (!SERVED_BY_ROBOT) {
+      banner(`This page was opened from a checkout rather than served by the robot, so it cannot `
+        + `say whether the two agree about the API. <code>duckctl open</code> serves it from the `
+        + `robot.`);
+    }
+  } catch (e) {
+    log("bad", "!! hello failed:", e.message || JSON.stringify(e));
+  }
+
+  try {
+    const info = await call("system.info");
+    if (info.name) $("robot").textContent = info.name;
+    $("robot").title = info.serial ? `serial ${info.serial}` : "no serial on this board";
+  } catch (e) {
+    log("bad", "!! system.info failed:", e.message || JSON.stringify(e));
+  }
+}
+
+// ── telemetry ──────────────────────────────────────────────────────────────────
+
+let healthTimer = null, statsTimer = null;
+
+function startTelemetry() {
+  identify();
+  // 2 Hz: enough to watch a robot, and decimation is server-side and per-subscriber, so this costs
+  // the robot a twenty-fifth of what a digital twin at 50 Hz would.
+  call("robot.subscribe", { hz: 2 }, true).catch(() => {});
+  poll();
+  healthTimer = setInterval(poll, 2000);
+  statsTimer = setInterval(readStats, 1000);
+}
+
+function stopTelemetry() {
+  clearInterval(healthTimer); healthTimer = null;
+  clearInterval(statsTimer); statsTimer = null;
+  // Rejected rather than dropped: a promise that is merely forgotten leaves its awaiting caller
+  // hanging for the life of the page, which is how a reconnect ends up with two of everything.
+  for (const [id, waiting] of inflight) {
+    if (waiting.reject) waiting.reject(new Error("the control channel closed"));
+    inflight.delete(id);
+  }
+  lastStats = null;
+}
+
+// `robot.health` and `robot.mode` are calls rather than stream fields, and neither is on the frame:
+// the mode is what the loop is running (walk or roller) and the health row is where anything wrong
+// gets named — a hot servo, a flat pack, a bus that stopped answering.
+async function poll() {
+  if (!open()) return;
+  try {
+    const mode = await call("robot.mode", {}, true);
+    $("t-mode").textContent = mode.mode || "–";
+  } catch { /* logged by `call` */ }
+  try {
+    const health = await call("robot.health", {}, true);
+    const verdict = health.healthy ? "healthy" : (health.degraded ? "degraded" : "unhealthy");
+    $("t-health").textContent = health.reason ? `${verdict} — ${health.reason}` : verdict;
+    $("t-health").className = health.healthy ? "" : (health.degraded ? "warn" : "bad");
+    // Absent is *not known yet* — the first second after startup, or a bus that cannot answer —
+    // and rendering it as an empty pack would be a lie a reader acts on.
+    $("t-battery").textContent = health.battery
+      ? `${health.battery.volts.toFixed(2)} V · ${Math.round(health.battery.percent)}%`
+      : "not read";
+    const motors = health.motors
+      ? `${health.motors.max_c.toFixed(0)} °C ${health.motors.hottest}` : null;
+    const cpu = health.cpu_temp_c !== undefined && health.cpu_temp_c !== null
+      ? `${health.cpu_temp_c.toFixed(0)} °C board` : null;
+    $("t-temps").textContent = [motors, cpu].filter(Boolean).join(" · ") || "not read";
+  } catch { /* logged by `call` */ }
+}
+
+function onState(state) {
+  if (!state) return;
+  $("t-policy").textContent = state.policy || "–";
+  const loop = state.loop || {};
+  $("t-loop").textContent = `${(loop.hz || 0).toFixed(1)} Hz · ${loop.missed || 0} missed`;
+
+  const safety = state.safety || {};
+  const flags = [safety.fallen ? "fallen" : null, safety.limp ? "limp" : null].filter(Boolean);
+  $("t-safety").textContent = flags.length ? flags.join(" · ") : "upright";
+  $("t-safety").className = flags.length ? "bad" : "";
+
+  const twist = (v) => v ? `${v[0].toFixed(2)} ${v[1].toFixed(2)} ${v[2].toFixed(2)}` : "–";
+  const move = state.move || {};
+  $("t-requested").textContent = twist(move.requested);
+  // The reason a limit applied, named rather than left to be inferred from two rows that differ:
+  // "the stick is forward and the robot is still" is unreadable without it.
+  const limited = (move.limited_by || []).join(", ");
+  $("t-applied").textContent = limited ? `${twist(move.applied)} — ${limited}` : twist(move.applied);
+  $("t-applied").className = limited ? "warn" : "";
+}
+
+// ── link quality ───────────────────────────────────────────────────────────────
+//
+// A stream that degrades is otherwise a picture that looks worse and a log that says nothing.
+
+let lastStats = null;
+
+async function readStats() {
+  if (!pc) return;
+  const report = await pc.getStats();
+  let inbound = null, pair = null;
+  report.forEach((s) => {
+    if (s.type === "inbound-rtp" && s.kind === "video") inbound = s;
+    if (s.type === "candidate-pair" && s.nominated) pair = s;
+  });
+  if (inbound) {
+    if (lastStats && inbound.timestamp > lastStats.timestamp) {
+      const seconds = (inbound.timestamp - lastStats.timestamp) / 1000;
+      const bits = (inbound.bytesReceived - lastStats.bytesReceived) * 8;
+      $("bitrate").textContent = `${Math.round(bits / seconds / 1000)} kbps`;
+      const lost = (inbound.packetsLost ?? 0) - (lastStats.packetsLost ?? 0);
+      const got = (inbound.packetsReceived ?? 0) - (lastStats.packetsReceived ?? 0);
+      const share = got + lost > 0 ? (100 * lost) / (got + lost) : 0;
+      $("loss").textContent = `${share.toFixed(1)}%`;
+      $("loss").className = share > 2 ? "bad" : "";
+    }
+    $("fps").textContent = inbound.framesPerSecond !== undefined
+      ? `${Math.round(inbound.framesPerSecond)}` : "–";
+    lastStats = inbound;
+  }
+  if (pair && pair.currentRoundTripTime !== undefined) {
+    $("rtt").textContent = `${Math.round(pair.currentRoundTripTime * 1000)} ms`;
+  }
+}
+
+// ── driving ────────────────────────────────────────────────────────────────────
+//
+// One twist, written by the keys and by both pads, resent at a fixed rate while it is non-zero and
+// once more when it returns to zero. The robot's deadman stops it if the sending stops — that is
+// what makes a dropped link safe — but an explicit zero stops it now rather than in half a second.
+
+const twist = { vx: 0, vy: 0, vyaw: 0 };
+const keys = new Set();
+let sending = false;
+
+function keyTwist() {
+  const held = (...names) => names.some((name) => keys.has(name));
+  const axis = (positive, negative) => (held(...positive) ? 1 : 0) - (held(...negative) ? 1 : 0);
+  return {
+    vx: axis(["w", "arrowup"], ["s", "arrowdown"]) * MAX_LINEAR,
+    vy: axis(["a"], ["d"]) * MAX_LINEAR,
+    vyaw: axis(["q", "arrowleft"], ["e", "arrowright"]) * MAX_ANGULAR,
+  };
+}
+
+const padTwist = { vx: 0, vy: 0, vyaw: 0 };
+
+function refreshTwist() {
+  const fromKeys = keyTwist();
+  // The pads win where they are held, because a pad at rest is 0 and adding the two would make a
+  // key held while a pad is pushed produce a velocity neither asked for.
+  twist.vx = padTwist.vx || fromKeys.vx;
+  twist.vy = padTwist.vy || fromKeys.vy;
+  twist.vyaw = padTwist.vyaw || fromKeys.vyaw;
+
+  const moving = twist.vx || twist.vy || twist.vyaw;
+  if (moving) { sending = true; return; }
+  if (sending) { sending = false; tell("robot.move", { vx: 0, vy: 0, vyaw: 0 }); }
+}
+
+setInterval(() => {
+  if (sending) tell("robot.move", { vx: twist.vx, vy: twist.vy, vyaw: twist.vyaw });
+}, 1000 / INTENT_HZ);
+
+addEventListener("keydown", (event) => {
+  // Keys are the robot's while nothing text-shaped has focus — the raw box in the drawer is a
+  // text field, and typing `robot.mode` into it should not walk the robot across the room. The
+  // optional call is for a keydown whose target is the document itself, which has no `matches`.
+  if (event.target?.matches?.("input, textarea, select")) return;
+  const key = event.key.toLowerCase();
+  if (!["w", "a", "s", "d", "q", "e", "arrowup", "arrowdown", "arrowleft", "arrowright"].includes(key)) return;
+  event.preventDefault();
+  keys.add(key);
+  refreshTwist();
+});
+addEventListener("keyup", (event) => { keys.delete(event.key.toLowerCase()); refreshTwist(); });
+// A key held while the page loses focus would otherwise stay held for as long as the tab is away.
+addEventListener("blur", () => { keys.clear(); refreshTwist(); });
+
+// A pad is a pointer inside a box: the fraction of the way from the centre to each edge, clamped,
+// with the knob drawn where the finger is so a stick that is not centred is visible rather than
+// inferred from the robot moving.
+function wirePad(pad, knob, onMove) {
+  const clamp = (v) => Math.max(-1, Math.min(1, v));
+  const read = (event) => {
+    const box = pad.getBoundingClientRect();
+    return {
+      x: clamp((2 * (event.clientX - box.left)) / box.width - 1),
+      y: clamp((2 * (event.clientY - box.top)) / box.height - 1),
+    };
+  };
+  const draw = (x, y) => {
+    knob.style.left = `${50 + 50 * x}%`;
+    knob.style.top = `${50 + 50 * y}%`;
+  };
+  pad.addEventListener("pointerdown", (event) => {
+    pad.setPointerCapture(event.pointerId);
+    const at = read(event);
+    draw(at.x, at.y); onMove(at);
+  });
+  pad.addEventListener("pointermove", (event) => {
+    if (!pad.hasPointerCapture(event.pointerId)) return;
+    const at = read(event);
+    draw(at.x, at.y); onMove(at);
+  });
+  const release = () => { draw(0, 0); onMove({ x: 0, y: 0 }); };
+  pad.addEventListener("pointerup", release);
+  pad.addEventListener("pointercancel", release);
+}
+
+wirePad($("pad-move"), $("knob-move"), (at) => {
+  // Up is forward, and `vy` is positive to the left — the trunk frame the protocol fixes, stated
+  // once in `duck-ipc-proto` so no consumer has to rediscover it.
+  padTwist.vx = -at.y * MAX_LINEAR;
+  padTwist.vy = -at.x * MAX_LINEAR;
+  refreshTwist();
+});
+
+wirePad($("pad-turn"), $("knob-turn"), (at) => {
+  padTwist.vyaw = -at.x * MAX_ANGULAR;
+  refreshTwist();
+});
+
+// ── looking ────────────────────────────────────────────────────────────────────
+//
+// A drag on the picture is a point in the trunk frame, and `robot.look` solves the IK for it — so
+// this page never has to know which way a positive head yaw turns. `clamped` in the reply is the
+// robot saying the point is beyond the head's reach; shown, because a gaze that stopped following
+// the pointer with nothing said reads as a broken page.
+
+const video = $("video");
+let looking = false;
+let lookAt = null;
+
+video.addEventListener("pointerdown", (event) => {
+  video.setPointerCapture(event.pointerId);
+  looking = true;
+  aim(event);
+});
+video.addEventListener("pointermove", (event) => { if (looking) aim(event); });
+const stopLooking = () => { looking = false; lookAt = null; $("gaze").hidden = true; };
+video.addEventListener("pointerup", stopLooking);
+video.addEventListener("pointercancel", stopLooking);
+
+function aim(event) {
+  const box = video.getBoundingClientRect();
+  const x = (2 * (event.clientX - box.left)) / box.width - 1;
+  const y = (2 * (event.clientY - box.top)) / box.height - 1;
+  lookAt = { x: LOOK.x, y: -x * LOOK.y, z: LOOK.z - y * LOOK.dz, neck_pitch: 0 };
+}
+
+// Its own timer rather than the twist's: a gaze and a velocity are separate intents, and one
+// stopping must not stop the other.
+setInterval(async () => {
+  if (!looking || !lookAt || !open()) return;
+  const point = lookAt;
+  try {
+    const result = await call("robot.look", point, true);
+    $("gaze").hidden = !result.clamped;
+  } catch { /* logged by `call` */ }
+}, 1000 / INTENT_HZ);
+
+// ── posture, skills, sounds ────────────────────────────────────────────────────
+
+for (const button of document.querySelectorAll("button[data-call]")) {
+  button.onclick = () => {
+    const confirmation = button.dataset.confirm;
+    // On `stop` and `shutdown` only. A confirm on either is what keeps `stop` from reading as an
+    // emergency stop: an e-stop is a thing you hit, and this is a request the robot may refuse.
+    if (confirmation && !confirm(confirmation)) return;
+    const params = button.dataset.params ? JSON.parse(button.dataset.params) : {};
+    call(button.dataset.call, params).catch(() => {});
+  };
+}
+
+$("do").onclick = () => call("robot.do", { skill: $("skill").value }).catch(() => {});
+
+// `wheee` is the held ride: `hold: true` keeps it going and the hold decays on its own if the trues
+// stop arriving, so a page that is closed mid-ride does not leave the robot going "wheee" forever.
+let riding = null;
+$("play").addEventListener("pointerdown", () => {
+  const tag = $("sound").value;
+  if (tag !== "wheee") { call("robot.sound", { tag }).catch(() => {}); return; }
+  call("robot.sound", { tag, hold: true }).catch(() => {});
+  riding = setInterval(() => tell("robot.sound", { tag: "wheee", hold: true }), 200);
+});
+const endRide = () => {
+  if (!riding) return;
+  clearInterval(riding); riding = null;
+  tell("robot.sound", { tag: "wheee", hold: false });
+};
+$("play").addEventListener("pointerup", endRide);
+$("play").addEventListener("pointercancel", endRide);
+addEventListener("blur", endRide);
+
+// ── the raw box ────────────────────────────────────────────────────────────────
+//
+// A whole line rather than a method and params, because what it is for is sending something this
+// page has no button for — including something malformed, to see what the robot says about it.
+
+$("send").onclick = () => {
+  if (!open()) { log("bad", "!! no control channel yet"); return; }
+  const line = $("raw").value;
+  log("out", "control →", line);
+  control.send(line);
+};
 </script>

--- a/mediad/webclient/index.html
+++ b/mediad/webclient/index.html
@@ -1,20 +1,20 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>mediad test client</title>
+<title>duck console</title>
 <!--
-  A test client for mediad. One file, no build step, no dependencies: serve it and point it at a
-  robot.
+  The robot's console. One file, no build step, no dependencies — mediad embeds this page and
+  serves it, so reaching it is an address and not a command:
 
-      cd mediad/webclient && python3 -m http.server 8080     # then http://localhost:8080/
+      http://<robot>:8080/          — or `duckctl open`, which finds the robot for you
 
-  **Serve it; do not open it from disk.** A file:// page has an opaque origin, and Chrome's
-  Private Network Access blocks requests from one to a private address like 192.168.x — which is
-  every robot. It fails as a websocket error with nothing useful in it. Firefox is more forgiving,
-  but serving costs one command and works everywhere.
+  **The robot serves it, and that is what makes the signalling target derivable.** The page was
+  served by the robot it is about to talk to, so the host is `location.hostname` and the port is
+  filled in by mediad as it serves (see SERVED_PORT below). Nothing is typed, and nothing here
+  holds a second copy of the port.
 
   It speaks gst-plugins-rs's signalling protocol directly rather than using its gstwebrtc-api
-  JS library, for one reason: a test client that needs npm is a test client nobody runs. The
-  protocol is small and the exact shapes are below, read off net/webrtc/protocol at 0.15.3.
+  JS library, for one reason: a client that needs npm is a client nobody runs. The protocol is
+  small and the exact shapes are below, read off net/webrtc/protocol at 0.15.3.
 
   What it exercises, which is everything mediad does today:
 
@@ -22,8 +22,14 @@
     * the video track, hardware-encoded H.264         (constrained-baseline, so a browser takes it)
     * the `control` datachannel, and the JSON-RPC on it, including a refusal   (§5)
 
-  Serve it over http, never https: ws:// from an https page is mixed content and blocked outright,
-  and a robot on a LAN has no certificate to offer wss.
+  Served over http, never https: ws:// from an https page is mixed content and blocked outright,
+  and a robot on a LAN has no certificate to offer wss. docs/design/webrtc-console.md §1.3 says
+  what that costs — a microphone, and on some browsers a gamepad — and when it changes.
+
+  Opening this file from a checkout still works for development: with no port substituted it
+  falls back to 8443, and the host comes from wherever it is served. A file:// page cannot reach
+  a robot at all — Chrome's Private Network Access blocks requests from an opaque origin to a
+  private address — so serve it, or let the robot serve it.
 -->
 <style>
   :root { color-scheme: light dark; }
@@ -46,11 +52,11 @@
 </style>
 
 <header>
-  <h1>mediad test client</h1>
-  <input id="url" type="text" value="ws://radxa-zero3.local:8443" spellcheck="false">
+  <h1>duck console</h1>
   <button id="connect">connect</button>
   <span id="state" class="pill">idle</span>
   <span id="dcstate" class="pill dim">no control channel</span>
+  <span id="signalling" class="pill dim"></span>
 </header>
 
 <section>
@@ -94,6 +100,19 @@ function log(cls, ...parts) {
   logEl.scrollTop = logEl.scrollHeight;
 }
 
+// **The signalling target, derived rather than typed.**
+//
+// mediad replaces the token below with its own `--port` as it serves this page (`web.rs`), so the
+// port is in one place and `--port` is safe to move. NaN means nobody substituted it — this page
+// was opened from a checkout rather than served by a robot — and then webrtcsink's own default is
+// the right guess. That same fact is what makes the two failures distinguishable below: a page the
+// robot served reaching no signalling port is a firewall between two ports on one robot, and a page
+// opened by hand reaching nothing is a wrong host.
+const SERVED_PORT = Number("{{SIGNALLING_PORT}}");
+const SERVED_BY_ROBOT = Number.isFinite(SERVED_PORT);
+const SIGNALLING_PORT = SERVED_BY_ROBOT ? SERVED_PORT : 8443;
+const SIGNALLING_URL = `ws://${location.hostname || "localhost"}:${SIGNALLING_PORT}`;
+
 let ws = null, pc = null, sessionId = null, control = null;
 
 function setState(text, cls = "pill") { $("state").textContent = text; $("state").className = cls + " pill"; }
@@ -104,13 +123,24 @@ function send(msg) {
   ws.send(JSON.stringify(msg));
 }
 
+$("signalling").textContent = SIGNALLING_URL;
+
 $("connect").onclick = () => {
   if (ws) { ws.close(); return; }
-  ws = new WebSocket($("url").value);
+  ws = new WebSocket(SIGNALLING_URL);
   setState("connecting…");
 
   ws.onopen = () => { setState("signalling"); $("connect").textContent = "disconnect"; };
-  ws.onerror = () => log("bad", "!! websocket error — wrong host, or mediad is not running");
+  // The one failure two ports can produce, named in words rather than as `websocket error`. If this
+  // page arrived from the robot, the robot is up and reachable and one of its two ports is not —
+  // which is a firewall between them far more often than it is mediad, since mediad serves both.
+  ws.onerror = () => log("bad", SERVED_BY_ROBOT
+    ? `!! this page came from this robot, but its signalling port (${SIGNALLING_PORT}) did not `
+      + `answer. mediad serves both ports, so it is running — check for a firewall between you `
+      + `and ${SIGNALLING_PORT}, and \`journalctl -u mediad -b\` for a pipeline that stopped.`
+    : `!! no answer from ${SIGNALLING_URL} — wrong host, or mediad is not running. This page was `
+      + `opened from a file rather than served by a robot; \`duckctl open\` serves it from the `
+      + `robot instead.`);
   ws.onclose = () => {
     setState("closed", "bad"); setDc("no control channel");
     $("connect").textContent = "connect";

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -879,7 +879,8 @@ struct HealthReport {
     robot_error: Option<String>,
     software: VersionReport,
     /// What `mediad` last said about the camera, or `None` — not running, or built before it
-    /// published anything. Absence is not a fault: `mediad` ships disabled.
+    /// published anything. Absence is not a fault on its own: a board with no camera or no
+    /// GStreamer stack runs no `mediad`, and the units block is where that is reported.
     #[serde(skip_serializing_if = "Option::is_none")]
     camera: Option<proto::CameraStats>,
 }
@@ -1074,8 +1075,8 @@ fn render_health(report: &HealthReport) -> String {
 
     // Between the robot verdict and the software block, because it is a fact about the hardware
     // rather than about which release is installed. Omitted entirely when `mediad` has published
-    // nothing — a line reading "camera unknown" on every robot that has never started `mediad`
-    // is noise, and `mediad` is disabled by default.
+    // nothing — "camera unknown" on a board with no camera is noise, and a `mediad` that is not
+    // running is already a line in the units block.
     if let Some(camera) = &report.camera {
         let rate = if camera.fps >= f64::from(camera.target_fps) * 0.9 {
             format!("{:.1} fps", camera.fps)

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -2059,8 +2059,9 @@ impl View {
     /// --json` carries the same numbers for anything that wants to read them.
     fn camera_caption() -> Vec<Span<'static>> {
         let Some(camera) = duck_ipc_proto::read_camera_stats() else {
-            // Silent rather than "camera unknown": `mediad` is disabled on most robots, and a
-            // caption implying a fault on every one of them is worse than no caption.
+            // Silent rather than "camera unknown": a board with no camera runs no `mediad`, and a
+            // caption implying a fault on every one of them is worse than no caption. Whether the
+            // daemon is running belongs to `robotctl health`, which says so in words.
             return vec![];
         };
 

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -371,6 +371,7 @@ cargo run -p xtask -- package \
     --include "updater/systemd/sysusers.d/robot.conf=systemd/sysusers.d/robot.conf" \
     --include "robotd/systemd/robotd.service=systemd/robotd.service" \
     --include "hooks/postinstall=hooks/postinstall" \
+    --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
     --include "scripts/robot-rescue=scripts/robot-rescue" \
     --include "scripts/robot-boot-check=scripts/robot-boot-check" \
     --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \
@@ -524,8 +525,9 @@ for svc in robotd configd padd updaterd btd mediad; do
         silent)
             # Not treated as a failure: systemd removes the runtime directory when a unit stops, so
             # this is what a deliberately disabled `padd` looks like, and what `mediad` looks like on
-            # a board with no GStreamer stack — `sudo /usr/local/sbin/robot-setup-gstreamer` — or no
-            # camera. Neither is something this push did.
+            # a board with no camera. The GStreamer stack is not a cause any more — the preinstall
+            # hook this push just ran installs it — so a silent `mediad` here is worth
+            # `journalctl -u mediad -b` rather than a command to type.
             echo "    [--] $svc published nothing — stopped, or a build too old to say"
             ;;
         stale)

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -342,8 +342,8 @@ cp "$BIN"/robotd staged/
 cp "$BIN"/configd staged/
 cp "$BIN"/btd staged/
 cp "$BIN"/padd staged/
-# The WebRTC gateway. Staged so a board *can* run it; its unit ships with no [Install], so
-# nothing starts it until someone does — see mediad/systemd/mediad.service for why.
+# The WebRTC gateway. Its unit ships with an `[Install]` section, so postinstall enables and starts
+# it and `on_apply` restarts it, exactly as for every other daemon here.
 cp "$BIN"/mediad staged/
 # The voice generator (postinstall renders the per-robot bank with it) and the
 # mic classifier pair — pet-detect for live listening, pet-features for training.
@@ -498,10 +498,6 @@ echo "    current -> $want"
 # no socket at all, so for that one it is the only answer available.
 deadline=$(($(date +%s) + 30))
 stale=""
-# Daemons that are legitimately still on the old release. Reported separately from `stale` because
-# they are not a fault, and separately from silence because the closing line must not then claim
-# that everything is running this build.
-deferred=""
 for svc in robotd configd padd updaterd btd mediad; do
     while :; do
         if [ ! -f "/run/${svc}/identity.json" ]; then
@@ -511,8 +507,8 @@ for svc in robotd configd padd updaterd btd mediad; do
         else
             state="stale"
         fi
-        # Only the two deferred ones are worth waiting for; the rest restarted before the reply, so
-        # a mismatch there is already a fault rather than a race.
+        # Only `updaterd` and `btd` are worth waiting for — they restart five seconds after the
+        # reply. The rest restarted before it, so a mismatch there is a fault rather than a race.
         case "$state:$svc" in
             ok:*) break ;;
             stale:updaterd|stale:btd|silent:updaterd|silent:btd)
@@ -527,27 +523,14 @@ for svc in robotd configd padd updaterd btd mediad; do
         ok) echo "    [ok] $svc" ;;
         silent)
             # Not treated as a failure: systemd removes the runtime directory when a unit stops, so
-            # this is also what a deliberately disabled `padd` looks like — and what `mediad` looks
-            # like on every board, since it ships with no `[Install]` section and is started by
-            # hand until it has proven itself over a few boots.
+            # this is what a deliberately disabled `padd` looks like, and what `mediad` looks like on
+            # a board with no GStreamer stack — `sudo /usr/local/sbin/robot-setup-gstreamer` — or no
+            # camera. Neither is something this push did.
             echo "    [--] $svc published nothing — stopped, or a build too old to say"
             ;;
         stale)
-            # `mediad` is the one daemon nothing restarts for us: it has no `[Install]` section and
-            # `updaterd` does not manage it, so after a push it goes on running the release it was
-            # started with. That is the design working, not a fix that did not take — so it is
-            # reported with what to do about it rather than failed.
-            case "$svc" in
-                mediad)
-                    echo "    [--] $svc is still on the previous release; nothing restarts it"
-                    echo "         sudo systemctl restart mediad"
-                    deferred="${deferred} ${svc}"
-                    ;;
-                *)
-                    echo "    [FAIL] $svc is not running $want"
-                    stale="${stale} ${svc}"
-                    ;;
-            esac
+            echo "    [FAIL] $svc is not running $want"
+            stale="${stale} ${svc}"
             ;;
     esac
 done
@@ -565,22 +548,10 @@ done
 # Answerable, not healthy. A bench board with no servo power reports degraded and that is a fact
 # about the bench, not about this build — the health gate draws the same distinction.
 robotctl health >/dev/null 2>&1 || echo "    [--] robotctl health did not answer cleanly; worth a look"
-
-# 3 rather than 0, so the closing line does not claim every daemon is running this build directly
-# under a line saying one of them is not. Which one is already named above, so the code is all the
-# caller needs.
-[ -z "$deferred" ] || exit 3
 REMOTE
 then
     echo "==> every daemon on $BOARD is running $VERSION"
 else
-    status=$?
-    if [ "$status" = 3 ]; then
-        # Deliberately not "every daemon": one is still on the old release, named above, and this
-        # line used to contradict it.
-        echo "==> $BOARD is running $VERSION, apart from the daemon marked [--] above"
-    else
-        echo "==> the release is live but not everything is running it" >&2
-        exit 1
-    fi
+    echo "==> the release is live but not everything is running it" >&2
+    exit 1
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -758,6 +758,21 @@ install_units() {
   The robot works without it — only the gamepad is unavailable."
     fi
 
+    # mediad last of the daemons, since it forwards calls to three of the ones above and its unit
+    # says `After=` them. It is safe to have running with nobody connected — `webrtcsink` listens
+    # and the pipeline sits at PLAYING.
+    #
+    # Allowed to fail like btd and padd, and for a sharper reason than either: `ExecStart` carries
+    # `--camera`, and it needs the GStreamer stack `setup-gstreamer.sh` installs. A board missing
+    # either has no WebRTC gateway and is still a robot that updates, walks and pairs.
+    if [ -f "${UNIT_DIR}/mediad.service" ]; then
+        enable_unit mediad.service || warn "mediad did not start; check:
+    journalctl -u mediad -b
+  A board with no camera, or provisioned before the GStreamer stack existed, is the usual cause:
+    sudo /usr/local/sbin/robot-setup-gstreamer
+  The robot works without it — only the camera and the WebRTC console are unavailable."
+    fi
+
     # The boot-time recovery net: three minutes into each boot, ask whether this release brought
     # its daemons up, and fall back to golden if it did not.
     #
@@ -780,6 +795,7 @@ install_units() {
     for unit in $shipped; do
         case "$unit" in
             updaterd.service|robotd.service|configd.service|btd.service|padd.service) ;;
+            mediad.service) ;;
             robot-boot-check.timer) ;;
             # Started by its timer, never enabled. See above.
             robot-boot-check.service) ;;

--- a/scripts/setup-gstreamer.sh
+++ b/scripts/setup-gstreamer.sh
@@ -6,9 +6,11 @@
 #
 #  1. **Different lifetime.** The overlay fix and the ONNX install in `setup-board.sh` are
 #     what makes a board a robot: without them there is no motor bus and no policy. GStreamer
-#     is what makes it a *camera*, and a board doing walking work needs none of it. Around
-#     100 MB of media stack installed on every board before anything uses it is a cost with
-#     no payer, so this is invoked rather than assumed.
+#     is what makes it a *camera*. That was a cost with no payer while nothing used it; `mediad`
+#     ships now, so the callers are provisioning (`provision.sh`, on by default) and the
+#     updater's pre-install hook, which runs this script out of the release on every apply —
+#     which is how a board provisioned before this existed gets the stack without anybody
+#     remembering a command.
 #  2. **Different question.** Everything in `setup-board.sh` either works or fails. Half of
 #     this script's value is the report at the end, which answers a question nothing else on
 #     the board answers: *can this kernel encode H.264 in hardware, and through which
@@ -21,6 +23,11 @@
 #
 # Full paths, because this advice gets copy-pasted and /tmp does not survive a reboot. The
 # first run leaves a copy at the second path.
+#
+# **`hooks/preinstall` runs this too**, from `scripts/setup-gstreamer.sh` in the release, with a
+# ten-minute ceiling and no token in its environment — which is why the plugins repository is
+# public and why nothing here may prompt. An xtask test keeps the packaging lists in step with
+# the hook that runs it.
 #
 #   --dev     also install the headers and pkg-config files needed to *build* against
 #             GStreamer — `gst-plugin-webrtc` on this board, or an aarch64 sysroot to

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -46,6 +46,19 @@ const APPLY_ACTION_TIMEOUT: Duration = Duration::from_secs(30);
 /// unbounded.
 const HOOK_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// The pre-install hook gets much longer, because it is the one that installs what the release
+/// needs and cannot have: ONNX Runtime, and the GStreamer stack for `mediad` — around 100 MB of
+/// apt on a board that has never had it, over whatever wifi the robot is on.
+///
+/// **Affordable precisely because of where it runs.** Nothing has been swapped yet, the old
+/// release is still live and serving, and a hook that runs long is a slow update rather than a
+/// robot at risk — where the same minutes spent in the post-install hook would sit between the
+/// swap and the restart, with the board running neither release properly.
+///
+/// Ten minutes is the point past which a stuck apt is more likely wedged than slow. Bounded, not
+/// unbounded, for the reason the ceiling exists at all.
+const PRE_INSTALL_HOOK_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Interval between health probes while the gate is open.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -768,7 +781,13 @@ impl Engine {
                 .map(|m| m.schema_version),
             new_schema_version: manifest.schema_version,
         };
-        hooks::run(extract_dir, hooks::HookKind::PreInstall, &ctx, HOOK_TIMEOUT).await?;
+        hooks::run(
+            extract_dir,
+            hooks::HookKind::PreInstall,
+            &ctx,
+            PRE_INSTALL_HOOK_TIMEOUT,
+        )
+        .await?;
 
         // 7. Publish the release directory with one rename, then arm the boot
         //    counter *before* the symlink swap so a crash in between is

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -57,7 +57,12 @@ const HOOK_TIMEOUT: Duration = Duration::from_secs(120);
 ///
 /// Ten minutes is the point past which a stuck apt is more likely wedged than slow. Bounded, not
 /// unbounded, for the reason the ceiling exists at all.
-const PRE_INSTALL_HOOK_TIMEOUT: Duration = Duration::from_secs(600);
+///
+/// The number lives in `duck-ipc-proto` because it is a contract with every client, not a private
+/// budget: the phase notification arrives before the hook, so this is the longest an apply can go
+/// silent, and a client with a shorter idle budget calls a working update a dead robot.
+const PRE_INSTALL_HOOK_TIMEOUT: Duration =
+    Duration::from_secs(crate::proto::UPDATE_MAX_SILENCE_SECONDS);
 
 /// Interval between health probes while the gate is open.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);

--- a/updater/src/hooks.rs
+++ b/updater/src/hooks.rs
@@ -94,8 +94,8 @@ impl HookContext {
 pub struct HookOutcome {
     pub ran: bool,
     pub exit_code: Option<i32>,
-    /// Captured output, truncated. Goes into the update log so a support ticket
-    /// can explain *why* a hook failed.
+    /// Captured output, truncated. Logged by [`run`] whatever the outcome, and
+    /// returned so a caller can put it in a reply too.
     pub output: String,
 }
 
@@ -191,6 +191,20 @@ pub async fn run(
         });
     }
 
+    // **Logged on success, not only on failure.** Both call sites take this outcome with `?` and
+    // drop it, so for a hook that worked the output went nowhere — and this is the hook that
+    // installs ONNX Runtime and the GStreamer stack, whose whole report is the answer to "can this
+    // board encode H.264 in hardware, at this release". A grep of `journalctl -u updaterd` for it
+    // came back empty on a board where the hook had plainly run, which is how this was found.
+    //
+    // Line by line rather than one entry: a multi-line message is one journal record, and what a
+    // reader does with this is grep it.
+    for line in text.lines() {
+        if !line.trim().is_empty() {
+            tracing::info!(hook = %hook_name, "{}", line.trim_end());
+        }
+    }
+
     Ok(HookOutcome {
         ran: true,
         exit_code: output.status.code(),
@@ -253,6 +267,93 @@ mod tests {
         .await
         .unwrap();
         assert!(!outcome.ran);
+    }
+
+    /// Collects whatever a `tracing` subscriber is handed, so a test can assert what reached the
+    /// journal rather than what a function returned.
+    #[derive(Clone, Default)]
+    struct Collected(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    /// The collector, installed once as the **global** default.
+    ///
+    /// A thread-local default (`set_default`) is not enough and the difference is not academic: it
+    /// passed run on its own and collected nothing under `cargo test`, because these events are
+    /// emitted wherever the runtime happens to poll the future rather than on the thread that
+    /// installed the guard. Global, once, and the assertions below are `contains` — so another
+    /// test's events landing in the same buffer are harmless.
+    fn log_collector() -> Collected {
+        static COLLECTED: std::sync::OnceLock<Collected> = std::sync::OnceLock::new();
+        COLLECTED
+            .get_or_init(|| {
+                let collected = Collected::default();
+                let subscriber = tracing_subscriber::fmt()
+                    .with_writer(collected.clone())
+                    .with_max_level(tracing::Level::INFO)
+                    .finish();
+                // Best effort: if something else in this binary got there first, the assertions
+                // below will say so rather than this failing obscurely here.
+                let _ = tracing::subscriber::set_global_default(subscriber);
+                collected
+            })
+            .clone()
+    }
+
+    impl std::io::Write for Collected {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Collected {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// A hook that *worked* must still say what it said.
+    ///
+    /// Both call sites take the outcome with `?` and drop it, so for a successful hook the returned
+    /// `output` reaches nobody — and the pre-install hook's report is the answer to "can this board
+    /// encode H.264 in hardware, at this release". A grep of `journalctl -u updaterd` for it came
+    /// back empty on a board where the hook had plainly run, which is what this test now holds.
+    #[tokio::test]
+    async fn a_successful_hook_reaches_the_log() {
+        let dir = tempfile::tempdir().unwrap();
+        write_hook(
+            dir.path(),
+            HookKind::PreInstall,
+            "#!/bin/sh\necho 'plugins already at v3'\necho 'mpph264enc present' >&2\n",
+        );
+
+        let collected = log_collector();
+
+        run(
+            dir.path(),
+            HookKind::PreInstall,
+            &ctx(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let logged = String::from_utf8(collected.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            logged.contains("plugins already at v3"),
+            "stdout did not reach the log: {logged}"
+        );
+        assert!(
+            logged.contains("mpph264enc present"),
+            "stderr did not reach the log: {logged}"
+        );
+        assert!(
+            logged.contains("preinstall"),
+            "the log does not name which hook said it: {logged}"
+        );
     }
 
     #[tokio::test]

--- a/updater/updater.example.toml
+++ b/updater/updater.example.toml
@@ -127,9 +127,9 @@ manifest_asset = "manifest.json"
 # updaterd start checks that happened (docs/design/restart-order.md §1 and §5). This is
 # why the updater must be resident and separate from `btd` (architecture.md §1.1).
 #
-# `mediad` is absent because it does not exist yet: naming a unit that isn't installed
-# makes `systemctl restart` fail, which fails the update, which rolls it back. Add it in
-# the same change that first ships it.
+# `mediad` is absent because it needs no entry: it ships in the release with an `[Install]`
+# section, so the derived set below already carries it. Name a unit here only when the
+# release does not ship it.
 # The restart set is derived from the units the release ships (`systemd/*.service`), minus `updaterd`
 # and `btd`, which must never be restarted by an update they are carrying. Anything named here is
 # *added* to that set — use it only for a unit the release does not ship.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -921,6 +921,66 @@ mod tests {
         }
     }
 
+    /// Every script a hook runs out of the release must be packaged.
+    ///
+    /// The pre-install hook installs what the release needs and cannot have — ONNX Runtime, and the
+    /// GStreamer stack — and for the second it runs `scripts/setup-gstreamer.sh` from the release
+    /// rather than carrying a second copy of the package list, the pinned plugins version and the
+    /// udev rule. A script that is referenced and not packaged makes that step a no-op that says so
+    /// in a log nobody reads, on exactly the boards it exists for: the hook skips it and `mediad`
+    /// then fails to start with a missing plugin.
+    ///
+    /// The same drift `every_unit_install_sh_expects_is_packaged` guards, one directory over.
+    #[test]
+    fn every_script_the_hooks_run_is_packaged() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent");
+
+        let mut scripts: Vec<String> = Vec::new();
+        for hook in ["hooks/preinstall.in", "hooks/postinstall"] {
+            let text =
+                std::fs::read_to_string(root.join(hook)).unwrap_or_else(|e| panic!("{hook}: {e}"));
+            // `script=scripts/<name>` — an assignment, which is how a hook names a path it runs,
+            // rather than every mention of the word in a comment.
+            for line in text.lines() {
+                let Some((_, rest)) = line.split_once("=scripts/") else {
+                    continue;
+                };
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || "._-".contains(*c))
+                    .collect();
+                if !name.is_empty() {
+                    scripts.push(format!("scripts/{name}"));
+                }
+            }
+        }
+        scripts.sort();
+        scripts.dedup();
+        assert!(
+            !scripts.is_empty(),
+            "no scripts/… path found in the hooks; this test is watching nothing"
+        );
+
+        for script in &scripts {
+            assert!(
+                root.join(script).exists(),
+                "a hook runs {script}, which does not exist"
+            );
+            for workflow in PACKAGING_SITES {
+                let text = std::fs::read_to_string(root.join(workflow))
+                    .unwrap_or_else(|e| panic!("{workflow}: {e}"));
+                let expected = format!("={script}");
+                assert!(
+                    text.contains(&expected),
+                    "{workflow} does not package {script}, but a hook runs it. \
+                     Add:  --include \"{script}={script}\""
+                );
+            }
+        }
+    }
+
     /// Every policy file in `policies/` must be packaged, at every packaging site.
     ///
     /// The `--include` list exists in three copies (the two workflows and `dev-push.sh`), and


### PR DESCRIPTION
Stacked on #134. The design doc **and** the four changes it proposed — the doc is now a record of
decisions with the code next to it rather than a request for one.

`mediad/webclient/index.html` proved the transport and stopped there. It needed
`python3 -m http.server`, a URL typed by hand against a hostname every board flashed from one image
shares, and it reached almost none of what `route.rs` permits. All four of those are gone.

**1. `mediad` serves the page.** One axum route on 8080, `include_str!`, and four problems deleted
rather than one: no python, no URL to type (the page derives its signalling target from
`location.hostname`, because the robot served it), Private Network Access stops applying since the
origin is now private rather than opaque, and page and binary can no longer be different versions.
Embedded rather than installed, to stay out of the `--include` list that lives in three copies. A
refused bind costs the console and not the video.

**2. Producer `meta`.** Name, serial, release and `API_VERSION`, so a peer knows which robot it found
before it negotiates anything. The name comes from `configd` with a three-second budget — `mediad` is
`After=configd.service` and not `Requires=`, so a robot that cannot learn its own name still streams.

**3. `duckctl ip` / `open`.** The advertisement `btd` already broadcasts, read without a connection, a
bond or a PIN, with `net.status` behind it for the bonded-Mac case that has stopped advertising the
service. `ip` prints the address alone so `ssh radxa@$(duckctl ip)` works; `open` puts
`http://<address>:8080/` in a browser. `0.0.0.0` is answered now, with the `wifi connect` that fixes
it, rather than asked again slowly.

**4. The page becomes a console.** Header from the producer `meta` and then `hello` and
`system.info`; link quality from `getStats()`; two pads and `W`/`A`/`S`/`D`/`Q`/`E` at a gamepad's
0.3 m/s and 1.5 rad/s, resent at 10 Hz against a 500 ms deadman; a drag on the picture into
`robot.look`; posture, skills and sounds; `robot.subscribe` at 2 Hz beside a polled `robot.health`;
and the raw box, the log and the two refusals in a drawer. Still one file, still no build step.

Also fixed on the way: the old `hello` button sent `apiVersion` where the wire is snake_case with
`deny_unknown_fields`, so it could only ever have been answered with invalid params.

The decisions this PR was opened to ask about, as they were taken:

- **axum**, because it is already in `Cargo.lock` and the alternative was sixty lines of
  hand-written HTTP parsing bound to `0.0.0.0` (§1.1).
- **Two ports now**, because it risks nothing in the media path — and §1.3 records where it ends up:
  our own signalling server and a certificate on the day two-way audio or a browser gamepad is
  wanted, both of which are secure-context APIs that `http://192.168.1.42` cannot have.
- **`duckctl` keeps the two commands**, thin, because the durable halves are `btd` broadcasting the
  address and `mediad` serving on a known port; the phone app will do the same two steps natively.

**5. `mediad` gets its `[Install]` section.** It shipped without one so a board could carry the
binary without running it — which had become a permanent manual step: nothing enabled it on install,
nothing restarted it on apply, and every push ended with `systemctl restart mediad`. One rule covers
all of that (a unit with an `[Install]` section is enabled on install and restarted on apply), so the
section is here and everything that stood in for its absence is gone: `install.sh` starts it after
the daemons it forwards to, `dev-push.sh` loses its `deferred` list and exit-3 path, and the updater
config and design doc stop saying `mediad` joins the restart list when it exists.

**6. `hooks/preinstall` installs the GStreamer stack**, which `setup-gstreamer.sh` has said was the
plan since it was written — the plugins repository is public precisely so a hook with no token can
fetch from it. The hook runs the release's own copy of that script rather than a second
implementation: the script owns the pinned plugins version, the package list, the Rockchip debs, the
udev rule and the encoder report. Never fatal, unlike the ONNX step above it — a board with no camera
stack still walks, pairs and updates, and refusing the update over it would mean a board that cannot
be fixed by the mechanism that fixes boards. The pre-install hook's ceiling goes from two minutes to
ten, which it can afford because nothing has been swapped yet; post-install keeps its two. Packaged
at all three sites with an xtask tripwire.

So the only way `mediad` is now missing on a robot is a board with no camera (it fails on `--camera`;
the unit's drop-in is the fix) or one where both provisioning and every update since have been unable
to reach the network. Either shows in `robotctl health` as a unit that is not running, and neither
touches the control loop, BLE, the pad or an update.

One behaviour change on every robot: **an update now restarts `mediad`, so it drops a live WebRTC
session.** §8 of `remote-webrtc.md` describes the gate that will hold an update while a session is
active; nothing sets that flag yet.

Left out deliberately: `dev-push.sh`'s `resolve_board` still hand-rolls address lookup with
`wifi status` and six lines of embedded Python. It becomes `duckctl ip` in its own change, since it
touches the push path.

Verified on this machine: `cargo test -p mediad -p duckctl`, `cargo clippy` for both including
`--target aarch64-unknown-linux-gnu` so the GStreamer path is really compiled, and the page driven
end to end against a scripted signalling server, control channel and daemon replies — handshake,
header, skew banner, intents and their zero on release, gaze, telemetry rows and a refusal. Not yet
run on a robot.
