### PR TITLE
updater: a refused restart is not an outage

### DIFF
--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -393,11 +393,21 @@ keeps its meaning — the robot could not be put back at all — and a failed ap
 is carried into the reported outcome and logged at `error`:
 
 ```text
-not healthy within 30s: …; the release was reverted but a unit did not restart (…), so
-something on this robot is down
+not healthy within 30s: …; the release was reverted, but restarting robotd failed: …
+`Restart=` may have brought it back since — `robotctl health` says whether it did.
 ```
 
-Both facts, in the order someone needs them: why the update failed first, then what is still down.
+Both facts, in the order someone needs them: why the update failed first, then the unit that did not
+come back with the revert.
+
+The second half of that sentence used to read "so something on this robot is down", and it was wrong
+often enough to be worth naming. Every daemon here runs `Restart=always`, and a daemon that exits
+immediately burns systemd's five starts per ten seconds long before the health gate's thirty are up —
+so the revert's restart is routinely refused with `Start request repeated too quickly` and the unit is
+back on its own moments later. A bench board printed that outage claim directly beneath its own
+`robot healthy` line. `restart_one` now clears the counter with `reset-failed` and tries once more,
+which removes the cause; the outcome reports the refusal it observed and names the command that
+answers what it cannot.
 
 The two rejected alternatives, since neither is obviously wrong. Making `postinstall` reversible is the
 change the hook explicitly declined; it needs state outside the release and adds a failure mode to the

--- a/scripts/systemd-test.sh
+++ b/scripts/systemd-test.sh
@@ -299,7 +299,7 @@ pass "current went back to 1.3.0"
 
 # The revert happened *and* one unit did not come back with it. Two facts, reported as two — this was
 # a single `rollback failed after a failed update`, which asserted the one thing that was false (the
-# robot had not been put back) and buried the one thing that was true (a daemon is down).
+# robot had not been put back) and buried the one thing that was true (a unit refused to restart).
 #
 # `hooks/postinstall` overwrote 1.3.0's good unit file with 1.4.0's broken one and by design does not
 # put it back, so the revert's own restart of a unit with that name inherits the same failure. The
@@ -307,11 +307,20 @@ pass "current went back to 1.3.0"
 # it. What changed is that this no longer reads as the recovery having failed.
 grep -q "rollback failed" "$WORK/ghost.log" \
     && { sed 's/^/    /' "$WORK/ghost.log"; fail "a revert that happened is still reported as a failed rollback"; }
-grep -q "did not restart" "$WORK/ghost.log" \
-    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not name the unit that did not come back"; }
+grep -q "the release was reverted" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not report the revert"; }
+grep -q "restarting needs-a-user failed" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not name the unit that would not come back"; }
+
+# And the claim it must NOT make. Every daemon here runs `Restart=always`, so a unit refusing a
+# restart on command is routinely back seconds later; a board on the bench printed "so something on
+# this robot is down" directly under its own `robot healthy` line. The outcome now reports the
+# refusal and names the command that answers what it cannot.
 grep -q "is down" "$WORK/ghost.log" \
-    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not say something is down"; }
-pass "reported as reverted and as having left something down, not as a failed rollback"
+    && { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome still asserts an outage it did not observe"; }
+grep -q "robotctl health" "$WORK/ghost.log" \
+    || { sed 's/^/    /' "$WORK/ghost.log"; fail "the outcome does not say how to find out whether it came back"; }
+pass "reported as reverted, naming the unit, without claiming an outage it never checked for"
 
 # The rest of the robot is still up, which is what keeps this a gap rather than an outage.
 in_container "systemctl is-active --quiet fake-robotd" \

--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -935,8 +935,9 @@ impl Engine {
     /// What a revert achieved: the release now live, and whatever went wrong after it was.
     ///
     /// Two facts rather than one, because they have different urgencies and used to be collapsed into
-    /// a single `RollbackFailed`. The version is the recovery; `apply_error` is a daemon that is down
-    /// on a robot which is otherwise back where it was.
+    /// a single `RollbackFailed`. The version is the recovery; `apply_error` is a unit that would not
+    /// restart on command, on a robot which is otherwise back where it was — not, despite what this
+    /// once said, a daemon that is down. [`Reverted::describe`] has the difference and why it bit.
     async fn rollback_to(
         &self,
         component: &str,
@@ -995,13 +996,15 @@ impl Engine {
             }
         };
         if let Some(detail) = &apply_error {
-            // At error, because a reverted robot with a dead daemon needs someone to look at it even
-            // though the operation it belongs to reports an outcome rather than a failure.
-            tracing::error!(
+            // At warn rather than error, and the wording changed with it. This is a restart that
+            // did not take on command, which `Restart=always` may already have undone; asserting an
+            // outage here is what made the reverted-board report contradict the health line next to
+            // it. See [`Reverted::describe`].
+            tracing::warn!(
                 component,
                 reverted_to = %previous,
                 error = %detail,
-                "reverted, but a unit did not restart — the release is back and something is down"
+                "reverted, but a unit refused to restart on command — check whether it came back"
             );
         }
 
@@ -1939,7 +1942,8 @@ impl Engine {
 /// The outcome of a revert: where the robot ended up, and what did not come back with it.
 struct Reverted {
     version: semver::Version,
-    /// The apply action's failure, when the swap succeeded and it did not.
+    /// The apply action's failure, when the swap succeeded and it did not. Names the unit — see
+    /// [`try_restart`].
     apply_error: Option<String>,
 }
 
@@ -1948,12 +1952,22 @@ impl Reverted {
     ///
     /// Appended rather than replacing: why the update failed is what someone is looking for, and a
     /// unit that then failed to restart is a second thing to act on, not a correction of the first.
+    ///
+    /// **What this deliberately no longer claims is that something is down.** It used to, and on a
+    /// bench board that sentence was false by the time anyone could read it: every daemon here runs
+    /// `Restart=always`, so a unit that refuses a restart *on command* is usually back seconds
+    /// later on its own. Reporting the refusal as an outage sent a reader looking for a dead daemon
+    /// on a robot whose own health line, printed directly above this one, said `robot healthy`.
+    ///
+    /// So it reports what it observed — a restart that did not take — and names the command that
+    /// answers the question it cannot. [`restart_one`] has already cleared the start-rate counter
+    /// and tried a second time by the time this runs, so reaching here means two refusals, not one.
     fn describe(&self, why: &str) -> String {
         match &self.apply_error {
             None => why.to_owned(),
             Some(detail) => format!(
-                "{why}; the release was reverted but a unit did not restart ({detail}), so \
-                 something on this robot is down"
+                "{why}; the release was reverted, but {detail}. `Restart=` may have brought it back \
+                 since — `robotctl health` says whether it did."
             ),
         }
     }
@@ -2345,11 +2359,26 @@ fn units_to_restart(release_dir: &Path, configured: &[String]) -> Vec<String> {
     units
 }
 
+/// Restart one unit, with the two failures that are not what they look like handled here.
+///
+/// **The rate limit is the interesting one, and it is the common case rather than a race.** systemd
+/// defaults to `StartLimitBurst=5` per `StartLimitIntervalSec=10s`; `robotd` sets `RestartSec=2s`.
+/// So a daemon that exits immediately — a bad config file, a missing library — burns its five
+/// starts in ten seconds and systemd refuses further ones with `Start request repeated too
+/// quickly`. The health gate then waits another twenty, and the rollback's restart lands squarely
+/// inside that refusal. It fails, and the robot is reported as having a daemon down when the
+/// release it is now on would start perfectly.
+///
+/// That is not hypothetical: it is what a board did on the bench, reporting "so something on this
+/// robot is down" while `robotctl health` two lines above said `robot healthy`. The counter is
+/// cleared and the restart tried once more, which is what `reset-failed` is for.
+///
+/// Unconditional rather than matched on the error text: `reset-failed` is a no-op on a unit that is
+/// not failed, and the alternative is grepping systemd's prose in whatever locale it was built
+/// with. The cost is one extra pair of calls on a path that has already failed; a unit that
+/// genuinely cannot start fails the second time too and is reported then.
 async fn restart_one(systemctl: &str, unit: &str) -> Result<(), Error> {
-    let mut c = tokio::process::Command::new(systemctl);
-    c.arg("restart").arg(unit);
-
-    match run_systemctl(c, "restart").await {
+    match try_restart(systemctl, unit).await {
         Ok(()) => Ok(()),
         Err(e) => {
             if unit_is_absent(systemctl, unit).await {
@@ -2361,12 +2390,34 @@ async fn restart_one(systemctl: &str, unit: &str) -> Result<(), Error> {
                      release that introduces a new daemon; install its unit file and it will \
                      restart on the next update."
                 );
-                Ok(())
-            } else {
-                Err(e)
+                return Ok(());
             }
+
+            tracing::warn!(
+                unit,
+                error = %e,
+                "restart refused; clearing the start-rate counter and trying once more"
+            );
+            let mut c = tokio::process::Command::new(systemctl);
+            c.arg("reset-failed").arg(unit);
+            // Ignored: a unit that was never failed makes this exit non-zero on some systemd
+            // versions, and that must not replace the restart's own error with a worse one.
+            let _ = run_systemctl(c, "reset-failed").await;
+
+            try_restart(systemctl, unit).await
         }
     }
+}
+
+/// One `systemctl restart`, with the unit named in the error.
+///
+/// Named, because the caller restarts up to six of them and the bare message — systemd's own
+/// "Job for X.service failed because the control process exited" wrapped in "restart failed" —
+/// reached the update log without ever saying which unit the job was for.
+async fn try_restart(systemctl: &str, unit: &str) -> Result<(), Error> {
+    let mut c = tokio::process::Command::new(systemctl);
+    c.arg("restart").arg(unit);
+    run_systemctl(c, &format!("restarting {unit}")).await
 }
 
 /// Does systemd know this unit at all?
@@ -2861,7 +2912,83 @@ esac
         let err = restart_one(path.to_str().unwrap(), "robotd")
             .await
             .unwrap_err();
-        assert!(format!("{err:?}").contains("restart failed"), "{err:?}");
+        // Named, so a reader of the update log knows which of six units the job was for.
+        assert!(
+            format!("{err:?}").contains("restarting robotd failed"),
+            "{err:?}"
+        );
+    }
+
+    /// The bench incident, reproduced. A daemon that exits immediately burns systemd's five starts
+    /// in ten seconds (`StartLimitBurst=5`, `robotd` at `RestartSec=2s`), and every restart after
+    /// that is refused with `Start request repeated too quickly` — including the rollback's, which
+    /// arrives while the gate's thirty seconds are still running down. The board then reported a
+    /// daemon down while `robotctl health` said `robot healthy`.
+    ///
+    /// The stub refuses the first restart the way systemd does and accepts one after `reset-failed`,
+    /// which is the sequence being asserted.
+    #[tokio::test]
+    async fn a_rate_limited_unit_is_reset_and_restarted_rather_than_reported_down() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("systemctl");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+echo "$@" >> "$(dirname "$0")/calls"
+if [ "$1" = show ]; then echo loaded; exit 0; fi
+if [ "$1" = reset-failed ]; then : > "$(dirname "$0")/cleared"; exit 0; fi
+[ -f "$(dirname "$0")/cleared" ] && exit 0
+echo 'Failed to restart robotd.service: Start request repeated too quickly.' >&2
+exit 1
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        restart_one(path.to_str().unwrap(), "robotd")
+            .await
+            .expect("a rate-limited unit must be reset and retried, not reported as a failure");
+
+        let calls = calls(dir.path());
+        assert!(
+            calls.contains("reset-failed robotd"),
+            "the start-rate counter was never cleared: {calls}"
+        );
+    }
+
+    /// The other half, so the retry cannot become "ignore the first failure". A unit that is
+    /// genuinely broken refuses both times and is reported, with `reset-failed` having been tried.
+    #[tokio::test]
+    async fn a_unit_that_refuses_twice_is_still_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("systemctl");
+        std::fs::write(
+            &path,
+            "#!/bin/sh\necho \"$@\" >> \"$(dirname \"$0\")/calls\"\nif [ \"$1\" = show ]; then echo loaded; exit 0; fi\nif [ \"$1\" = reset-failed ]; then exit 0; fi\necho 'job failed' >&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let err = restart_one(path.to_str().unwrap(), "robotd")
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").contains("restarting robotd failed"),
+            "{err:?}"
+        );
+        assert_eq!(
+            calls(dir.path()).matches("restart robotd").count(),
+            2,
+            "the second attempt is the whole point of clearing the counter"
+        );
     }
 
     /// A stub that records its whole argument list and nothing else. `stub_systemctl` above answers

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -875,10 +875,18 @@ async fn a_revert_whose_restart_fails_is_still_a_revert() {
                 "the release must be reported as reverted, because it was"
             );
             // Why the update failed comes first — that is what someone is looking for — and the
-            // daemon that did not come back is a second thing to act on rather than a correction.
+            // unit that did not come back is a second thing to act on rather than a correction.
             assert!(reason.contains("not healthy"), "{reason}");
-            assert!(reason.contains("did not restart"), "{reason}");
-            assert!(reason.contains("is down"), "{reason}");
+            assert!(reason.contains("the release was reverted"), "{reason}");
+
+            // The claim it must not make. Every daemon runs `Restart=always`, so a refused restart
+            // is not an outage — asserting one put "something on this robot is down" under a
+            // `robot healthy` line on a bench board.
+            assert!(
+                !reason.contains("is down"),
+                "an outage this never checked for: {reason}"
+            );
+            assert!(reason.contains("robotctl health"), "{reason}");
         }
         other => panic!("expected RolledBack, got {other:?}"),
     }


### PR DESCRIPTION
A board reported, in one line, that a release had been reverted and *"so something on this robot is down"* — directly above its own `robot healthy` line. The claim was false, and for a reason that fires on nearly every rollback rather than in a race.

## What happens

systemd defaults to `StartLimitBurst=5` per `StartLimitIntervalSec=10s`; `robotd` sets `RestartSec=2s`. A daemon that exits immediately burns that budget in ten seconds, and every start after it is refused with `Start request repeated too quickly`. The health gate is still counting down its thirty, so the revert's own restart lands inside the refusal:

```
14:54:55–14:55:13   robotd restart counter climbs 5 → 13, each exit immediate
14:55:14            rollback swaps current back, then runs `systemctl restart robotd`
14:55:14            robotd.service: Start request repeated too quickly.   ← the "failure"
14:55:20            robotd up on the reverted release, healthy since
```

## The fix

`restart_one` clears the counter with `reset-failed` and tries once more. Unconditional rather than matched on the error text — `reset-failed` is a no-op on a unit that is not failed, and the alternative is grepping systemd's prose in whatever locale it was built with. A unit that genuinely cannot start refuses the second time too and is reported then.

The wording goes with it: the outcome reports the refusal it observed and names `robotctl health`, which answers the question it cannot. And `try_restart` names the unit in the error — the caller restarts up to six of them, and systemd's own "Job for X.service failed" was the only thing that ever said which.

## Tests

Two new ones in `restart_tests`: a stub that refuses like systemd and accepts after `reset-failed` (asserting the counter is cleared), and one that refuses both times (asserting two attempts and an error, so the retry cannot become "ignore the first failure"). `updater/tests/apply.rs` and `scripts/systemd-test.sh` now assert the outcome does **not** claim an outage it never checked for.

294 tests pass; clippy clean.

## Not in this PR

The other half of the board's complaint — the reason names the gate's symptom (`unreachable`) and never the cause, which was one line away in robotd's journal. Separate change.