### PR TITLE
Follow the repository rename to pollen-robotics/microduck

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,7 @@ export DUCK_TOKEN=github_pat_replace_with_your_token
 ```
 
 ```bash
-curl -fsSL -H "Authorization: Bearer $DUCK_TOKEN" https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/provision.sh -o /tmp/provision.sh && sudo DUCK_TOKEN="$DUCK_TOKEN" DUCK_DEV_KEY=/tmp/team.dev.pub sh /tmp/provision.sh
+curl -fsSL -H "Authorization: Bearer $DUCK_TOKEN" https://raw.githubusercontent.com/pollen-robotics/microduck/main/scripts/provision.sh -o /tmp/provision.sh && sudo DUCK_TOKEN="$DUCK_TOKEN" DUCK_DEV_KEY=/tmp/team.dev.pub sh /tmp/provision.sh
 ```
 
 `provision.sh` runs `setup-board.sh`, `migrate-network.sh` and `install.sh` in order, warns for
@@ -99,7 +99,7 @@ group is created before the reboot, so the session you log back into already has
 No token and no dev key.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/provision.sh -o /tmp/provision.sh && sudo sh /tmp/provision.sh
+curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck/main/scripts/provision.sh -o /tmp/provision.sh && sudo sh /tmp/provision.sh
 ```
 
 ```bash

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -473,7 +473,7 @@ done only when genuinely needed, never unconditionally on every update.
 
 ### 6.1 ⚠ A private repository cannot serve the fleet
 
-**Unresolved, and it constrains M4.** `pollen-robotics/microduck_daemon` is private, and a
+**Unresolved, and it constrains M4.** `pollen-robotics/microduck` is private, and a
 private repo's `releases/download/<tag>/<asset>` URL returns **404 — with or without a
 token**. Verified directly:
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -48,7 +48,7 @@ makes two things urgent that would otherwise have waited:
 1. **Dev-channel installs** — install a specific branch or commit on a board, without
    cutting a release. This is now ahead of `btd`: teammates will use `robotctl`, not the
    phone app.
-2. ~~**A repo and a dev signing key**~~ — **done.** `pollen-robotics/microduck_daemon`
+2. ~~**A repo and a dev signing key**~~ — **done.** `pollen-robotics/microduck`
    (private), CI green on first fix; `team.dev` key generated. The signing secrets and the
    `release` environment are in place too, and `0.2.0` went out through them.
 

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -757,7 +757,7 @@ ln -sfn releases/under-test /opt/robot/daemon/current
 # board keep a stale on_apply list for months — so this takes the branch a re-install takes,
 # and substitutes the repository the way the fetch path would.
 mkdir -p /etc/robot
-sed "s|\"ORG/duck-daemon\"|\"pollen-robotics/microduck_daemon\"|" \
+sed "s|\"ORG/duck-daemon\"|\"pollen-robotics/microduck\"|" \
     /bin/deploy/updater.toml > /etc/robot/updater.toml
 cp /bin/deploy/robotd.toml /etc/robot/robotd.toml
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 #
 # Install the robot daemon on a fresh board, from nothing.
 #
-#   curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/main/scripts/install.sh | sudo sh
+#   curl -fsSL https://raw.githubusercontent.com/pollen-robotics/microduck/main/scripts/install.sh | sudo sh
 #
 # Target: 64-bit Debian userland on aarch64 — Armbian 26.2.x on the Radxa Zero 3, and
 # whatever else Debian 12/13 arm64 you point it at. Needs `curl` and coreutils and
@@ -49,7 +49,7 @@ set -eu
 # ── knobs ────────────────────────────────────────────────────────────────────
 
 # The repository releases are published from. Override for a fork or a test repo.
-REPO="${DUCK_REPO:-pollen-robotics/microduck_daemon}"
+REPO="${DUCK_REPO:-pollen-robotics/microduck}"
 
 # Branch the trusted keys are read from. Pin to a tag for a reproducible provisioning run.
 #

--- a/scripts/migrate-network.sh
+++ b/scripts/migrate-network.sh
@@ -46,7 +46,7 @@ SELF=/usr/local/sbin/robot-migrate-network
 
 # Where this script came from, for the commands it prints. Same override names as install.sh
 # and setup-board.sh, so a fork or a pinned tag is one decision for the whole bring-up.
-REPO="${DUCK_REPO:-pollen-robotics/microduck_daemon}"
+REPO="${DUCK_REPO:-pollen-robotics/microduck}"
 REF="${DUCK_REF:-main}"
 RAW="https://raw.githubusercontent.com/${REPO}/${REF}/scripts"
 # For a private repository. Only ever interpolated into printed commands, and by name rather

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -668,7 +668,7 @@ if [ -n "$USE_LOCAL" ]; then
     say "sending this clone's provision.sh"
     scp -q "$_local" "$(scp_target /tmp/provision.sh)" || die "could not copy provision.sh"
 else
-    _raw="https://raw.githubusercontent.com/pollen-robotics/microduck_daemon/${REF:-main}/scripts/provision.sh"
+    _raw="https://raw.githubusercontent.com/pollen-robotics/microduck/${REF:-main}/scripts/provision.sh"
     say "having the board fetch provision.sh from ${REF:-main}"
     # Fetched by the board rather than by this machine and copied over: the board is the one
     # that has to be able to reach GitHub with that token, and finding out here would prove

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -69,7 +69,7 @@ ENV_FORCE="${DUCK_FORCE_REINSTALL:-}"
 ENV_WEIRD_BLE="${DUCK_WEIRD_BLE:-}"
 ENV_GSTREAMER="${DUCK_GSTREAMER:-}"
 
-REPO="${ENV_REPO:-pollen-robotics/microduck_daemon}"
+REPO="${ENV_REPO:-pollen-robotics/microduck}"
 REF="${ENV_REF:-main}"
 RAW="https://raw.githubusercontent.com/${REPO}/${REF}/scripts"
 

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -81,7 +81,7 @@ SELF=/usr/local/sbin/robot-setup-board
 # Where the sibling scripts come from, for the commands this prints. Same override names as
 # `install.sh`, so a fork or a pinned tag is one decision for the whole bring-up rather than
 # per script. Nothing here is fetched by this script — see `fetch_cmd`.
-REPO="${DUCK_REPO:-pollen-robotics/microduck_daemon}"
+REPO="${DUCK_REPO:-pollen-robotics/microduck}"
 REF="${DUCK_REF:-main}"
 RAW="https://raw.githubusercontent.com/${REPO}/${REF}/scripts"
 


### PR DESCRIPTION
The repository is now `pollen-robotics/microduck`. Eleven hardcoded references still named `pollen-robotics/microduck_daemon`:

- the `DUCK_REPO`/`ENV_REPO` defaults in `install.sh`, `provision.sh`, `setup-board.sh` and `migrate-network.sh`
- the raw URL `provision-board.sh` hands the board when it is not sending a local clone
- the repository `board-test.sh` substitutes into `updater.toml` in place of the `ORG/duck-daemon` placeholder
- the copy-paste bootstrap `curl` lines in `deploy/README.md` and the `install.sh` header comment
- two prose mentions in `docs/design/updater-design.md` and `docs/project/roadmap.md`

Everything else was already parametrised on `${REPO}`, `${GITHUB_REPOSITORY}` or `github.repository`, and the `ORG/duck-daemon` / `ORG/robot-daemon` strings stay as placeholders — `install.sh` still fails hard if one survives an install.

Nothing was broken before this. GitHub keeps the old slug alive: `raw.githubusercontent.com/…/microduck_daemon/…` answers 200 directly, and `api.github.com/repos/…/microduck_daemon/…` answers 301 to the numeric repository on the same host, so the bearer token survives the redirect and `updater`'s five-redirect budget follows it. Boards already carrying the old slug in `/etc/robot/updater.toml` keep updating for that reason; they would only break if another repository claimed the old name.

Touched shell scripts pass `sh -n`.