### PR TITLE
duckctl: the client is named for the robot, not for the radio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ padd/           gamepad → intents — an ordinary socket client, no privileged
 updater/        engine + updaterd
 robotd/         control daemon
 configd/        wifi · robot name · pairing PIN · reboot · gamepad pairing
-btd/            the BLE front door, plus duck-btctl (a laptop client, never shipped)
+btd/            the BLE front door
+duckctl/        the laptop-side client — never shipped, never cross-built
 robotctl/       the local CLI
 xtask/          package · sign · promote — build tooling, never shipped
 deploy/         what a robot is configured with: updater.toml, robotd.toml, trust anchor, journald

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,6 @@ name = "btd"
 version = "0.9.1"
 dependencies = [
  "bluer",
- "btleplug",
  "clap",
  "dbus",
  "duck-ipc-proto",
@@ -1049,6 +1048,19 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "duckctl"
+version = "0.9.1"
+dependencies = [
+ "btd",
+ "btleplug",
+ "clap",
+ "duck-ipc-proto",
+ "futures",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,21 @@
 # docs/design/architecture.md §1. `robotd`, `btd` and `mediad` are all siblings now.
 [workspace]
 resolver = "3"
-members = ["btd", "configd", "duck-control", "duck-ipc-proto", "kinematics", "mediad", "odometry", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
+members = ["btd", "configd", "duck-control", "duck-ipc-proto", "duckctl", "kinematics", "mediad", "odometry", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
+
+# Everything except `duckctl`, and that exception is the whole reason this key exists.
+#
+# `cargo board --bins` — in `dev-push.sh` and in the release workflow — builds every default
+# member for aarch64, which is right for a robot's daemons and wrong for the client a developer
+# runs on their own machine: it would cross-compile a Bluetooth stack for a board that must never
+# see one, on the release path, for nothing.
+#
+# The alternative was naming the binaries explicitly at each `--bins` call site. There are two of
+# them and they would have to be kept in step by hand, which is the failure this repo keeps
+# writing down. One list here, and a new daemon is picked up by both without anybody remembering.
+#
+# `--workspace` is unaffected, so CI still lints and tests `duckctl` exactly as before.
+default-members = ["btd", "configd", "duck-control", "duck-ipc-proto", "kinematics", "mediad", "odometry", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
 
 # ONNX Runtime, which robotd dlopens to run a policy. One source of truth: `xtask package`
 # bakes these into the release's preinstall hook, and a test asserts scripts/setup-board.sh

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ robots off a bad release — are in [CONTRIBUTING.md](CONTRIBUTING.md#releasing)
 |---|---|
 | [Cheat sheet](docs/robot/cheatsheet.md) | Every `robotctl` command: wifi, updates, rollback, pinning, logs. |
 | [Dev board cheat sheet](docs/robot/cheatsheet-dev.md) | Branch builds, release candidates, and the restart traps after an update. |
-| [`duck-btctl` cheat sheet](docs/robot/duck-btctl.md) | Every `duck-btctl` command: the robot over Bluetooth, from a laptop, with no network. |
+| [`duckctl` cheat sheet](docs/robot/duckctl.md) | Every `duckctl` command: the robot over Bluetooth, from a laptop, with no network. |
 | [Setting up a dev board](docs/robot/install-dev.md) | From nothing, and the fix when `--ref` is refused. |
 | [How it works](docs/design/architecture.md) | The whole system on one page — five daemons, one bus, how an update reaches the robot — then a page per part. |
 

--- a/btd/Cargo.toml
+++ b/btd/Cargo.toml
@@ -49,19 +49,6 @@ futures = "0.3"
 duck-ipc-proto = { path = "../duck-ipc-proto", features = ["test-support"] }
 tempfile = "3.27.0"
 
-# `duck-btctl`, the laptop-side client in examples/. A dev-dependency on purpose: an example's deps
-# never reach the shipped artifact, so btleplug is not on the robot.
-#
-# btleplug rather than bluer because this half runs on a developer's machine — CoreBluetooth on
-# macOS, BlueZ on Linux, WinRT on Windows. bluer would make the client Linux-only, which defeats
-# the point of having one.
-btleplug = "0.11"
-futures = "0.3"
-serde_json = "1"
-
-# Cargo builds an example under `cargo test` but does not run its `#[test]`s unless the target
-# asks for it, and the name matching in `duck-btctl` is worth pinning: the rule it encodes comes from
-# how btleplug reports names on macOS, which no compiler catches if it changes.
-[[example]]
-name = "duck-btctl"
-test = true
+# No examples here any more. The laptop-side client and the advertisement watcher both needed
+# `btleplug`, and both moved to `duckctl/` — see its manifest for what that bought and for how
+# the "never on the robot" guarantee survived the move.

--- a/btd/src/adv.rs
+++ b/btd/src/adv.rs
@@ -1,14 +1,14 @@
 //! What the advertisement carries besides the name: the robot's IPv4 address.
 //!
 //! Platform-independent, and here rather than in [`crate::bluez`] for [`crate::gatt`]'s reason —
-//! it is wire contract. The robot encodes with [`address_data`] and `duck-btctl` decodes with
+//! it is wire contract. The robot encodes with [`address_data`] and `duckctl` decodes with
 //! [`address_in`], so the two halves cannot disagree about the layout. A decoder written
 //! separately in the client would agree only with itself.
 //!
 //! ## Why the advertisement rather than a call
 //!
 //! `net.status` already reports the address, and reading it costs a connection, a bond and the
-//! PIN — per robot. `duck-btctl scan` deliberately connects to nothing, which is what makes it the
+//! PIN — per robot. `duckctl scan` deliberately connects to nothing, which is what makes it the
 //! command to reach for when a robot is unreachable, so a listing can only report what an
 //! advertisement carries. Broadcasting the address is therefore the only way `scan` can answer
 //! "where do I ssh?", and that is the question a listing is most often read to answer.
@@ -54,7 +54,7 @@ pub fn address_data(address: Option<Ipv4Addr>) -> Vec<u8> {
 /// `None` covers three cases that a listing renders differently and this function does not
 /// distinguish, because it cannot: no field at all, a field of the wrong length, and a field
 /// saying `0.0.0.0`. The caller has the advertisement and can tell the first from the third; see
-/// `duck-btctl`'s listing, which does.
+/// `duckctl`'s listing, which does.
 pub fn address_in(manufacturer_data: &HashMap<u16, Vec<u8>>) -> Option<Ipv4Addr> {
     let bytes: [u8; 4] = manufacturer_data
         .get(&COMPANY_ID)?

--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -318,7 +318,7 @@ async fn serve_on_an_adapter(
                     write: true,
                     // Write-without-response as well: a chunked request needs no ATT
                     // acknowledgement per chunk. A client that wants a *refusal* to be visible
-                    // must use the acknowledged form, which is why `duck-btctl` does.
+                    // must use the acknowledged form, which is why `duckctl` does.
                     write_without_response: true,
                     encrypt_write: require_pairing,
                     // No `.await` between receiving a chunk and enqueueing it. BlueZ dispatches
@@ -534,7 +534,7 @@ impl std::fmt::Display for Advertised {
 ///
 /// - **BlueZ caches it over the advertised name.** `Device1.Name` is what `btleplug` reports, so
 ///   on Linux a robot is `duck-5b21` until the first connection and `radxa-zero3` after it, and
-///   `duck-btctl --name duck-5b21` then finds nothing. Two scans a minute apart disagreed;
+///   `duckctl --name duck-5b21` then finds nothing. Two scans a minute apart disagreed;
 /// - **CoreBluetooth keeps both**, and `btleplug` joins them as `radxa-zero3 [duck-5b21]`;
 /// - **a phone's Bluetooth settings shows the GAP name**, which is the case that matters most and
 ///   the one nothing in this repo could see.
@@ -583,7 +583,7 @@ async fn advertise(
             tracing::warn!(
                 error = %e,
                 "BlueZ refused the advertisement carrying the address; retrying without it, so \
-                 `duck-btctl scan` will show this robot with no address at all"
+                 `duckctl scan` will show this robot with no address at all"
             );
             adapter.advertise(advertisement(None)).await
         }

--- a/btd/src/framing.rs
+++ b/btd/src/framing.rs
@@ -49,7 +49,7 @@ impl std::fmt::Display for FramingError {
 }
 
 // A real error, not just a Debug-able enum: this crate is a library, and a client using it — the
-// `duck-btctl` example is the first — wants `?` to work.
+// `duckctl` example is the first — wants `?` to work.
 impl std::error::Error for FramingError {}
 
 impl Reassembler {

--- a/btd/src/gatt.rs
+++ b/btd/src/gatt.rs
@@ -3,7 +3,7 @@
 //! Platform-independent on purpose. These live here rather than in [`crate::bluez`] because they
 //! are part of the wire contract, exactly like the method names in `duck-ipc-proto` — the robot
 //! serves them and every client must look for them, so a client that cannot compile for Linux
-//! still needs them. `examples/duck-btctl.rs`, which runs on a laptop, is the case that proves it.
+//! still needs them. `examples/duckctl.rs`, which runs on a laptop, is the case that proves it.
 //!
 //! Random v4 UUIDs rather than anything derived: they are ours, and they must not change once an
 //! app has shipped against them. Written out in full so that grepping for a value finds this
@@ -29,7 +29,7 @@ pub const SERVICE_UUID: uuid::Uuid = uuid::uuid!("6f5d2a10-3b47-4c8e-9a1f-2d7e8c
 /// subscribe to it for the answers.
 ///
 /// Chunked in both directions, delimited by the newline that already separates NDJSON messages —
-/// see [`crate::framing`], which is the module both the robot and `duck-btctl` use.
+/// see [`crate::framing`], which is the module both the robot and `duckctl` use.
 ///
 /// The read is part of the contract, not an optional nicety. It requires an authenticated
 /// encrypted link, so it is what makes a central pair *before* it writes — a subscribe needs no

--- a/configd/src/nm.rs
+++ b/configd/src/nm.rs
@@ -67,7 +67,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(45);
 /// How long to wait for a requested scan to complete before answering with what NM already has.
 ///
 /// A sweep of both bands takes a few seconds on this radio. The cap matters because a client is
-/// blocked on the reply: `duck-btctl` allows 60s for a scan, so this must stay well inside that.
+/// blocked on the reply: `duckctl` allows 60s for a scan, so this must stay well inside that.
 const SCAN_WAIT: Duration = Duration::from_secs(10);
 /// How often `LastScan` is re-read while waiting.
 const SCAN_POLL: Duration = Duration::from_millis(250);

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Start at the [README](../README.md) if you have a robot and want to use it.
 | [`pair-a-gamepad.md`](robot/pair-a-gamepad.md) | Once per pad: pairing mode, `pad pair`, and what to do when it will not bond. |
 | [`cheatsheet-dev.md`](robot/cheatsheet-dev.md) | The commands that need a dev board: branch builds, candidates, dev pushes. |
 | [`dev-push.md`](robot/dev-push.md) | Build on your machine and install on the board over ssh, with no CI run. |
-| [`duck-btctl.md`](robot/duck-btctl.md) | Every `duck-btctl` command — the robot over Bluetooth, from a laptop. |
+| [`duckctl.md`](robot/duckctl.md) | Every `duckctl` command — the robot from a laptop, over Bluetooth. |
 | [`install-dev.md`](robot/install-dev.md) | Setting up a board for development, from nothing. |
 | [`install-by-hand.md`](robot/install-by-hand.md) | The same install as separate commands, for testing one step at a time. |
 

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -144,7 +144,7 @@ them. Nothing across it checks the number — `configd` gates no `net.*` or `sys
 version, `updaterd` requires no handshake before `update.status`, and `updaterd`'s `hello` no longer
 refuses on it either. So a client that refuses on skew refuses calls the robot would have answered —
 and it refuses them on the transport that exists for a robot with no network, where `net.connect` is
-the way out of the skew. `duck-btctl` warns and proceeds, and an app should do the same: surface the
+the way out of the skew. `duckctl` warns and proceeds, and an app should do the same: surface the
 mismatch, let the call go, and report the JSON-RPC error if a method whose shape changed is actually
 reached. Those errors name themselves — `METHOD_NOT_FOUND` for a route this release does not have,
 `INVALID_PARAMS` for a parameter it does not know — which is what makes proceeding safe rather than
@@ -276,7 +276,7 @@ is nowhere to send the answer.
 
 ### 3.3 One thing the mobile app will hit: do not scan with a service filter  · **measured**
 
-`duck-btctl` is a test tool and deliberately not much more — the real client is a phone app. But one of its
+`duckctl` is a test tool and deliberately not much more — the real client is a phone app. But one of its
 bugs is a property of CoreBluetooth rather than of the tool, so it is worth writing down before
 someone rediscovers it on iOS.
 
@@ -290,7 +290,7 @@ could only match peripherals the filtered scan had already returned.
 The app should scan unfiltered and discriminate its own candidates, strongest evidence first:
 advertised UUID, then a known name or a stored peripheral identifier, and treat "serves our
 characteristic" as the only authoritative identity test — it is knowable solely after connecting. An
-iOS app has a better third tier than `duck-btctl` does, `retrievePeripherals(withIdentifiers:)`, which
+iOS app has a better third tier than `duckctl` does, `retrievePeripherals(withIdentifiers:)`, which
 `btleplug` does not expose; storing the identifier after a first successful connection is the right
 move there and removes the guesswork entirely.
 
@@ -300,7 +300,7 @@ appears.
 
 ### 3.4 The robot has to advertise often enough to be caught  · **measured**
 
-`duck-btctl` reported `no robot found` on roughly half its runs, and for a while that was read as flakiness
+`duckctl` reported `no robot found` on roughly half its runs, and for a while that was read as flakiness
 in the tool — or as the gamepad, whose LE link shares the radio. It was neither. `btd` registered its
 advertisement without an interval, so BlueZ used the kernel's default of **1.28 s**, and a central
 scanning at a low duty cycle does not catch a 1.28 s advertiser reliably.
@@ -332,7 +332,7 @@ nothing for the first connection, which is the one that matters most.
 carries this, the gamepad's LE link and wifi, and airtime spent shouting comes out of what the robot
 is for.
 
-`btd/examples/advwatch.rs` is the measurement, kept because the claim is only checkable by re-running
+`duckctl/examples/advwatch.rs` is the measurement, kept because the claim is only checkable by re-running
 it: arrivals per device with signal strength, then the robot's silences.
 
 **Confirmed on the board.** With 100-150 ms installed, the same two-minute watch from the same Mac:
@@ -342,7 +342,7 @@ it: arrivals per device with signal strength, then the robot's silences.
 | 1.28 s, the default | 16 | 7.5 s | 30.8 s | 7 |
 | 100-150 ms | 151 | 0.8 s | 3.8 s | **0** |
 
-Nine times as often, and — the part that matters — nothing left within a factor of two of `duck-btctl`'s
+Nine times as often, and — the part that matters — nothing left within a factor of two of `duckctl`'s
 eight-second window, so the failure it was diagnosed from cannot occur. The robot went from 34th of
 106 devices heard to 7th of 74.
 
@@ -570,7 +570,7 @@ rather than 1, a PIN keeping its leading zero, and no passphrase in the log. Plu
 which is a real cross-link check: `btd` is the only binary pulling C beyond `zstd`, because `bluer`
 links libdbus built from vendored source by `zig cc`.
 
-`duck-btctl` (`cargo run -p btd --example duck-btctl`) is the phone's stand-in and the only way to exercise
+`duckctl` (`cargo run -p duckctl`) is the phone's stand-in and the only way to exercise
 the radio. An **example, not a binary**, so `btleplug` never reaches the robot; `btleplug` rather
 than `bluer` because it must run on a developer's Mac. It reuses `btd::framing`, so the chunking is
 genuinely the client half of the robot's own code rather than a reimplementation free to agree with
@@ -688,7 +688,7 @@ of the robot has not.
 
 #### The advertisement carries the robot's IPv4 address
 
-`duck-btctl scan` connects to nothing, which is what makes it the command to reach for when a robot
+`duckctl scan` connects to nothing, which is what makes it the command to reach for when a robot
 is unreachable — and it is why a listing can only report what an advertisement carries. So the
 question a listing is most often read to answer, *where do I ssh?*, had no answer in it: the address
 is in `net.status`, and reading that costs a connection, a bond and the PIN, per robot.
@@ -778,7 +778,7 @@ line (`serving BLE ... address=`):
 - `50:37:CD:16:2B:EC` — two `btd` starts within one boot, 10:04 and 10:05
 - `50:37:CD:16:1B:92` — every boot after, 10:18 onward, fifteen of them
 
-Between them: no reflash. Nothing done to the board but BLE connections through `duck-btctl` and gamepad
+Between them: no reflash. Nothing done to the board but BLE connections through `duckctl` and gamepad
 pairing. The top four bytes held; only the low two moved, which fits a driver that generates an
 address once behind a vendor prefix and caches it rather than reading one out of the module. `configd`
 never power-cycles the adapter — it only powers one on that is off — so pad pairing has no obvious

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -21,7 +21,8 @@ Companion to [`architecture.md`](../design/architecture.md) (what we're building
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
 | `deploy/` | shipped `updater.toml`, `robotd.toml`, trust anchor, journald retention drop-in |
 | `scripts/` | `install.sh` provisioning · `board-test.sh` — **passing in CI**: 13 checks on emulated aarch64, Debian 13 (Trixie) |
-| `btd/` | BLE transport adapter — framing, the routed subset, the BlueZ backend, a pairing agent, plus `duck-btctl` for a laptop. **Works on hardware**, unencrypted by default — the blocker, [`app-path-design.md`](../design/app-path-design.md) §5.5 |
+| `btd/` | BLE transport adapter — framing, the routed subset, the BlueZ backend, a pairing agent. **Works on hardware**, unencrypted by default — the blocker, [`app-path-design.md`](../design/app-path-design.md) §5.5 |
+| `duckctl/` | The robot from a laptop. BLE today; named for the robot rather than the radio, because `mediad` is a second transport |
 | `configd/` | wifi over NetworkManager, robot name and the identity it derives from the SoC serial, pairing PIN, reboot. **Drives a real NetworkManager on a board**: provisioned over BLE, joined, and rejoined by itself after a reboot. `--fake-net` still serves the whole surface off-board |
 | tests | **458 passing**, including the health gate, the battery+thermal readout and the policy/safety path against a real `robotd` process, and `configd`'s authorisation over real sockets in `board-test.sh` |
 | missing | `mediad`, app, SDK |
@@ -220,7 +221,7 @@ provisioning step the pairing PIN now depends on (below). It also means the app 
 talk to before the app exists, which is the right order for finding out that an API is wrong.
 
 **The update path over Bluetooth is now driven rather than merely routed**, which is what that
-order was for: `update-over-ble.md` records what driving it from `duck-btctl` turned up, including
+order was for: `update-over-ble.md` records what driving it from `duckctl` turned up, including
 one defect that made "start an update and watch it" an update the robot silently never performed.
 `update.rollback` and `update.select` are reachable from a phone as of that work.
 
@@ -244,7 +245,8 @@ robotctl/       CLI
 robotd/         control, gait, safety — no kinematics yet
 padd/           gamepad → intents; a client, with no privilege the app will not have
 mediad/         camera, encode, perception, WebRTC gateway  (not built yet)
-btd/            BLE transport adapter + duck-btctl (dev client)
+btd/            BLE transport adapter
+duckctl/        the client, from a laptop (dev tool, never shipped)
 xtask/          build/publish tooling — never ships
 ```
 

--- a/docs/project/update-over-ble.md
+++ b/docs/project/update-over-ble.md
@@ -134,7 +134,7 @@ and `watch` — the same words `robotctl update` uses, so a command learned on t
 the radio. Params are built from `duck_ipc_proto`'s own types rather than hand-written JSON, which
 is what `call` left to whoever was typing: `update.apply`'s target is an externally tagged enum, so
 `--ref` and `--version` are different JSON *shapes*, and a wrong one is a parse error with nothing
-in it to act on. [`duck-btctl.md`](../robot/duck-btctl.md) has every command.
+in it to act on. [`duckctl.md`](../robot/duckctl.md) has every command.
 
 Progress prints as one line per event on stderr, which that page already promised and the tool did
 not do.

--- a/docs/robot/cheatsheet-dev.md
+++ b/docs/robot/cheatsheet-dev.md
@@ -111,7 +111,7 @@ The result is an ordinary gated update, so the restart traps above still apply.
 [`dev-push.md`](dev-push.md) has the setup, the container build, `--dry-run`, the first push to a
 board below 0.5.0, and what to do when it fails.
 
-## From a laptop — `duck-btctl`
+## From a laptop — `duckctl`
 
 Reaching the robot over Bluetooth LE, with no network and no ssh:
-[`duck-btctl.md`](duck-btctl.md) has every command.
+[`duckctl.md`](duckctl.md) has every command.

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -9,7 +9,7 @@ Read-only commands need no privilege. Anything that **changes** the robot needs 
 
 Branch builds, release candidates and the restart traps after an update are in
 [`cheatsheet-dev.md`](cheatsheet-dev.md) — they need a dev board. The same robot over Bluetooth from
-a laptop, with no network and no ssh, is [`duck-btctl.md`](duck-btctl.md).
+a laptop, with no network and no ssh, is [`duckctl.md`](duckctl.md).
 
 ## On the robot — `robotctl`
 

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -49,8 +49,8 @@ export DUCK_ROBOT=duck-c51b
 scripts/dev-push.sh
 ```
 
-The name is the one `duck-btctl scan` lists and `robotctl system set-name` sets — the same
-`DUCK_ROBOT` that tool reads ([`duck-btctl.md`](duck-btctl.md)). Its address is
+The name is the one `duckctl scan` lists and `robotctl system set-name` sets — the same
+`DUCK_ROBOT` that tool reads ([`duckctl.md`](duckctl.md)). Its address is
 asked for over Bluetooth — the robot's own `net.status` answers with it — and then cached, so only
 a push that cannot reach the cached address goes back to the radio. That is what makes a new DHCP
 lease, a reflash or a different network cost nothing to follow.
@@ -272,7 +272,7 @@ grep -c 'DEV BOARD' /var/lib/robot/provision.log
 the name path to resolve an address.
 
 ```bash
-duck-btctl scan
+duckctl scan
 ```
 
 Nothing listed is a robot that is off, out of range, or already connected to a phone. Give the
@@ -286,7 +286,7 @@ scripts/dev-push.sh radxa@192.168.1.42
 there is nothing to ssh to. Join one over the same radio:
 
 ```bash
-duck-btctl --name duck-c51b wifi connect <ssid> --psk <passphrase>
+duckctl --name duck-c51b wifi connect <ssid> --psk <passphrase>
 ```
 
 **`still <address>, which ssh could not reach`** — the address never moved, so whatever ssh is
@@ -328,7 +328,7 @@ This should not have been necessary, so it is worth reading the journal for why 
 |---|---|
 | `DUCK_ROBOT` | The robot, by name. Its address is found over Bluetooth and cached. |
 | `DUCK_BOARD_USER` | The ssh user on the board, for the name path. Default `radxa`. |
-| `DUCK_PIN` | The robot's pairing PIN, if it is not the factory `000000`. Read by `duck-btctl`. |
+| `DUCK_PIN` | The robot's pairing PIN, if it is not the factory `000000`. Read by `duckctl`. |
 | `DUCK_BOARD_CACHE` | Where resolved addresses are cached. Default `~/.cache/duck/boards`. |
 | `DUCK_BOARD` | The board, by address, instead of an argument. `radxa@192.168.1.42`. |
 | `DUCK_DEV_SECRET_KEY` | The dev signing key. Default `~/.duck-keys/team.dev.key`. |

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -1,32 +1,37 @@
-# `duck-btctl` — every command
+# `duckctl` — every command
 
-Talk to a robot over Bluetooth LE from a laptop, with no network and no ssh. It is the phone app's
-stand-in, and the way to reach a robot that has never seen a wifi network.
+Talk to a robot from a laptop, with no network and no ssh. It is the phone app's stand-in, and the
+way to reach a robot that has never seen a wifi network.
 
-An *example* rather than a binary, so it is never on a robot. `robotctl` is the tool that ships,
-and [`cheatsheet.md`](cheatsheet.md) has its commands — most of which have a `duck-btctl`
-equivalent below.
+Bluetooth LE is how it gets there today, and the name deliberately does not say so: `mediad` gives
+a robot a second transport that reaches a different set of methods, so the tool is named for what
+it talks to rather than for the radio it currently uses. It was `duck-btctl` while BLE was the only
+answer.
+
+**Never on a robot.** Nothing in a release depends on it — `robotctl` is the tool that ships, and
+[`cheatsheet.md`](cheatsheet.md) has its commands, most of which have a `duckctl` equivalent
+below.
 
 ## Getting it
 
 Run it from a clone of this repo:
 
 ```bash
-cargo run -q -p btd --example duck-btctl -- --name <robot-name> info
+cargo run -q -p duckctl -- --name <robot-name> info
 ```
 
 Or install it once, at the cost of a snapshot that no longer follows the branch:
 
 ```bash
-cargo install --path btd --example duck-btctl
+cargo install --path duckctl
 ```
 
 ```bash
-duck-btctl --name <robot-name> info
+duckctl --name <robot-name> info
 ```
 
 Every command below is written in the installed form. Prefix it with
-`cargo run -q -p btd --example duck-btctl --` to run it from the clone instead.
+`cargo run -q -p duckctl --` to run it from the clone instead.
 
 This tool used to install itself as `btctl`. If `which btctl` still finds one, it is a build from
 whenever you installed it and it will never change again:
@@ -38,7 +43,7 @@ cargo uninstall btd --bin btctl
 ## Finding a robot
 
 ```bash
-duck-btctl scan
+duckctl scan
 ```
 
 ```
@@ -54,9 +59,9 @@ that list, and it is worth reading when the robot you want is not in the first o
 Each robot broadcasts its IPv4 address, so this is also where the address to ssh to comes from. No
 connection is made and no PIN is needed. `no address` on the line means the robot is not on a
 network; a line with no address at all means a release from before robots broadcast one, and
-`duck-btctl wifi status` still reports it.
+`duckctl wifi status` still reports it.
 
-The SSID is not in the listing — it does not fit in an advertisement. `duck-btctl wifi status` has
+The SSID is not in the listing — it does not fit in an advertisement. `duckctl wifi status` has
 it, along with the signal and both addresses.
 
 A robot that has never been renamed calls itself `duck-` plus four characters derived from its
@@ -94,7 +99,7 @@ export DUCK_ROBOT=duck-c51b
 Put that line in `~/.zshrc` to keep it. Every command below then works without `--name`:
 
 ```bash
-duck-btctl info
+duckctl info
 ```
 
 `DUCK_PIN` does the same for `--pin`, which a robot with a PIN of its own needs on every command:
@@ -106,14 +111,14 @@ export DUCK_PIN=418299
 For one command against a different robot, `--name` still wins:
 
 ```bash
-duck-btctl --name duck-ffff info
+duckctl --name duck-ffff info
 ```
 
 To ignore the default for one command — a bench with somebody else's robot on it — set it to
 nothing:
 
 ```bash
-DUCK_ROBOT= duck-btctl scan
+DUCK_ROBOT= duckctl scan
 ```
 
 `scan` marks the robot `DUCK_ROBOT` names and lists it first, and every command that goes looking
@@ -122,13 +127,13 @@ for it says so before it starts scanning.
 ## Identity
 
 ```bash
-duck-btctl --name <robot-name> info
+duckctl --name <robot-name> info
 ```
 
 Name, serial and uptime.
 
 ```bash
-duck-btctl --name <robot-name> name <new-name>
+duckctl --name <robot-name> name <new-name>
 ```
 
 Up to 24 characters. It takes effect within a few seconds and needs no restart, but the Mac keeps
@@ -139,44 +144,44 @@ A rename does not follow `DUCK_ROBOT`. The tool says so afterwards; the variable
 by hand, or every later command looks for a name that no longer answers.
 
 ```bash
-duck-btctl --name <robot-name> reboot
+duckctl --name <robot-name> reboot
 ```
 
 ## Wifi
 
 ```bash
-duck-btctl --name <robot-name> wifi status
+duckctl --name <robot-name> wifi status
 ```
 
 SSID, signal and addresses.
 
 ```bash
-duck-btctl --name <robot-name> wifi scan
+duckctl --name <robot-name> wifi scan
 ```
 
 Takes a few seconds — the robot sweeps the radio rather than returning the previous scan.
 
 ```bash
-duck-btctl --name <robot-name> wifi connect <ssid> --psk <passphrase>
+duckctl --name <robot-name> wifi connect <ssid> --psk <passphrase>
 ```
 
 Omit `--psk` for an open network. Joining disconnects the robot from the network it is on, so an ssh
 session over wifi drops; that is the command working. It can take up to 45 seconds to answer.
 
 ```bash
-duck-btctl --name <robot-name> wifi forget <ssid>
+duckctl --name <robot-name> wifi forget <ssid>
 ```
 
 ## Is it alright
 
 ```bash
-duck-btctl --name <robot-name> health
+duckctl --name <robot-name> health
 ```
 
 Whether the control loop is healthy.
 
 ```bash
-duck-btctl --name <robot-name> status
+duckctl --name <robot-name> status
 ```
 
 The version handshake and the update status.
@@ -184,7 +189,7 @@ The version handshake and the update status.
 ## Which release is it running
 
 ```bash
-duck-btctl --name <robot-name> version
+duckctl --name <robot-name> version
 ```
 
 The API version, the release, and the git revision it was built from. A `revision` of `null` means
@@ -196,25 +201,25 @@ Same words as `robotctl update`, so a command learned on the robot works here. E
 takes `--component <name>` and defaults to `daemon`, which is the only component a robot has today.
 
 ```bash
-duck-btctl --name <robot-name> update check
+duckctl --name <robot-name> update check
 ```
 
 ```bash
-duck-btctl --name <robot-name> update status
+duckctl --name <robot-name> update status
 ```
 
 ```bash
-duck-btctl --name <robot-name> update versions
+duckctl --name <robot-name> update versions
 ```
 
 ```bash
-duck-btctl --name <robot-name> update log --limit 20
+duckctl --name <robot-name> update log --limit 20
 ```
 
 Installing takes minutes and prints progress lines as it goes:
 
 ```bash
-duck-btctl --name <robot-name> update apply
+duckctl --name <robot-name> update apply
 ```
 
 ```
@@ -230,7 +235,7 @@ duck-btctl --name <robot-name> update apply
   "to": "0.6.0"
 }
 note: the robot restarts its daemons now, and `btd` about five seconds after this reply — so this
-connection drops. That is the update working. Reconnect and run `duck-btctl update status`:
+connection drops. That is the update working. Reconnect and run `duckctl update status`:
 `last_attempt` carries the outcome of what just ran.
 ```
 
@@ -240,15 +245,15 @@ The connection dropping after an apply is the update working, not a failure. Rec
 A branch build, an exact version, or the staging candidate:
 
 ```bash
-duck-btctl --name <robot-name> update apply --ref my-branch
+duckctl --name <robot-name> update apply --ref my-branch
 ```
 
 ```bash
-duck-btctl --name <robot-name> update apply --version 0.5.1
+duckctl --name <robot-name> update apply --version 0.5.1
 ```
 
 ```bash
-duck-btctl --name <robot-name> update apply --staging
+duckctl --name <robot-name> update apply --staging
 ```
 
 `--dry-run` verifies everything and stops before the swap. `--ref` and `--version` are alternatives;
@@ -257,11 +262,11 @@ asking for both is refused.
 Going back — the previous release, or one named from `update versions`:
 
 ```bash
-duck-btctl --name <robot-name> update rollback
+duckctl --name <robot-name> update rollback
 ```
 
 ```bash
-duck-btctl --name <robot-name> update select 0.5.1
+duckctl --name <robot-name> update select 0.5.1
 ```
 
 Both are gated like an apply, so one that does not come up is reverted. Neither discards anything.
@@ -269,7 +274,7 @@ Both are gated like an apply, so one that does not come up is reverted. Neither 
 Progress for an update somebody else started, or one triggered by the robot itself:
 
 ```bash
-duck-btctl --name <robot-name> update watch
+duckctl --name <robot-name> update watch
 ```
 
 It prints where the update in flight has got to and then everything that follows. It never receives
@@ -278,11 +283,11 @@ a reply, so it ends with Ctrl-C.
 ## Anything else — `call`
 
 ```bash
-duck-btctl --name <robot-name> call <method> '<json-params>'
+duckctl --name <robot-name> call <method> '<json-params>'
 ```
 
 Params default to `{}`. These are reachable over Bluetooth but have no wrapper of their own, and are
-written without the `duck-btctl --name <robot-name>` in front of them:
+written without the `duckctl --name <robot-name>` in front of them:
 
 | | |
 |---|---|
@@ -308,7 +313,7 @@ minutes with nothing arriving at all — which is why they are the way to run an
 ## What it prints
 
 Replies go to stdout as pretty JSON, and everything else — progress, diagnosis, what the radio
-saw — to stderr. So `duck-btctl ... info > reply.json` keeps the two apart, and a JSON-RPC error
+saw — to stderr. So `duckctl ... info > reply.json` keeps the two apart, and a JSON-RPC error
 from the robot still exits non-zero. Progress lines start with `·` and are one line each, so
 `update apply > outcome.json` leaves them on screen and keeps the outcome in the file.
 
@@ -337,7 +342,7 @@ Those commands are `robotctl` on the robot.
 ## When it cannot find the robot
 
 ```bash
-duck-btctl --verbose scan
+duckctl --verbose scan
 ```
 
 An empty list — not one pair of earbuds — points at the Mac rather than the robot: Bluetooth off,

--- a/docs/robot/install-dev.md
+++ b/docs/robot/install-dev.md
@@ -178,7 +178,7 @@ Nothing to do — the rest of the run is addressed there.
 
 Three things stop it working, and it says which:
 
-- It needs `cargo` and this clone, because `duck-btctl` is an example rather than an installed binary.
+- It needs `cargo` and this clone, because `duckctl` is an example rather than an installed binary.
 - It can only ask once `btd` is running, which on a board being provisioned for the first time is a
   few minutes into phase 2.
 - The robot reports its **wifi** address, so a board you reach over ethernet is not covered.

--- a/duckctl/Cargo.toml
+++ b/duckctl/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "duckctl"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "The robot from a laptop — over BLE today, over whatever reaches it next"
+
+# **The client half, and it runs nowhere near the robot.** `robotctl` is the tool that ships and
+# it speaks unix sockets on the board; this one reaches a robot from the outside, so it carries a
+# Bluetooth stack, a scanner, and every laptop-side concern the daemons must not have.
+#
+# It was an example of `btd` until it was not. An example's dependencies are dev-dependencies, so
+# `btleplug` could never reach the shipped artifact — a real guarantee, obtained as a side effect
+# of which directory the file sat in. Its own crate keeps the guarantee and states it directly:
+# **nothing on the robot depends on `duckctl`**, so nothing here is in a release. Two things
+# stopped being awkward on the way — `cargo install --path duckctl` rather than
+# `cargo install --path btd --example duck-btctl`, which `dev-push.sh` carried a fallback for,
+# and a name that no longer says `bt` when the robot is about to have a second transport.
+#
+# It is **excluded from `default-members`** in the workspace root, which is what keeps it off the
+# board: `cargo board --bins` builds every default member for aarch64, and this is a tool for the
+# machine the developer is sitting at. `--workspace` still lints and tests it.
+
+[dependencies]
+# The robot's own halves of the wire, used rather than reimplemented. `framing` in particular is
+# the *client* side of the module the robot chunks with, so an asymmetry between them would show
+# up as this tool not working — which makes it a test of the protocol rather than a second
+# implementation free to agree with itself.
+btd = { path = "../btd" }
+
+# `API_VERSION`, and the `semver` re-export it is compared with. The version handshake is a
+# contract between this client and every daemon, so it is read from the crate that defines it
+# rather than kept as a number here that could drift.
+duck-ipc-proto = { path = "../duck-ipc-proto" }
+
+# `btleplug` rather than `bluer`, because this runs on a developer's machine: CoreBluetooth on
+# macOS, BlueZ on Linux, WinRT on Windows. `bluer` would make the client Linux-only, which defeats
+# the point of having one.
+btleplug = "0.11"
+clap = { workspace = true, features = ["derive"] }
+futures = "0.3"
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+
+# `advwatch` measures how often an advertisement actually arrives. It lives here rather than with
+# `btd` for the same reason the client does: it is a scanner, and scanners run on laptops.
+[[example]]
+name = "advwatch"

--- a/duckctl/examples/advwatch.rs
+++ b/duckctl/examples/advwatch.rs
@@ -1,6 +1,6 @@
 //! `advwatch` — how often does a robot's advertisement actually arrive?
 //!
-//! `duck-btctl` scans for eight seconds and either finds a robot or does not, which makes a slow
+//! `duckctl` scans for eight seconds and either finds a robot or does not, which makes a slow
 //! advertiser look like a broken one. This watches continuously instead and prints the arrival
 //! pattern, so "found it on the second try" can be read as a number.
 //!
@@ -11,11 +11,11 @@
 //! suffering from range or interference.
 //!
 //! ```text
-//! cargo run -p btd --example advwatch -- <robot-name>
+//! cargo run -p duckctl --example advwatch -- <robot-name>
 //! ```
 //!
 //! Reads as: arrivals per device with signal strength, then a one-character-per-second timeline for
-//! the robot, then the gaps. A gap as long as `duck-btctl`'s scan window is a run that reports no robot.
+//! the robot, then the gaps. A gap as long as `duckctl`'s scan window is a run that reports no robot.
 
 use std::time::{Duration, Instant};
 
@@ -184,7 +184,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // One character per second: '#' is a second with at least one report, '.' is silence. The gap
-    // structure is the whole question — 8s of '.' is a failed `duck-btctl` run.
+    // structure is the whole question — 8s of '.' is a failed `duckctl` run.
     let seconds = WATCH.as_secs() as usize;
     let mut timeline = vec![b'.'; seconds];
     for hit in &hits {
@@ -235,7 +235,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let over_scan = gaps.iter().filter(|g| **g >= 8.0).count();
     println!(
-        "{over_scan} gap(s) of 8s or more — each one is a `duck-btctl` run that would report no robot"
+        "{over_scan} gap(s) of 8s or more — each one is a `duckctl` run that would report no robot"
     );
     Ok(())
 }

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -1,9 +1,15 @@
-//! `duck-btctl` — talk to a robot over BLE from a laptop.
+//! `duckctl` — the robot from a laptop.
 //!
 //! The phone app's stand-in, and the only way to test `btd` against a real radio.
 //!
-//! An **example, not a binary**, so `btleplug` never reaches the robot: examples' dependencies
-//! are dev-dependencies, and nothing here is in the shipped artifact. `robotctl` is the tool
+//! **Bluetooth is how it reaches a robot today, not what it is.** `mediad` gives a robot a second
+//! transport that reaches a different set of methods by design — `robot.move` is refused over BLE
+//! and permitted over WebRTC, `net.connect` the other way round — so the name says which robot
+//! rather than which radio. It was called `duck-btctl` while BLE was the only answer.
+//!
+//! **Nothing on the robot depends on this crate**, which is what keeps `btleplug` out of a
+//! release. It used to be an example of `btd` for the same purpose, obtained as a side effect of
+//! the directory it sat in; a crate nobody depends on states it directly. `robotctl` is the tool
 //! that ships, and it speaks unix sockets on the robot itself.
 //!
 //! `btleplug` rather than `bluer`, because this runs on a developer's machine: CoreBluetooth on
@@ -15,12 +21,12 @@
 //! it a real test of the protocol rather than a reimplementation that could agree with itself.
 //!
 //! ```text
-//! cargo run -p btd --example duck-btctl -- scan          # robots in range, and their addresses
-//! cargo run -p btd --example duck-btctl -- status
-//! cargo run -p btd --example duck-btctl -- wifi scan
-//! cargo run -p btd --example duck-btctl -- wifi connect "Pollen" --psk secret
-//! cargo run -p btd --example duck-btctl -- name "Ducky"
-//! cargo run -p btd --example duck-btctl -- call robot.health
+//! cargo run -p duckctl -- scan          # robots in range, and their addresses
+//! cargo run -p duckctl -- status
+//! cargo run -p duckctl -- wifi scan
+//! cargo run -p duckctl -- wifi connect "Pollen" --psk secret
+//! cargo run -p duckctl -- name "Ducky"
+//! cargo run -p duckctl -- call robot.health
 //! ```
 //!
 //! `DUCK_ROBOT` and `DUCK_PIN` in the environment are the defaults for `--name` and `--pin`, for
@@ -231,7 +237,7 @@ const DEFAULT_PIN: &str = "000000";
 /// clap reads the variable with `env::var_os` and treats `DUCK_ROBOT=` as a value, so a variable
 /// exported in a shell profile could only be escaped by unsetting it — and the command that needs
 /// escaping is the one being typed now, on a bench that has somebody else's robot on it. Empty means
-/// unset, so `DUCK_ROBOT= duck-btctl scan` is the escape hatch, in the shape a shell already has.
+/// unset, so `DUCK_ROBOT= duckctl scan` is the escape hatch, in the shape a shell already has.
 ///
 /// **Provenance is carried rather than recomputed.** A default makes the tool *stricter*: it
 /// suppresses the already-connected fallback tier, and turns "the first robot found wins" into "no
@@ -295,7 +301,7 @@ impl Target {
         match &self.name {
             Some(name) if self.from_env => format!(
                 "\n\nNothing on this command line said {name:?} — `DUCK_ROBOT` in this shell's \
-                 environment did. `DUCK_ROBOT= duck-btctl …` ignores it for one command, and \
+                 environment did. `DUCK_ROBOT= duckctl …` ignores it for one command, and \
                  `unset DUCK_ROBOT` for the shell."
             ),
             _ => String::new(),
@@ -543,7 +549,7 @@ async fn listing(seen: &[Seen], verbose: bool, target: &Target) -> String {
     if silent > 0 {
         out.push_str(&format!(
             "\n\n{silent} of them broadcast no address, which is a release from before `btd` \
-             advertised one. `duck-btctl wifi status` still reports it; updating the robot puts it \
+             advertised one. `duckctl wifi status` still reports it; updating the robot puts it \
              in this list."
         ));
     }
@@ -667,7 +673,7 @@ async fn step<T>(
 #[command(
     // Spelled out because clap would otherwise take it from the crate, and `--version` on the
     // installed binary answered `btd 0.5.1` — the daemon's name, for the laptop-side client.
-    name = "duck-btctl",
+    name = "duckctl",
     version,
     about = "Talk to a robot over BLE — the phone app's stand-in",
     long_about = "Finds a robot advertising the duck GATT service and speaks the same JSON-RPC \
@@ -682,7 +688,7 @@ struct Cli {
     /// board that has never been renamed answers to its derived default, `duck-7f3a`.
     ///
     /// `export DUCK_ROBOT=duck-c51b` in a shell profile makes that the robot every command talks
-    /// to. `DUCK_ROBOT= duck-btctl …` ignores it for one command.
+    /// to. `DUCK_ROBOT= duckctl …` ignores it for one command.
     //
     // The id is spelled out rather than derived from the field, because clap keys arguments by id
     // and the `name` subcommand has a positional argument that derives the same one. With both
@@ -1266,7 +1272,7 @@ fn dropped(command: &Command) -> String {
 
     let next = if restarting {
         "An update restarts the robot's daemons, `btd` among them, so this is as likely to be the \
-         update finishing as failing. Reconnect and run `duck-btctl update status`: \
+         update finishing as failing. Reconnect and run `duckctl update status`: \
          `last_attempt` carries the outcome of what ran."
     } else {
         "Reconnect and try again. Anything the robot had already started — an update in \
@@ -1284,7 +1290,7 @@ fn silence(idle: Duration) -> String {
     format!(
         "nothing from the robot for {idle:?}, so it has stopped answering. Anything it had \
              already started — an update in particular — carries on without this connection: \
-             reconnect and run `duck-btctl update status`."
+             reconnect and run `duckctl update status`."
     )
 }
 
@@ -1547,7 +1553,7 @@ fn update_request_line(update: &Update) -> Result<(String, Duration), Box<dyn st
 
 /// One progress notification, as a line for a person.
 ///
-/// Progress goes to stderr like everything that is not an answer, so `duck-btctl … > reply.json`
+/// Progress goes to stderr like everything that is not an answer, so `duckctl … > reply.json`
 /// keeps the two apart — and printing it as pretty JSON, which is what this used to do, put a
 /// dozen lines of punctuation on stdout for every percent of a download.
 fn progress_line(params: &serde_json::Value) -> String {
@@ -1591,7 +1597,7 @@ fn restart_note(command: &Command, reply: &serde_json::Value) -> Option<&'static
         "applied" | "rolled_back" => Some(
             "note: the robot restarts its daemons now, and `btd` about five seconds after this \
              reply — so this connection drops. That is the update working. Reconnect and run \
-             `duck-btctl update status`: `last_attempt` carries the outcome of what just ran.",
+             `duckctl update status`: `last_attempt` carries the outcome of what just ran.",
         ),
         _ => None,
     }
@@ -1798,9 +1804,8 @@ mod tests {
     /// found nothing, and listed the robot it was talking to seconds earlier as merely in range.
     #[test]
     fn a_rename_still_selects_the_robot_by_the_name_it_has_now() {
-        let cli =
-            Cli::try_parse_from(["duck-btctl", "--name", "duck-c51b", "name", "leduckpierre"])
-                .expect("the rename form parses");
+        let cli = Cli::try_parse_from(["duckctl", "--name", "duck-c51b", "name", "leduckpierre"])
+            .expect("the rename form parses");
 
         assert_eq!(cli.name.as_deref(), Some("duck-c51b"), "which robot");
         let Command::Name { name } = &cli.command else {
@@ -1853,7 +1858,7 @@ mod tests {
     #[test]
     fn an_empty_value_is_no_default_at_all() {
         let escaped = Target::new(None, Some(String::new()));
-        assert_eq!(escaped.wanted(), None, "`DUCK_ROBOT= duck-btctl …`");
+        assert_eq!(escaped.wanted(), None, "`DUCK_ROBOT= duckctl …`");
         assert!(
             escaped.provenance().is_empty(),
             "no name, nothing to explain"
@@ -2022,7 +2027,7 @@ mod tests {
     #[test]
     fn apply_asks_for_the_target_the_flags_named() {
         let wire = |args: &[&str]| {
-            let mut argv = vec!["duck-btctl", "update", "apply"];
+            let mut argv = vec!["duckctl", "update", "apply"];
             argv.extend_from_slice(args);
             let cli = Cli::try_parse_from(argv).expect("parses");
             request_line(&cli.command).expect("a request").0
@@ -2057,7 +2062,7 @@ mod tests {
     fn a_ref_and_a_version_cannot_both_be_named() {
         assert!(
             Cli::try_parse_from([
-                "duck-btctl",
+                "duckctl",
                 "update",
                 "apply",
                 "--ref",
@@ -2082,7 +2087,7 @@ mod tests {
             (vec!["rollback"], "update.rollback"),
             (vec!["select", "0.5.1"], "update.select"),
         ] {
-            let mut argv = vec!["duck-btctl", "update"];
+            let mut argv = vec!["duckctl", "update"];
             argv.extend_from_slice(&args);
             let cli = Cli::try_parse_from(argv).expect("parses");
             let (line, _) = request_line(&cli.command).expect("a request");
@@ -2093,7 +2098,7 @@ mod tests {
     /// `select` sends the version as a version, and defaults the component like the rest.
     #[test]
     fn select_names_a_version_and_defaults_the_component() {
-        let cli = Cli::try_parse_from(["duck-btctl", "update", "select", "0.5.1"]).expect("parses");
+        let cli = Cli::try_parse_from(["duckctl", "update", "select", "0.5.1"]).expect("parses");
         let (line, _) = request_line(&cli.command).expect("a request");
         assert!(line.contains(r#""version":"0.5.1""#), "{line}");
         assert!(line.contains(r#""component":"daemon""#), "{line}");
@@ -2105,7 +2110,7 @@ mod tests {
     #[test]
     fn an_update_is_given_the_longest_silence() {
         let budget = |args: &[&str]| {
-            let mut argv = vec!["duck-btctl"];
+            let mut argv = vec!["duckctl"];
             argv.extend_from_slice(args);
             let cli = Cli::try_parse_from(argv).expect("parses");
             request_line(&cli.command).expect("a request").1
@@ -2154,7 +2159,7 @@ mod tests {
     /// update, so it has to be trustworthy.
     #[test]
     fn a_restart_is_announced_only_when_the_release_changed() {
-        let apply = Cli::try_parse_from(["duck-btctl", "update", "apply"])
+        let apply = Cli::try_parse_from(["duckctl", "update", "apply"])
             .expect("parses")
             .command;
 
@@ -2177,13 +2182,13 @@ mod tests {
         assert!(restart_note(&apply, &dry_run).is_none());
 
         // And nothing else announces one, however it answered.
-        let status = Cli::try_parse_from(["duck-btctl", "update", "status"])
+        let status = Cli::try_parse_from(["duckctl", "update", "status"])
             .expect("parses")
             .command;
         assert!(restart_note(&status, &applied).is_none());
 
         // Nor a component whose release does not ship `btd`.
-        let model = Cli::try_parse_from(["duck-btctl", "update", "apply", "--component", "model"])
+        let model = Cli::try_parse_from(["duckctl", "update", "apply", "--component", "model"])
             .expect("parses")
             .command;
         assert!(restart_note(&model, &applied).is_none());
@@ -2198,7 +2203,7 @@ mod tests {
     #[test]
     fn a_drop_during_an_apply_points_at_the_record() {
         let note = |argv: &[&str]| {
-            let mut full = vec!["duck-btctl"];
+            let mut full = vec!["duckctl"];
             full.extend_from_slice(argv);
             dropped(&Cli::try_parse_from(full).expect("parses").command)
         };

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -82,7 +82,7 @@ done
 # nobody can keep in a shell profile: `DUCK_BOARD=radxa@192.168.1.42` goes stale, and the way
 # that reads is a push that hangs until ssh times out.
 #
-# A robot's *name* does not move. `duck-btctl` finds it over BLE by that name and `net.status`
+# A robot's *name* does not move. `duckctl` finds it over BLE by that name and `net.status`
 # answers with the address it currently has — which makes the radio the way out of exactly the
 # situation the network cannot help with, and needs nothing on the LAN to be known or guessed.
 #
@@ -92,24 +92,26 @@ done
 BOARD_USER="${DUCK_BOARD_USER:-radxa}"
 CACHE_DIR="${DUCK_BOARD_CACHE:-$HOME/.cache/duck/boards}"
 
-# The installed client if there is one, the example in this clone otherwise. `duck-btctl` is an
-# example rather than a binary, so it reaches a PATH only via `cargo install --path btd --example
-# duck-btctl`, and plenty of clones have never run that.
-btctl() {
-    if command -v duck-btctl >/dev/null 2>&1; then
-        duck-btctl "$@"
+# The installed client if there is one, this clone's otherwise. `cargo install --path duckctl` is
+# what puts it on a PATH, and plenty of clones have never run it.
+#
+# Not named `duckctl`: a function by that name would match its own `duckctl "$@"` below and
+# recurse until the shell gives up.
+client() {
+    if command -v duckctl >/dev/null 2>&1; then
+        duckctl "$@"
     else
-        cargo run -q -p btd --example duck-btctl -- "$@"
+        cargo run -q -p duckctl -- "$@"
     fi
 }
 
 # `net.status` for one robot, JSON on stdout.
 #
-# Only `--name` is passed. A robot with a PIN of its own needs `DUCK_PIN`, which `duck-btctl`
-# reads for itself (`docs/robot/duck-btctl.md`) — repeating it here would be a second place to
+# Only `--name` is passed. A robot with a PIN of its own needs `DUCK_PIN`, which `duckctl`
+# reads for itself (`docs/robot/duckctl.md`) — repeating it here would be a second place to
 # keep in step, and passing its factory default unconditionally would override the real one.
 ble_status() {
-    btctl --name "$1" wifi status
+    client --name "$1" wifi status
 }
 
 # A robot name in, `user@address` out. Everything else goes to stderr, so the substitution that
@@ -134,7 +136,7 @@ resolve_board() {
     echo "==> asking $robot_name over Bluetooth where it is" >&2
     reply="$(ble_status "$robot_name")" || {
         echo "could not reach $robot_name over Bluetooth" >&2
-        echo "  duck-btctl scan                                  # is it advertising?" >&2
+        echo "  duckctl scan                                  # is it advertising?" >&2
         echo "  scripts/dev-push.sh $BOARD_USER@<address>        # or say where it is" >&2
         return 1
     }
@@ -149,7 +151,7 @@ print((r.get("result") or {}).get("ip4") or "")')" || return 1
     if [ -z "$address" ]; then
         echo "$robot_name answered over Bluetooth but has no wifi address" >&2
         echo "Join it to a network first — over the same radio, so this needs no ssh:" >&2
-        echo "  duck-btctl --name '$robot_name' wifi connect <ssid> --psk <passphrase>" >&2
+        echo "  duckctl --name '$robot_name' wifi connect <ssid> --psk <passphrase>" >&2
         return 1
     fi
 
@@ -172,9 +174,9 @@ print((r.get("result") or {}).get("ip4") or "")')" || return 1
 }
 
 # The command line beats the environment, and an address beats a name: an address needs no radio.
-# `DUCK_ROBOT` is the same variable `duck-btctl` defaults `--name` to, so one exported name serves
+# `DUCK_ROBOT` is the same variable `duckctl` defaults `--name` to, so one exported name serves
 # both tools — and empty means unset in both, so `DUCK_ROBOT= scripts/dev-push.sh radxa@…` works.
-# `--name` here is `duck-btctl`'s sense of it: which robot to talk to. `provision-board.sh --name`
+# `--name` here is `duckctl`'s sense of it: which robot to talk to. `provision-board.sh --name`
 # means the opposite way round — the name to *give* a board — because provisioning is the one place
 # a name is assigned rather than used to find something.
 if [ -z "$BOARD" ] && [ -z "$ROBOT" ]; then

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -81,7 +81,7 @@
 # which is read off the board before the reboot while ssh still works. Adopting an address means
 # ssh'ing somewhere new, and doing that to a robot chosen by scan order is worse than waiting.
 #
-# It needs `cargo` and this clone, because `duck-btctl` is an example rather than an installed
+# It needs `cargo` and this clone, because `duckctl` is an example rather than an installed
 # binary. Without either, the wait is exactly what it was before and says so. Three more things it
 # cannot do:
 #
@@ -116,7 +116,7 @@ ROBOT_NAME=""
 
 # ── the Bluetooth fallback ───────────────────────────────────────────────────
 #
-# `duck-btctl` is an example rather than a binary — deliberately, so `btleplug` never reaches a
+# `duckctl` is an example rather than a binary — deliberately, so `btleplug` never reaches a
 # robot — which means the only way to run it is `cargo` against this clone.
 BLE_MANIFEST="$(dirname "$0")/../Cargo.toml"
 
@@ -405,7 +405,7 @@ ble_probe_start() {
     [ -z "$BLE_PID" ] || return 0
 
     {
-        if cargo run -q --manifest-path "$BLE_MANIFEST" -p btd --example duck-btctl -- \
+        if cargo run -q --manifest-path "$BLE_MANIFEST" -p duckctl -- \
             --name "$BLE_NAME" --pin "$BLE_PIN" wifi status \
             >"${BLE_DIR}/out" 2>"${BLE_DIR}/err"
         then
@@ -442,7 +442,7 @@ ble_verdict() {
     rm -f "${BLE_DIR}/verdict"
 }
 
-# Why the last probe failed, as `duck-btctl` put it.
+# Why the last probe failed, as `duckctl` put it.
 #
 # Its own words rather than a paraphrase, and not matched on either: it explains a name nobody
 # answers to, two robots answering to one, a missing adapter and a refused PIN, each differently and
@@ -614,7 +614,7 @@ elif ! command -v cargo >/dev/null 2>&1; then
   address changes across the reboot. Not fatal — the board finishes on its own either way, and
   the wait below is what it always was. Install Rust to get the fallback."
 elif [ ! -f "$BLE_MANIFEST" ]; then
-    warn "${BLE_MANIFEST} is not there, so this is not being run from a clone and duck-btctl
+    warn "${BLE_MANIFEST} is not there, so this is not being run from a clone and duckctl
   cannot be built — no Bluetooth fallback if the board's address changes across the reboot."
 else
     BLE_NAME="$(learn_ble_name)"

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -918,8 +918,8 @@ impl Server {
 ///
 /// So the pair of versions goes to the journal, where it turns a later shape error from a puzzle into
 /// a diagnosis, and `HelloResult::api_version` hands the client the same fact so it can say so
-/// itself. `duck-btctl` reached this conclusion from the far end of the link first — see
-/// `btd/examples/duck-btctl.rs`.
+/// itself. `duckctl` reached this conclusion from the far end of the link first — see
+/// `duckctl/src/main.rs`.
 fn note_version_skew(client: u32) {
     tracing::warn!(
         client,


### PR DESCRIPTION
`duck-btctl` was an example of `btd`, and both halves of that description stop fitting now that `mediad` is on `main`.

**The name.** There are two transports to a robot, and they reach different method sets by design — `robot.move` is refused over BLE and permitted over WebRTC, `net.connect` the other way round. A tool named after one radio teaches everyone that it is the way in, at exactly the moment it stops being the only one. What a person will eventually want is a client that knows which transport can serve a call and says so; that tool cannot be called `btctl`.

**The move.** A transport-agnostic client cannot stay an example of the BLE daemon — it would need `btleplug` *and* a WebSocket client, and only one of those belongs to `btd`. Two things stop being awkward on the way:

- `cargo install --path duckctl`, rather than `cargo install --path btd --example duck-btctl` — odd enough that `dev-push.sh` carried a fallback for clones that never ran it.
- The guarantee the example arrangement bought — `btleplug` never in a release — was a side effect of which directory the file sat in. It is now stated: **nothing on the robot depends on `duckctl`**.

`advwatch` comes too. It is a scanner, and scanners run on laptops.

**`default-members` is what keeps it off the board.** `cargo board --bins` — in `dev-push.sh` and in the release workflow — builds every default member for aarch64, and cross-compiling a Bluetooth stack for a board that must never see one is both wasted and wrong. One list in the workspace root, rather than naming binaries at each of the two `--bins` call sites and keeping them in step by hand. `--workspace` is unaffected, so CI lints and tests it exactly as before.

**No shim.** `duck-btctl` is gone rather than aliased: one user and one robot, and a second name is a second thing to keep in step.

**`docs/project/` keeps saying `duck-btctl`.** Those are dated records — an update session, four install-path bugs and what closed them — and putting a name into an account of something that happened before the tool had it makes the record false. Their links are repointed so they still resolve; their prose is not. `roadmap.md` is the exception and is updated, because it describes the repo as it is now.

## Checks

- `cargo test -p duckctl` — 31 tests, the same ones `[[example]] test = true` existed to run, now ordinary unit tests.
- `cargo test -p btd -p xtask` — clean, including the packaging tripwires.
- `cargo clippy -p duckctl -p btd -p configd -p updater --all-targets` — clean.
- `cargo fmt --all --check` — clean. The shorter name re-wrapped a few lines.
- `sh -n` + `shellcheck --shell=sh` on both touched scripts, as CI runs them.
- `cargo metadata` confirms `duckctl` is the one workspace member excluded from `default-members`.

`cargo clippy --workspace` was not run to completion locally: `tof`'s vendored C builds on Linux and not on this macOS host, on `main` as well as here.