### PR TITLE
docs: make the reference pages describe the seven daemons that exist

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -142,8 +142,10 @@ jobs:
           # anyone drives the robot from, and the intent API only stays honest if the
           # thing exercising it daily is actually on the robot.
           cp target/aarch64-unknown-linux-gnu/release/padd staged/
-          # mediad is the WebRTC gateway. Shipped so a board *can* run it; its unit has no
-          # [Install], so nothing starts it until someone does. See mediad/systemd/mediad.service.
+          # mediad is the WebRTC gateway. Its unit carries an [Install] section, so postinstall
+          # enables it and an update restarts it like any other daemon
+          # (docs/design/restart-order.md §1). It was once shipped inert, and this comment
+          # said so for two releases after that stopped being true.
           cp target/aarch64-unknown-linux-gnu/release/mediad staged/
           # The voice generator (postinstall renders the per-robot bank with it) and the
           # mic classifier pair — pet-detect for live listening, pet-features for training.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,34 @@ For working on the daemons themselves. To use a robot rather than change it, see
 
 ## Building and testing
 
-Needs Rust **1.89+** (stable) and nothing else. macOS and Linux both work for development; the
-robot is aarch64 Linux.
+Needs Rust **1.89+** (stable). The robot is aarch64 Linux; you develop on Linux or macOS, and
+the two are not quite the same checkout — see below.
 
 ```bash
 cargo test --workspace
 ```
 
-508 tests, no hardware, no network, no Docker. If they pass, your checkout is sound.
+No hardware, no network, no Docker. If they pass, your checkout is sound.
+
+**On Linux** that command needs some C libraries first, the same ones CI installs: `padd` binds
+`libudev` through `gilrs`, and `mediad`'s pipeline is `cfg(target_os = "linux")`, so a Linux host
+compiles GStreamer where a Mac does not.
+
+```bash
+sudo apt-get install -y libudev-dev libgstreamer1.0-dev
+```
+
+```bash
+sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev
+```
+
+**On macOS** `tof` does not build at all: its vendored ST driver compiles `vendor/platform.c`,
+which includes `linux/i2c.h`, and `build.rs` has no `cfg` around it. Exclude the crate. That is
+**936 tests passing**, and the eight it leaves out are the ToF driver's own:
+
+```bash
+cargo test --workspace --exclude tof
+```
 
 Those tests are also where the engine's failure paths are: a bad signature, a release that comes
 up unhealthy, a post-install hook that fails, power loss between the swap and the health gate.
@@ -38,9 +58,9 @@ RUSTFLAGS="-D warnings" cargo clippy -p configd --all-targets --target aarch64-u
 ```
 
 `scripts/board-test.sh` runs in CI against the userland we ship: it cross-compiles for the board
-and executes 13 checks — rollback, tampered-artifact refusal, boot-counter recovery, socket
-modes, peer-credential authorization — on Debian 13 (Trixie). `BOARD_IMAGES=` runs it against
-another.
+and executes 60 assertions — rollback, tampered-artifact refusal, boot-counter recovery, socket
+modes, peer-credential authorization, and everything `setup-board.sh` and `install.sh` do to a
+board — on Debian 13 (Trixie). `BOARD_IMAGES=` runs it against another.
 
 To run a change on a real robot without publishing it, `scripts/dev-push.sh <user@board>` builds
 here and installs there as an ordinary gated update. It cross-compiles with `cargo zigbuild` by
@@ -51,22 +71,42 @@ set up at all. Setup, the flags and the failure modes:
 ## The layout
 
 ```
-duck-ipc-proto/ the wire contract
-duck-control/   the control core: model · bus · IMU · observations · policy · safety
-padd/           gamepad → intents — an ordinary socket client, no privileged access
-updater/        engine + updaterd
-robotd/         control daemon
-configd/        wifi · robot name · pairing PIN · reboot · gamepad pairing
-btd/            the BLE front door
-duckctl/        the laptop-side client — never shipped, never cross-built
-robotctl/       the local CLI
-xtask/          package · sign · promote — build tooling, never shipped
+the daemons — one crate each, one unit each, all in the same release artifact
+  robotd/         control daemon: the 50 Hz loop, the voice, the theremin, the chorale
+  updater/        engine + updaterd
+  configd/        wifi · robot name · pairing PIN · reboot · gamepad pairing
+  btd/            the BLE front door
+  padd/           gamepad → intents — an ordinary socket client, no privileged access
+  mediad/         camera, mic, WebRTC, the remote gateway, and the console it serves
+  tof/            tofd: the head's 8×8 depth sensor. Publishes frames, reads nothing
+
+the libraries they drive — no sockets, no systemd, nothing starts them
+  duck-ipc-proto/ the wire contract
+  duck-control/   the control core: model · bus · IMU · observations · policy · safety
+  kinematics/     the MJCF model and forward kinematics; head and hand chains
+  odometry/       where the robot has been, from foot contacts and the IMU
+  sounds/         synthesis, per-robot voice personality, the chorale's score
+  pet-detect/     a small CNN that hears head scratches on the onboard mic
+  robotd-params/  robotd's startup parameters: schema, defaults, validation
+
+the tools
+  robotctl/       the local CLI, including `monitor`
+  duckctl/        the laptop-side client — never shipped, never cross-built
+  xtask/          package · sign · promote — build tooling, never shipped
+  test-support/   signed-release fixtures for tests; never shipped
+
 deploy/         what a robot is configured with: updater.toml, robotd.toml, trust anchor, journald
+policies/       the ONNX networks a release ships
+hooks/          preinstall · postinstall — what runs inside an update, from the artifact
 scripts/        provision-board.sh · dev-push.sh + dev-build.Dockerfile (from your machine) ·
-                provision.sh → setup-board.sh · migrate-network.sh · install.sh (on the board) ·
+                provision.sh → setup-board.sh → setup-gstreamer.sh · setup-rkaiq.sh ·
+                migrate-network.sh · install.sh (on the board) ·
+                robot-boot-check · robot-rescue (recovery, installed to /usr/local/sbin) ·
                 pad-link-test.sh · pad-stack-report.sh (gamepad radio, on the board) ·
-                board-test.sh (CI)
-docs/           robot/ (using one) · design/ (how it works) · project/ (roadmap, records)
+                board-test.sh · systemd-test.sh (CI) · cross-sysroot.sh (cross-builds) ·
+                bake-duck-mesh.py (the monitor's 3D model, run by hand)
+docs/           robot/ (using one) · design/ (how it works) · project/ (roadmap, records) ·
+                ideas/ (not designed yet)
 ```
 
 Services talk over unix sockets, JSON-RPC 2.0 one object per line. The contract lives in

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -354,7 +354,7 @@ bad time" than a clock.
 /etc/robot/trusted_keys/release-*.pub   trust anchor
 /opt/robot/daemon/releases/<version>/   the release tree
 /opt/robot/daemon/current -> releases/<version>
-/etc/systemd/system/{updaterd,robotd}.service   copied out of the release
+/etc/systemd/system/*.service           every unit the release ships, copied out of it
 /usr/lib/sysusers.d/robot.conf          creates the `robot` group
 /var/lib/robot/updater/                 lock, update log, boot counter
 /usr/local/bin/robotctl -> current/bin/robotctl

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ own the mechanism is the bug.
 | | |
 |---|---|
 | [`architecture.md`](design/architecture.md) | The service split, the IPC contract, state ownership, safety and authority. |
-| [`robotd-design.md`](design/robotd-design.md) | The control loop: the Dynamixel bus and who owns the port, the model, sensing, observations, policy, safety. |
+| [`robotd-design.md`](design/robotd-design.md) | The control loop: the Dynamixel bus and who owns the port, the model, sensing, observations, policy, safety — and what else hangs off the tick. |
 | [`updater-design.md`](design/updater-design.md) | The update engine: verification, atomic swap, health gate, rollback, release format. |
 | [`restart-order.md`](design/restart-order.md) | Which unit restarts, at which step, on every path that moves `current` — and at boot. |
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
@@ -51,6 +51,16 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 | [`slice-2-bringup.md`](project/slice-2-bringup.md) | What a real Radxa Zero 3W did with slice 2. |
 | [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what it turned up, and what rollback over a radio was decided on. |
 | [`media-bringup.md`](project/media-bringup.md) | What a Radxa Zero 3W does about video: the VPU, what MPP needs, and the two plugins that have to be built. |
+| [`pad-minimal-pairing.md`](project/pad-minimal-pairing.md) | The smallest board configuration a gamepad will bond under, found by taking one away at a time. |
+
+## `ideas/` — not designed yet
+
+Holding pens. Something that is going to need a design doc, written down before it has one, so the
+thinking is not lost and does not get mistaken for a decision.
+
+| | |
+|---|---|
+| [`autonomous_behavior.md`](ideas/autonomous_behavior.md) | The behavior stack: what the runtime's brain has to give up, and the ideas the chorale and theremin work left behind. |
 
 ## Elsewhere
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -15,26 +15,26 @@ rewritten). v1 targets a **single, well-specified hardware configuration**.
 
 ## The shape of it
 
-Five daemons on one board, talking over unix sockets. One of them drives the robot; the
-other four exist so that the first one can be broken without the board becoming
-unreachable.
+Seven daemons on one board, talking over unix sockets. One of them drives the robot; three
+of the others exist so that the first one can be broken without the board becoming unreachable,
+and the rest are transports and sensors that own nothing.
 
 ```text
-   gamepad          phone             you, on a laptop          a GitHub release
-      │ BLE/USB        │ BLE                │ ssh                       │ https
-      ▼                ▼                    ▼                           │
-  ┌────────┐      ┌────────┐          ┌──────────┐                      │
-  │  padd  │      │  btd   │          │ robotctl │                      │
-  └───┬────┘      └───┬────┘          └────┬─────┘                      │
-      │               │  a subset of the same API                       │
-      │  robot.*      │  robot.health · update.* · net.* · pad.* · system.*
-      ▼               ▼                    ▼                            │
-  ┌──────────────────────────────────────────────────────────────────┐  │
-  │   one unix socket per service · JSON-RPC 2.0, one object a line  │  │
-  └────┬──────────────────────┬─────────────────────────┬────────────┘  │
-       ▼                      ▼                         ▼               │
-  ┌───────────┐        ┌─────────────┐           ┌─────────────┐        │
-  │  robotd   │        │  configd    │           │  updaterd   │◄───────┘
+   gamepad          phone          you, on a laptop     a peer, anywhere    a GitHub release
+      │ BLE/USB        │ BLE             │ ssh                 │ WebRTC              │ https
+      ▼                ▼                 ▼                     ▼                     │
+  ┌────────┐      ┌────────┐       ┌──────────┐          ┌──────────┐                │
+  │  padd  │      │  btd   │       │ robotctl │          │  mediad  │                │
+  └───┬────┘      └───┬────┘       └────┬─────┘          └────┬─────┘                │
+      │               │  a subset of the same API             │                      │
+      │  robot.*      │  robot.health · update.* · net.* · pad.* · system.*           │
+      ▼               ▼                 ▼                     ▼                      │
+  ┌──────────────────────────────────────────────────────────────────┐               │
+  │   one unix socket per service · JSON-RPC 2.0, one object a line  │               │
+  └────┬──────────────────────┬─────────────────────────┬────────────┘               │
+       ▼                      ▼                         ▼                            │
+  ┌───────────┐        ┌─────────────┐           ┌─────────────┐                     │
+  │  robotd   │        │  configd    │           │  updaterd   │◄────────────────────┘
   │ robot.*   │        │ net.* pad.* │           │ update.*    │
   │ 50 Hz     │        │ system.*    │           │ verify      │
   │ loop      │        │ wifi, name, │           │ swap        │
@@ -45,8 +45,9 @@ unreachable.
   15 servos + IMU      BlueZ · NetworkManager           ▼
   on one UART                                    /opt/robot/daemon/current
 
-  ┌ not built ────────────────────────────────────────────────────────┐
-  │  mediad — camera, mic, perception, WebRTC, and the remote gateway │
+  ┌ publishes, answers nothing ───────────────────────────────────────┐
+  │  tofd — the head's 8×8 depth matrix, on /run/tofd/tof.sock.       │
+  │         mediad and robotd read it; it reads no one.               │
   └───────────────────────────────────────────────────────────────────┘
 ```
 
@@ -56,15 +57,19 @@ fast", "look there", "stand up" — and the safety layer inside `robotd` decides
 actually executable. Nothing else in the system can command a motor
 ([`robotd-design.md`](robotd-design.md)).
 
-**The other three survive a dead `robotd`.** `configd`, `updaterd` and `btd` have no systemd
+**Three of them survive a dead `robotd`.** `configd`, `updaterd` and `btd` have no systemd
 dependency on it, no ML runtime, and no media stack, because they are the recovery path: a
 robot whose control loop will not start is exactly the robot someone needs to reconfigure,
 update, or roll back. That is also why config lives in `configd` and not in `robotd` (§1.1).
+`mediad` and `padd` do depend on it, and are allowed to: a robot with no camera and no gamepad
+is still a robot you can update.
 
-**`btd` and `padd` own nothing.** They are transports. `btd` forwards a subset of the API
-from BLE to whichever socket answers it; `padd` reads a gamepad and sends the same intents an
-app would. Both are replaceable without touching robot behaviour, and both are exercised
-daily, so the API an app will use cannot quietly rot.
+**`btd`, `padd` and `mediad` own nothing of the robot.** They are transports. `btd` forwards a
+subset of the API from BLE to whichever socket answers it; `padd` reads a gamepad and sends the
+same intents an app would; `mediad` carries the same calls over a WebRTC data channel and owns only
+the pipeline. All three are replaceable without touching robot behaviour, and all three are
+exercised daily, so the API an app will use cannot quietly rot. `tofd` is the odd one out: it owns
+one sensor, publishes frames, and reads nothing (§1).
 
 **Releases are swapped, not patched.** A build lands as a whole directory under
 `/opt/robot/daemon/releases/<version>/`; `updaterd` verifies its signature, moves the
@@ -77,9 +82,11 @@ counter ([`updater-design.md`](updater-design.md)).
 | `robotd` | motor control, sensing, policies, safety, `robot.health` | `/run/robotd.sock` | the Dynamixel bus |
 | `configd` | wifi, robot identity and name, pairing PIN, gamepad bonding, reboot | `/run/configd.sock` | BlueZ and NetworkManager over D-Bus |
 | `updaterd` | releases: verify, install, swap, health-gate, roll back | `/run/updaterd.sock` | GitHub releases, `systemctl`, `robotd` |
-| `btd` | nothing — BLE transport for a subset of the API | a BLE GATT service | all three sockets |
+| `btd` | nothing — BLE transport for a subset of the API | a BLE GATT service | `robotd`, `configd`, `updaterd` — not `padd` or `tofd`, whose streams a radio this narrow cannot carry |
 | `padd` | nothing — gamepad transport; serves a raw input tap | `/run/padd/pad.sock` (`pad.input` only) | `/run/robotd.sock` |
-| `robotctl` | nothing — the CLI, and the tool that must work on a broken robot | — | all four sockets |
+| `mediad` | the camera and audio pipeline; nothing of the robot — WebRTC transport and the remote front door (§5.2) | TCP: the console on `:8080`, signalling on `:8443` — no unix socket of its own | `robotd`, `configd`, `updaterd` |
+| `tofd` | the head's ToF sensor: an 8×8 depth matrix it publishes and nobody else reads | `/run/tofd/tof.sock` (`tof.stream`) | the HAT's I²C bus |
+| `robotctl` | nothing — the CLI, and the tool that must work on a broken robot | — | every socket above |
 
 Where the state lives, and what survives an update:
 

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -7,11 +7,11 @@ three different documents, and the answer decides how a skew is diagnosed.
 Everything here is read from the code, and each step names the function that owns it. Where a
 narrative comment elsewhere disagrees with this page, the comment is the bug.
 
-## 1. The five daemons, and the unit that is not one
+## 1. The seven daemons, and the unit that is not one
 
-A release ships five daemons — `robotd`, `configd`, `btd`, `padd`, `updaterd` — each `ExecStart`ing a
-path under `/opt/robot/daemon/current/bin/`, so each is stale the instant the symlink moves, and each
-is either restarted by the update or restarted after it.
+A release ships seven daemons — `robotd`, `configd`, `btd`, `padd`, `mediad`, `tofd`, `updaterd` —
+each `ExecStart`ing a path under `/opt/robot/daemon/current/bin/`, so each is stale the instant the
+symlink moves, and each is either restarted by the update or restarted after it.
 
 It also ships `robot-boot-check.service`, which is **not** one of them and which an update must never
 restart: it asks whether the release that booted came up and hands over to `robot-rescue` if not, so
@@ -23,6 +23,8 @@ no `[Install]` section, and that is what keeps it out — see §1.1.
 | `robotd` | yes | — |
 | `configd` | yes | — |
 | `padd` | yes | — |
+| `mediad` | yes | — |
+| `tofd` | yes | — |
 | `updaterd` | **never** — it is the process performing the update | yes |
 | `btd` | **never** — it may be the transport the update arrived over | yes |
 
@@ -71,10 +73,12 @@ units an update cannot touch are exactly the two it exists to watch.
 On today's release `units_to_restart` is exactly:
 
 ```
-configd, padd, robotd
+configd, mediad, padd, robotd, tofd
 ```
 
-in that order — alphabetical, so the order is identical on every board and in every test.
+in that order — alphabetical, so the order is identical on every board and in every test. Nothing
+was added to `deploy/updater.toml` to put `mediad` and `tofd` in that list, and nothing needed to
+be: both ship a unit with an `[Install]` section, which is the whole rule.
 
 Two consequences of deriving it from the release rather than from the board:
 
@@ -115,7 +119,7 @@ onto the release carrying it. This cost a confused round of "the hook ran and lo
 | 9 | arm the boot counter (`pending.json`), *before* the swap | no |
 | 10 | swap `current` → `releases/<ver>` | no |
 | 11 | **`hooks/postinstall`** (cwd = `releases/<ver>`) | **starts newly shipped units** |
-| 12 | `on_apply` — `systemctl restart` each unit from §1, one at a time | **configd, padd, robotd** |
+| 12 | `on_apply` — `systemctl restart` each unit from §1, one at a time | **configd, mediad, padd, robotd, tofd** |
 | 13 | `releases/<ver>/bin/updaterd --self-test` | no |
 | 14 | health gate: poll `robotd` over its socket, every 500 ms, up to 30 s | no |
 | 15 | confirm the boot counter, prune old releases | no |
@@ -142,10 +146,12 @@ The hook ships inside the signed artifact and runs with the release directory as
 1. `install` every `systemd/sysusers.d/*.conf` to `/usr/lib/sysusers.d/`, then run
    `systemd-sysusers`. Accounts before units, because a unit naming a missing `User=` fails to start
    and reads as a broken daemon.
-2. `install` every `systemd/*.service` to `/etc/systemd/system/`, overwriting. **All five**, including
-   `updaterd.service` and `btd.service` — the hook has no exclusion list, and does not need one.
+2. `install` every `systemd/*.service` to `/etc/systemd/system/`, overwriting. **All of them**,
+   including `updaterd.service` and `btd.service` — the hook has no exclusion list, and does not
+   need one.
 3. `systemctl daemon-reload`.
-4. `systemctl enable --now` each of the five.
+4. `systemctl enable --now` each unit that has an `[Install]` section (§1.1); one without is
+   installed and left alone, and a `.timer` is enabled without `--now`.
 
 Step 4 is why the exclusions in §1 still hold: `--now` means *start*, and starting an already-running
 unit is a no-op. It does not restart `updaterd` or `btd`. What it does do is start a unit the board
@@ -214,7 +220,7 @@ Two things follow that are easy to miss:
 health gate, revert on failure. They do **not** run hooks and do **not** self-test — no artifact was
 extracted, so there is nothing new to install or prove.
 
-| | hooks | `on_apply` (configd, padd, robotd) | self-test | deferred updaterd/btd restart |
+| | hooks | `on_apply` (§1) | self-test | deferred updaterd/btd restart |
 |---|---|---|---|---|
 | `update apply` | yes | yes | yes | **yes** |
 | `update select <ver>` | no | yes | no | **yes** |
@@ -243,7 +249,7 @@ restart fails the transition (`../project/install-path-gap.md`).
 
 ## 4. At boot
 
-systemd starts the five daemons from `multi-user.target`, and `robot-boot-check.timer` arms the
+systemd starts the daemons from `multi-user.target`, and `robot-boot-check.timer` arms the
 recovery check for 180 seconds in. There is **no ordering between the daemons**
 beyond `padd` after `robotd` (advisory — `padd` exits and retries every 5 s if the socket is absent)
 and `btd` after `dbus`/`bluetooth`. Nothing waits on `updaterd`, and `updaterd` waits on nothing but
@@ -385,20 +391,24 @@ unchanged: a stopped unit and a daemon that published nothing are still not stal
    because on a board with no release they are facts rather than policy: `on_apply = none` (the units
    live inside the release being installed) and `health = none` (there is no `robotd` to probe).
    So §2 runs with steps 12, 13 and 14 skipped — but **step 11 still runs**, and
-   `hooks/postinstall` is what installs the units and `enable --now`s all five. The daemons first
-   start there, from inside the hook. Step 16 is not skipped either: the bootstrap install schedules
+   `hooks/postinstall` is what installs the units and `enable --now`s every one with an
+   `[Install]` section. The daemons first start there, from inside the hook. Step 16 is not skipped either: the bootstrap install schedules
    the `updaterd` and `btd` restarts for 5 s later, while `install.sh` is still running.
-3. `install_units`: copy the units again, `daemon-reload`, then `enable --now` `updaterd`, `robotd`,
-   `configd`, `btd`, `padd` in that order — `configd` before `btd` because `btd` asks `configd` for the
-   pairing PIN. Redundant with the hook and harmless; it is also the path for a release older than the
+3. `install_units`: copy the units again, `daemon-reload`, then `enable --now` `updaterd`,
+   `robotd`, `configd`, `btd`, `padd`, `mediad` in that order — `configd` before `btd` because `btd`
+   asks `configd` for the pairing PIN, and `mediad` last because its unit is `After=` three of the
+   others. `btd`, `padd` and `mediad` may fail without failing the install: a robot with no radio, no
+   gamepad or no camera still updates and walks. Then `robot-boot-check.timer` is enabled *without*
+   `--now`. Redundant with the hook and harmless; it is also the path for a release older than the
    hook. A unit the release ships that this function does not know is installed, reported, and left
-   alone.
+   alone — which is what `tofd` currently gets, having been added to the release and not to this
+   list. The hook enabled it a step earlier, so the warning is noise rather than a missing daemon.
 4. `install_token_dropin`: write the `GITHUB_TOKEN` drop-in, `daemon-reload`, and
    `systemctl try-restart updaterd` — `daemon-reload` alone would leave the *running* `updaterd`
    without the token, which is every board.
 
-`DUCK_FORCE_REINSTALL=1` adds `stop_for_reinstall` before step 2: `systemctl stop` on `padd`, `btd`,
-`configd`, `robotd`, `updaterd`, in that order. Nothing is live while the swap happens, and there is
+`DUCK_FORCE_REINSTALL=1` adds `stop_for_reinstall` before step 2: `systemctl stop` on `padd`,
+`tofd`, `btd`, `configd`, `robotd`, `updaterd`, in that order. Nothing is live while the swap happens, and there is
 no health gate behind it.
 
 ## 7. Diagnosing a skew
@@ -408,7 +418,7 @@ Two version numbers are legitimately different at once, and which pair it is dec
 | observation | means |
 |---|---|
 | `updaterd` or `btd` behind the installed release, for a few seconds after an update | expected — the deferred restart has not fired yet |
-| `btd`, `robotd`, `configd` or `padd` disagreeing with `current` at all, persistently | the restart did not take effect *and* §5 did not fix it — so either `updaterd` has not restarted since, or its restart failed (journal, at `error`) |
+| `btd`, `robotd`, `configd`, `padd`, `mediad` or `tofd` disagreeing with `current` at all, persistently | the restart did not take effect *and* §5 did not fix it — so either `updaterd` has not restarted since, or its restart failed (journal, at `error`) |
 | `updaterd` behind it, persistently | the deferred restart never landed, and §5 will not fix this one. `robotctl update apply daemon` repairs it — it reports `already_current` with `updaterd` in `stale` and schedules the restart. `systemctl restart updaterd` is the same fix by hand; either way the journal has why it did not land |
 | any daemon reporting `build unknown (old)` | it predates the identity mechanism, so §5 leaves it alone. One update makes it answerable |
 

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -83,14 +83,14 @@ deliberately:
         │ on_apply: systemctl restart robotd              │
         └─────────────────────────────────────────────────┘
 
-   ┌ not built ─────────────────────────────────┐
+   ┌ the two transports ────────────────────────┐
    │  mediad — WebRTC + JSON-RPC relay          │  phone, browser and LLM
    │  btd    — BLE, a subset of the same API    │  clients arrive through here
    └────────────────────────────────────────────┘
 ```
 
 Every one of those speaks the same two vocabularies — intents in, state out — so `mediad`
-will **relay** frames rather than translate them (§3.1, §3.2). `updaterd` only ever asks
+**relays** frames rather than translating them (§3.1, §3.2). `updaterd` only ever asks
 questions: nothing in the update path can command a motor.
 
 ### 1.3 The crate boundary
@@ -101,10 +101,21 @@ duck-control/    robot model · bus · IMU · RobotIo · obs · policy · safety
                  everything between reading the bus and writing it
                  no tokio, no sockets, no systemd
 robotd/          the process: socket, JSON-RPC, systemd, health reporting
+robotd-params/   the startup parameters: schema, defaults, validation (§4.2)
+kinematics/      the MJCF model, forward kinematics, head and hand chains
+odometry/        where the robot is, from foot contacts and the IMU
+sounds/          the voice: synthesis, per-robot personality, the chorale's score
+pet-detect/      the camera-side detector robotd polls, off the loop
 robotctl/        CLI
 padd/            gamepad → intents
 updater/         engine + updaterd
 ```
+
+Everything below `robotd/` in that list is a **library it drives**, not a service: no tokio
+runtime of its own, no socket, nothing systemd starts. They are separate crates for the same
+reason `duck-control` is — the compiler is what keeps daemon concerns out of them, and
+`kinematics` in particular has two consumers (`odometry` and `robotd`'s head FK) that would
+otherwise each grow a copy of the model.
 
 `duck-control` holds everything between reading the bus and writing it; `robotd` is the
 process around it. The compiler enforces that boundary, which is what stops daemon concerns
@@ -772,6 +783,50 @@ all it has. Pairing a pad therefore belongs to `configd` (`architecture.md` §1)
 a device needs root and BlueZ, and a `padd` holding either would no longer be exercising the API
 the app will use.
 
+### 4.4 Odometry, on the sample the loop already took
+
+`odometry::Odometry::alpha()` is stepped once per tick from the joint positions and the IMU
+quaternion the loop has just read, and its estimate goes out on the state stream as
+`odom: { position, yaw }`. `robotctl monitor` draws it as a path map under the 3D view.
+
+**Contact-based**, ported from the prototype runtime: one sole corner is the ground anchor, the
+trunk's world pose follows from it by forward kinematics through the `kinematics` crate's model,
+and the anchor moves when another corner drops below it — so a step never makes the estimate jump.
+Heading is the IMU's integrated yaw, so the world frame is wherever the robot was looking at boot.
+There is no magnetometer and nothing corrects drift; this is relative motion, and every consumer
+has to treat it that way.
+
+It costs the loop two chain evaluations per tick and no extra bus traffic, which is why it runs at
+the loop's own rate rather than the prototype's separate 100 Hz. That cost is the reason the
+"no odometry" decision in §7 was reversed rather than re-argued: the objection was never the
+arithmetic, it was that nothing read the answer.
+
+### 4.5 What else the loop drives, and why none of it has a design page
+
+`robotd` grew four subsystems after slice 2 that are not control and not safety. They share a
+shape: each hangs off the tick, none may block it, and none can reach the bus except through the
+intents the loop already arbitrates.
+
+| in the process | what it is | where the reasoning lives |
+|---|---|---|
+| `sound.rs` | the voice at play time — one `aplay` child, and a new sound kills the old one, because the codec's PCM is exclusive | the module header |
+| `theremin.rs` | depth from `tofd` at 15 Hz → a note, a mouth opening, and a line of state, sampled by the 50 Hz loop and never waited on | the module header |
+| `chorale.rs` | several ducks singing one piece: the lowest id conducts, the conductor owns the seating, `btd` carries the beacons and does no thinking | the module header |
+| `pet-detect/` | a ~20 KB CNN over a 40-band log-mel window from the onboard mic, in its own worker | the crate header |
+
+Plus `soc.rs`, which reads the board's own thermal zones out of `sysfs` — not behind `RobotIo`,
+because it has to keep answering when the motor bus does not.
+
+**None of them has a design page, and that is the rule working rather than a gap.** A service earns
+one when a second reader would otherwise have to derive its contract from the code
+(`../README.md`). These have exactly one implementation and one consumer each, and their decisions
+are local enough to live in the module header next to what they constrain. What they need instead
+is to be *operable*, and that is the cheat sheet's job: [the voice], [the chorale], [the theremin].
+
+[the voice]: ../robot/cheatsheet.md#the-voice
+[the chorale]: ../robot/cheatsheet.md#the-duck-chorale
+[the theremin]: ../robot/cheatsheet.md#play-the-duck-the-tof-theremin
+
 ## 5. Why it exists, and where it came from
 
 ### 5.1 The goal, which is not "a good `robotd`"
@@ -867,7 +922,7 @@ Each test's comment says which failure it exists to prevent, per the repo conven
 | adopt current pose on start | an update must not move a standing robot |
 | bring-up as a state machine, not a flag | `set_torque` is a transaction per joint |
 | the fall verdict reports, it does not gate | what to do about a fall is a control decision (§2.4) |
-| no odometry | nothing reads it; one 50 Hz rate instead of 50/100 |
+| ~~no odometry~~ — reversed | `monitor`'s path map reads it, and it is one `kinematics` pass on a sample the loop already took (§4.4) |
 | the priority chain keeps the runtime's shape | the skills were tuned against its quirks |
 | gamepad as its own crate | keeps `gilrs` out of the recovery CLI |
 | sim after slice 2 | hardware is the validation path; `FakeIo` covers laptop development |
@@ -876,7 +931,10 @@ Each test's comment says which failure it exists to prevent, per the repo conven
 
 MuJoCo backend and the `RemoteIo` protocol · the skill abstraction · policy bundle manifests and
 `model_api` gating · `look`/`pose`/`do` intents · gaze IK · live params reload and the config store ·
-odometry · thermal limits · rate limits · per-device IMU calibration.
+thermal limits · rate limits · per-device IMU calibration.
+
+**Odometry has left this list.** It was deferred because nothing read it; `robotctl monitor`'s
+path map now does. §4.4.
 
 ## 9. Open
 

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -862,7 +862,7 @@ components. Adapting to a new robot = new config + new signing key + (maybe) a
 new health probe.
 
 The authoritative, parse-tested example is
-[`updater/updater.example.toml`](../updater/updater.example.toml) — a unit test
+[`updater/updater.example.toml`](../../updater/updater.example.toml) — a unit test
 parses it, so it cannot drift from the code. Abridged here:
 
 ```toml

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Status: draft · Date: 2026-08-05 · Owner: pierre
+Status: draft · Date: 2026-08-05, revised 2026-08-26 · Owner: pierre
 
 Companion to [`architecture.md`](../design/architecture.md) (what we're building) and
 [`updater-design.md`](../design/updater-design.md) (how it ships). This is *order and sequencing*
@@ -13,9 +13,9 @@ Companion to [`architecture.md`](../design/architecture.md) (what we're building
 | `updater/` | engine, verification, store, journal, hooks, preflight, GitHub/HF/local sources, IPC server, systemd unit — **done** |
 | `duck-control/` | robot model · bus · IMU · `RobotIo` · observations · ONNX policy · safety — **slices 1–2 done, and run on a robot**. A library: no tokio, no sockets, no systemd |
 | `duck-ipc-proto/` | wire contract for `update.*` and `robot.*` — **done**; serde/serde_json/semver only, so nothing on the recovery path pulls the engine's tree |
-| `robotd/` | a real 50 Hz loop driving walk/stand through the safety layer, intents, health from deadline adherence and policy state — **slices 1–2 done, and it walks on a board**; no kinematics |
+| `robotd/` | a real 50 Hz loop driving walk/stand through the safety layer, intents, health from deadline adherence and policy state — **slices 1–2 done, and it walks on a board**. Since then: kinematics, contact odometry, the voice, the ToF theremin and the chorale, all hung off the same tick ([`robotd-design.md`](../design/robotd-design.md) §4.4–4.5) |
 | `padd/` | gamepad → intents, as an ordinary socket client — **done**, ships in the release and runs as its own unit from boot, so pairing a pad is the only step; needs libudev, installed by CI and the board cross-build |
-| `robotctl/` | the operator CLI — `update`, `health`, `version`, `monitor`, `net`, `system`, `pad`, `completions`; depends on `duck-ipc-proto`, not `updater`, so it stays on the recovery path |
+| `robotctl/` | the operator CLI — `update`, `health`, `version`, `monitor`, `net`, `system`, `robot`, `pad`, `configure`, `quack`, `chorale`, `theremin`, `completions`; depends on `duck-ipc-proto`, not `updater`, so it stays on the recovery path |
 | `xtask/` | package · sign · promote — **done**, byte-identical promotion verified |
 | `.github/` | ci · release · promote — **all three run for real**: `0.2.0` was tagged to staging, verified through the engine, installed on a board and promoted to stable on 2026-08-05, byte-identical (§16.3) |
 | bootstrap | `updaterd install` + `scripts/install.sh` — a robot installs its first release through the **ordinary engine**, so there is no bootstrap-only code path to drift |
@@ -24,8 +24,10 @@ Companion to [`architecture.md`](../design/architecture.md) (what we're building
 | `btd/` | BLE transport adapter — framing, the routed subset, the BlueZ backend, a pairing agent. **Works on hardware**, unencrypted by default — the blocker, [`app-path-design.md`](../design/app-path-design.md) §5.5 |
 | `duckctl/` | The robot from a laptop. BLE today; named for the robot rather than the radio, because `mediad` is a second transport |
 | `configd/` | wifi over NetworkManager, robot name and the identity it derives from the SoC serial, pairing PIN, reboot. **Drives a real NetworkManager on a board**: provisioned over BLE, joined, and rejoined by itself after a reboot. `--fake-net` still serves the whole surface off-board |
-| tests | **458 passing**, including the health gate, the battery+thermal readout and the policy/safety path against a real `robotd` process, and `configd`'s authorisation over real sockets in `board-test.sh` |
-| missing | `mediad`, app, SDK |
+| `mediad/` | camera, mic, encode and the WebRTC gateway, plus the console it serves. **Streaming to a browser on the LAN from a Radxa Zero 3W**, hardware H.264 through `mpph264enc`, with a `control` datachannel alongside — [`remote-webrtc.md`](../design/remote-webrtc.md) §0. Ships in the release and runs as its own unit |
+| `tof/` | `tofd`: the head's 8×8 ToF matrix, published on its own socket at 15 Hz. Read by `robotd`'s theremin and drawn by `robotctl monitor`; a board with no sensor fitted runs it anyway and says so |
+| tests | **936 passing** on a Mac (`--exclude tof`), a few more on Linux — including the health gate, the battery+thermal readout and the policy/safety path against a real `robotd` process, and `configd`'s authorisation over real sockets in `board-test.sh` |
+| missing | the app, the SDK, and reaching a robot from outside the LAN |
 | on hardware | walking through the intent API, the update path (install · health gate · commit · auto-rollback), a signed release installed from the stable channel, BLE provisioning of wifi. The loop held 50.0 Hz with `missed=3` in 15022 ticks before inference |
 | not on hardware | the numbers M4 exists for: thermals, eMMC write timing, battery under load, and whether logs survive a power cut. The 30s health-gate timeout is still a guess |
 
@@ -195,12 +197,27 @@ off-board (`deploy/README.md`):
 cleanly with the gate passing, and `journalctl -u robotd -b -1` returns the previous boot's
 logs after a power cut.
 
-### M5 — `mediad`, WebRTC, SDK
+### M5 — `mediad`, WebRTC, SDK  ·  in progress
 
 Camera/mic, encode, perception, the remote gateway. Privacy lands here and not later:
 per-session consent and a visible streaming indicator are cheap now and expensive to
 bolt on. The SDK's WebSocket + snapshot path (§5.3) is what makes "an LLM drives the
 robot" easy.
+
+**Landed, on hardware.** `mediad` ships in the release and runs as its own unit. The camera
+reaches a browser on the LAN through the VPU — `mpph264enc` → `webrtcsink`, constrained baseline —
+with a `control` datachannel carrying the same JSON-RPC every other transport speaks, and the
+console is served by the robot itself so there is a URL and nothing to install
+([`remote-webrtc.md`](../design/remote-webrtc.md) §0, [`webrtc-console.md`](../design/webrtc-console.md)).
+Two GStreamer plugins had to be built from source to get there, which is its own record
+([`media-bringup.md`](media-bringup.md)), and the camera has since got 3A through `rkaiq`.
+
+**Still open, and they are what keeps this milestone from closing:** reaching a robot from outside
+the LAN — the design is the same one with a proxy in front (§7), deliberately built second — the
+SDK, and the privacy pair. Consent and the streaming indicator are *not* done, and this is the
+milestone that was supposed to stop them being bolted on, and the reason given for deferring them
+is a hardware one — an LED under software control, which does not yet exist
+([`remote-webrtc.md`](../design/remote-webrtc.md) §11).
 
 **Done when:** telepresence works from outside the LAN, and a server-side script can
 fetch a frame and send an intent in a few dozen lines.
@@ -230,22 +247,31 @@ bricked release recovers without a laptop.
 
 ## Organisation
 
-**One repo, one workspace.** `robotd`, `btd`, `configd` and `padd` have joined as siblings;
-`mediad` is the one still outstanding. They co-version because they all ship in the same
+**One repo, one workspace.** `robotd`, `btd`, `configd`, `padd`, `mediad` and `tofd` are all
+siblings now — nothing is outstanding. They co-version because they all ship in the same
 `daemon` artifact — one version line is correct, and models version separately already.
 
 **Crate layout as it should end up:**
 
+It ended up wider than this section first drew it — the libraries `robotd` drives are their own
+crates now, for the reason `duck-control` was: the compiler is what keeps daemon concerns out of
+them. The list lives in [CONTRIBUTING.md](../../CONTRIBUTING.md#the-layout) rather than here,
+because it is reference and this page is a record. The shape:
+
 ```
 duck-ipc-proto/ wire types — serde/serde_json/semver only; btd/robotd/robotctl depend
                 on this, never on updater
-configd/        wifi (NetworkManager), robot name, pairing PIN, reboot, gamepad pairing (BlueZ)
 updater/        engine + updaterd
-robotctl/       CLI
-robotd/         control, gait, safety — no kinematics yet
+robotd/         control, gait, safety, the voice, the theremin, the chorale
+duck-control/   the control core, extracted from the prototype runtime
+kinematics/  odometry/  sounds/  pet-detect/  robotd-params/
+                libraries robotd drives — no sockets, nothing systemd starts
+configd/        wifi (NetworkManager), robot name, pairing PIN, reboot, gamepad pairing (BlueZ)
 padd/           gamepad → intents; a client, with no privilege the app will not have
-mediad/         camera, encode, perception, WebRTC gateway  (not built yet)
+mediad/         camera, encode, WebRTC gateway, and the console it serves
+tof/            tofd — the head's depth sensor, published on its own socket
 btd/            BLE transport adapter
+robotctl/       CLI
 duckctl/        the client, from a laptop (dev tool, never shipped)
 xtask/          build/publish tooling — never ships
 ```

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -68,9 +68,28 @@ network is configured at all — because `walk` is a mode two releases with diff
 report. A robot with no policy says so, and one whose policy would not load says that instead,
 which the stream's `held` cannot distinguish.
 
+Down the right-hand side, **the robot drawn as it is standing** — the same visual model the
+policies were trained against, posed by the measured joint angles and tilted by the IMU's gravity
+vector. A leg folded the wrong way, a head pitched into the floor and a duck lying on its side are
+all just numbers in the joints table; every one of them is obvious here. It is on by default and
+appears whenever the terminal is wide enough (about 110 columns — the tables come first, and the
+robot takes what is spare). **`d`** turns it off; **`[`** and **`]`**, or `←`/`→`, orbit it.
+
+Whenever the ToF is delivering frames, what it sees is drawn into the same scene — yellow for a
+hit, green for floor — depth-tested against the robot's own body, so a point behind the beak is
+hidden by it. That is what makes "is it seeing my hand, or is it seeing itself" answerable. It
+needs no key: the points appear when frames arrive and go when they stop.
+
+Under it, when the column is tall enough, **a map of where the robot has been**: odometry's track
+from the foot contacts and the IMU, in braille. The panel never grows — the world zooms out as the
+track does, so the whole path stays in frame. `+` is where it started, `●` is the robot with a
+short ray for its heading, screen-up is the heading it booted with. There is no magnetometer, so
+this is relative motion and it drifts; it answers "did it walk in a circle" and not "where is it".
+
 `q` quits; `↑`/`↓` scroll the joint list on a window too short for all of it; `u` switches the
-angles between degrees and radians; `p` opens the pad's raw input stream — every evdev report from
-the gamepad, with the gaps between them, which is the only place a stalled radio is visible
+angles between degrees and radians; `t` opens the [ToF matrix](#the-tof-sensor-tofd); `d` toggles
+the robot view and `[` / `]` orbit it; `p` opens the pad's raw input stream — every evdev report
+from the gamepad, with the gaps between them, which is the only place a stalled radio is visible
 ([pair a gamepad](pair-a-gamepad.md#when-it-drops-while-you-are-driving)). Angles are degrees on screen — joints, head and the yaw rate.
 Redirected or piped it prints one line per tick instead, so `> run.log` and `| grep FALLEN`
 behave, and those numbers stay radians whatever the screen is set to. The joint vectors are in

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -73,7 +73,7 @@ export DUCK_BOARD=radxa@192.168.1.42
 
 It cross-compiles the workspace, packages the same artifact a release does, signs it with the dev
 key, copies it to `~/duck-sideload` on the board, and applies it there through
-`robotctl update apply --from`. Then it waits for the five daemons to report the new release:
+`robotctl update apply --from`. Then it waits for the daemons to report the new release:
 
 ```
 ==> building 0.5.1-dev.local.1763400000.g7fc1444 for the board (zigbuild)
@@ -89,12 +89,18 @@ key, copies it to `~/duck-sideload` on the board, and applies it there through
     [ok] padd
     [ok] updaterd
     [ok] btd
+    [ok] mediad
 ==> every daemon on radxa@192.168.1.42 is running 0.5.1-dev.local.1763400000.g7fc1444
 ```
 
 `updaterd` and `btd` restart five seconds after the apply replies, so those two lines take a moment
 to arrive. A `[--] padd published nothing` is not a failure — it is also what a stopped or
-deliberately disabled daemon looks like.
+deliberately disabled daemon looks like, and what `mediad` looks like on a board with no camera.
+
+`tofd` is **not** on that list, and its absence is the script's rather than the board's: the update
+restarted it like every other unit with an `[Install]` section
+([`restart-order.md`](../design/restart-order.md) §1), and `dev-push.sh` simply does not ask it.
+`robotctl version` on the board does.
 
 On the board, that version is what `robotctl version` reports:
 

--- a/docs/robot/install-by-hand.md
+++ b/docs/robot/install-by-hand.md
@@ -87,7 +87,7 @@ install what that branch last built.
 cannot bond a gamepad at all. See [`pair-a-gamepad.md`](pair-a-gamepad.md).
 
 `DUCK_NO_START=1` installs the release, the units, the users and the groups and enables **nothing**
-— not even for the next boot. It also stops and disables any of the five a previous install left
+— not even for the next boot. It also stops and disables any daemon a previous install left
 running, so the state is the same whether the card is fresh or not. For separating a board-level
 fault from the daemons: reboot into a board with nothing of ours running, test, then bring them up
 one at a time.

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -270,5 +270,6 @@ axis and button mappings, whatever else matches.
 
 ---
 
-Driving — the controls, the speed limits, and running `padd` from a laptop over a forwarded socket —
-is in the [README](../../README.md#drive-it).
+Driving — the controls and the speed limits — is in the
+[cheat sheet](cheatsheet.md#gamepad-configd); running `padd` from a laptop over a forwarded socket
+is in the [dev cheat sheet](cheatsheet-dev.md#from-a-laptop--drive-with-a-pad-in-your-hands).


### PR DESCRIPTION
Audited every doc against the code. `docs/robot/cheatsheet.md` was current; the reference pages were written before `mediad`, `tofd` and five library crates landed, and still described five daemons.

## The one that matters

`restart-order.md` named the update's restart set as `configd, padd, robotd`. It is `configd, mediad, padd, robotd, tofd` — derived from the units the release ships minus `NEVER_RESTART`, exactly as that page's own rule says. `deploy/updater.toml:115` had said so for two releases. That page is what someone reads while diagnosing a version skew, so a wrong list there sends the diagnosis somewhere else.

## The rest

| page | was |
|---|---|
| `architecture.md` | "Five daemons", and an ASCII box labelling `mediad` **not built** — while §1's own table three screens down described both it and `tofd` |
| `robotd-design.md` | odometry on the "deferred, deliberately" list; the crate boundary omitted every library `robotd` gained |
| `CONTRIBUTING.md` | 508 tests (936), 13 board checks (60), and a layout missing eight crates |
| `roadmap.md` | `missing: mediad, app, SDK`; M5 written as unstarted |
| `docs/README.md` | `pad-minimal-pairing.md` and all of `ideas/` off the index |
| `deploy/README.md` | `/etc/systemd/system/{updaterd,robotd}.service` as the installed set |

## Added

**The monitor's 3D robot view was documented nowhere** — not the view, not `d`/`[`/`]`, not the ToF contact points drawn into the scene, not the odometry path map under it, not `scripts/bake-duck-mesh.py`. It is in the cheat sheet now.

**`robotd-design.md` §4.4 and §4.5.** §4.4 is odometry: what it is, what it costs the tick, and why the "no odometry" decision was reversed rather than re-argued — the objection was that nothing read the answer, and `monitor` does. §4.5 names the voice, the theremin, the chorale and pet detection, and says why none of them earns a design page: one implementation, one consumer, decisions local enough to live in the module header. What they needed was to be operable, which the cheat sheet already does.

## Two things found on the way, both fixed here

- `_build-release.yml` carried a comment saying `mediad.service` has no `[Install]` section. It has one, which is why an update restarts it.
- Two dead links: `updater-design.md` → `updater.example.toml` (wrong depth, never resolved) and `pair-a-gamepad.md` → `README.md#drive-it`, whose target the README rewrite removed.

## Two things found and *not* fixed — they are code

- **`cargo test --workspace` does not work on either platform out of the box.** Linux needs `libudev-dev` and three GStreamer `-dev` packages; macOS cannot build `tof` at all — `build.rs` compiles `vendor/platform.c`, which includes `linux/i2c.h`, with no `cfg` around it. Documented as it is, with `--exclude tof` for the Mac. A `cfg(target_os = "linux")` in `tof/build.rs` would delete the caveat.
- **`install.sh` warns about `tofd.service` on every fresh install** — "installed but not enabled — this script does not know where it belongs in the start order". `hooks/postinstall` enabled it a step earlier, so it is noise, not a missing daemon. Noted in `restart-order.md` §6 rather than papered over. Adding `tofd.service` to `install_units`' case list is the fix.
- `scripts/dev-push.sh` checks six daemons and not `tofd`. Also noted in the doc rather than changed.

## Verified

- `cargo test --workspace --exclude tof` — 936 passing, 0 failed
- `cargo test -p xtask` — the tests that parse `_build-release.yml`
- every relative link and every `#anchor` across `*.md`, `docs/**`, `deploy/README.md` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)