### PR TITLE
Held D-pad up switches drive mode again, without a restart

### DIFF
--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -216,10 +216,15 @@ fn permits(call: &proto::Call) -> bool {
         // robot, and that is `robotctl` or the pad's long-press, deliberately.
         RobotShutdown => false,
 
-        // Constant for the life of the process, and only a stick-mapping hint for local
-        // clients like `padd`. An app gets the same answer through `system.info` territory
-        // when it ever needs one; no reason to open another read to the radio today.
+        // Only a stick-mapping hint for local clients like `padd`. An app gets the same answer
+        // through `system.info` territory when it ever needs one; no reason to open another read
+        // to the radio today.
         RobotMode => false,
+
+        // Switching modes means the robot goes home, loads other policies and drives differently
+        // — and the reason to switch is that somebody just put wheels on it. That is a decision
+        // made in the room, holding the pad, the same place `robot.shutdown` is refused for.
+        RobotSetMode(_) => false,
 
         // Power to the joints. A phone button that drops the robot on the floor is not one to
         // offer, and `robot.init` is its counterpart: standing a robot up moves every joint at once,

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -177,12 +177,20 @@ mapping is the prototype's, so muscle memory carries over:
 | **LB / RB** | left / right kick |
 | **DPad-Down** | sit ↔ stand |
 | **RT / LT** | mouth (either trigger) — RT also quacks; LT rides the "wheee" while held |
+| **DPad-Up**, held 3 s | switch drive mode, walk ⇄ roller |
 | **Select**, held 2 s | sit down, then power off |
 
 There is no stop button: release the sticks and the robot stands, and `robotd`'s deadman stops it
 if `padd` dies. On a roller robot (`mode = "roller"` in `robotd.toml`) the sticks take the roller
 shaping automatically — asymmetric push/brake, no strafe — and A triggers the crouch. The
 other skills ride along: sit, kicks and the roulade work on wheels too, as the prototype has it.
+
+**Holding DPad-Up switches between the two**, for when you have just put wheels on the duck or
+taken them off: the robot quacks once for walking or twice for roller, returns to its home pose,
+loads that mode's policies there and drives again — a few seconds, torque on throughout, no
+restart. `robotd.toml` is not touched, so a reboot comes back in the configured mode; make it
+stick with `robotctl configure` (or `[policy] mode`). It is a hold rather than a press because
+D-pad up is easy to lean on while driving.
 
 `pad status` answers two questions separately, because a connected pad and a dead driver look
 identical from the outside:

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -143,7 +143,15 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// with it. Additive, same rule as every method before it — plus an optional `theremin`
 /// block in `robot.state`, absent while the instrument is down, so a client from v12 sees
 /// exactly the frame it saw before.
-pub const API_VERSION: u32 = 14;
+///
+/// # v15 — `robot.setMode`
+///
+/// Walk and roller stop being a startup constant: the mode can be switched while the robot runs,
+/// which is what the gamepad's held D-pad up does. Additive as a method — but `robot.mode`'s
+/// answer, and the policy names in the `robot.subscribe` acknowledgement, can now *change* during
+/// a session. A client that read either once and cached it forever was already making an
+/// assumption this method breaks; nothing about a frame's shape changes.
+pub const API_VERSION: u32 = 15;
 
 /// The longest an update may legitimately go quiet, in seconds — the pre-install hook's ceiling.
 ///
@@ -378,12 +386,20 @@ pub mod method {
     pub const ROBOT_CHORALE: &str = "robot.chorale";
     /// Sit down gracefully, then power the machine off. The prototype's Select long-press.
     pub const ROBOT_SHUTDOWN: &str = "robot.shutdown";
-    /// Which drive mode this `robotd` was configured with: `walk` or `roller`.
+    /// Which drive mode this `robotd` is in: `walk` or `roller`.
     ///
-    /// Constant for the life of the process — switching modes is a params edit plus a
-    /// restart. Exists so `padd` can shape its stick mapping to the mode without owning
-    /// config it has no business reading.
+    /// `[policy] mode` is where it starts; [`ROBOT_SET_MODE`] moves it while the robot runs, so
+    /// this is a question with a changing answer rather than a startup constant. Exists so `padd`
+    /// can shape its stick mapping to the mode without owning config it has no business reading.
     pub const ROBOT_MODE: &str = "robot.mode";
+
+    /// Switch drive mode: `walk` or `roller`.
+    ///
+    /// Held on the gamepad's D-pad up, as the prototype held it — putting wheels on a duck is a
+    /// thing you do in the room with it, not from a laptop. The robot returns to its home pose,
+    /// loads the other mode's policies, and drives again; the config is untouched, so a reboot
+    /// comes back in the configured mode.
+    pub const ROBOT_SET_MODE: &str = "robot.setMode";
 
     /// Turn the connection into a stream of [`ROBOT_STATE`] notifications.
     pub const ROBOT_SUBSCRIBE: &str = "robot.subscribe";
@@ -613,6 +629,8 @@ pub enum Call {
     RobotShutdown,
     /// Which drive mode this robotd runs: walk or roller.
     RobotMode,
+    /// Switch drive mode; see [`method::ROBOT_SET_MODE`].
+    RobotSetMode(SetModeParams),
     RobotSubscribe(SubscribeParams),
     // ── net.* ────────────────────────────────────────────────────────────────
     NetStatus,
@@ -737,6 +755,7 @@ impl Call {
             Call::ChoraleHeard(_) => method::CHORALE_HEARD,
             Call::RobotShutdown => method::ROBOT_SHUTDOWN,
             Call::RobotMode => method::ROBOT_MODE,
+            Call::RobotSetMode(_) => method::ROBOT_SET_MODE,
             Call::RobotSubscribe(_) => method::ROBOT_SUBSCRIBE,
             Call::NetStatus => method::NET_STATUS,
             Call::NetScan => method::NET_SCAN,
@@ -848,6 +867,7 @@ impl Call {
             | Call::RobotSound(_)
             | Call::RobotTheremin(_)
             | Call::RobotChorale(_)
+            | Call::RobotSetMode(_)
             | Call::RobotShutdown => (Robot, Prompt),
             Call::RobotSubscribe(_) => (Robot, Stream),
             // `btd` asking what to put on the air. The answering connection carries the beacon
@@ -931,6 +951,7 @@ impl Call {
             Call::RobotDo(p) => encode(p),
             Call::RobotPose(p) => encode(p),
             Call::RobotMouth(p) => encode(p),
+            Call::RobotSetMode(p) => encode(p),
             Call::RobotSound(p) => encode(p),
             Call::RobotTheremin(p) => encode(p),
             Call::RobotChorale(p) => encode(p),
@@ -1013,6 +1034,7 @@ impl Call {
             method::CHORALE_HEARD => Call::ChoraleHeard(decode(params)?),
             method::ROBOT_SHUTDOWN => Call::RobotShutdown,
             method::ROBOT_MODE => Call::RobotMode,
+            method::ROBOT_SET_MODE => Call::RobotSetMode(decode(params)?),
             method::ROBOT_SUBSCRIBE => Call::RobotSubscribe(decode(params)?),
             method::NET_STATUS => Call::NetStatus,
             method::NET_SCAN => Call::NetScan,
@@ -1684,6 +1706,16 @@ impl Default for PoseParams {
 pub struct MouthParams {
     /// 0 closed, 1 fully open. Clamped by the robot.
     pub open: f64,
+}
+
+/// Which mode to switch to, for [`Call::RobotSetMode`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SetModeParams {
+    /// `"walk"` or `"roller"`. A string for the same reason [`ModeResult`] carries one: a mode
+    /// this build has never heard of should come back as a refusal naming what it does know,
+    /// not as a parse error with no explanation in it.
+    pub mode: String,
 }
 
 /// Answer to [`Call::RobotMode`].

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -96,6 +96,12 @@ fn permits(call: &proto::Call) -> bool {
         // which is the condition BLE could not meet.
         RobotShutdown => true,
 
+        // Not this one, even though the peer can watch. A mode switch says "this duck now has
+        // wheels on it", which is a claim about hardware only somebody in the room can make —
+        // and getting it wrong drives the robot with the wrong policy. The pad in that room is
+        // where it belongs.
+        RobotSetMode(_) => false,
+
         // ── the streams BLE pointed here ────────────────────────────────────
         //
         // `pad.input` exists to measure the cadence of its own delivery, and `btd` refuses it

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -156,6 +156,13 @@ const IDLE_POLL: Duration = Duration::from_millis(500);
 /// Select held this long sits the robot down and powers it off.
 const SHUTDOWN_HOLD: Duration = Duration::from_secs(2);
 
+/// D-pad up held this long switches drive mode, walk ⇄ roller.
+///
+/// Three seconds, longer than the shutdown hold, and the prototype's number. D-pad up is a
+/// direction anybody might lean on for a moment while driving; the mode switch takes the robot
+/// home and reloads its policies, so it has to be a hold nobody performs by accident.
+const MODE_HOLD: Duration = Duration::from_secs(3);
+
 /// Body-pose stick ranges, from the training env via the prototype: z is asymmetric
 /// (little headroom up at the standing height, more crouch down), angles capped at ~15°.
 const BODY_MAX_Z_UP: f64 = 0.010;
@@ -225,10 +232,10 @@ fn main() -> std::process::ExitCode {
 
     let mut next_id = 1u64;
 
-    // Which robot is this? A roller duck wants the roller stick shaping. Asked once —
-    // the answer cannot change while robotd lives, and neither process outlives a restart
-    // of the other in practice (systemd restarts both on update).
-    let roller = match request(&mut stream, &mut next_id, &proto::Call::RobotMode) {
+    // Which robot is this? A roller duck wants the roller stick shaping. Asked once at startup,
+    // then kept in step by the D-pad-up switch below — which is this process asking for the
+    // change, so it knows the answer without asking again.
+    let mut roller = match request(&mut stream, &mut next_id, &proto::Call::RobotMode) {
         Ok(Some(answer)) => match answer.result_as::<proto::ModeResult>() {
             Ok(mode) => mode.mode == "roller",
             Err(_) => false,
@@ -240,7 +247,8 @@ fn main() -> std::process::ExitCode {
         hz = args.hz,
         roller,
         "driving — Start toggles the policy, Y head mode, B body pose, A ground pick, \
-         LB/RB kicks, DPad-Down sit, triggers mouth, Select (2s) shutdown"
+         LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Up (3s) walk/roller, \
+         Select (2s) shutdown"
     );
 
     let period = Duration::from_secs_f64(1.0 / args.hz as f64);
@@ -248,6 +256,8 @@ fn main() -> std::process::ExitCode {
     // Whether a pad was there last tick, so appearing and disappearing are each logged once.
     let mut driving = false;
     let mut select_held_since: Option<Instant> = None;
+    let mut dpad_up_held_since: Option<Instant> = None;
+    let mut mode_switch_sent = false;
     let mut shutdown_sent = false;
     // Trigger levels last tick, for the sound edges: RT quacks on its rising edge, LT
     // starts the wheee ride. The prototype's threshold.
@@ -423,6 +433,49 @@ fn main() -> std::process::ExitCode {
         } else {
             select_held_since = None;
             shutdown_sent = false;
+        }
+
+        // D-pad up held three seconds: switch drive mode, which is what somebody who has just
+        // put wheels on the duck (or taken them off) wants. Sent once per hold, and the target is
+        // named rather than toggled — so a request that crosses a switch from somewhere else asks
+        // for a mode rather than for "the other one", which could be either by the time it lands.
+        if pad.is_pressed(Button::DPadUp) {
+            let held = dpad_up_held_since.get_or_insert(tick);
+            if tick.duration_since(*held) >= MODE_HOLD && !mode_switch_sent {
+                mode_switch_sent = true;
+                let target = if roller { "walk" } else { "roller" };
+                tracing::warn!(
+                    target,
+                    "DPad-Up held — asking the robot to switch drive mode"
+                );
+                let call = proto::Call::RobotSetMode(proto::SetModeParams {
+                    mode: target.to_owned(),
+                });
+                match request(&mut stream, &mut next_id, &call) {
+                    Ok(Some(answer)) => match answer.result_as::<proto::IntentResult>() {
+                        // The stick shaping follows the robot, and only when it agreed: a refused
+                        // switch that changed the mapping here would leave the pad driving a
+                        // walking duck with roller curves.
+                        Ok(result) if result.accepted => {
+                            roller = target == "roller";
+                            tracing::warn!(roller, "drive mode switched");
+                        }
+                        Ok(result) => tracing::warn!(
+                            reason = result.reason.as_deref().unwrap_or("no reason given"),
+                            "the robot refused the mode switch"
+                        ),
+                        Err(e) => tracing::error!(error = %e, "unreadable answer to the switch"),
+                    },
+                    Ok(None) => tracing::warn!("no answer to the mode switch"),
+                    Err(e) => {
+                        tracing::error!(error = %e, "mode switch request failed");
+                        return std::process::ExitCode::FAILURE;
+                    }
+                }
+            }
+        } else {
+            dpad_up_held_since = None;
+            mode_switch_sent = false;
         }
 
         let deadzone = |v: f32| {

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -112,7 +112,8 @@ pub const REGISTRY: &[Entry] = &[
     feature(
         "policy.mode",
         Kind::Choice(&["walk", "roller"]),
-        "Legs or the roller: picks policies and per-mode tuning defaults",
+        "Legs or the roller: picks policies and tuning. Held DPad-Up switches it live; this is \
+         the mode a reboot comes back in",
     ),
     entry(
         "policy.walk",

--- a/robotd/src/intents.rs
+++ b/robotd/src/intents.rs
@@ -15,6 +15,12 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
+/// "No mode switch pending" in [`Intents::mode_switch`].
+///
+/// 255 rather than 0, because 0 is a real mode code and a sentinel that collides with a value is
+/// how a "switch to walking" request becomes a no-op.
+pub const MODE_NONE: u8 = u8::MAX;
+
 /// Encodings for [`Intents::power`]. An `AtomicU8` rather than two bools, so "init" and "relax"
 /// cannot both be pending — they are alternatives, and the last one asked for wins.
 const POWER_NONE: u8 = 0;
@@ -150,6 +156,13 @@ pub struct Intents {
     skills: std::sync::atomic::AtomicU32,
     /// A shutdown was requested. A level, not an edge: once asked, the sequence runs.
     shutdown: AtomicBool,
+    /// A drive-mode switch was requested, and which mode to switch to.
+    ///
+    /// An `AtomicU8` holding [`MODE_NONE`] or a mode's code, for the same reason `shutdown` is a
+    /// flag: the IPC thread writes and the control loop takes, with nothing to lock. The last
+    /// request wins — two arriving in the same tick means somebody pressed twice, and the second
+    /// answer is the one they are waiting for.
+    mode_switch: AtomicU8,
     /// Pending one-shot sound tags, a bitmask taken once per tick like the skills.
     sounds: std::sync::atomic::AtomicU32,
     /// The wheee hold, as a stamped level: `padd` re-notifies while the trigger is down,
@@ -213,6 +226,7 @@ impl Intents {
             chorale_heard: std::sync::Mutex::new(Vec::new()),
             skills: std::sync::atomic::AtomicU32::new(0),
             shutdown: AtomicBool::new(false),
+            mode_switch: AtomicU8::new(MODE_NONE),
             sounds: std::sync::atomic::AtomicU32::new(0),
             wheee: ArcSwap::from_pointee(Stamped {
                 value: false,
@@ -324,6 +338,22 @@ impl Intents {
             WheeeHold::Held
         } else {
             WheeeHold::Decayed
+        }
+    }
+
+    /// Ask for a drive-mode switch, by the code the caller and the loop agree on.
+    ///
+    /// The code rather than [`Mode`] itself, so this module does not have to know what modes
+    /// exist — `main.rs` owns that mapping and the loop reads it back.
+    pub fn request_mode_switch(&self, code: u8) {
+        self.mode_switch.store(code, Ordering::Relaxed);
+    }
+
+    /// Take a pending mode switch. Taken, so the sequence runs once per request.
+    pub fn take_mode_switch(&self) -> Option<u8> {
+        match self.mode_switch.swap(MODE_NONE, Ordering::Relaxed) {
+            MODE_NONE => None,
+            code => Some(code),
         }
     }
 

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -29,10 +29,10 @@ mod theremin;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use arc_swap::ArcSwapOption;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use clap::{Parser, Subcommand};
 use duck_control::fall::{FallPredictor, FallPredictorConfig};
 use duck_control::io::RobotIo;
@@ -277,6 +277,61 @@ fn parse_duration(raw: &str) -> Result<Duration, String> {
 /// control loop. A robot whose loop is wedged still has to be able to say "I am not
 /// healthy" — if answering required the loop's lock, the one situation where `updaterd`
 /// needs an answer is the situation it would hang in.
+/// [`Mode`] as the byte [`RobotState::mode`] holds, and back.
+///
+/// Two tiny functions rather than a numeric cast, so the mapping is written down once: a mode
+/// added later gets a code here and nowhere else, and an unknown byte reads as walking rather
+/// than panicking on the IPC thread.
+fn mode_code(mode: Mode) -> u8 {
+    match mode {
+        Mode::Walk => 0,
+        Mode::Roller => 1,
+    }
+}
+
+fn mode_of(code: u8) -> Mode {
+    match code {
+        1 => Mode::Roller,
+        _ => Mode::Walk,
+    }
+}
+
+/// The policy file names for one mode, as a set.
+///
+/// `None` in a skill slot doubles as "this robot cannot do that", which is what lets `dispatch`
+/// refuse a `robot.do` for a skill this mode has no network for instead of queueing a request the
+/// loop will drop — and roller mode is exactly that case: no standing network, a crouch where the
+/// ground pick was.
+#[derive(Debug, Clone, Default)]
+struct PolicyNames {
+    walk: Option<String>,
+    stand: Option<String>,
+    sitstand: Option<String>,
+    ground_pick: Option<String>,
+    kick_left: Option<String>,
+    kick_right: Option<String>,
+    roulade: Option<String>,
+}
+
+impl PolicyNames {
+    /// The names for `policy`, or all-`None` when no policy is wanted.
+    fn of(policy: &params::ResolvedPolicy) -> Self {
+        if !policy.enabled {
+            return Self::default();
+        }
+        let name = |path: &Option<std::path::PathBuf>| path.as_deref().and_then(file_name);
+        Self {
+            walk: file_name(&policy.walk),
+            stand: name(&policy.stand),
+            sitstand: name(&policy.sitstand),
+            ground_pick: name(&policy.ground_pick),
+            kick_left: name(&policy.kick_left),
+            kick_right: name(&policy.kick_right),
+            roulade: name(&policy.roulade),
+        }
+    }
+}
+
 struct RobotState {
     /// Epoch for every timestamp below. `Instant` so the clock cannot go backwards.
     started: Instant,
@@ -329,24 +384,20 @@ struct RobotState {
     /// Why the policy is not loaded, if it is not. Set once at startup; the loop keeps
     /// running and holds the pose, so a broken bundle is a rollback rather than a crash.
     policy_error: ArcSwapOption<String>,
-    /// Which policy files this process was configured with, as file names. `None` when the
-    /// policy is disabled.
+    /// Which policy files this process is running, as file names. `None` when the policy is
+    /// disabled.
     ///
     /// From the params rather than from the loaded network, and therefore known before the
     /// control thread has finished loading anything — a client that subscribes during startup
     /// gets the answer rather than a race. What *failed* to load is `policy_error`; this is
     /// what was asked for, and the pair is what distinguishes "no policy wanted" from "the
     /// policy this release ships would not load".
-    policy_walk: Option<String>,
-    policy_stand: Option<String>,
-    /// The skill networks, same provenance. `None` doubles as "this robot cannot do that",
-    /// which is what lets `dispatch` refuse a `robot.do` for a skill that was never
-    /// configured instead of queueing a request the loop will drop.
-    policy_sitstand: Option<String>,
-    policy_ground_pick: Option<String>,
-    policy_kick_left: Option<String>,
-    policy_kick_right: Option<String>,
-    policy_roulade: Option<String>,
+    ///
+    /// **One swap for the whole set rather than seven fields**, because a mode switch replaces
+    /// all of them at once: a reader that caught `walk` from roller beside `stand` from walking
+    /// would be told about a robot that does not exist. Swapped by the control loop, which is
+    /// the only thing that loads a policy.
+    policies: ArcSwap<PolicyNames>,
     /// Whether this robot can make a sound at all: audio enabled, and a bank with wavs in
     /// it. Same job as the `policy_*` fields above — false is "this robot cannot do that",
     /// which is what lets `dispatch` refuse a `robot.sound` with a reason instead of
@@ -362,8 +413,12 @@ struct RobotState {
     /// Whether this robot's config allows it to sing with others. Read once at startup, like the
     /// policies: `[chorale] accept`, false by default.
     chorale_accepted: bool,
-    /// `walk` or `roller` — constant for the life of the process; `robot.mode` reports it.
-    mode: &'static str,
+    /// `walk` or `roller`, as `robot.mode` reports it.
+    ///
+    /// Not constant any more: `robot.setMode` switches it while the robot runs, so this is stored
+    /// rather than read from the params it started as. An `AtomicU8` over [`Mode`] because it is
+    /// read on the IPC side and written by the control loop, and there is nothing to allocate.
+    mode: AtomicU8,
     /// Published by the loop so the IPC side can answer without consulting it.
     fallen: AtomicBool,
     /// The policy is driving and has been asked for a non-zero velocity.
@@ -405,20 +460,11 @@ impl RobotState {
             state_tx: tokio::sync::broadcast::Sender::new(STATE_BUFFER),
             chorale_tx: tokio::sync::broadcast::Sender::new(8),
             policy_error: ArcSwapOption::empty(),
-            policy_walk: {
-                let policy = params.policy.resolved();
-                policy.enabled.then(|| file_name(&policy.walk)).flatten()
-            },
-            policy_stand: named_policy(params, |p| p.stand.clone()),
-            policy_sitstand: named_policy(params, |p| p.sitstand.clone()),
-            policy_ground_pick: named_policy(params, |p| p.ground_pick.clone()),
-            policy_kick_left: named_policy(params, |p| p.kick_left.clone()),
-            policy_kick_right: named_policy(params, |p| p.kick_right.clone()),
-            policy_roulade: named_policy(params, |p| p.roulade.clone()),
+            policies: ArcSwap::from_pointee(PolicyNames::of(&params.policy.resolved())),
             has_voice: params.audio.enabled && has_any_wav(&params.audio.bank),
             theremin_ready: AtomicBool::new(false),
             chorale_accepted: params.chorale.accept,
-            mode: params.policy.mode.as_str(),
+            mode: AtomicU8::new(mode_code(params.policy.mode)),
             fallen: AtomicBool::new(false),
             moving: AtomicBool::new(false),
             homed: AtomicBool::new(false),
@@ -1002,55 +1048,25 @@ async fn adopt_startup_pose<T: RobotIo>(
 /// back. The alternative — refusing to start — becomes a crashloop under
 /// `Restart=always` and reaches the health gate as `Unreachable`, which blames the wrong
 /// thing in the journal.
-async fn control_loop<T: RobotIo>(
-    io: T,
-    state: Arc<RobotState>,
-    intents: Arc<Intents>,
-    params: Params,
-    period: Duration,
-    poweroff: PowerOff,
-) {
-    let policy_cfg = params.policy.resolved();
-    let mut safety = Safety::new(
-        io,
-        SafetyConfig {
-            fall_gravity_z: params.safety.fall_gravity_z,
-            fall_debounce: Duration::from_millis(params.safety.fall_debounce_ms),
-            deadman: Duration::from_millis(params.safety.deadman_ms),
-            gain_running: policy_cfg.gain,
-            gain_limp: params.safety.gain_limp,
-        },
-    );
-
-    let Some(mut hold) = adopt_startup_pose(&mut safety, &state, period).await else {
-        return;
-    };
-
-    // Was the robot powered on already sitting? A seated duck has hips and knees folded
-    // far from the standing pose. If so, the first bring-up rises via the sitstand network
-    // instead of dragging the legs through the linear ramp — the ramp is for a robot that
-    // is roughly standing.
-    const LEG_JOINTS: [usize; 10] = [0, 1, 2, 3, 4, 10, 11, 12, 13, 14];
-    let leg_deviation = LEG_JOINTS
-        .iter()
-        .map(|&j| (hold[j] - DEFAULT_POSITION[j]).abs())
-        .sum::<f64>()
-        / LEG_JOINTS.len() as f64;
-    let mut seated_boot = leg_deviation > SEATED_BOOT_RAD;
-    if seated_boot {
-        tracing::warn!(
-            deviation = format!("{leg_deviation:.2}"),
-            "seated boot detected — will stand up via the sitstand policy"
-        );
-    }
-
-    // A policy that was *not wanted* is healthy; one that was wanted and could not be
-    // loaded is not. Collapsing those two would either make a bench robot look broken or
-    // let a release with an unusable bundle pass the health gate.
-    let mut controller = if !policy_cfg.enabled {
+/// Load one mode's policy bundle, or `None` when there is nothing to load.
+///
+/// A function rather than a block inline in the loop's preamble, because it runs twice: once at
+/// startup, and again on every `robot.setMode` — which is a mode's whole difference, since the
+/// networks and the tuning are all a mode *is* by the time params are resolved.
+///
+/// A policy that was *not wanted* is healthy; one that was wanted and could not be loaded is not.
+/// Collapsing those two would either make a bench robot look broken or let a release with an
+/// unusable bundle pass the health gate.
+fn build_controller(
+    policy_cfg: &params::ResolvedPolicy,
+    limp_fall: bool,
+    state: &RobotState,
+) -> Option<Controller> {
+    if !policy_cfg.enabled {
         tracing::warn!("policy disabled; holding the startup pose");
-        None
-    } else {
+        return None;
+    }
+    {
         let tuning = Tuning {
             action_scale: policy_cfg.action_scale,
             standing_action_scale: policy_cfg.standing_action_scale,
@@ -1093,7 +1109,7 @@ async fn control_loop<T: RobotIo>(
                     ground_pick = ?policy_cfg.ground_pick.as_ref().map(|p| p.display().to_string()),
                     kicks = policy_cfg.kick_left.is_some() || policy_cfg.kick_right.is_some(),
                     roulade = ?policy_cfg.roulade.as_ref().map(|p| p.display().to_string()),
-                    limp_fall = params.safety.limp_fall,
+                    limp_fall,
                     "policy loaded"
                 );
                 Some(Controller::new(policy, tuning, skills))
@@ -1104,7 +1120,55 @@ async fn control_loop<T: RobotIo>(
                 None
             }
         }
+    }
+}
+
+async fn control_loop<T: RobotIo>(
+    io: T,
+    state: Arc<RobotState>,
+    intents: Arc<Intents>,
+    params: Params,
+    period: Duration,
+    poweroff: PowerOff,
+) {
+    // `mut` because a mode switch replaces it: the resolved policy *is* the mode, once the
+    // per-mode defaults have been applied.
+    let mut policy_cfg = params.policy.resolved();
+    let mut safety = Safety::new(
+        io,
+        SafetyConfig {
+            fall_gravity_z: params.safety.fall_gravity_z,
+            fall_debounce: Duration::from_millis(params.safety.fall_debounce_ms),
+            deadman: Duration::from_millis(params.safety.deadman_ms),
+            gain_running: policy_cfg.gain,
+            gain_limp: params.safety.gain_limp,
+        },
+    );
+
+    let Some(mut hold) = adopt_startup_pose(&mut safety, &state, period).await else {
+        return;
     };
+
+    // Was the robot powered on already sitting? A seated duck has hips and knees folded
+    // far from the standing pose. If so, the first bring-up rises via the sitstand network
+    // instead of dragging the legs through the linear ramp — the ramp is for a robot that
+    // is roughly standing.
+    const LEG_JOINTS: [usize; 10] = [0, 1, 2, 3, 4, 10, 11, 12, 13, 14];
+    let leg_deviation = LEG_JOINTS
+        .iter()
+        .map(|&j| (hold[j] - DEFAULT_POSITION[j]).abs())
+        .sum::<f64>()
+        / LEG_JOINTS.len() as f64;
+    let mut seated_boot = leg_deviation > SEATED_BOOT_RAD;
+    if seated_boot {
+        tracing::warn!(
+            deviation = format!("{leg_deviation:.2}"),
+            "seated boot detected — will stand up via the sitstand policy"
+        );
+    }
+
+    // Loaded once here and again on a mode switch — see `build_controller`.
+    let mut controller = build_controller(&policy_cfg, params.safety.limp_fall, &state);
 
     tracing::warn!(
         joints = NUM_JOINTS,
@@ -1135,6 +1199,12 @@ async fn control_loop<T: RobotIo>(
     let mut last_summary = Instant::now();
     let mut was_driving = false;
     let mut bringup = Bringup::Limp;
+    // A mode switch in flight: the mode to end up in, once the robot is home. `None` the rest of
+    // the time, which is nearly always.
+    let mut mode_change: Option<Mode> = None;
+    // The policy params this loop is running, which a mode switch replaces. Owned rather than
+    // borrowed from `params` because the mode is no longer what the file said.
+    let mut policy_params = params.policy.clone();
 
     // Command smoothing, per the prototype: `cmd += α × (target − cmd)` at the tick rate.
     // A stick snap becomes a ramp the gait can follow; the state lives here because it is
@@ -1459,6 +1529,47 @@ async fn control_loop<T: RobotIo>(
             }
         }
 
+        // A drive-mode switch: `robot.setMode`, which the pad's held D-pad up sends.
+        //
+        // The robot goes back to its home pose first and the policies load there, for the reason
+        // the prototype relaunched into pose 0: swapping the network under a moving gait means the
+        // next tick is a different policy's idea of what the legs were doing. Torque stays on
+        // throughout — the robot holds itself up across the swap rather than sitting down.
+        if let Some(code) = intents.take_mode_switch() {
+            let target = mode_of(code);
+            if target == policy_params.mode {
+                tracing::info!(
+                    mode = target.as_str(),
+                    "already in that mode; nothing to switch"
+                );
+            } else if mode_change.is_some() {
+                tracing::warn!(mode = target.as_str(), "a mode switch is already in flight");
+            } else {
+                tracing::warn!(
+                    from = policy_params.mode.as_str(),
+                    to = target.as_str(),
+                    "mode switch: going home before loading the other policies"
+                );
+                // The prototype's cue, and worth keeping: one quack for walking, two for roller,
+                // so the robot says which mode it is going to without anybody reading a log.
+                if let Some(voice) = voice.as_mut() {
+                    voice.play("chirp", false);
+                    if target == Mode::Roller {
+                        voice.play("chirp", false);
+                    }
+                }
+                mode_change = Some(target);
+                // Home the robot with the machinery `init` and a fall recovery already use: it
+                // ramps per tick, and `driving` is false until it reaches Ready.
+                if let Some(sensors) = sensors.as_ref() {
+                    bringup = Bringup::Homing {
+                        from: sensors.positions,
+                        since: tick_start,
+                    };
+                }
+            }
+        }
+
         // The sit-then-power-off sequence: `robot.shutdown`, or a genuinely empty pack.
         // The battery reading is a ~10 s EMA refreshed once a second, so a load sag cannot
         // reach the floor — a pack that gets there is spent.
@@ -1721,6 +1832,27 @@ async fn control_loop<T: RobotIo>(
         if let Bringup::Homing { .. } = bringup
             && bringup.homing_target(tick_start).is_none()
         {
+            // Home, and a switch waiting: load the other mode's bundle here, where the robot is
+            // standing still at a known pose with torque on. `Policy::load` validates and warms
+            // up each network, so this blocks the loop for a moment — deliberately, and in the one
+            // place where a stalled command stream costs nothing, because the robot is holding a
+            // pose rather than mid-stride. Missed ticks in that window are expected.
+            if let Some(target) = mode_change.take() {
+                policy_params.mode = target;
+                let cfg = policy_params.resolved();
+                state.policy_error.store(None);
+                controller = build_controller(&cfg, params.safety.limp_fall, &state);
+                // Published together with the mode, and only after the load: a client that reads
+                // `robot.mode` and gets the new one must not then be told the old mode's networks.
+                state.policies.store(Arc::new(PolicyNames::of(&cfg)));
+                state.mode.store(mode_code(target), Ordering::Relaxed);
+                policy_cfg = cfg;
+                tracing::warn!(
+                    mode = target.as_str(),
+                    loaded = controller.is_some(),
+                    "mode switch complete"
+                );
+            }
             tracing::warn!("at the home pose; the policy has the robot");
             bringup = Bringup::Ready;
             hold = DEFAULT_POSITION;
@@ -2145,19 +2277,6 @@ async fn control_loop<T: RobotIo>(
 /// which would read as "no policy".
 fn file_name(path: &std::path::Path) -> Option<String> {
     Some(path.file_name()?.to_string_lossy().into_owned())
-}
-
-/// One resolved optional policy slot as its reportable file name — `None` when the policy
-/// is disabled outright or the slot is not configured in this mode.
-fn named_policy(
-    params: &Params,
-    pick: impl Fn(&params::ResolvedPolicy) -> Option<std::path::PathBuf>,
-) -> Option<String> {
-    let policy = params.policy.resolved();
-    if !policy.enabled {
-        return None;
-    }
-    pick(&policy).as_deref().and_then(file_name)
 }
 
 /// The sample a tick steps from, and how stale it may get.
@@ -2598,12 +2717,15 @@ fn dispatch(
         // down; the loop still arbitrates against whatever move is mid-flight, exactly as
         // the prototype's buttons did.
         proto::Call::RobotDo(p) => {
+            let policies = state.policies.load();
             let configured = match p.skill {
-                proto::Skill::GroundPick => state.policy_ground_pick.is_some(),
-                proto::Skill::KickLeft => state.policy_kick_left.is_some(),
-                proto::Skill::KickRight => state.policy_kick_right.is_some(),
-                proto::Skill::SitToggle => state.policy_sitstand.is_some(),
-                proto::Skill::Roulade => state.policy_roulade.is_some(),
+                // One load for the whole decision: these are the *current* mode's networks, and
+                // reading them field by field could straddle a mode switch.
+                proto::Skill::GroundPick => policies.ground_pick.is_some(),
+                proto::Skill::KickLeft => policies.kick_left.is_some(),
+                proto::Skill::KickRight => policies.kick_right.is_some(),
+                proto::Skill::SitToggle => policies.sitstand.is_some(),
+                proto::Skill::Roulade => policies.roulade.is_some(),
             };
             // Not refused for being down. A skill on a fallen robot is the human's call,
             // and refusing it is how a robot ends up unable to do the thing that would
@@ -2680,10 +2802,37 @@ fn dispatch(
             proto::Response::ok(Some(id), &proto::IntentResult::accepted())
         }
 
+        // Switch drive mode. Refused here for the two things this side knows: a mode nobody has
+        // heard of, and a robot with no policy to switch between — the loop arbitrates the rest.
+        //
+        // "Already in that mode" is an acceptance rather than a refusal: the caller asked for a
+        // state and that state is what they get, and a pad held a beat too long should not report
+        // an error.
+        proto::Call::RobotSetMode(p) => {
+            let target = match p.mode.as_str() {
+                "walk" => Some(Mode::Walk),
+                "roller" => Some(Mode::Roller),
+                _ => None,
+            };
+            let result = match target {
+                None => proto::IntentResult::refused("mode must be \"walk\" or \"roller\""),
+                Some(_) if state.policies.load().walk.is_none() => proto::IntentResult::refused(
+                    "no policy on this robot, so there is nothing to switch between",
+                ),
+                Some(mode) => {
+                    intents.request_mode_switch(mode_code(mode));
+                    proto::IntentResult::accepted()
+                }
+            };
+            proto::Response::ok(Some(id), &result)
+        }
+
         proto::Call::RobotMode => proto::Response::ok(
             Some(id),
             &proto::ModeResult {
-                mode: state.mode.to_owned(),
+                mode: mode_of(state.mode.load(Ordering::Relaxed))
+                    .as_str()
+                    .to_owned(),
             },
         ),
 
@@ -2742,28 +2891,30 @@ fn dispatch(
             },
         ),
 
-        proto::Call::RobotSubscribe(_) => proto::Response::ok(
-            Some(id),
-            &proto::SubscribeResult {
-                accepted: true,
-                walk: state.policy_walk.clone(),
-                stand: state.policy_stand.clone(),
-                sitstand: state.policy_sitstand.clone(),
-                ground_pick: state.policy_ground_pick.clone(),
-                kick_left: state.policy_kick_left.clone(),
-                kick_right: state.policy_kick_right.clone(),
-                roulade: state.policy_roulade.clone(),
-                unavailable: state.policy_error.load_full().map_or_else(
-                    || {
-                        state
-                            .policy_walk
-                            .is_none()
-                            .then(|| "no policy configured; holding the startup pose".to_owned())
-                    },
-                    |e| Some(format!("policy would not load: {e}")),
-                ),
-            },
-        ),
+        proto::Call::RobotSubscribe(_) => {
+            let policies = state.policies.load();
+            proto::Response::ok(
+                Some(id),
+                &proto::SubscribeResult {
+                    accepted: true,
+                    walk: policies.walk.clone(),
+                    stand: policies.stand.clone(),
+                    sitstand: policies.sitstand.clone(),
+                    ground_pick: policies.ground_pick.clone(),
+                    kick_left: policies.kick_left.clone(),
+                    kick_right: policies.kick_right.clone(),
+                    roulade: policies.roulade.clone(),
+                    unavailable: state.policy_error.load_full().map_or_else(
+                        || {
+                            policies.walk.is_none().then(|| {
+                                "no policy configured; holding the startup pose".to_owned()
+                            })
+                        },
+                        |e| Some(format!("policy would not load: {e}")),
+                    ),
+                },
+            )
+        }
 
         proto::Call::RobotStop => {
             intents.stop();
@@ -3053,6 +3204,116 @@ mod tests {
     /// **The point of slice 1.** A loop that ticked once and then wedged must report
     /// unhealthy, not stay healthy forever on the strength of that one tick. This is what
     /// the updater's auto-rollback actually gates on.
+    /// `robot.setMode` is accepted, refused or a no-op — and never a parse error.
+    ///
+    /// The refusals are what this test is for. A robot with no policy has nothing to switch
+    /// between, and a mode nobody has heard of must come back naming the two that exist rather
+    /// than as a decode failure the caller cannot act on.
+    #[test]
+    fn setting_the_mode_accepts_refuses_and_says_which() {
+        let params = Params::default();
+        assert_eq!(params.policy.mode, Mode::Walk, "the shipped default");
+        let s = RobotState::new(&params, false, false);
+        let intents = Arc::new(Intents::new());
+        let id = || proto::Id::Number(1);
+        let set = |mode: &str| -> proto::IntentResult {
+            dispatch(
+                &s,
+                &intents,
+                id(),
+                &proto::Call::RobotSetMode(proto::SetModeParams {
+                    mode: mode.to_owned(),
+                }),
+            )
+            .result
+            .expect("a result")
+            .as_object()
+            .map(|o| serde_json::from_value(serde_json::Value::Object(o.clone())).expect("shape"))
+            .expect("an object")
+        };
+
+        // Default params name a walking bundle, so there is something to switch between.
+        assert!(set("roller").accepted, "a real mode is accepted");
+        assert_eq!(
+            intents.take_mode_switch(),
+            Some(mode_code(Mode::Roller)),
+            "the loop is the thing that switches; dispatch only queues it"
+        );
+
+        // The same mode is an acceptance, not a refusal: the caller asked for a state.
+        assert!(set("walk").accepted);
+        assert_eq!(intents.take_mode_switch(), Some(mode_code(Mode::Walk)));
+
+        let refused = set("hovercraft");
+        assert!(!refused.accepted);
+        let reason = refused.reason.unwrap_or_default();
+        assert!(
+            reason.contains("walk") && reason.contains("roller"),
+            "{reason}"
+        );
+        assert_eq!(
+            intents.take_mode_switch(),
+            None,
+            "a refused switch must not reach the loop"
+        );
+
+        // A robot with no policy at all: nothing to switch between, and saying so beats homing
+        // the robot for a swap that would load nothing.
+        let mut bare = Params::default();
+        bare.policy.enabled = false;
+        let s = RobotState::new(&bare, false, false);
+        let response = dispatch(
+            &s,
+            &intents,
+            id(),
+            &proto::Call::RobotSetMode(proto::SetModeParams {
+                mode: "roller".to_owned(),
+            }),
+        );
+        let result: proto::IntentResult =
+            serde_json::from_value(response.result.expect("a result")).expect("shape");
+        assert!(!result.accepted);
+        assert!(
+            result.reason.unwrap_or_default().contains("no policy"),
+            "the reason must name the cause"
+        );
+    }
+
+    /// Roller mode has no standing network, and the published set must say so.
+    ///
+    /// This is the reason the names are swapped as a set rather than left at what startup
+    /// resolved: `dispatch` refuses a `robot.do` for a skill whose slot is `None`, so a stale set
+    /// would have the robot accepting a kick in a mode with no kick network — or refusing the
+    /// crouch that roller mode does have.
+    #[test]
+    fn the_published_policy_names_are_one_modes_answer() {
+        let walk = PolicyNames::of(&Params::default().policy.resolved());
+        assert!(walk.stand.is_some(), "walking has a standing network");
+
+        let mut rolling = Params::default();
+        rolling.policy.mode = Mode::Roller;
+        let roller = PolicyNames::of(&rolling.policy.resolved());
+        assert!(
+            roller.stand.is_none(),
+            "roller mode loads no standing network"
+        );
+        assert_ne!(
+            walk.walk, roller.walk,
+            "the driving network differs by mode"
+        );
+        assert_ne!(
+            walk.ground_pick, roller.ground_pick,
+            "the ground-pick slot holds the crouch in roller mode"
+        );
+
+        // Disabled means every slot empty, which is what `robot.subscribe` reports as "no policy
+        // configured" rather than as a load failure.
+        let mut off = Params::default();
+        off.policy.enabled = false;
+        let none = PolicyNames::of(&off.policy.resolved());
+        assert!(none.walk.is_none() && none.roulade.is_none());
+    }
+
     #[test]
     fn a_stalled_loop_reports_unhealthy() {
         // A short window so the test does not sleep for the real 500 ms default. Two

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -626,6 +626,7 @@ impl Server {
             | Call::ChoraleHeard(_)
             | Call::RobotShutdown
             | Call::RobotMode
+            | Call::RobotSetMode(_)
             | Call::RobotSubscribe(_) => Response::err(
                 Some(id),
                 proto::Error::new(


### PR DESCRIPTION
The prototype switched walk ⇄ roller on a three-second D-pad up hold; the port lost it, so changing modes meant editing robotd.toml and restarting.

It switches in place rather than relaunching. The mode is not much once params are resolved — a set of policy files and some tuning — so the loop rebuilds its controller instead of the process exiting: the robot returns to its home pose with the machinery `init` and fall recovery already use, loads the other mode's bundle there, and drives again. Torque stays on throughout, connections survive, and the IMU filter never has to converge again. `Policy::load` validates and warms up each network, so the loop blocks for a moment at the home pose — the one place a stalled command stream costs nothing, since the robot is holding a pose rather than mid-stride.

What this breaks is the assumption that the mode is a startup constant, which two published things depended on. `robot.mode` now answers from a live value, and the policy names in the `robot.subscribe` acknowledgement move behind a single swap rather than seven fields: roller mode has no standing network and a crouch where the ground pick was, and `dispatch` refuses `robot.do` for a slot that is `None` — so a stale set means accepting a kick this mode cannot do. One swap, because a reader that caught walk's `stand` beside roller's `walk` would be told about a robot that does not exist.

`robot.setMode` (API v15) is refused on BLE and in the WebRTC console: the reason to switch is that somebody just put wheels on the duck, which is a claim about hardware only whoever is in the room can make. padd asks for a named mode rather than a toggle, and moves its stick shaping only when the robot accepted. Nothing writes config, so a reboot comes back in the configured mode.