### PR TITLE
The pipeline stops rotating: it cost the encoder its zero-copy path

### DIFF
--- a/docs/project/media-bringup.md
+++ b/docs/project/media-bringup.md
@@ -332,6 +332,30 @@ This cost three separate debugging rounds, each with a failure that named someth
 **`mediad.service` needs `SupplementaryGroups=video`** — with `Environment=GST_PLUGIN_PATH`, that
 is two lines standing between a working pipeline and four different confusing failures.
 
+### The rotation that cost 22 fps
+
+The camera is mounted a quarter turn off, and the obvious fix — `videoflip` before the tee, so every
+consumer gets an upright picture — is the wrong one, measured on a robot:
+
+| | RGA failures | frames lost by `v4l2src` | fps | SoC |
+|---|---|---|---|---|
+| without the flip | 0 | 0 | ~30 | fine |
+| with the flip | 5522 in one session | 1565 | 7–8 | 97 °C, CPU at 408 MHz |
+
+`mpph264enc` hands the UYVY→NV12 conversion to the SoC's 2D engine and pays nothing for it.
+`videoflip`'s output is a buffer the RGA refuses — `10000 is unsupport format`, then `RGA_BLIT fail:
+Bad address` on a `rect[0, 0, 720, 1280]` — so MPP falls back to converting **every frame in
+software**. That saturates the CPU, the SoC hits its thermal limit, everything throttles to 408 MHz,
+and the camera drops frames it cannot deliver. The rotation itself is the smaller half of the bill.
+
+So nothing in the pipeline rotates. The mount is *reported* (`media.video`, once per control
+channel) and whoever displays the picture turns it: the console does it with a CSS transform, which
+is free, and a perception consumer folds it into the resampling it already does. `--flip-in-pipeline`
+puts the old behaviour back for a consumer that cannot rotate for itself and can afford this.
+
+The proper fix, if an upright stream is ever genuinely needed, is an RGA element in the plugin set:
+the 2D engine rotates for nothing, which is why the encoder can afford to use it.
+
 ### Two things known to be unfinished
 
 **The bitrate came out ~50× under target.** 15,553 bytes for 3.3 s of capture against

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -219,6 +219,14 @@ fn main() -> ExitCode {
                 }
             };
 
+        // What every peer is told about the picture. The geometry is the *encoded* frame — the
+        // pipeline does not rotate, so it is the capture geometry — and the rotation is the mount.
+        let video = mediad::session::Video {
+            width: args.width,
+            height: args.height,
+            rotate: args.rotate,
+        };
+
         // One session per peer, each with its own connections to the services it talks to. Per
         // peer rather than shared, so one peer's minutes-long update cannot silence another's
         // telemetry — which is the same reason a session keeps one connection per lane.
@@ -234,12 +242,12 @@ fn main() -> ExitCode {
                     }
                 }
             });
-            // Before anything else on this channel: the page cannot rotate the picture for
-            // display until it knows how far the camera is mounted from upright.
+            // Pushed as a courtesy for a client that only listens — and it may well arrive before
+            // the peer's datachannel is open, in which case it is dropped. The console *asks*
+            // (`media.video`), which is why that path exists and this one is best-effort.
             {
                 let to_peer = channel.outbound.clone();
-                let line =
-                    mediad::session::video_notification(args.width, args.height, args.rotate);
+                let line = mediad::session::video_notification(video);
                 tokio::spawn(async move {
                     let _ = to_peer.send(line).await;
                 });
@@ -249,6 +257,7 @@ fn main() -> ExitCode {
                 channel.inbound,
                 channel.outbound,
                 pool,
+                video,
             ));
         }
 

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -87,16 +87,23 @@ struct Args {
     #[arg(long, default_value_t = 30)]
     fps: u32,
 
-    /// Turn the picture this many degrees clockwise: 0, 90, 180 or 270.
+    /// How far the camera is mounted from upright, clockwise: 0, 90, 180 or 270.
     ///
-    /// **90 because the head camera is mounted a quarter turn off**, so a straight capture is
-    /// sideways. This is the one place that fact is written down; see `pipeline::Rotation` for why
-    /// it is turned on the robot rather than in the console.
-    ///
-    /// A quarter turn swaps the frame's width and height, and it costs a CPU pass — `--rotate 0`
-    /// is the way to take that pass out if the control loop starts missing ticks while streaming.
+    /// **90, because the head camera is mounted a quarter turn off**, and this is the one place that
+    /// fact is written down. It no longer means "rotate the pixels": it is told to whoever displays
+    /// the video, and they rotate for free — the console with a CSS transform on the GPU. Rotating
+    /// here cost 145% of a core and 22 fps; `pipeline::Rotation` has the numbers.
     #[arg(long, default_value_t = 90)]
     rotate: u32,
+
+    /// Rotate in the pipeline as well, so the *encoded stream* comes out upright.
+    ///
+    /// **Off by default because it is expensive in a way that does not look like rotation.** It
+    /// breaks `mpph264enc`'s zero-copy path to the SoC's 2D engine, so MPP converts every frame in
+    /// software: measured at 97 °C, the CPU throttled to 408 MHz and 8 fps out of a 30 fps camera.
+    /// Worth it only for a consumer that cannot rotate for itself.
+    #[arg(long)]
+    flip_in_pipeline: bool,
 }
 
 #[cfg(target_os = "linux")]
@@ -124,12 +131,23 @@ fn main() -> ExitCode {
 
     // Refused before anything starts: a bad angle is a typo on a command line, and the daemon
     // should say so rather than opening a camera first.
-    let rotation = match mediad::pipeline::Rotation::from_degrees(args.rotate) {
+    // Validated even when the pipeline will not use it, because it is still what every consumer is
+    // told about the mount — a typo should not reach the console as a rotation nobody can apply.
+    let mount = match mediad::pipeline::Rotation::from_degrees(args.rotate) {
         Ok(rotation) => rotation,
         Err(e) => {
             tracing::error!(error = %e, "mediad cannot start");
             return ExitCode::FAILURE;
         }
+    };
+    let rotation = if args.flip_in_pipeline {
+        tracing::warn!(
+            degrees = args.rotate,
+            "--flip-in-pipeline: rotating in the pipeline costs the encoder its zero-copy path"
+        );
+        mount
+    } else {
+        mediad::pipeline::Rotation::None
     };
 
     runtime.block_on(async move {
@@ -216,6 +234,17 @@ fn main() -> ExitCode {
                     }
                 }
             });
+            // Before anything else on this channel: the page cannot rotate the picture for
+            // display until it knows how far the camera is mounted from upright.
+            {
+                let to_peer = channel.outbound.clone();
+                let line =
+                    mediad::session::video_notification(args.width, args.height, args.rotate);
+                tokio::spawn(async move {
+                    let _ = to_peer.send(line).await;
+                });
+            }
+
             tokio::spawn(mediad::session::run(
                 channel.inbound,
                 channel.outbound,

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -25,12 +25,12 @@
 //! NV12 because that is what the rkisp capture path emits and what `mpph264enc` takes, so nothing
 //! *converts* anywhere: no `videoconvert`, and no RGA pass, between capture and either consumer.
 //!
-//! **`videoflip` is the one pass, and it is a rotation rather than a conversion.** The head camera
-//! is mounted a quarter turn off, so a straight capture is sideways; turning it before the tee is
-//! what lets both consumers — and the console's drag-to-look, which maps a gaze off the same
-//! geometry — agree about which way is up. It costs CPU on the SoC that runs `robotd`'s control
-//! loop, which is why it is one element and one flag ([`Rotation`], `--rotate 0`) rather than a
-//! property of the pipeline nobody can take out.
+//! **Nothing converts and nothing rotates.** The head camera is mounted a quarter turn off, and for
+//! one afternoon this pipeline fixed that with a `videoflip` before the tee — which broke
+//! `mpph264enc`'s zero-copy path to the 2D engine and had MPP converting every frame in software:
+//! 97 °C, the CPU throttled to 408 MHz, 8 fps out of a 30 fps camera. Rotation is now the
+//! consumer's business, because for both consumers it is free — a CSS transform in the browser, and
+//! a resample the detector was doing anyway. [`Rotation`] has the numbers.
 //!
 //! **Each branch has its own `queue`, and the raw one is leaky.** A `tee` without queues runs its
 //! branches on one thread, so a slow consumer stalls the others — here that would mean a
@@ -89,17 +89,22 @@ use gstreamer_video as gst_video;
 use gstreamer_webrtc as gst_webrtc;
 use tokio::sync::mpsc;
 
-/// How far the picture is turned before anything downstream sees it.
+/// How far the picture is turned *in the pipeline* — which, by default, is not at all.
 ///
-/// **The head camera is mounted a quarter turn off**, so the sensor's rows run down the world
-/// rather than across it and a straight capture comes out sideways. That is a fact about the
-/// robot, not a preference, which is why the default is a quarter turn rather than none.
+/// **This defaulted to a quarter turn for one afternoon and cost 145% of a core.** `mpph264enc`
+/// hands the UYVY→NV12 conversion to the SoC's 2D engine and pays nothing for it; `videoflip`'s
+/// output is a buffer the RGA refuses — `10000 is unsupport format`, then `RGA_BLIT fail: Bad
+/// address` on a `rect[0, 0, 720, 1280]` — so MPP fell back to converting **every frame in
+/// software**. Measured on the robot: 97 °C, the CPU throttled from 1.8 GHz to 408 MHz, 1565 frames
+/// lost by `v4l2src` in one session, and 8 fps out of a 30 fps camera. The boot before that change
+/// had zero RGA failures and zero lost frames.
 ///
-/// Turned here rather than in the console, and the console is the reason: it maps a drag on the
-/// picture to a gaze (`aim` in `webclient/index.html`), so a page that rotated the video in CSS
-/// would send the robot looking 90° away from where the operator pointed. Rotating before the tee
-/// also means the raw branch — the one a perception consumer reads — sees the same picture the
-/// stream does, rather than each consumer having to know about the mount.
+/// So the pipeline no longer rotates pixels. The camera is still mounted a quarter turn off, and the
+/// consumer that has to care rotates for itself, for free: the console does it with a CSS transform
+/// on the GPU, and a perception consumer folds the turn into the resampling it already does.
+/// [`Settings::rotation`] stays for a consumer that genuinely needs an upright *encoded* stream —
+/// `--flip-in-pipeline` — and now that its cost is written down, that is a choice rather than a
+/// default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Rotation {
     /// Leave the frame as the sensor delivered it.
@@ -167,8 +172,8 @@ pub struct Settings {
     pub width: u32,
     pub height: u32,
     pub fps: u32,
-    /// How far to turn the picture; see [`Rotation`]. The capture geometry above is the sensor's,
-    /// *before* this is applied.
+    /// How far the *pipeline* turns the picture; see [`Rotation`]. Almost always `None` — the
+    /// capture geometry above is then also what leaves the tee.
     pub rotation: Rotation,
 }
 
@@ -321,20 +326,16 @@ pub fn start(
         .build()
         .map_err(|_| anyhow!("no capsfilter element; gstreamer core is incomplete"))?;
 
-    // ── the turn ────────────────────────────────────────────────────────────
+    // ── the turn, when somebody asks for it ─────────────────────────────────
     //
-    // `videoflip` from `gstreamer1.0-plugins-good`, which the board already has — see the package
-    // list in `scripts/setup-gstreamer.sh`. It is a CPU pass, and this pipeline was built to have
-    // none: "no `videoconvert`, and no RGA pass, between capture and either consumer". A quarter
-    // turn of 4:2:2 720p is real work (a scattered write per pixel, so the copy is cache-hostile
-    // rather than merely large), and it lands on the SoC that also runs `robotd`'s control loop.
+    // `videoflip` from `gstreamer1.0-plugins-good`, and **off unless asked**: see [`Rotation`] for
+    // the measurement. It does not merely cost a CPU pass of its own — it takes the encoder's
+    // zero-copy path down with it, because the RGA will not touch what it produces, so the true
+    // price is a software colour conversion of every frame as well.
     //
-    // It buys a picture that is the right way up for every consumer at once, which is worth a
-    // pass — but if the loop starts missing ticks when the camera streams, this is the first
-    // thing to suspect and `--rotate 0` is how to confirm it in one restart. The cheaper fix, if
-    // it comes to that, is the SoC's 2D engine: the RGA is already doing one operation per frame
-    // inside `mpph264enc`, and a rotation is the same class of operation — it needs an RGA element
-    // in the plugin set, which this one does not have.
+    // Left in for the consumer that cannot rotate for itself and can afford this. If that ever
+    // becomes the common case, the fix is an RGA element in the plugin set (the 2D engine can
+    // rotate for nothing), not this.
     let flip = match rotation.video_direction() {
         Some(direction) => Some(
             gst::ElementFactory::make("videoflip")

--- a/mediad/src/session.rs
+++ b/mediad/src/session.rs
@@ -32,6 +32,22 @@ use crate::upstream::Pool;
 /// `inbound` carries one JSON-RPC object per item, as the peer sent it. `outbound` is where replies
 /// and notifications go, merged from every service — the peer sorts them out by `id`, which is its
 /// business rather than ours.
+/// What the video is, told to a peer once when its channel opens.
+///
+/// **The rotation is the whole point.** Nothing on the robot rotates pixels any more — a `videoflip`
+/// in the pipeline cost the encoder its zero-copy path and the board 22 fps — so the stream a
+/// browser receives is the picture the camera took, sideways on a robot whose camera is mounted a
+/// quarter turn off. The page cannot work out by how much: a 180° mount is indistinguishable from an
+/// upright one, and even a quarter turn is only a guess from the aspect ratio. So it is told.
+///
+/// A notification, with no id, because the page already treats an id-less line as something that
+/// streams (`robot.state` is the other one) — no new mechanism at either end.
+pub fn video_notification(width: u32, height: u32, rotate_degrees: u32) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","method":"media.video","params":{{"width":{width},"height":{height},"rotate":{rotate_degrees}}}}}"#
+    )
+}
+
 pub async fn run(
     mut inbound: mpsc::Receiver<String>,
     outbound: mpsc::Sender<String>,
@@ -338,6 +354,21 @@ mod tests {
 
         let reply = h.to_peer.recv().await.unwrap();
         assert!(reply.contains("robot.teleport"), "{reply}");
+    }
+
+    /// The line that tells a page how the camera is mounted.
+    ///
+    /// Hand-built JSON, so this is the only thing between a console that rotates the picture and one
+    /// that shows it sideways and says nothing.
+    #[test]
+    fn the_video_notification_carries_the_mount_rotation() {
+        let line = video_notification(1280, 720, 90);
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid json");
+        assert_eq!(parsed["method"], "media.video");
+        assert!(parsed.get("id").is_none(), "a notification carries no id");
+        assert_eq!(parsed["params"]["width"], 1280);
+        assert_eq!(parsed["params"]["height"], 720);
+        assert_eq!(parsed["params"]["rotate"], 90);
     }
 
     /// Garbage is answered rather than dropped, with a null id because there is none to echo.

--- a/mediad/src/session.rs
+++ b/mediad/src/session.rs
@@ -32,6 +32,25 @@ use crate::upstream::Pool;
 /// `inbound` carries one JSON-RPC object per item, as the peer sent it. `outbound` is where replies
 /// and notifications go, merged from every service — the peer sorts them out by `id`, which is its
 /// business rather than ours.
+/// What the video is: the frame the encoder sends, and how far the camera is mounted from upright.
+///
+/// Held by the session because a peer has to be able to *ask*. Pushing it when the channel appears
+/// races the browser: `mediad` writes the line the moment `webrtcsink` hands over the channel, and
+/// if the peer's datachannel is not open yet the line is dropped — which is exactly what happened,
+/// and the console showed a sideways picture with nothing in the log to say why. The push is kept
+/// as a courtesy for a client that only listens; `media.video` as a *call* is what the console uses,
+/// because a question it asks when it is ready cannot arrive too early.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Video {
+    pub width: u32,
+    pub height: u32,
+    /// Degrees clockwise the camera is mounted from upright.
+    pub rotate: u32,
+}
+
+/// The method a peer asks with. Answered here rather than routed: no service owns it.
+const VIDEO_METHOD: &str = "media.video";
+
 /// What the video is, told to a peer once when its channel opens.
 ///
 /// **The rotation is the whole point.** Nothing on the robot rotates pixels any more — a `videoflip`
@@ -42,9 +61,14 @@ use crate::upstream::Pool;
 ///
 /// A notification, with no id, because the page already treats an id-less line as something that
 /// streams (`robot.state` is the other one) — no new mechanism at either end.
-pub fn video_notification(width: u32, height: u32, rotate_degrees: u32) -> String {
+pub fn video_notification(video: Video) -> String {
+    let Video {
+        width,
+        height,
+        rotate,
+    } = video;
     format!(
-        r#"{{"jsonrpc":"2.0","method":"media.video","params":{{"width":{width},"height":{height},"rotate":{rotate_degrees}}}}}"#
+        r#"{{"jsonrpc":"2.0","method":"{VIDEO_METHOD}","params":{{"width":{width},"height":{height},"rotate":{rotate}}}}}"#
     )
 }
 
@@ -52,13 +76,14 @@ pub async fn run(
     mut inbound: mpsc::Receiver<String>,
     outbound: mpsc::Sender<String>,
     mut pool: Pool,
+    video: Video,
 ) {
     while let Some(line) = inbound.recv().await {
         let line = line.trim().to_string();
         if line.is_empty() {
             continue;
         }
-        if let Some(reply) = handle(&line, &mut pool).await {
+        if let Some(reply) = handle(&line, &mut pool, video).await {
             // A closed outbound means the peer is gone; there is nothing left to do for it.
             if outbound.send(reply).await.is_err() {
                 break;
@@ -70,7 +95,7 @@ pub async fn run(
 
 /// Route one line. Returns a reply to send back only when this transport answers it itself —
 /// which is to say, only when it refuses.
-async fn handle(line: &str, pool: &mut Pool) -> Option<String> {
+async fn handle(line: &str, pool: &mut Pool, video: Video) -> Option<String> {
     let request: proto::Request = match serde_json::from_str(line) {
         Ok(request) => request,
         Err(e) => {
@@ -88,6 +113,22 @@ async fn handle(line: &str, pool: &mut Pool) -> Option<String> {
     // serialises that as `null` — which is right: a refusal to a notification is still worth
     // sending, because silence would look like acceptance.
     let id = request.id.clone();
+
+    // Answered here, before anything tries to make a `Call` of it: this is `mediad`'s own question
+    // about `mediad`'s own pipeline, and there is no service to route it to.
+    if request.method == VIDEO_METHOD {
+        return Some(
+            serde_json::to_string(&proto::Response::ok(
+                id,
+                &serde_json::json!({
+                    "width": video.width,
+                    "height": video.height,
+                    "rotate": video.rotate,
+                }),
+            ))
+            .expect("Response serialises"),
+        );
+    }
 
     let call = match request.as_call() {
         Ok(call) => call,
@@ -193,7 +234,16 @@ mod tests {
                 }
             }
         });
-        tokio::spawn(run(inbound, outbound, pool));
+        tokio::spawn(run(
+            inbound,
+            outbound,
+            pool,
+            Video {
+                width: 1280,
+                height: 720,
+                rotate: 90,
+            },
+        ));
         Harness {
             to_peer,
             from_peer,
@@ -362,13 +412,42 @@ mod tests {
     /// that shows it sideways and says nothing.
     #[test]
     fn the_video_notification_carries_the_mount_rotation() {
-        let line = video_notification(1280, 720, 90);
+        let line = video_notification(Video {
+            width: 1280,
+            height: 720,
+            rotate: 90,
+        });
         let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid json");
         assert_eq!(parsed["method"], "media.video");
         assert!(parsed.get("id").is_none(), "a notification carries no id");
         assert_eq!(parsed["params"]["width"], 1280);
         assert_eq!(parsed["params"]["height"], 720);
         assert_eq!(parsed["params"]["rotate"], 90);
+    }
+
+    /// `media.video` is answered by the session, not routed to a service.
+    ///
+    /// This is the path the console uses, and it exists because pushing the same information when
+    /// the channel appears races the browser's datachannel and loses — a sideways picture with
+    /// nothing in the log. A question the page asks when it is ready cannot arrive too early.
+    #[tokio::test]
+    async fn the_page_can_ask_what_the_video_is() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut h = harness(sockets_in(dir.path()), dir);
+
+        h.from_peer
+            .send(r#"{"jsonrpc":"2.0","id":7,"method":"media.video","params":{}}"#.into())
+            .await
+            .unwrap();
+
+        let reply = h.to_peer.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&reply).expect("valid json");
+        assert_eq!(parsed["id"], 7, "{reply}");
+        assert_eq!(parsed["result"]["width"], 1280);
+        assert_eq!(parsed["result"]["height"], 720);
+        assert_eq!(parsed["result"]["rotate"], 90);
+        // No service was involved: it is answered here, and nothing was forwarded.
+        assert!(parsed.get("error").is_none(), "{reply}");
     }
 
     /// Garbage is answered rather than dropped, with a null id because there is none to echo.

--- a/mediad/webclient/index.html
+++ b/mediad/webclient/index.html
@@ -67,12 +67,20 @@
   .row { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
   .hint { margin: .5rem 0 0; font-size: 12px; opacity: .6; }
 
-  /* 16/9 is the placeholder, held only until a frame arrives: the robot's camera is mounted a
-     quarter turn off and `mediad --rotate` turns it, so the picture is portrait. `fitVideoBox`
-     then gives the box the stream's own shape — a box pinned to 16/9 would letterbox a portrait
-     picture into a sliver, and it is the surface the operator drags on to aim. */
-  video { width: 100%; background: #111; aspect-ratio: 16/9; border-radius: 4px; display: block;
-          touch-action: none; cursor: crosshair; margin: 0 auto; }
+  /* 16/9 is the placeholder, held until the robot says what the video is. The camera is mounted a
+     quarter turn off and nothing on the robot rotates the picture — so this does, on the GPU. */
+  #videobox { display: grid; justify-content: center; line-height: 0; container-type: size;
+              aspect-ratio: 16/9; width: 100%; }
+  #videobox > video { grid-area: 1 / 1; width: 100%; height: 100%; background: #111;
+                      border-radius: 4px; display: block; touch-action: none; cursor: crosshair; }
+  /* A rotated element still occupies its pre-transform box, so a quarter turn needs the video sized
+     to the *swapped* axes. `100cqh`/`100cqw` are the wrapper's own height and width — exactly that
+     swap, done by the browser, and it survives a resize with no JavaScript. */
+  #videobox > video.turn90, #videobox > video.turn270 { width: 100cqh; height: 100cqw;
+                                                        place-self: center; }
+  #videobox > video.turn90  { transform: rotate(90deg); }
+  #videobox > video.turn270 { transform: rotate(-90deg); }
+  #videobox > video.turn180 { transform: rotate(180deg); }
   .stats { margin-top: .5rem; font: 12px/1.4 ui-monospace, monospace; gap: .75rem; }
   .stats b { font-weight: 600; opacity: .55; font-size: 11px; text-transform: uppercase; }
 
@@ -117,7 +125,13 @@
 <main>
   <section>
     <h2>video</h2>
-    <video id="video" autoplay muted playsinline></video>
+    <!-- The wrapper is the *upright* picture and the video is turned inside it, because the robot
+         no longer rotates pixels: doing that in the pipeline cost the encoder its zero-copy path to
+         the 2D engine, and the board 22 fps. Everything that reads coordinates off this — the
+         drag-to-look below — keeps working, because the wrapper is the space it always was. -->
+    <div id="videobox">
+      <video id="video" autoplay muted playsinline></video>
+    </div>
     <div class="row stats">
       <span><b>bitrate</b> <span id="bitrate">–</span></span>
       <span><b>fps</b> <span id="fps">–</span></span>
@@ -397,6 +411,8 @@ function newPeerConnection() {
   // first point the dimensions are known, and `resize` covers a stream that changes shape while
   // playing — which a `--rotate` change on the robot does, without the page reloading.
   const fitVideoBox = () => {
+    // `onVideoInfo` owns the sizing when the camera is mounted off upright.
+    if (mountRotation) return;
     const element = $("video");
     const { videoWidth: w, videoHeight: h } = element;
     if (!w || !h) return;
@@ -492,6 +508,8 @@ function onControl(data) {
   // arriving this way is worth seeing in full rather than summarised.
   if (msg.id === undefined || msg.id === null) {
     if (msg.method === "robot.state") { onState(msg.params); return; }
+    // How far the camera is mounted from upright. Sent once when the channel opens.
+    if (msg.method === "media.video") { onVideoInfo(msg.params); return; }
     log("in", "control ←", data.slice(0, 400));
     return;
   }
@@ -779,6 +797,33 @@ video.addEventListener("pointermove", (event) => { if (looking) aim(event); });
 const stopLooking = () => { looking = false; lookAt = null; $("gaze").hidden = true; };
 video.addEventListener("pointerup", stopLooking);
 video.addEventListener("pointercancel", stopLooking);
+
+// ── the camera is mounted sideways, and the robot does not rotate the pixels ───────────────────
+//
+// Rotating in the pipeline cost 145% of a core: `videoflip`'s buffers are ones the SoC's 2D engine
+// refuses, so the encoder converted every frame in software — 97 °C, the CPU throttled to 408 MHz,
+// 8 fps out of a 30 fps camera. Here the turn is a GPU transform and costs nothing.
+//
+// **The wrapper stays upright.** It is the space `aim` maps a drag from, and the space anything drawn
+// over the video would be in; only the <video> inside it turns. So nothing else on this page has to
+// know about the mount.
+let mountRotation = 0;
+
+function onVideoInfo({ width, height, rotate }) {
+  mountRotation = ((rotate % 360) + 360) % 360;
+  log("dim", `video ${width}x${height}, camera mounted ${mountRotation}° off upright`);
+
+  const quarter = mountRotation === 90 || mountRotation === 270;
+  const [uw, uh] = quarter ? [height, width] : [width, height];
+  const box = $("videobox");
+
+  // Portrait is capped by height so a tall picture cannot push the rest of the page off screen;
+  // landscape fills the column as it always did.
+  box.style.aspectRatio = `${uw} / ${uh}`;
+  box.style.width = uh > uw ? "auto" : "100%";
+  box.style.height = uh > uw ? "min(70vh, 80vw)" : "auto";
+  $("video").className = mountRotation ? `turn${mountRotation}` : "";
+}
 
 function aim(event) {
   const box = video.getBoundingClientRect();

--- a/mediad/webclient/index.html
+++ b/mediad/webclient/index.html
@@ -577,6 +577,10 @@ let healthTimer = null, statsTimer = null;
 
 function startTelemetry() {
   identify();
+  // **Asked, not waited for.** The robot also pushes this when the channel appears, which races
+  // this page's datachannel and loses — the picture then stays sideways with nothing in the log to
+  // say why. Asking once the channel is open cannot arrive too early.
+  call("media.video", {}, true).then(onVideoInfo).catch(() => {});
   // 2 Hz: enough to watch a robot, and decimation is server-side and per-subscriber, so this costs
   // the robot a twenty-fifth of what a digital twin at 50 Hz would.
   call("robot.subscribe", { hz: 2 }, true).catch(() => {});


### PR DESCRIPTION
# The pipeline stops rotating: it cost the encoder its zero-copy path

The camera is mounted a quarter turn off, and the fix that shipped for it — `videoflip` before the
tee, so every consumer gets an upright picture — turns out to cost far more than a rotation.
Measured on a robot, same board, consecutive boots:

| | RGA failures | frames lost by `v4l2src` | fps | SoC |
|---|---|---|---|---|
| before the flip | 0 | 0 | ~30 | fine |
| with the flip | 5522 in one session | 1565 | 7–8 | 97 °C, CPU throttled to 408 MHz |

`mpph264enc` hands the UYVY→NV12 conversion to the SoC's 2D engine and pays nothing for it.
`videoflip`'s output is a buffer the RGA refuses — `10000 is unsupport format`, then `RGA_BLIT fail:
Bad address` on a `rect[0, 0, 720, 1280]` — so MPP falls back to converting **every frame in
software**. The CPU saturates, the SoC hits its thermal limit, everything throttles to 408 MHz, and
the camera drops frames it can no longer deliver. The rotation itself is the smaller half of the
bill.

## What changes

**Nothing in the pipeline rotates.** `--rotate` still says how far the camera is mounted from
upright (default 90) — it is now information rather than an operation.

**`media.video`** tells each control channel, once when it opens, the frame size and that rotation.
A page cannot work it out: a 180° mount is indistinguishable from an upright one, and a quarter turn
is only a guess from the aspect ratio.

**The console rotates for display**, with a CSS transform on the GPU. The part worth knowing: the
wrapper stays in *upright* coordinates and only the `<video>` inside it turns, so drag-to-look — and
anything else that reads coordinates off the picture — keeps working untouched. The axis swap is
`100cqh`/`100cqw` container units, so the browser does the arithmetic and a resize needs no
JavaScript.

**`--flip-in-pipeline`** puts the old behaviour back for a consumer that cannot rotate for itself,
with the price documented next to the flag.

## Notes

The real fix for an upright *stream*, if one is ever needed, is an RGA element in the plugin set:
the 2D engine rotates for nothing, which is why the encoder can afford to use it. `mpph264enc` has
no rotation property and our plugin build has no RGA element — both checked on the board.

A perception consumer needs upright pixels too, and gets them for free by folding the turn into the
resampling it already does; that lands with the duck detector rather than here.

`docs/project/media-bringup.md` carries the table above, so the next person who reaches for
`videoflip` finds out what it costs before the robot does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
