### PR TITLE
ci: the board job stops emulating the architecture it targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,18 @@ jobs:
 
   board:
     # The target is aarch64; this is the only job that proves the binaries run there.
-    runs-on: ubuntu-latest
+    #
+    # On an aarch64 runner, so the containers further down run natively. Under QEMU on x86_64 the
+    # cost was not in the binaries under test — thirty of those checks went by in nine seconds —
+    # but in the shell-heavy ones, where every `sh`, `sed` and `grep` is emulated: the first
+    # setup-board.sh run alone took 148s, each later variant ~17s, and the install.sh block ran
+    # for four and a half minutes. That was more than half of this job, and this job is what the
+    # whole run waits on.
+    #
+    # Moving back to an x86_64 runner means restoring `docker/setup-qemu-action` with
+    # `platforms: arm64`, dropped below. Without it `docker run --platform linux/arm64` does not
+    # fall back to anything — it fails with an exec format error.
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -200,13 +211,11 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.1
-      - run: cargo install cargo-zigbuild --locked
 
-      # arm64 containers on an x86_64 runner need emulation; on arm64 runners this is
-      # a no-op. Kept so the job works on either.
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
+      # A prebuilt binary, not `cargo install cargo-zigbuild --locked`. Building it from source
+      # appeared free only because rust-cache had already restored ~/.cargo/bin; on a cold cache
+      # it is minutes, and changing the runner architecture is exactly what makes the cache cold.
+      - uses: taiki-e/install-action@cargo-zigbuild
 
       - run: ./scripts/board-test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,8 @@ jobs:
     # cost was not in the binaries under test — thirty of those checks went by in nine seconds —
     # but in the shell-heavy ones, where every `sh`, `sed` and `grep` is emulated: the first
     # setup-board.sh run alone took 148s, each later variant ~17s, and the install.sh block ran
-    # for four and a half minutes. That was more than half of this job, and this job is what the
-    # whole run waits on.
+    # for four and a half minutes. Natively that phase is 30s, and the job went 550s -> 196s —
+    # enough that `check` is now what the run waits on rather than this.
     #
     # Moving back to an x86_64 runner means restoring `docker/setup-qemu-action` with
     # `platforms: arm64`, dropped below. Without it `docker run --platform linux/arm64` does not

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -13,12 +13,14 @@
 #
 # Not a substitute for hardware, but it catches everything that only appears off the
 # dev machine: cross-linking (notably `zstd`'s C code), glibc floors, unix-socket and
-# file-permission semantics, and anything that quietly depended on macOS. On an Apple
-# Silicon host these containers run arm64 *natively*, so it's fast and not emulated.
+# file-permission semantics, and anything that quietly depended on macOS. On an arm64 host —
+# an Apple Silicon Mac, or CI's runner — these containers run *natively*, so it's fast. On
+# x86_64 every process inside them is emulated, and the shell-heavy checks below dominate.
 #
 # Usage:  scripts/board-test.sh
 #
-# Requires: cargo-zigbuild, zig, docker.
+# Requires: cargo-zigbuild, zig, docker — and on an x86_64 host, binfmt registered for arm64,
+# or the containers fail to exec at all.
 
 set -eu
 


### PR DESCRIPTION
`board` is what the whole run waits on — 515s, 556s, 692s over the three runs before this. It moves to a native aarch64 runner here, and lands at **196s**.

## Measured, warm cache both sides

| phase | x86_64 | `ubuntu-24.04-arm` |
| --- | --- | --- |
| cross-compile | 243s | **117s** |
| fixtures + packaging | 7s | 4s |
| container checks | **295s** | **30s** |
| **job total** | **550s** | **196s** |

The container phase was the reason for the change and it behaved as expected: 295s → 30s. Under QEMU the cost was never in the binaries under test — thirty of those checks, from `installed 1.0.0` through `btd runs on the target`, went by in nine seconds — but in the shell-heavy ones, where every `sh`, `sed` and `grep` inside the container is emulated. `setup-board.sh` alone took 148s on its first run and ~17s per later variant; the `install.sh` block ran for about four and a half minutes.

The cross-compile halving was not predicted and is the larger surprise. I have no confirmed cause from the logs — the `docker info` dump that would have shown the runner's core count came from the QEMU step this PR removes — so treat it as measured, not explained.

The whole run is now bounded by `check` at 309s rather than `board` at 550s.

## What changed

- `board` runs on `ubuntu-24.04-arm`. `check` and `coverage` stay on x86_64: they do no emulation, so there was no QEMU time there to reclaim. The compile result above makes them worth revisiting separately, since `check` is now the critical path.
- `docker/setup-qemu-action` is gone. It was already documented as a no-op on an arm64 runner and cost 11s plus a failed binfmt cache save. The comment on `runs-on` names it as the thing to restore if the runner ever goes back to x86_64, because without it `docker run --platform linux/arm64` fails with an exec format error rather than falling back.
- `cargo install cargo-zigbuild --locked` becomes `taiki-e/install-action@cargo-zigbuild`. That step showed 1s only because rust-cache had restored `~/.cargo/bin`; changing the runner architecture is precisely what makes that cache cold. Same action the coverage job already uses for `cargo-llvm-cov`.
- `board-test.sh`'s header claimed Apple Silicon was the only native case, which implied CI was emulated — now backwards. It also now names the x86_64 binfmt requirement, since CI no longer installs QEMU on your behalf.

Nothing else in the job reads the host architecture: `cross-sysroot.sh` uses curl/ar/tar and pulls arm64 `.debs` either way, the glibc floor check is `file` + `strings`, and `zigbuild` targets aarch64 regardless of where it runs. Prebuilt `cargo-zigbuild-aarch64-unknown-linux-gnu` and zig 0.14.1 `aarch64-linux` both exist, so the pins hold.

## Runner availability

Not a blocker, and not contingent on the repo being public: the arm64 runner was picked up immediately on this private repo under the org's free plan. Opening the repo changes the billing, not the access.

## On the two runs in this PR's history

Attempt 1 was a cold `rust-cache` ("No cache found") and took 561s, which is not comparable to a warm x86 baseline — its compile was 411s and its fixture minting 26s. Attempt 2 is the warm run quoted above, where minting returns to 4s. The cold numbers are cache artefacts, not architecture.