### PR TITLE
Three papercuts, and the two things one of them was hiding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,11 @@ sudo apt-get install -y libudev-dev libgstreamer1.0-dev
 sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev
 ```
 
-**On macOS** `tof` does not build at all: its vendored ST driver compiles `vendor/platform.c`,
-which includes `linux/i2c.h`, and `build.rs` has no `cfg` around it. Exclude the crate. That is
-**936 tests passing**, and the eight it leaves out are the ToF driver's own:
-
-```bash
-cargo test --workspace --exclude tof
-```
+**On macOS** the command above is the whole of it — **942 tests passing**, nothing excluded. Two
+of the ToF driver's own tests do not run there, because there is no driver to run them against:
+`vendor/platform.c` reaches the bus through `linux/i2c.h`, so `build.rs` compiles it on Linux
+targets only and `sensor.rs` offers a `Sensor` that cannot be opened. `tofd` still builds and
+`tofd --fake` still serves frames, which is the only way it runs off a board anyway.
 
 Those tests are also where the engine's failure paths are: a bad signature, a release that comes
 up unhealthy, a post-install hook that fails, power loss between the swap and the health gate.

--- a/configd/src/units.rs
+++ b/configd/src/units.rs
@@ -29,18 +29,24 @@ use duck_ipc_proto as proto;
 pub const PADD: &str = "padd.service";
 
 /// Every unit a daemon release manages, in the order a reader wants them: the update engine, then
-/// the robot, then the three that depend on both.
+/// the robot, then the ones that depend on both.
 ///
 /// Hardcoded rather than discovered, and that is a real limitation worth naming: a unit added to a
 /// release and not to this list is invisible here. The alternative — asking systemd for everything
 /// and filtering — reports units this project does not own, which is worse for a status line.
-/// `scripts/install.sh` enables exactly these.
-pub const MANAGED: [&str; 5] = [
+/// `scripts/install.sh` knows exactly these.
+///
+/// It has already cost once: `mediad` and `tofd` shipped units two releases before they were named
+/// here, so the block a person reads after an update — the one that exists to say which daemon is
+/// still on the old release — could not report either of them at all.
+pub const MANAGED: [&str; 7] = [
     "updaterd.service",
     "robotd.service",
     "configd.service",
     "btd.service",
     "padd.service",
+    "mediad.service",
+    "tofd.service",
 ];
 
 /// What systemd says about one unit. The narrow question, kept for `pad.status`.

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -401,8 +401,9 @@ unchanged: a stopped unit and a daemon that published nothing are still not stal
    gamepad or no camera still updates and walks. Then `robot-boot-check.timer` is enabled *without*
    `--now`. Redundant with the hook and harmless; it is also the path for a release older than the
    hook. A unit the release ships that this function does not know is installed, reported, and left
-   alone — which is what `tofd` currently gets, having been added to the release and not to this
-   list. The hook enabled it a step earlier, so the warning is noise rather than a missing daemon.
+   alone. `tofd` is named as known but gets no `enable_unit` of its own: the hook enabled it a step
+   earlier and nothing depends on it, so there is no ordering for this function to have an opinion
+   about.
 4. `install_token_dropin`: write the `GITHUB_TOKEN` drop-in, `daemon-reload`, and
    `systemctl try-restart updaterd` — `daemon-reload` alone would leave the *running* `updaterd`
    without the token, which is every board.

--- a/docs/robot/dev-push.md
+++ b/docs/robot/dev-push.md
@@ -90,6 +90,7 @@ key, copies it to `~/duck-sideload` on the board, and applies it there through
     [ok] updaterd
     [ok] btd
     [ok] mediad
+    [ok] tofd
 ==> every daemon on radxa@192.168.1.42 is running 0.5.1-dev.local.1763400000.g7fc1444
 ```
 
@@ -97,10 +98,9 @@ key, copies it to `~/duck-sideload` on the board, and applies it there through
 to arrive. A `[--] padd published nothing` is not a failure — it is also what a stopped or
 deliberately disabled daemon looks like, and what `mediad` looks like on a board with no camera.
 
-`tofd` is **not** on that list, and its absence is the script's rather than the board's: the update
-restarted it like every other unit with an `[Install]` section
-([`restart-order.md`](../design/restart-order.md) §1), and `dev-push.sh` simply does not ask it.
-`robotctl version` on the board does.
+A `[--] tofd published nothing` means a release from before `tofd` published an identity at all —
+one more push fixes it — rather than a sensor that is missing: `tofd` runs whether or not one is
+fitted.
 
 On the board, that version is what `robotctl version` reports:
 

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -461,11 +461,11 @@ fi
 # ── did every daemon actually move? ──
 #
 # The apply reporting success means the swap happened and the health gate passed. It does not mean
-# the five daemons are running the release that was swapped in, and the gap between those two is
+# the seven daemons are running the release that was swapped in, and the gap between those two is
 # where an afternoon goes: four wifi fixes were once verified as broken against a `configd` that
-# had never restarted. `robotd`, `configd` and `padd` restart during the update; `updaterd` and
-# `btd` restart five seconds after it replies, because the first cannot restart itself mid-update
-# and the second may be carrying the reply (docs/design/restart-order.md).
+# had never restarted. `robotd`, `configd`, `padd`, `mediad` and `tofd` restart during the update;
+# `updaterd` and `btd` restart five seconds after it replies, because the first cannot restart
+# itself mid-update and the second may be carrying the reply (docs/design/restart-order.md).
 #
 # So this is the one check that observes the whole mechanism end to end, on real systemd, with real
 # timing — and nothing else in the repository can. A container cannot: the transient timer, the
@@ -501,7 +501,7 @@ echo "    current -> $want"
 # no socket at all, so for that one it is the only answer available.
 deadline=$(($(date +%s) + 30))
 stale=""
-for svc in robotd configd padd updaterd btd mediad; do
+for svc in robotd configd padd updaterd btd mediad tofd; do
     while :; do
         if [ ! -f "/run/${svc}/identity.json" ]; then
             state="silent"
@@ -527,7 +527,8 @@ for svc in robotd configd padd updaterd btd mediad; do
         silent)
             # Not treated as a failure: systemd removes the runtime directory when a unit stops, so
             # this is what a deliberately disabled `padd` looks like, and what `mediad` looks like on
-            # a board with no camera. The GStreamer stack is not a cause any more — the preinstall
+            # a board with no camera. `tofd` runs whether or not a sensor is fitted, so silent there
+            # is a release from before it published an identity at all — one push fixes it. The GStreamer stack is not a cause any more — the preinstall
             # hook this push just ran installs it — so a silent `mediad` here is worth
             # `journalctl -u mediad -b` rather than a command to type.
             echo "    [--] $svc published nothing — stopped, or a build too old to say"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -797,6 +797,12 @@ install_units() {
         case "$unit" in
             updaterd.service|robotd.service|configd.service|btd.service|padd.service) ;;
             mediad.service) ;;
+            # No `enable_unit` of its own, unlike the three above: `postinstall` enabled every
+            # unit carrying an `[Install]` section a step earlier, and nothing depends on this
+            # one — `robotd` does not read depth and `monitor` says "no depth stream" and
+            # carries on. Naming it here is what stops that being reported as a daemon this
+            # script forgot, which is how it read on every fresh install.
+            tofd.service) ;;
             robot-boot-check.timer) ;;
             # Started by its timer, never enabled. See above.
             robot-boot-check.service) ;;

--- a/tof/build.rs
+++ b/tof/build.rs
@@ -18,6 +18,13 @@
 //! Warnings are not errors here: `vl53l?cx_api.c` is upstream code we do not
 //! edit, and a new compiler finding something in it must not be able to stop a
 //! robot release from building.
+//!
+//! **Linux only, and quietly so.** `vendor/platform.c` reaches the bus through
+//! `linux/i2c.h`'s `I2C_RDWR` ioctl, which exists on no other platform — so on a
+//! developer's Mac there is nothing here to compile and `sensor.rs` gates the
+//! calls that would need it. Skipping rather than failing is what lets
+//! `cargo test --workspace` run off a board at all; `tofd --fake` is how this
+//! daemon is run there anyway.
 
 struct Generation {
     /// Directory under `vendor/`, and the name of the static library.
@@ -52,6 +59,14 @@ const HOOKS: [&str; 6] = [
 ];
 
 fn main() {
+    // The target, not the host: a build script is compiled for the machine it runs
+    // on, so `cfg!(target_os)` here would answer for the laptop and cross-compiling
+    // to the board would build nothing.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        println!("cargo::rerun-if-changed=build.rs");
+        return;
+    }
+
     let vendor = std::path::Path::new("vendor");
 
     for generation in &GENERATIONS {

--- a/tof/src/lib.rs
+++ b/tof/src/lib.rs
@@ -25,6 +25,12 @@
 //! prototype reached the older sensor through a pip package and a `.so` loaded by
 //! ctypes; nothing here needs either.
 //!
+//! Which makes the driver **Linux-only**, and deliberately visibly so: on any
+//! other target `build.rs` compiles none of the C and [`Sensor`] is uninhabited,
+//! so `open` refuses rather than a build failing. `tofd --fake` is how this daemon
+//! runs off a board, and it is unaffected — as is `cargo test --workspace`, which
+//! is the point.
+//!
 //! ## What a frame is, and is not
 //!
 //! Raw zone distances and ST's per-zone status, in the sensor's own frame. There

--- a/tof/src/main.rs
+++ b/tof/src/main.rs
@@ -136,13 +136,15 @@ async fn main() -> std::process::ExitCode {
         )
         .init();
 
+    // The shared one, not a private copy: as well as the journal line, it publishes
+    // `/run/tofd/identity.json`, which is where `robotctl health` and
+    // `scripts/dev-push.sh` read the release a daemon is actually running from.
+    // `tofd` was the one daemon that published nothing, so both reported it as
+    // silent — the exact gap the macro was written for, one daemon later.
+    duck_ipc_proto::log_startup_identity!("tofd");
+
     let args = Args::parse();
-    tracing::warn!(
-        service = "tofd",
-        build = env!("CARGO_PKG_VERSION"),
-        socket = %args.socket.display(),
-        "starting"
-    );
+    tracing::info!(socket = %args.socket.display(), hz = args.hz, "starting");
 
     let status = Arc::new(Status::new(args.hz));
     let (frames, _) = tokio::sync::broadcast::channel(FRAME_BUFFER);

--- a/tof/src/sensor.rs
+++ b/tof/src/sensor.rs
@@ -18,14 +18,21 @@
 //! quietly share and corrupt the first one's state. [`Sensor::open`] refuses
 //! instead.
 
+#[cfg(target_os = "linux")]
 use std::ffi::CString;
 use std::path::Path;
+#[cfg(target_os = "linux")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use anyhow::{Context, Result, anyhow, bail};
+#[cfg(target_os = "linux")]
+use anyhow::{Context, anyhow};
+use anyhow::{Result, bail};
 
-use crate::{COLS, Frame, ROWS, ZONES};
+use crate::Frame;
+#[cfg(target_os = "linux")]
+use crate::{COLS, ROWS, ZONES};
 
+#[cfg(target_os = "linux")]
 unsafe extern "C" {
     /// Generation-agnostic: `vendor/probe.c`, no driver involved.
     fn tof_probe_id(
@@ -55,6 +62,7 @@ unsafe extern "C" {
 }
 
 /// Held for the life of the process by the one [`Sensor`] that exists.
+#[cfg(target_os = "linux")]
 static TAKEN: AtomicBool = AtomicBool::new(false);
 
 /// Which sensor answered the ID probe.
@@ -72,6 +80,9 @@ pub enum Generation {
 }
 
 impl Generation {
+    // Both this and `driver` below are only ever reached from an open sensor, and
+    // no sensor opens without the driver — see the off-board `Sensor` at the end.
+    #[cfg(target_os = "linux")]
     fn from_ids(device_id: u8, revision_id: u8) -> Self {
         match revision_id {
             0x0C => Self::L8cx,
@@ -92,6 +103,7 @@ impl Generation {
     }
 
     /// The shim this generation drives through. `None` for one neither ULD knows.
+    #[cfg(target_os = "linux")]
     fn driver(&self) -> Option<Driver> {
         match self {
             Self::L8cx => Some(Driver::L8),
@@ -102,12 +114,14 @@ impl Generation {
 }
 
 /// Which set of `extern "C"` functions to call. One variant per vendored ULD.
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Driver {
     L5,
     L8,
 }
 
+#[cfg(target_os = "linux")]
 impl Driver {
     // Each of these is the same call into a different generation's shim. Wrapped
     // one per operation rather than as a table of function pointers because the
@@ -198,12 +212,14 @@ impl Driver {
 }
 
 /// An open, initialised sensor, ranging or not.
+#[cfg(target_os = "linux")]
 pub struct Sensor {
     generation: Generation,
     driver: Driver,
     ranging: bool,
 }
 
+#[cfg(target_os = "linux")]
 impl Sensor {
     /// Probe what is on the bus, then open it with the matching driver.
     ///
@@ -310,6 +326,7 @@ impl Sensor {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl Drop for Sensor {
     fn drop(&mut self) {
         if self.ranging {
@@ -322,7 +339,49 @@ impl Drop for Sensor {
     }
 }
 
-#[cfg(test)]
+/// The same type on a platform with no i2c-dev, so the daemon still builds there.
+///
+/// `vendor/platform.c` reaches the bus through Linux's `I2C_RDWR` ioctl, so
+/// `build.rs` compiles no driver anywhere else and there is nothing for `open` to
+/// open. This is not a fake sensor and must never become one — `tofd --fake`
+/// already exists for a laptop, and it says what it is in its name. This exists so
+/// that `cargo test --workspace` works off a board.
+///
+/// Uninhabited on purpose: `open` is the only constructor and it always fails, so
+/// the compiler discharges every other method instead of leaving a body that could
+/// one day return an invented frame.
+#[cfg(not(target_os = "linux"))]
+pub struct Sensor(std::convert::Infallible);
+
+#[cfg(not(target_os = "linux"))]
+impl Sensor {
+    pub fn open(bus: &Path, _address: u8) -> Result<Self> {
+        bail!(
+            "no i2c-dev on this platform, so {} cannot be opened — off a board, run `tofd --fake`",
+            bus.display()
+        )
+    }
+
+    pub fn generation(&self) -> Generation {
+        match self.0 {}
+    }
+
+    pub fn start(&mut self, _hz: u8) -> Result<()> {
+        match self.0 {}
+    }
+
+    pub fn data_ready(&self) -> Result<bool> {
+        match self.0 {}
+    }
+
+    pub fn read_frame(&mut self) -> Result<Frame> {
+        match self.0 {}
+    }
+}
+
+// Both tests reach the driver — one the generation-to-shim mapping, the other the
+// single-instance claim — so neither has anything to say where no driver is built.
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
The three code items `#154` found and wrote down rather than fixed — a docs change is not the place for code. The third one could not work on its own, and finding out why turned up two more faults.

## The three

**`cargo test --workspace` works on a Mac now — 942 passing, nothing excluded.** `vendor/platform.c` reaches the bus through `linux/i2c.h`, so `build.rs` compiles the vendored ULDs only when the *target* is Linux. Read from `CARGO_CFG_TARGET_OS`, not `cfg!`: a build script is compiled for the host, so `cfg!(target_os)` there answers for the laptop and cross-compiling to the board would build nothing.

The Rust side goes with it. Off a board `Sensor` is `Infallible` — `open` is the only constructor and it always fails, so every other method is discharged by the compiler rather than left as a body that could one day return an invented frame. `tofd` still builds off a board and `tofd --fake` still serves frames, which is the only way it runs there anyway.

**`install.sh` stops reporting `tofd` as a daemon it forgot.** `hooks/postinstall` enables every unit carrying an `[Install]` section a step earlier, so the warning was noise on every fresh install. Named as known, with no `enable_unit` of its own — nothing depends on `tofd`, so there is no start ordering for that function to have an opinion about.

**`dev-push.sh` checks all seven daemons.** It checked six, and the comment above it said five, restarted in a set of three — two daemons out of date in both directions.

## What the third one was hiding

Adding `tofd` to that loop reports `[--] tofd published nothing` on every board, forever. Two reasons, and both are the same defect one file apart:

- **`tofd` published no identity.** Six daemons call `log_startup_identity!`; `tofd` had a hand-rolled `warn!` that logged a version and wrote no `/run/tofd/identity.json`. That macro exists because `padd` was once the one daemon whose journal could not say which build was running, and its doc comment predicts this exactly: *"a shared definition makes the next daemon's omission a missing call rather than a missing idea."* `tofd` was the next daemon.
- **`configd::units::MANAGED` was still five units.** `mediad` and `tofd` have shipped units for two releases. So the `units` block of `robotctl health` — the block that exists to say which daemon is still running the old release after an update — could not report either of them at all. This is the same fault as the restart set `#154` corrected in `restart-order.md`, in the code rather than the doc.

Both are fixed here, because the third papercut is not fixed without them.

## Docs that were describing the old behaviour

- `CONTRIBUTING.md` — the macOS section no longer says to exclude `tof`.
- `restart-order.md` §6 — `tofd` is known to `install_units` now, and the note says why it still gets no `enable_unit`.
- `dev-push.md` — the sample output gains `[ok] tofd`, and a paragraph claiming `robotctl version` could answer for `tofd` is gone. It could not, for both reasons above.

## Verified

- `cargo test --workspace` — **942 passing, 0 failed**, on macOS with no `--exclude`
- `cargo board -p tof --bins` — the driver still cross-compiles for aarch64 Linux
- `cargo fmt --all --check` clean; clippy introduces nothing new (the one `Option::zip` warning is pre-existing in `chorale.rs`, which `#151` is editing)
- `shellcheck -S warning` clean on both scripts

Not verified on hardware: the `[ok] tofd` line needs one push to a board carrying this release, since the identity it reads is written by the build being installed.