### PR TITLE
readme: the intro clips get their names back

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ recipe, and the export to ONNX that this repo loads.
 <table>
 <tr>
 <td width="50%">
-  <video src="https://github.com/user-attachments/assets/1323be2e-969d-492b-be10-023b23f2a2c2" controls width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/356a6011-8e0d-4b28-bda9-da78646583a3" controls width="100%"></video>
 </td>
 <td width="50%">
   <video src="https://github.com/user-attachments/assets/abfbf250-1b1c-42cb-8430-00267e2b148a" controls width="100%"></video>
@@ -51,10 +51,10 @@ recipe, and the export to ONNX that this repo loads.
 </tr>
 <tr>
 <td width="50%">
-  <video src="https://github.com/user-attachments/assets/abbfdc75-6e00-436c-979e-91eed53e120f" controls width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/7e70c1da-e120-428f-ae0b-f4de62f25984" controls width="100%"></video>
 </td>
 <td width="50%">
-  <video src="https://github.com/user-attachments/assets/7ce4bf4c-3088-4688-89fd-b6e51d751c91" controls width="100%"></video>
+  <video src="https://github.com/user-attachments/assets/3eef63a5-6f84-47cf-90de-e717e6d7f8f0" controls width="100%"></video>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
The vpcC re-upload in af9daf5 carried the temp filenames the fix script had written, so three of the four tiles announced themselves as `duck-<old-uuid>-vpcCfix.mp4` in the player header.

That header is not something the README controls. GitHub wraps a `user-attachments` video in its own `<details>` and puts the attachment's upload filename in the `<summary>`. `alt`, `title` and `aria-label` are all dropped by the sanitiser, and a hand-written `<details><summary>` wrapper just nests a second player inside. The name is fixed at upload time, so the same bytes went up again as `walk.MP4`, `grasp.MP4` and `standup.MP4` — no re-encode, identical files to the ones af9daf5 published.

Verified through the renderer itself (`POST https://api.github.com/markdown`, repo context), the four tiles now read in caption order:

| tile | caption | player header |
|---|---|---|
| 1 | It walks. | `walk.MP4` |
| 2 | It rolls. | `roller_cut.mp4` (untouched) |
| 3 | It picks things up. | `grasp.MP4` |
| 4 | It gets back up. | `standup.MP4` |