### PR TITLE
Camera 3a

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -166,6 +166,8 @@ jobs:
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
             --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
+            --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
+            --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -154,6 +154,8 @@ jobs:
             --include "robotd/systemd/robotd.service=systemd/robotd.service" \
             --include "hooks/postinstall=hooks/postinstall" \
             --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
+            --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
+            --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/docs/project/media-bringup.md
+++ b/docs/project/media-bringup.md
@@ -336,7 +336,8 @@ is two lines standing between a working pipeline and four different confusing fa
 
 **The bitrate came out ~50× under target.** 15,553 bytes for 3.3 s of capture against
 `bps=2000000` is about 37 kbps. Either the scene was static enough for CBR to collapse — plausible,
-the ISP was on raw defaults and the image is green and noisy until `setup_rkaiq.sh` runs — or
+the ISP was on raw defaults and the image is green and noisy until `scripts/setup-rkaiq.sh` runs
+(ported from the prototype; provisioning and the pre-install hook both run it now) — or
 capture is delivering well below 30 fps. The frame count has not been measured. If it is the
 latter, the sensor mode is the suspect: the IMX219 boots in 3280x2464 and the prototype pins the
 mode with `media-ctl` before every capture (`camera.rs:277`).

--- a/hooks/preinstall.in
+++ b/hooks/preinstall.in
@@ -155,6 +155,27 @@ install_gstreamer() {
     fi
 }
 
+# The camera's 3A engine, for the same reason and on the same terms as the GStreamer stack
+# above: it is what gives the camera auto exposure and white balance, a board provisioned
+# before it existed should get it from an ordinary update, and a board that cannot install it
+# still has a robot — with a green, fixed-exposure camera.
+install_rkaiq() {
+    script=scripts/setup-rkaiq.sh
+    if [ ! -f "$script" ]; then
+        say "no ${script} in this release; skipping the camera 3A engine"
+        return 0
+    fi
+
+    say "checking the camera 3A engine"
+    if sh "$script"; then
+        say "camera 3A engine ready"
+    else
+        say "the camera 3A engine did not finish installing — the camera will run on raw ISP
+  defaults, which is green, noisy and fixed-exposure. Everything else is unaffected. To retry:
+    sudo /usr/local/sbin/robot-setup-rkaiq"
+    fi
+}
+
 have="$(installed_onnx)"
 
 if at_least "$have" "$ONNX_FLOOR"; then
@@ -174,3 +195,4 @@ else
 fi
 
 install_gstreamer
+install_rkaiq

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -63,8 +63,10 @@ struct Args {
 
     /// Sensor exposure in lines (~19 µs each) and analogue gain, where 256 is 1x.
     ///
-    /// There is no 3A daemon on this platform, so nothing converges these. The defaults are the
-    /// prototype's, and with the boot values the picture is black rather than merely dark.
+    /// The starting values only: with the driver's boot values the picture is black rather than
+    /// merely dark, so something must write the sensor before the first frame. On a board where
+    /// `scripts/setup-rkaiq.sh` installed the 3A engine, it converges exposure from here; on one
+    /// where it did not, these are what the camera keeps. The defaults are the prototype's.
     #[arg(long, default_value_t = 600)]
     exposure: u32,
 

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -84,6 +84,17 @@ struct Args {
 
     #[arg(long, default_value_t = 30)]
     fps: u32,
+
+    /// Turn the picture this many degrees clockwise: 0, 90, 180 or 270.
+    ///
+    /// **90 because the head camera is mounted a quarter turn off**, so a straight capture is
+    /// sideways. This is the one place that fact is written down; see `pipeline::Rotation` for why
+    /// it is turned on the robot rather than in the console.
+    ///
+    /// A quarter turn swaps the frame's width and height, and it costs a CPU pass — `--rotate 0`
+    /// is the way to take that pass out if the control loop starts missing ticks while streaming.
+    #[arg(long, default_value_t = 90)]
+    rotate: u32,
 }
 
 #[cfg(target_os = "linux")]
@@ -105,6 +116,16 @@ fn main() -> ExitCode {
         Ok(runtime) => runtime,
         Err(e) => {
             tracing::error!(error = %e, "no tokio runtime");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Refused before anything starts: a bad angle is a typo on a command line, and the daemon
+    // should say so rather than opening a camera first.
+    let rotation = match mediad::pipeline::Rotation::from_degrees(args.rotate) {
+        Ok(rotation) => rotation,
+        Err(e) => {
+            tracing::error!(error = %e, "mediad cannot start");
             return ExitCode::FAILURE;
         }
     };
@@ -152,10 +173,6 @@ fn main() -> ExitCode {
             mediad::pipeline::Source::Test
         };
 
-        // `_frames` is the raw NV12 tap off the tee. Nothing reads it yet — perception and the
-        // `get_frame` surface in `architecture.md` §5.3 are what it is for — but the branch runs
-        // from the start rather than being added later, because a tee inserted into a live
-        // pipeline is a different and much harder problem than a tee that was always there.
         let settings = mediad::pipeline::Settings {
             host: args.host.clone(),
             port: args.port,
@@ -163,8 +180,13 @@ fn main() -> ExitCode {
             width: args.width,
             height: args.height,
             fps: args.fps,
+            rotation,
         };
 
+        // `_frames` is the raw NV12 tap off the tee. Nothing reads it yet — perception and the
+        // `get_frame` surface in `architecture.md` §5.3 are what it is for — but the branch runs
+        // from the start rather than being added later, because a tee inserted into a live
+        // pipeline is a different and much harder problem than a tee that was always there.
         let (_pipeline, mut channels, _frames) =
             match mediad::pipeline::start(source, &producer, &settings) {
                 Ok(started) => started,

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -7,9 +7,9 @@
 //! ## Shape
 //!
 //! ```text
-//!                                    ┌─ queue ─ webrtcsink ── encoder-setup → mpph264enc
-//! videotestsrc | camera ─ NV12 ─ tee ┤              │
-//!                                    └─ queue ─     │  run-signalling-server=true
+//!                                                ┌─ queue ─ webrtcsink ─ setup → mpph264enc
+//! videotestsrc | camera ─ NV12 ─ videoflip ─ tee ┤          │
+//!                                                └─ queue ─ │  run-signalling-server=true
 //!                                       (leaky)     │
 //!                                          │        └─ consumer-added → "control" channel
 //!                                      appsink
@@ -23,7 +23,14 @@
 //! need pixels, and taking them off the encoded branch would mean decoding what we just encoded.
 //!
 //! NV12 because that is what the rkisp capture path emits and what `mpph264enc` takes, so nothing
-//! converts anywhere: no `videoconvert`, and no RGA pass, between capture and either consumer.
+//! *converts* anywhere: no `videoconvert`, and no RGA pass, between capture and either consumer.
+//!
+//! **`videoflip` is the one pass, and it is a rotation rather than a conversion.** The head camera
+//! is mounted a quarter turn off, so a straight capture is sideways; turning it before the tee is
+//! what lets both consumers — and the console's drag-to-look, which maps a gaze off the same
+//! geometry — agree about which way is up. It costs CPU on the SoC that runs `robotd`'s control
+//! loop, which is why it is one element and one flag ([`Rotation`], `--rotate 0`) rather than a
+//! property of the pipeline nobody can take out.
 //!
 //! **Each branch has its own `queue`, and the raw one is leaky.** A `tee` without queues runs its
 //! branches on one thread, so a slow consumer stalls the others — here that would mean a
@@ -82,6 +89,67 @@ use gstreamer_video as gst_video;
 use gstreamer_webrtc as gst_webrtc;
 use tokio::sync::mpsc;
 
+/// How far the picture is turned before anything downstream sees it.
+///
+/// **The head camera is mounted a quarter turn off**, so the sensor's rows run down the world
+/// rather than across it and a straight capture comes out sideways. That is a fact about the
+/// robot, not a preference, which is why the default is a quarter turn rather than none.
+///
+/// Turned here rather than in the console, and the console is the reason: it maps a drag on the
+/// picture to a gaze (`aim` in `webclient/index.html`), so a page that rotated the video in CSS
+/// would send the robot looking 90° away from where the operator pointed. Rotating before the tee
+/// also means the raw branch — the one a perception consumer reads — sees the same picture the
+/// stream does, rather than each consumer having to know about the mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rotation {
+    /// Leave the frame as the sensor delivered it.
+    None,
+    /// A quarter turn clockwise: what this robot's mount needs.
+    Cw90,
+    Cw180,
+    /// A quarter turn anticlockwise, for a head assembled the other way round.
+    Cw270,
+}
+
+impl Rotation {
+    /// From degrees clockwise, which is how the flag is written.
+    pub fn from_degrees(degrees: u32) -> Result<Self> {
+        match degrees {
+            0 => Ok(Self::None),
+            90 => Ok(Self::Cw90),
+            180 => Ok(Self::Cw180),
+            270 => Ok(Self::Cw270),
+            other => Err(anyhow!(
+                "rotation must be 0, 90, 180 or 270 degrees clockwise, not {other}"
+            )),
+        }
+    }
+
+    /// `videoflip`'s `video-direction`, or `None` where there is nothing to do.
+    ///
+    /// `90r` is clockwise and `90l` anticlockwise, which is GStreamer's naming and not ours.
+    fn video_direction(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::Cw90 => Some("90r"),
+            Self::Cw180 => Some("180"),
+            Self::Cw270 => Some("90l"),
+        }
+    }
+
+    /// The frame size after the turn. A quarter turn swaps the axes; a half turn does not.
+    ///
+    /// Everything that reads a raw frame depends on this being right: [`Frame`] carries the
+    /// dimensions the buffer is in, and a consumer handed 1280x720 for a 720x1280 buffer reads
+    /// the picture diagonally rather than failing.
+    fn output(self, width: u32, height: u32) -> (u32, u32) {
+        match self {
+            Self::Cw90 | Self::Cw270 => (height, width),
+            Self::None | Self::Cw180 => (width, height),
+        }
+    }
+}
+
 /// Where the signalling server listens, and what the video is.
 ///
 /// One value rather than six positional arguments. `start` had reached eight of them, and two of
@@ -99,6 +167,9 @@ pub struct Settings {
     pub width: u32,
     pub height: u32,
     pub fps: u32,
+    /// How far to turn the picture; see [`Rotation`]. The capture geometry above is the sensor's,
+    /// *before* this is applied.
+    pub rotation: Rotation,
 }
 
 /// Where the video comes from.
@@ -175,8 +246,13 @@ pub fn start(
         width,
         height,
         fps,
+        rotation,
         ..
     } = settings;
+
+    // What leaves the pipeline, which is what every consumer downstream of the tee sees. Only the
+    // capture side uses `width`/`height` from here on.
+    let (out_width, out_height) = rotation.output(width, height);
     let host = settings.host.as_str();
 
     // `GST_DEBUG` has to be in the environment before `init`, which is when GStreamer parses it.
@@ -241,6 +317,36 @@ pub fn start(
         .property("caps", &caps)
         .build()
         .map_err(|_| anyhow!("no capsfilter element; gstreamer core is incomplete"))?;
+
+    // ── the turn ────────────────────────────────────────────────────────────
+    //
+    // `videoflip` from `gstreamer1.0-plugins-good`, which the board already has — see the package
+    // list in `scripts/setup-gstreamer.sh`. It is a CPU pass, and this pipeline was built to have
+    // none: "no `videoconvert`, and no RGA pass, between capture and either consumer". A quarter
+    // turn of 4:2:2 720p is real work (a scattered write per pixel, so the copy is cache-hostile
+    // rather than merely large), and it lands on the SoC that also runs `robotd`'s control loop.
+    //
+    // It buys a picture that is the right way up for every consumer at once, which is worth a
+    // pass — but if the loop starts missing ticks when the camera streams, this is the first
+    // thing to suspect and `--rotate 0` is how to confirm it in one restart. The cheaper fix, if
+    // it comes to that, is the SoC's 2D engine: the RGA is already doing one operation per frame
+    // inside `mpph264enc`, and a rotation is the same class of operation — it needs an RGA element
+    // in the plugin set, which this one does not have.
+    let flip = match rotation.video_direction() {
+        Some(direction) => Some(
+            gst::ElementFactory::make("videoflip")
+                .property_from_str("video-direction", direction)
+                .build()
+                .map_err(|_| {
+                    anyhow!(
+                        "no videoflip element, so the picture cannot be turned the right way up. \
+                         It comes from gstreamer1.0-plugins-good: \
+                         sudo /usr/local/sbin/robot-setup-gstreamer"
+                    )
+                })?,
+        ),
+        None => None,
+    };
 
     let tee = make("tee")?;
 
@@ -348,9 +454,20 @@ pub fn start(
         .build()
         .map_err(|_| anyhow!("no queue element; gstreamer core is incomplete"))?;
 
+    // The turn happens before the tee, so this branch carries the rotated geometry. Built from
+    // `out_width`/`out_height` rather than reusing `caps`: handing the appsink the capture caps
+    // would fail negotiation on a quarter turn, and silently describe the wrong shape on a half
+    // one.
+    let out_caps = gst::Caps::builder("video/x-raw")
+        .field("format", CAPTURE_FORMAT)
+        .field("width", out_width as i32)
+        .field("height", out_height as i32)
+        .field("framerate", gst::Fraction::new(fps as i32, 1))
+        .build();
+
     let frames = Frames::default();
     let appsink = gst_app::AppSink::builder()
-        .caps(&caps)
+        .caps(&out_caps)
         // `sync=false` so this branch never waits on the clock: a snapshot wants the newest frame
         // as soon as it exists, and pacing it would only add latency to a consumer that is not
         // rendering anything.
@@ -358,7 +475,13 @@ pub fn start(
         .max_buffers(1)
         .drop(true)
         .build();
-    wire_frames(&appsink, frames.clone(), width, height);
+    wire_frames(&appsink, frames.clone(), out_width, out_height);
+
+    if let Some(flip) = flip.as_ref() {
+        pipeline
+            .add(flip)
+            .context("could not add videoflip to the pipeline")?;
+    }
 
     pipeline
         .add_many([
@@ -384,7 +507,11 @@ pub fn start(
         consumers.clone(),
     )?;
 
-    gst::Element::link_many([&src, &capsfilter, &tee]).context(
+    match flip.as_ref() {
+        Some(flip) => gst::Element::link_many([&src, &capsfilter, flip, &tee]),
+        None => gst::Element::link_many([&src, &capsfilter, &tee]),
+    }
+    .context(
         "could not link the source to the tee. A caps failure here means the source cannot \
          produce NV12 at the requested size and rate.",
     )?;
@@ -418,6 +545,9 @@ pub fn start(
         ?source,
         width,
         height,
+        out_width,
+        out_height,
+        ?rotation,
         fps,
         "signalling server listening"
     );
@@ -1191,4 +1321,54 @@ fn open_control_channel(
 
     tracing::info!(peer, "control channel open");
     Ok(Channel { inbound, outbound })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A quarter turn swaps the frame's axes; a half turn does not.
+    ///
+    /// [`Frame`] carries the dimensions its buffer is in, and the raw branch is handed these
+    /// rather than reading them back off the caps. Get this wrong and a consumer reads a 720x1280
+    /// picture as 1280x720 — which is not a failure, it is a diagonal smear, and the kind of thing
+    /// that gets blamed on the camera.
+    #[test]
+    fn a_quarter_turn_swaps_the_frame_size() {
+        assert_eq!(Rotation::None.output(1280, 720), (1280, 720));
+        assert_eq!(Rotation::Cw90.output(1280, 720), (720, 1280));
+        assert_eq!(Rotation::Cw180.output(1280, 720), (1280, 720));
+        assert_eq!(Rotation::Cw270.output(1280, 720), (720, 1280));
+    }
+
+    /// The mount is a quarter turn clockwise, and `90r` is GStreamer's name for that.
+    ///
+    /// Named the wrong way round, the picture is upside down twice over: the console's drag-to-look
+    /// maps a gaze off the same geometry, so a 180° error there sends the robot looking away from
+    /// where the operator pointed rather than merely showing a sideways picture.
+    #[test]
+    fn clockwise_is_90r_and_identity_is_nothing_at_all() {
+        assert_eq!(Rotation::Cw90.video_direction(), Some("90r"));
+        assert_eq!(Rotation::Cw270.video_direction(), Some("90l"));
+        assert_eq!(Rotation::Cw180.video_direction(), Some("180"));
+        // Not `Some("identity")`: no element is built at all, so the pass costs nothing.
+        assert_eq!(Rotation::None.video_direction(), None);
+    }
+
+    /// Only the four right angles, and a wrong one is refused rather than rounded.
+    #[test]
+    fn only_right_angles_are_accepted() {
+        for (degrees, expected) in [
+            (0, Rotation::None),
+            (90, Rotation::Cw90),
+            (180, Rotation::Cw180),
+            (270, Rotation::Cw270),
+        ] {
+            assert_eq!(Rotation::from_degrees(degrees).unwrap(), expected);
+        }
+        for bad in [45, 89, 91, 360, 1] {
+            let error = Rotation::from_degrees(bad).unwrap_err().to_string();
+            assert!(error.contains("0, 90, 180 or 270"), "{error}");
+        }
+    }
 }

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -113,10 +113,13 @@ pub enum Source {
 
 /// The head camera, and the two things it will not work without.
 ///
-/// **There is no 3A daemon on this platform.** Nothing converges exposure or gain, so a capture
-/// with the driver's boot defaults comes out black — this is not tuning, it is the difference
-/// between a picture and no picture. Values are in the sensor's own units: exposure in lines
-/// (~19 µs each) and analogue gain where 256 is 1x, up to 2816 for 11x.
+/// **These are a starting exposure, not a policy.** A capture with the driver's boot defaults
+/// comes out black, so something has to write the sensor before the first frame — that is what
+/// these are for, and they are the difference between a picture and no picture on a board with
+/// no 3A. Where `scripts/setup-rkaiq.sh` has run, Rockchip's engine owns exposure from its first
+/// statistics onward and these hold for the few frames before that; where it has not, they are
+/// all there is and the picture stays at one exposure. Values are in the sensor's own units:
+/// exposure in lines (~19 µs each) and analogue gain where 256 is 1x, up to 2816 for 11x.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Camera {
     pub device: String,

--- a/mediad/webclient/index.html
+++ b/mediad/webclient/index.html
@@ -67,8 +67,12 @@
   .row { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
   .hint { margin: .5rem 0 0; font-size: 12px; opacity: .6; }
 
+  /* 16/9 is the placeholder, held only until a frame arrives: the robot's camera is mounted a
+     quarter turn off and `mediad --rotate` turns it, so the picture is portrait. `fitVideoBox`
+     then gives the box the stream's own shape — a box pinned to 16/9 would letterbox a portrait
+     picture into a sliver, and it is the surface the operator drags on to aim. */
   video { width: 100%; background: #111; aspect-ratio: 16/9; border-radius: 4px; display: block;
-          touch-action: none; cursor: crosshair; }
+          touch-action: none; cursor: crosshair; margin: 0 auto; }
   .stats { margin-top: .5rem; font: 12px/1.4 ui-monospace, monospace; gap: .75rem; }
   .stats b { font-weight: 600; opacity: .55; font-size: 11px; text-transform: uppercase; }
 
@@ -388,6 +392,24 @@ function newPeerConnection() {
     log("dim", "track:", event.track.kind);
     $("video").srcObject = event.streams[0];
   };
+
+  // Take the box's shape from the stream rather than assuming landscape. `loadedmetadata` is the
+  // first point the dimensions are known, and `resize` covers a stream that changes shape while
+  // playing — which a `--rotate` change on the robot does, without the page reloading.
+  const fitVideoBox = () => {
+    const element = $("video");
+    const { videoWidth: w, videoHeight: h } = element;
+    if (!w || !h) return;
+    element.style.aspectRatio = `${w} / ${h}`;
+    // Landscape fills the column; portrait is capped by height instead, or `width: 100%` on a
+    // 9:16 stream makes a box nearly twice the column's width tall and pushes everything else
+    // off the screen.
+    const portrait = h > w;
+    element.style.width = portrait ? "auto" : "100%";
+    element.style.height = portrait ? "min(70vh, 80vw)" : "auto";
+  };
+  $("video").addEventListener("loadedmetadata", fitVideoBox);
+  $("video").addEventListener("resize", fitVideoBox);
 
   pc.onicecandidate = (event) => {
     if (!event.candidate) return;

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -372,6 +372,8 @@ cargo run -p xtask -- package \
     --include "robotd/systemd/robotd.service=systemd/robotd.service" \
     --include "hooks/postinstall=hooks/postinstall" \
     --include "scripts/setup-gstreamer.sh=scripts/setup-gstreamer.sh" \
+    --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
+    --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
     --include "scripts/robot-rescue=scripts/robot-rescue" \
     --include "scripts/robot-boot-check=scripts/robot-boot-check" \
     --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/scripts/provision-board.sh
+++ b/scripts/provision-board.sh
@@ -47,6 +47,10 @@
 #   --no-gstreamer    skip the GStreamer stack `mediad` needs. Installed by default, with a
 #                     report of what this board can encode. It needs no reboot, so it can also
 #                     be added or re-run later:  sudo /usr/local/sbin/robot-setup-gstreamer
+#   --no-rkaiq        skip the camera's 3A engine (auto exposure, white balance, denoise).
+#                     Installed by default. Without it the camera runs on raw ISP defaults:
+#                     green, noisy and stuck at one exposure. Re-run later with:
+#                     sudo /usr/local/sbin/robot-setup-rkaiq
 #   --weird-ble       for a Radxa Zero 3W whose Bluetooth cannot bond a gamepad at all, even with
 #                     `btd` paused. Implies `--pause-btd-on-pair`, and additionally sets
 #                     `Privacy = device`.
@@ -109,6 +113,7 @@ USE_LOCAL=""
 NO_BLE=""
 WEIRD_BLE=""
 NO_GSTREAMER=""
+NO_RKAIQ=""
 PAUSE_BTD=""
 # The name to give the robot. Not `BLE_NAME` below, which points the other way: the name this board
 # already answers to, used to find it again after the reboot.
@@ -184,6 +189,7 @@ while [ $# -gt 0 ]; do
         --no-dev-key) NO_DEV_KEY=1; shift ;;
         --no-ble)     NO_BLE=1; shift ;;
         --no-gstreamer) NO_GSTREAMER=1; shift ;;
+        --no-rkaiq)   NO_RKAIQ=1; shift ;;
         --weird-ble)  WEIRD_BLE=1; shift ;;
         --pause-btd-on-pair) PAUSE_BTD=1; shift ;;
         --local)      USE_LOCAL=1; shift ;;
@@ -690,6 +696,7 @@ _env="DUCK_TOKEN='${DUCK_TOKEN:-}'"
 [ -z "$WEIRD_BLE" ] || _env="${_env} DUCK_WEIRD_BLE=1"
 [ -z "$PAUSE_BTD" ]  || _env="${_env} DUCK_PAUSE_BTD=1"
 [ -z "$NO_GSTREAMER" ] || _env="${_env} DUCK_GSTREAMER=0"
+[ -z "$NO_RKAIQ" ]     || _env="${_env} DUCK_RKAIQ=0"
 
 # The name is a flag rather than one more `DUCK_*`, because on the board it goes no further than
 # `robotctl system set-name`. Single-quoted with any quote of its own escaped: a name is free text,

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -68,6 +68,7 @@ ENV_DEV_KEY="${DUCK_DEV_KEY:-}"
 ENV_FORCE="${DUCK_FORCE_REINSTALL:-}"
 ENV_WEIRD_BLE="${DUCK_WEIRD_BLE:-}"
 ENV_GSTREAMER="${DUCK_GSTREAMER:-}"
+ENV_RKAIQ="${DUCK_RKAIQ:-}"
 
 REPO="${ENV_REPO:-pollen-robotics/microduck}"
 REF="${ENV_REF:-main}"
@@ -128,6 +129,17 @@ WEIRD_BLE="$ENV_WEIRD_BLE"
 # default rather than a flag anybody has to know about.
 GSTREAMER="${ENV_GSTREAMER:-1}"
 
+# Install the camera's 3A engine? Passed to `setup-rkaiq.sh`.
+#
+# **On** by default, and paired with the GStreamer stack above: that one makes the board able to
+# encode a picture, this one makes the picture worth encoding. Without it the ISP has no tuning
+# and no 3A loop — green, noisy, and stuck at whatever exposure `mediad` pinned — so a board
+# with the stack and not the engine has a camera nobody wants to look at.
+#
+# `DUCK_RKAIQ=0` turns it off — `--no-rkaiq` on `provision-board.sh`. Empty is *not* off, for
+# the reason spelled out above.
+RKAIQ="${ENV_RKAIQ:-1}"
+
 # The branch the operator asked for, or empty. Kept apart from `REF` because they answer different
 # questions: `REF` is always set — it defaults to `main` — and says where the *scripts* come from,
 # while this says whether a *branch build of the daemon* was asked for. Provisioning plainly with no
@@ -166,6 +178,7 @@ DEV_KEY_KEPT="${STATE_DIR}/team.dev.pub"
 SETUP_SELF=/usr/local/sbin/robot-setup-board
 MIGRATE_SELF=/usr/local/sbin/robot-migrate-network
 GST_SELF=/usr/local/sbin/robot-setup-gstreamer
+RKAIQ_SELF=/usr/local/sbin/robot-setup-rkaiq
 
 say()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
@@ -537,6 +550,23 @@ phase_two() {
         else
             tmp=/tmp/setup-gstreamer.sh
             fetch setup-gstreamer.sh "$tmp"
+            sh "$tmp"
+        fi
+    fi
+
+    # The camera's 3A engine, on the same terms — see `RKAIQ` above. After GStreamer because it
+    # ends by restarting the camera stream, and there is no stream to restart until `mediad` has
+    # a stack to run on.
+    #
+    # Two files, not one: the script builds an LD_PRELOAD shim from the C source beside it, and
+    # fetching the script alone would leave it with nothing to compile.
+    if [ -n "$RKAIQ" ] && [ "$RKAIQ" != 0 ]; then
+        if [ -x "$RKAIQ_SELF" ]; then
+            "$RKAIQ_SELF"
+        else
+            tmp=/tmp/setup-rkaiq.sh
+            fetch setup-rkaiq.sh "$tmp"
+            fetch rkaiq-modinfo-shim.c /tmp/rkaiq-modinfo-shim.c
             sh "$tmp"
         fi
     fi

--- a/scripts/rkaiq-modinfo-shim.c
+++ b/scripts/rkaiq-modinfo-shim.c
@@ -1,0 +1,76 @@
+/* LD_PRELOAD shim for rkaiq_3A_server on the Radxa Zero 3W (RK3566).
+ *
+ * librkaiq queries the sensor driver's module info (sensor / module / lens
+ * names, used to pick the IQ tuning file in /etc/iqfiles) through the
+ * RKMODULE_GET_MODULE_INFO private ioctl. The ioctl number encodes
+ * sizeof(struct rkmodule_inf), which drifts between BSP kernel versions —
+ * the Radxa camera-engine-rkaiq deb was built against different headers
+ * than the Armbian vendor kernel (5203 vs 5207 bytes on 6.1.115), so the
+ * ioctl fails with ENOTTY, librkaiq silently ends up with an empty IQ file
+ * name ("/etc/iqfiles//") and segfaults.
+ *
+ * This shim intercepts the mismatched ioctl (type 'V', nr 0xc0 = private 0),
+ * probes the kernel's expected struct size once by brute force, performs the
+ * call with the kernel's own ioctl number, and copies back the base info
+ * (first 96 bytes: sensor[32] + module[32] + lens[32]) which is all librkaiq
+ * reads for IQ file selection.
+ *
+ * Build:   gcc -shared -fPIC -O2 -o rkaiq_modinfo_shim.so rkaiq-modinfo-shim.c -ldl
+ * Install: see scripts/setup-rkaiq.sh, which builds it on the board — the
+ *          struct size it probes for is a property of the running kernel, so a
+ *          binary built anywhere else would be guessing. The systemd drop-in
+ *          sets LD_PRELOAD for the rkaiq_3A service alone; nothing else on the
+ *          board has this ioctl intercepted.
+ *
+ * Carried here from the prototype (microduck_runtime/radxa_setup) unchanged in
+ * substance: it is the only thing that makes the Radxa engine deb run on the
+ * Armbian vendor kernel, and it was arrived at by finding the byte count.
+ */
+#define _GNU_SOURCE
+#include <string.h>
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <sys/ioctl.h>
+
+#define MODINFO_TYPE 0x56 /* 'V' */
+#define MODINFO_NR   0xc0 /* BASE_VIDIOC_PRIVATE + 0 */
+
+static int (*real_ioctl)(int, unsigned long, ...);
+
+/* Find the ioctl number the running kernel accepts for GET_MODULE_INFO by
+ * scanning candidate struct sizes. Runs once; ~10k failing syscalls ≈ 10 ms. */
+static unsigned long probe_kernel_req(int fd) {
+    static unsigned long cached;
+    if (cached) return cached;
+    static char buf[16384];
+    for (unsigned sz = 96; sz < sizeof(buf); sz++) {
+        unsigned long req = _IOC(_IOC_READ, MODINFO_TYPE, MODINFO_NR, sz);
+        if (real_ioctl(fd, req, buf) == 0) {
+            cached = req;
+            return req;
+        }
+    }
+    return 0;
+}
+
+int ioctl(int fd, unsigned long req, ...) {
+    if (!real_ioctl) real_ioctl = dlsym(RTLD_NEXT, "ioctl");
+    va_list ap; va_start(ap, req); void *arg = va_arg(ap, void*); va_end(ap);
+
+    if (_IOC_TYPE(req) == MODINFO_TYPE && _IOC_NR(req) == MODINFO_NR
+        && _IOC_DIR(req) == _IOC_READ) {
+        unsigned long kreq = probe_kernel_req(fd);
+        if (kreq != 0 && kreq != req) {
+            static char kbuf[16384];
+            memset(kbuf, 0, sizeof(kbuf));
+            int r = real_ioctl(fd, kreq, kbuf);
+            if (r == 0 && arg) {
+                unsigned sz = _IOC_SIZE(req);
+                memset(arg, 0, sz);
+                memcpy(arg, kbuf, sz < 96 ? sz : 96);
+            }
+            return r;
+        }
+    }
+    return real_ioctl(fd, req, arg);
+}

--- a/scripts/setup-rkaiq.sh
+++ b/scripts/setup-rkaiq.sh
@@ -1,0 +1,296 @@
+#!/bin/sh
+# Install Rockchip's rkaiq 3A engine and the IMX219 tuning, so the camera has auto exposure,
+# white balance and noise reduction instead of raw ISP defaults.
+#
+# Without this the ISP runs with no tuning and no 3A loop at all: the picture is green, noisy,
+# and fixed at whatever exposure `mediad` pinned at startup — which is a still photo of one
+# lighting condition, not a camera. The engine is what makes the head camera usable in a room
+# whose lights change.
+#
+#   sudo sh /tmp/setup-rkaiq.sh
+#   sudo /usr/local/sbin/robot-setup-rkaiq          # later, to re-check
+#
+# Full paths, because this advice gets copy-pasted and /tmp does not survive a reboot. The
+# first run leaves a copy at the second path.
+#
+# **`hooks/preinstall` runs this too**, from `scripts/setup-rkaiq.sh` in the release, so a board
+# provisioned before this existed gets the engine from an ordinary update rather than from
+# somebody remembering a command. Same contract as `setup-gstreamer.sh`: never prompt, never be
+# fatal, and say what happened.
+#
+#   --sensor NAME   tuning to install for (default imx219). Radxa's IQ package only ships
+#                   imx219 and ov5647; anything else needs its own
+#                   <sensor>_<module>_default.json in /etc/iqfiles.
+#   --help
+#
+# Idempotent: the debs are only fetched when missing, the IQ patch is a no-op once applied, and
+# the shim is rebuilt each run because it is cheap and because the kernel it probes can change
+# under it.
+#
+# Radxa Zero 3W on the Armbian vendor kernel. Needs the camera overlay active — the ISP
+# parameter and statistics nodes only exist there, and the engine has nothing to talk to
+# without them.
+#
+# ── Why a vendor engine at all ────────────────────────────────────────────────
+#
+# There is no other 3A on this platform. libcamera's rkisp1 IPA drives the *mainline* rkisp1
+# driver; this board runs Rockchip's vendor rkisp on the vendor kernel, which is also where the
+# hardware encoder `mediad` depends on lives (`docs/project/media-bringup.md`). Choosing
+# mainline to get an open 3A would cost the VPU, so the vendor engine — a prebuilt deb from
+# Radxa's pool, taken as a direct download the way the MPP packages are — is the route.
+#
+# ── What differs from the prototype's version of this script ──────────────────
+#
+# **rkaiq's auto exposure stays enabled here, and that is the whole point.** The prototype
+# patched `ae_calib CommCtrl.Enable` to 0 because its runtime owned sensor exposure: it ran a
+# software AE loop over decoded MJPEG frames, and pinned exposure outright in laser mode, where
+# rkaiq writing its own values at stream start turned the image black. Neither reason survives
+# here — there is no laser mode, and `mediad` has no AE of its own. So the engine owns exposure,
+# which is exactly the missing behaviour, and `mediad`'s `--exposure`/`--analogue-gain` become
+# the values the sensor holds for the few frames before the engine's first stats arrive.
+set -e
+
+SENSOR=imx219
+SELF=/usr/local/sbin/robot-setup-rkaiq
+SHIM_SO=/usr/local/lib/rkaiq_modinfo_shim.so
+IQ_DIR=/etc/iqfiles
+DROP_IN_DIR=/etc/systemd/system/rkaiq_3A.service.d
+PIN=/usr/local/bin/rkaiq-pin-sensor-mode
+
+# Radxa's apt pool, as direct .deb downloads rather than an entry in sources.list — the same
+# route `setup-gstreamer.sh` takes for MPP, and for the same reason: one pinned artifact each,
+# no third-party repository left enabled on the robot afterwards.
+POOL=https://radxa-repo.github.io/bullseye/pool/main
+RKAIQ_DEB="$POOL/c/camera-engine-rkaiq/camera_engine_rkaiq_rk3568_arm64-fixed.deb"
+IQ_DEB="$POOL/r/rockchip-iqfiles/rockchip-iqfiles-rk356x_0.1.16_all.deb"
+
+# The sensor mode the engine must agree with `mediad` about. See `pin_mode` below for why this
+# is here at all, and keep it in step with `pin_sensor_mode` in `mediad/src/pipeline.rs`.
+SENSOR_W=1920
+SENSOR_H=1080
+
+say()  { printf '== %s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '2,/^set -e/{/^set -e/d;s/^# \{0,1\}//;p;}' "$0"
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sensor) SENSOR="${2:?--sensor needs a name}"; shift 2 ;;
+        --help|-h) usage ;;
+        *) die "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+[ "$(id -u)" = 0 ] || die "run as root: sudo sh $0"
+
+# Where this script and its shim source live, so a run from /tmp, from the release, or from a
+# clone all find the C file. The release lays both out side by side under scripts/.
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SHIM_SRC="${HERE}/rkaiq-modinfo-shim.c"
+
+# ── the engine and its tuning ─────────────────────────────────────────────────
+
+fetch_deb() {
+    package="$1"
+    url="$2"
+    if dpkg -s "$package" >/dev/null 2>&1; then
+        say "${package} already installed"
+        return 0
+    fi
+    tmp="/tmp/${package}.deb"
+    say "fetching ${package}"
+    curl -fsSL -o "$tmp" "$url" || die "could not download ${url}
+  The camera works without 3A — green, noisy and fixed-exposure — so this is not fatal to the
+  robot, but it is fatal to image quality. Check the board's network and re-run:
+    sudo ${SELF}"
+    dpkg -i "$tmp" || die "dpkg could not install ${tmp}"
+    rm -f "$tmp"
+}
+
+fetch_deb camera-engine-rkaiq-rk3568 "$RKAIQ_DEB"
+fetch_deb rockchip-iqfiles-rk356x "$IQ_DEB"
+
+say "installing ${SENSOR} tuning into ${IQ_DIR}"
+mkdir -p "$IQ_DIR"
+for f in /usr/share/rockchip-iqfiles-rk356x/"${SENSOR}"_*; do
+    [ -e "$f" ] || continue
+    [ -e "${IQ_DIR}/$(basename "$f")" ] || cp "$f" "$IQ_DIR/"
+done
+
+# `set -e` plus a glob that matches nothing would end the script here, which is the wrong
+# outcome for a sensor nobody has tuning for: the engine still runs, badly, and saying so is
+# more useful than stopping.
+if ! ls "${IQ_DIR}/${SENSOR}"_*.json >/dev/null 2>&1; then
+    warn "no IQ tuning for '${SENSOR}' in ${IQ_DIR}.
+  Radxa's package ships imx219 and ov5647 only. The engine will run on raw ISP defaults, which
+  looks green and noisy. Drop a ${SENSOR}_<module>_default.json in ${IQ_DIR} to fix it."
+fi
+
+# Two enum names in Radxa's IQ file are newer than the parser in Radxa's own engine deb. Left
+# alone they are warnings, except that the AE strategy field silently falls back to a default —
+# and AE is what this script exists to deliver, so it is not a warning we can shrug at.
+#
+# Only characterised for imx219: another sensor's file may not contain these names at all, and
+# rewriting enums in tuning nobody has read is how you get an image that is subtly wrong.
+if [ "$SENSOR" = imx219 ] && [ -f "${IQ_DIR}/imx219_rpi-camera-v2_default.json" ]; then
+    say "checking IQ enum names against the engine's parser"
+    python3 - <<'PY'
+# Binary mode throughout: the file has CRLF line endings that text mode would rewrite, and a
+# diff of the whole file is not what anyone wants out of this.
+path = "/etc/iqfiles/imx219_rpi-camera-v2_default.json"
+raw = open(path, "rb").read()
+renames = [
+    (b"AECV2_STRATEGY_MODE_LOWLIGHT_PRIOR", b"AECV2_STRATEGY_MODE_LOWLIGHT"),
+    (b"CALIB_AWB_HDR_FRAME_CHOOSE_MODE_AUTO", b"CALIB_AWB_HDR_FR_CH_AUTO"),
+]
+changed = 0
+for old, new in renames:
+    n = raw.count(old)
+    if n:
+        raw = raw.replace(old, new)
+        changed += n
+if changed:
+    open(path, "wb").write(raw)
+    print(f"   renamed {changed} enum value(s) the parser does not know")
+else:
+    print("   enum names already match the parser")
+
+# The prototype zeroed `ae_calib CommCtrl.Enable` here, to stop rkaiq's AE from fighting a
+# runtime that owned exposure itself. Nothing owns exposure now, so AE must be ON — and these
+# are the same physical boards, so a file left at 0 by that script (or by an apt upgrade, or by
+# hand) is the likeliest way to end up with an engine running and still no auto exposure.
+# Assert it rather than assume it: turning it back on is the entire point of this port.
+import re
+m = re.search(rb'("CommCtrl":\s*\{\s*"Enable":\s*)0', raw)
+if m:
+    raw = raw[: m.start()] + m.group(1) + b"1" + raw[m.end() :]
+    open(path, "wb").write(raw)
+    print("   auto exposure was DISABLED in this file — turned it back on")
+else:
+    print("   auto exposure is enabled")
+PY
+fi
+
+# ── the ioctl shim ────────────────────────────────────────────────────────────
+#
+# Without this, `rkaiq_3A_server` segfaults on this kernel before it ever reaches a frame; the
+# reasoning is in the C file's header. Built on the board because the struct size it probes for
+# belongs to the running kernel.
+
+if [ ! -f "$SHIM_SRC" ]; then
+    die "no ${SHIM_SRC} beside this script.
+  The release carries scripts/rkaiq-modinfo-shim.c next to scripts/setup-rkaiq.sh; a copy of
+  the script alone cannot build the shim, and the engine segfaults without it."
+fi
+
+if ! command -v gcc >/dev/null 2>&1; then
+    say "installing gcc, to build the shim"
+    apt-get install -y --no-install-recommends gcc \
+        || die "could not install gcc, so the shim cannot be built"
+fi
+
+say "building the ioctl shim"
+gcc -shared -fPIC -O2 -o "$SHIM_SO" "$SHIM_SRC" -ldl \
+    || die "could not build ${SHIM_SRC}"
+
+# ── the sensor-mode pin ───────────────────────────────────────────────────────
+#
+# `rkaiq_3A_server` reads the sensor's resolution once, at startup, and programs the ISP input
+# with it for every stream afterwards. The IMX219 boots in 3280x2464; `mediad` captures from
+# the 1920x1080 mode (`pin_sensor_mode`, which is also what gets 30 fps rather than 21). The
+# engine starts long before `mediad` does, so without this it reads the boot mode and every
+# later capture dies with CIF_ISP_PIC_SIZE_ERROR — the camera delivers no frame at all, which
+# reads as "the camera is broken" rather than "two components disagree by a resolution".
+#
+# So pin the mode before the engine starts, to the same geometry `mediad` pins. Both pinning it
+# is deliberate: `mediad` cannot rely on this script having run, and this script cannot rely on
+# `mediad` having started.
+
+say "installing the sensor-mode pin at ${PIN}"
+cat > "$PIN" <<PIN_HEAD
+#!/bin/sh
+# Pin the ${SENSOR} into its ${SENSOR_W}x${SENSOR_H} mode before rkaiq_3A_server reads it.
+# Installed by scripts/setup-rkaiq.sh. Keep in step with pin_sensor_mode in
+# mediad/src/pipeline.rs.
+SENSOR="${SENSOR}"
+WANT="${SENSOR_W}x${SENSOR_H}"
+PIN_HEAD
+cat >> "$PIN" <<'PIN_BODY'
+# This runs at sysinit, which can be before the camera driver has probed — so wait for the
+# entity rather than concluding there is no camera. Ten seconds, then give up quietly: a board
+# with no camera module must still boot, and the engine's own log says the rest.
+i=0
+while [ "$i" -lt 40 ]; do
+    for m in /dev/media*; do
+        [ -e "$m" ] || continue
+        entity=$(media-ctl -d "$m" -p 2>/dev/null \
+            | sed -n "s/^- entity [0-9]*: \(m[0-9]*_[bf]_${SENSOR} [0-9-]*\).*/\1/p" \
+            | head -1)
+        if [ -n "$entity" ]; then
+            if media-ctl -d "$m" --set-v4l2 "\"${entity}\":0[fmt:SRGGB10_1X10/${WANT}]"; then
+                echo "pinned ${entity} to ${WANT} on ${m}"
+            else
+                echo "could not pin ${entity} to ${WANT} on ${m}" >&2
+            fi
+            exit 0
+        fi
+    done
+    i=$((i + 1))
+    sleep 0.25
+done
+echo "no ${SENSOR} entity appeared; leaving the sensor mode alone" >&2
+exit 0
+PIN_BODY
+chmod 755 "$PIN"
+
+# ── wiring, and the report ────────────────────────────────────────────────────
+
+say "wiring the shim and the pin into rkaiq_3A.service"
+mkdir -p "$DROP_IN_DIR"
+cat > "${DROP_IN_DIR}/robot.conf" <<DROPIN
+# Installed by scripts/setup-rkaiq.sh. Both lines are load-bearing: LD_PRELOAD is what keeps
+# the engine from segfaulting on this kernel, and the pin is what keeps it from programming the
+# ISP with the sensor's boot resolution.
+[Service]
+Environment=LD_PRELOAD=${SHIM_SO}
+ExecStartPre=${PIN}
+DROPIN
+
+systemctl daemon-reload
+systemctl enable rkaiq_3A >/dev/null 2>&1 || warn "could not enable rkaiq_3A"
+
+# Leave a copy for the next person, exactly as setup-gstreamer.sh does.
+if [ "$(cd "$(dirname "$0")" && pwd)/$(basename "$0")" != "$SELF" ]; then
+    mkdir -p /usr/local/sbin
+    install -m 755 "$0" "$SELF"
+    install -m 644 "$SHIM_SRC" /usr/local/lib/rkaiq-modinfo-shim.c
+fi
+
+# The ISP nodes exist only on the vendor kernel with the camera overlay active. Before the
+# reboot that brings those up there is nothing to restart into, and that is a normal state
+# during provisioning rather than a failure.
+if [ -e /dev/video8 ] && [ -e /dev/video9 ]; then
+    systemctl restart rkaiq_3A || warn "rkaiq_3A would not restart"
+    # The engine either survives its own startup or segfaults in it, and which one it did is the
+    # single fact worth reporting. A second is enough for the latter.
+    sleep 1
+    if pgrep rkaiq_3A_server >/dev/null 2>&1; then
+        say "rkaiq_3A_server is running — restart the camera stream for it to take effect:
+    sudo systemctl restart mediad"
+    else
+        warn "rkaiq_3A_server is not running. The camera still works, with no 3A:
+    journalctl -t rkaiq -b --no-pager | tail -40
+  A segfault here means the shim did not match this kernel (${SHIM_SRC})."
+    fi
+else
+    say "the ISP nodes are not present yet, so nothing to start.
+  That is expected before the reboot into the vendor kernel with the camera overlay; rkaiq_3A
+  is enabled and starts on the next boot."
+fi
+
+say "done"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1270,6 +1270,39 @@ mod tests {
         );
     }
 
+    /// `setup-rkaiq.sh` builds an LD_PRELOAD shim from a C file beside it, so the C file has to
+    /// be packaged too.
+    ///
+    /// Not covered by `every_script_the_hooks_run_is_packaged`, which watches `script=scripts/…`
+    /// assignments in the hooks: the shim is not a script anything runs, it is a source file the
+    /// script compiles. Packaged without it, the engine is installed and then segfaults on this
+    /// kernel — which looks like a broken camera rather than a missing file, and the script says
+    /// so and stops rather than guessing.
+    #[test]
+    fn the_rkaiq_shim_travels_with_its_script() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent");
+
+        const SHIM: &str = "scripts/rkaiq-modinfo-shim.c";
+        assert!(root.join(SHIM).exists(), "{SHIM} is missing");
+
+        let script = std::fs::read_to_string(root.join("scripts/setup-rkaiq.sh")).unwrap();
+        assert!(
+            script.contains("rkaiq-modinfo-shim.c"),
+            "setup-rkaiq.sh must name the shim source it builds"
+        );
+
+        for workflow in PACKAGING_SITES {
+            let text = std::fs::read_to_string(root.join(workflow))
+                .unwrap_or_else(|e| panic!("{workflow}: {e}"));
+            assert!(
+                text.contains(&format!("={SHIM}")),
+                "{workflow} packages setup-rkaiq.sh but not {SHIM}, which it cannot run without"
+            );
+        }
+    }
+
     /// Same trap, same shape: `scripts/setup-gstreamer.sh` is fetched standalone with `curl`, so
     /// it carries a literal plugin version and cannot read Cargo.toml. A drift here is a board
     /// running plugins nobody can name — which is exactly what building them ourselves, from
@@ -1378,6 +1411,7 @@ mod tests {
             "setup-board.sh",
             "migrate-network.sh",
             "setup-gstreamer.sh",
+            "setup-rkaiq.sh",
             "install.sh",
             "provision.sh",
             "provision-board.sh",


### PR DESCRIPTION
# The camera gets 3A, and the picture comes out upright

The camera worked but had no auto exposure, no white balance and no denoise — nothing converged the ISP, so `mediad` pinned one exposure and that was the picture for every lighting condition. And the head camera is mounted a quarter turn off, so it was sideways too.

**`scripts/setup-rkaiq.sh`** ports Rockchip's rkaiq engine and the IMX219 tuning from the prototype. It's a sibling of `setup-gstreamer.sh` with the same contract — never prompts, never fatal, leaves a copy at `/usr/local/sbin/robot-setup-rkaiq` — and runs from provisioning (`--no-rkaiq` to skip) and the pre-install hook, so boards provisioned earlier get it from an ordinary update. The LD_PRELOAD ioctl shim (without it the engine segfaults on this kernel) and the sensor-mode pin before the engine starts are carried over intact.

**rkaiq's own AE stays enabled, unlike the prototype**, which disabled it because its runtime owned exposure — a software AE loop plus pinned values in laser mode. Neither applies here, and AE is the missing behaviour. Since these are the same physical boards, the script sets the flag back to 1 if it finds it off.

**`mediad --rotate`** (default 90° clockwise) turns the picture before the tee, so the stream, the raw perception branch, and the console's drag-to-look — which maps a gaze off the same geometry — all agree which way is up. A quarter turn swaps the frame's axes, so the raw branch gets post-rotation caps and `Frame` carries the rotated size. The console stops assuming landscape.

Both validated on the robot. Note: the rotation is a CPU pass in a pipeline built to have none, on the SoC running robotd's control loop — `--rotate 0` isolates it, and the cheaper fix (RGA) needs an element our plugin build doesn't ship yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)