### PR TITLE
The login-shell files arrive by update, and a test says they must

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -174,6 +174,7 @@ jobs:
             --include "deploy/overlays/rk3568-npu-enable.dts=deploy/overlays/rk3568-npu-enable.dts" \
             --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
             --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
+            --include "scripts/setup-login.sh=scripts/setup-login.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -160,6 +160,7 @@ jobs:
             --include "deploy/overlays/rk3568-npu-enable.dts=deploy/overlays/rk3568-npu-enable.dts" \
             --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
             --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
+            --include "scripts/setup-login.sh=scripts/setup-login.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \
             --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,9 @@ the tools
 
 deploy/         what a robot is configured with: updater.toml, robotd.toml, trust anchor, journald
 policies/       the ONNX networks a release ships
-hooks/          preinstall · postinstall — what runs inside an update, from the artifact
+hooks/          preinstall · postinstall — what runs inside an update, from the artifact,
+                and the only thing that runs on every board on every update: anything
+                install.sh does to a board belongs here too (updater-design.md §9.1)
 scripts/        provision-board.sh · dev-push.sh + dev-build.Dockerfile (from your machine) ·
                 provision.sh → setup-board.sh → setup-gstreamer.sh · setup-rkaiq.sh ·
                 migrate-network.sh · install.sh (on the board) ·

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 |---|---|
 | [`roadmap.md`](project/roadmap.md) | Milestones, and what works today versus what is designed. |
 | [`ci-setup.md`](project/ci-setup.md) | One-time setup for the release pipeline: keys, secrets, rotation. |
-| [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what closed it. Closed. |
+| [`install-path-gap.md`](project/install-path-gap.md) | Why four install-path bugs reached a board, and what closed it. Closed — the rule it taught is [`updater-design.md`](design/updater-design.md) §9.1. |
 | [`slice-2-bringup.md`](project/slice-2-bringup.md) | What a real Radxa Zero 3W did with slice 2. |
 | [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what it turned up, and what rollback over a radio was decided on. |
 | [`media-bringup.md`](project/media-bringup.md) | What a Radxa Zero 3W does about video: the VPU, what MPP needs, and the two plugins that have to be built. |

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -868,7 +868,7 @@ so no unsigned code ever runs. Rust binary or shell script — the engine just
   config-schema migrations, `udev`/permission tweaks, data conversions across
   `schema_version` bumps.
 
-### 9.1 If a board needs it, the hook does it
+### 9.1 If a fresh install does it, the hook does it
 
 **A release is not installed until everything it needs is on the board.** Shipping a file
 into the release directory is not installing it; shipping a script into the release
@@ -876,7 +876,16 @@ directory is not running it. The hook is the only thing that runs on every board
 update, so it is where "this board must have X before this release works" belongs — not in
 a provisioning script that ran once before X existed, and not in a human's memory.
 
-This has now been got wrong three times, in three different shapes:
+**The question is not whether the release needs it. It is whether a fresh install does it.**
+"Needs" is a judgement, and it has already let a case through: a snippet that puts the robot's
+name in the shell prompt is not something a release *needs*, so it went into `install.sh` and
+nowhere else, and no board that has only ever updated has it. Ask the mechanical question
+instead — **does
+`scripts/install.sh` write this file or run this command?** — because that one can be answered
+by grepping a single file, and because a board that is not brand new gets exactly what the
+hooks do and nothing else.
+
+This has now been got wrong four times, in four different shapes:
 
 1. **Units.** A release that added a daemon put its `.service` inside the artifact and
    nowhere systemd looks. `btd` failed with `203/EXEC` on a board where the release was
@@ -890,13 +899,31 @@ This has now been got wrong three times, in three different shapes:
    into the release beside the model — and never called it. Every board would have shipped
    a detector that could not reach the NPU until somebody SSH'd in, and the way you find
    that out is `rknn_init` returning a number.
+4. **The login shell.** `install.sh` grew a `/etc/profile.d` snippet putting the robot's name
+   beside the hostname — `microduck@radxa-zero3 (coincoin):~$` — so that three ssh windows to
+   three ducks are not three identical prompts. Nothing else installs it, and `install.sh` is
+   not packaged into a release, so no hook *could*. A board provisioned before it was written
+   took every update since and never got it; the way you find that out is `ls: cannot access
+   '/etc/profile.d/robot-name-prompt.sh'` on a board whose release contains the feature.
 
 The shape is the same every time: the work was *done*, and the thing that makes the work
 reach a board was left out. It is invisible in review, because the diff that adds the
 script looks complete.
 
-**Corollaries, each of which has a test.**
+The fourth adds a way it can look *right*. Its two neighbours in `install.sh` — the login
+banner and the `robotctl` completions — have the same gap and are older, so the surrounding
+code read as the pattern to follow. Three functions in a row that only a fresh install runs
+are not a precedent; they are three instances.
 
+**Corollaries.**
+
+- **Anything `install.sh` does to a board, a hook does too.** The other three are instances of
+  this one, and its direction is the one the mistake is actually made in: a step is added to
+  `install.sh`, where it is easy to test on the board being provisioned anyway, and the update
+  path never learns about it. `install.sh` is not in the artifact and a hook cannot call it, so
+  the shared step belongs in a `scripts/setup-*.sh` that both run — which is what
+  `setup-gstreamer.sh` already is. The three corollaries below have tests; this one does not
+  yet, and it is the one that would have caught all four.
 - **A script the hook runs must be packaged.** `every_script_the_hooks_run_is_packaged`
   reads `script=scripts/…` assignments out of both hooks and fails the build if any
   packaging site omits one.
@@ -909,10 +936,11 @@ script looks complete.
   board with no camera, no Bluetooth adapter or no NPU is still a robot; those install
   steps say what was lost, name the command to retry, and return success.
 
-**This is what the split between provisioning and updating is for.** `provision.sh` sets up
-a new board. Every board provisioned before a thing existed is fixed by an ordinary update
-— which means a release may assume nothing about when its board was provisioned, and a
-setup step that only provisioning performs is a step half the fleet will never get.
+**This is what the split between provisioning and updating is for.** `provision.sh` and
+`install.sh` set up a new board, and they run once. Every board provisioned before a thing
+existed is fixed by an ordinary update — which means a release may assume nothing about when
+its board was provisioned, and a setup step that only provisioning performs is a step half the
+fleet will never get.
 
 ## 10. Reusable, config-driven engine
 

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -928,6 +928,17 @@ are not a precedent; they are three instances.
   a fresh install does. It is a forcing function rather than a proof — the escape hatch is a line
   in a table — but all four instances would have had to argue for that line, and none of them
   could have.
+- **A hook step must be idempotent, and it must be cheap when there is nothing to do.** The
+  first because it runs on every board on every update rather than once, so "already done" is the
+  normal case and not the exception. The second because the cost is paid on every update for
+  ever: a step that takes ten seconds on a board that already has everything is ten seconds added
+  to every future release, and the hook phase grows by one step per feature while the budget does
+  not move. The budgets are 600s for pre-install (`UPDATE_MAX_SILENCE_SECONDS`, a contract with
+  every client — it is the longest an apply may go silent) and 120s for post-install, shared with
+  the units, the accounts and the restart. The shape that works is a stamp: `setup-npu.sh` writes
+  the runtime version to `/usr/lib/librknnrt.version` and compares it, `setup-gstreamer.sh`
+  compares a stamp and two `dpkg -s` calls, and both do nothing measurable on a board that is
+  already set up.
 - **A script the hook runs must be packaged.** `every_script_the_hooks_run_is_packaged`
   reads `script=scripts/…` assignments out of both hooks and fails the build if any
   packaging site omits one.

--- a/docs/design/updater-design.md
+++ b/docs/design/updater-design.md
@@ -922,8 +922,12 @@ are not a precedent; they are three instances.
   `install.sh`, where it is easy to test on the board being provisioned anyway, and the update
   path never learns about it. `install.sh` is not in the artifact and a hook cannot call it, so
   the shared step belongs in a `scripts/setup-*.sh` that both run — which is what
-  `setup-gstreamer.sh` already is. The three corollaries below have tests; this one does not
-  yet, and it is the one that would have caught all four.
+  `setup-gstreamer.sh` and `setup-login.sh` are.
+  `every_install_sh_step_reaches_an_updated_board` reads `install.sh`'s call sites and fails
+  unless each is either performed by a hook too or written down, with a reason, as something only
+  a fresh install does. It is a forcing function rather than a proof — the escape hatch is a line
+  in a table — but all four instances would have had to argue for that line, and none of them
+  could have.
 - **A script the hook runs must be packaged.** `every_script_the_hooks_run_is_packaged`
   reads `script=scripts/…` assignments out of both hooks and fails the build if any
   packaging site omits one.

--- a/docs/project/install-path-gap.md
+++ b/docs/project/install-path-gap.md
@@ -4,11 +4,13 @@ Status: closed · Date: 2026-08-05, revised 2026-08-07 and 2026-08-11 · Owner: 
 
 Four bugs in a row reached a board, all in the install path, none caught by 418 tests or by
 `board-test.sh`. This records why, and what closed it. The general rule this taught — anything a
-board needs before a release works belongs in a hook, because that is the only thing that runs on
-every board on every update — outgrew this document and now lives in `updater-design.md` §9.1,
-where it has since caught two more instances. Written the same day, while the reasons were
-still concrete, and kept in the past tense it has earned rather than rewritten as reference — what it
-is useful for now is the shape of the mistake, not the state of the tree.
+fresh install does to a board belongs in a hook too, because that is the only thing that runs on
+every board on every update — outgrew this document and now lives in `updater-design.md` §9.1.
+**That is where to read it; this page is the story, not the rule.** It has been got wrong twice
+more since, so §9.1 is worth reading before adding an install step rather than after. Written the
+same day, while the reasons were still concrete, and kept in the past tense it has earned rather
+than rewritten as reference — what it is useful for now is the shape of the mistake, not the state
+of the tree.
 
 A second section covers two findings that *look* like the same thing and are not: version skew
 between a daemon that is already running and a release that has just been installed. Neither would

--- a/hooks/postinstall
+++ b/hooks/postinstall
@@ -48,6 +48,20 @@ for script in robot-rescue robot-boot-check; do
         || echo "postinstall: cannot install ${script}; the board keeps the previous copy" >&2
 done
 
+# The login-shell files: the `robotctl` completions, the motd banner naming the release actually
+# live, and the robot's name in the prompt. `install.sh` runs this same script on a fresh board;
+# running it here is the only reason a board provisioned before one of them was written ever gets
+# it, which is the whole of `docs/design/updater-design.md` §9.1 — and its fourth instance was
+# exactly this file, missing for months on a board whose release contained the feature.
+#
+# Never fatal, and not because it is unlikely to fail: a shell prompt is not worth rolling an
+# update back for.
+script=scripts/setup-login.sh
+if [ -f "$script" ]; then
+    sh "$script" \
+        || echo "postinstall: the login-shell files did not install; they are cosmetic" >&2
+fi
+
 # The robot's voice bank, rendered from the SoC serial by the release's own generator.
 # Idempotent — a marker records the seed and bank version, and a current bank is a no-op —
 # so this runs on every install and only actually renders on the first one (or when the

--- a/hooks/postinstall
+++ b/hooks/postinstall
@@ -13,7 +13,10 @@
 # directory, where systemd never looks — `btd.service` failed with `203/EXEC` on a board where the
 # release was complete and correct. Worse, `on_apply` could not restart a unit that was not there
 # yet, so the release which first carries a daemon could not restart anything at all. Both cost an
-# afternoon; see `docs/project/install-path-gap.md`.
+# afternoon; see `docs/project/install-path-gap.md` for that one, and
+# `docs/design/updater-design.md` §9.1 for the rule it and three others since have taught:
+# anything a fresh install does to a board, a hook does too, because this is the only thing that
+# runs on every board on every update.
 #
 # A non-zero exit from a hook FAILS THE UPDATE and triggers rollback, so the rule here is: fail
 # only for things that mean the release is not installable, and warn for everything else. Copying a

--- a/hooks/preinstall.in
+++ b/hooks/preinstall.in
@@ -134,7 +134,8 @@ install_onnx() {
 # This is what the split between provisioning and updating is for. `provision.sh` installs the
 # stack on a new board; every board provisioned before that existed, and every board whose
 # plugins are older than the version this release was built against, is fixed by an ordinary
-# update instead of by somebody remembering a command.
+# update instead of by somebody remembering a command. `docs/design/updater-design.md` §9.1
+# owns that rule and the four times it has been broken.
 #
 # Never fatal, for the reason in the header. Its report goes to the update log either way, which
 # is where "this board cannot encode H.264 in hardware" belongs.

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -1068,19 +1068,24 @@ for f in /etc/profile.d/robot-name-prompt.sh /etc/bash_completion.d/robotctl /et
 done
 echo "    [ok] postinstall alone installs the login-shell files"
 
-# The asymmetry, pinned because it is easy to assume otherwise: the hook places units and
-# accounts and nothing else. Both of these were deleted above and the hook did not restore
-# either, so a release that added a journald drop-in or moved robotctl delivers neither on an
-# update — only install.sh does those, and it runs once, by hand, at provisioning time.
+# What the hook does NOT place, which is now a short list and worth naming exactly: the journald
+# drop-in and the robotctl symlink. Both were deleted above and the hook restored neither, so a
+# release that changed either delivers it to no board that only updates — only install.sh does
+# those, and it runs once, by hand, at provisioning time.
+#
+# This comment used to say the hook placed "units and accounts and nothing else", which stopped
+# being true when it took on the recovery scripts, then the voice bank, then the login-shell
+# files. The contract is the two lines below, not the sentence above them.
 #
 # Asserted rather than merely documented because the reasonable next change to this hook is to
-# make it place everything install.sh places, and the person making it should find a test that
-# states the current contract instead of discovering it on a board.
+# make it place everything install.sh places — the remaining half of updater-design.md §9.1 —
+# and the person making it should find a test that states the current contract instead of
+# discovering it on a board.
 test ! -f /etc/systemd/journald.conf.d/10-robot.conf \
     || { echo "    [FAIL] postinstall now installs the journald drop-in"; exit 1; }
 test ! -e /usr/local/bin/robotctl \
     || { echo "    [FAIL] postinstall now creates the robotctl symlink"; exit 1; }
-echo "    [ok] postinstall covers units and accounts only, as documented"
+echo "    [ok] postinstall leaves the journald drop-in and the robotctl symlink alone"
 '
 
 for image in $IMAGES; do

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -504,10 +504,18 @@ chmod +x /stub/curl /stub/find /stub/systemctl
 touch /usr/local/lib/libonnxruntime.so.9.9.9
 ln -sf libonnxruntime.so.9.9.9 /usr/local/lib/libonnxruntime.so
 
-# The motd directory the login banner installs into. Present on the image, so the fixture has to
-# have it too or install_login_banner correctly does nothing and the assertion below would be
-# testing the fixture rather than the installer.
-mkdir -p /etc/update-motd.d
+# The directories the login-shell files install into. All three are present on the image, so the
+# fixture has to have them too or `setup-login.sh` correctly does nothing and the assertions below
+# would be testing the fixture rather than the installer.
+mkdir -p /etc/update-motd.d /etc/profile.d /etc/bash_completion.d
+
+# A named robot, which is what the prompt snippet reads. Without it the snippet falls back to
+# `duck-xxxx` off the SoC serial, and a container has no /proc/device-tree — so the interesting
+# half of the assertion below would be skipped on exactly the machine running it.
+mkdir -p /var/lib/robot/config
+cat > /var/lib/robot/config/config.json <<"NAMED"
+{"name": "coincoin"}
+NAMED
 
 # A BlueZ config with [General] but no Privacy key — the insert-after-[General] branch, which
 # is the one a stock Armbian image takes.
@@ -834,6 +842,35 @@ grep -q "robotctl update status" /etc/update-motd.d/40-robot \
     || { echo "    [FAIL] the banner does not report a rolled-back update"; exit 1; }
 echo "    [ok] the login banner is installed and reports a rolled-back update"
 
+# The name of the robot in the prompt: the fourth instance of updater-design.md §9.1, and the
+# reason `setup-login.sh` exists: it lived in install.sh alone, so no board that had only ever
+# updated had it.
+test -f /etc/profile.d/robot-name-prompt.sh \
+    || { echo "    [FAIL] the prompt snippet was not installed"; exit 1; }
+test -f /etc/bash_completion.d/robotctl \
+    || { echo "    [FAIL] the robotctl completions were not installed"; exit 1; }
+
+# Not just present — actually injecting. The snippet cannot edit PS1 directly, because ~/.bashrc
+# sets PS1 after /etc/profile.d has run; it hooks PROMPT_COMMAND and rewrites PS1 at the first
+# prompt instead. That indirection is the part that silently does nothing when it is wrong, so
+# drive it: source the snippet against a stock Debian PS1 and run what PROMPT_COMMAND would run.
+#
+# In a file rather than `bash -c`, and double quotes throughout: this whole check runs inside a
+# single-quoted string, where one apostrophe ends the script early and the error names a line
+# three hundred below.
+cat > /tmp/prompt-check.sh <<"CHECK"
+. /etc/profile.d/robot-name-prompt.sh
+PS1="\u@\h:\w\$ "
+_robot_name_inject
+printf "%s" "$PS1"
+CHECK
+prompt="$(bash /tmp/prompt-check.sh)"
+case "$prompt" in
+    *"(coincoin)"*) ;;
+    *) echo "    [FAIL] the prompt does not name the robot: ${prompt}"; exit 1 ;;
+esac
+echo "    [ok] the login shell has the completions, and the prompt names the robot"
+
 # Through `current`, not at a versioned directory: the symlink has to follow the active
 # release, or robotctl on PATH silently pins to whichever release installed it.
 link="$(readlink /usr/local/bin/robotctl)"
@@ -970,6 +1007,9 @@ rm -f /etc/systemd/system/*.service /etc/systemd/system/*.timer /usr/lib/sysuser
 # The journald drop-in and the robotctl symlink go too, so the asymmetry asserted at the end is
 # a real absence rather than a leftover from the install above.
 rm -f /etc/systemd/journald.conf.d/10-robot.conf /usr/local/bin/robotctl
+# And the login-shell files, for the opposite reason: the hook is supposed to put these back, and
+# leaving the ones install.sh wrote in place would make that assertion vacuous.
+rm -f /etc/profile.d/robot-name-prompt.sh /etc/bash_completion.d/robotctl /etc/update-motd.d/40-robot
 ( cd "$REL" && PATH="/stub:$PATH" sh "$REL"/hooks/postinstall > /tmp/hook.log 2>&1 ) || {
     echo "    [FAIL] hooks/postinstall exited non-zero, which fails an update"
     cat /tmp/hook.log
@@ -1017,6 +1057,16 @@ for script in robot-rescue robot-boot-check; do
         || { echo "    [FAIL] postinstall did not install ${script}"; exit 1; }
 done
 echo "    [ok] postinstall refreshes the recovery scripts in /usr/local/sbin"
+
+# The login-shell files, which is the reason setup-login.sh exists: they lived in install.sh alone,
+# so no board that had only ever updated had them, and the one that made this obvious had been
+# running the release that added the prompt for a month with the stock prompt. An update puts them
+# on a board that was provisioned before they were written, which is the only path most boards have.
+for f in /etc/profile.d/robot-name-prompt.sh /etc/bash_completion.d/robotctl /etc/update-motd.d/40-robot; do
+    test -f "$f" \
+        || { echo "    [FAIL] postinstall alone did not install ${f}"; exit 1; }
+done
+echo "    [ok] postinstall alone installs the login-shell files"
 
 # The asymmetry, pinned because it is easy to assume otherwise: the hook places units and
 # accounts and nothing else. Both of these were deleted above and the hook did not restore

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -378,6 +378,7 @@ cargo run -p xtask -- package \
     --include "deploy/overlays/rk3568-npu-enable.dts=deploy/overlays/rk3568-npu-enable.dts" \
     --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
     --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
+    --include "scripts/setup-login.sh=scripts/setup-login.sh" \
     --include "scripts/robot-rescue=scripts/robot-rescue" \
     --include "scripts/robot-boot-check=scripts/robot-boot-check" \
     --include "updater/systemd/robot-boot-check.service=systemd/robot-boot-check.service" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -721,17 +721,22 @@ install_units() {
         fi
     done
 
-    # The login-shell files: bash completions, the motd banner, and the robot's name in the
-    # prompt.
+    # The login-shell files: the `robotctl` completions, the motd banner, and the robot's name in
+    # the prompt.
     #
-    # Before adding a fourth line here, read `docs/design/updater-design.md` §9.1. This script
-    # runs once, on a board being set up, so a step only it performs is a step that every board
-    # provisioned earlier never gets. And the update path cannot reach this file — `install.sh`
-    # is not in the artifact — so anything that must also arrive by update belongs in a
-    # `scripts/setup-*.sh` that this script and a hook both run.
-    install_completions
-    install_login_banner
-    install_name_prompt
+    # Run from the installed release rather than written here, like the sysusers files above: it is
+    # the copy a signature was checked against, and it is the same file `hooks/postinstall` runs on
+    # every update. That second caller is the point — a step only this script performs reaches no
+    # board that was provisioned before it was written (`docs/design/updater-design.md` §9.1), and
+    # anything added here must go in that script rather than in a function beside this call.
+    setup_login="${INSTALL_DIR}/current/scripts/setup-login.sh"
+    if [ -f "$setup_login" ]; then
+        sh "$setup_login" || warn "the login-shell files did not install; the prompt, the banner
+  and the completions are all cosmetic and the robot is unaffected."
+    else
+        warn "the release carries no scripts/setup-login.sh, so the prompt will not name this
+  robot. The next update installs it."
+    fi
 
     systemctl daemon-reload
     enable_unit updaterd.service
@@ -822,138 +827,6 @@ install_units() {
     done
 }
 
-# Tab-completion for `robotctl`, so an operator on a board they are debugging over a flaky
-# ssh link types `update apply` rather than remembering it.
-#
-# A *loader* rather than a generated snapshot: it asks the live binary for its completions
-# at shell start, so after an update adds a subcommand the completions describe the release
-# now installed, with no reinstall step and nothing for a rollback to leave behind. The cost
-# is one process per interactive bash — the same shape `bash-completion` itself uses for
-# dynamic completers.
-#
-# Written by hand rather than shipped in the artifact for the same reason: the artifact
-# would then have to carry a file whose only content is this indirection.
-# What the robot is running, and whether it is working, printed at every ssh login.
-#
-# This exists because of a specific failure that cost an afternoon: a dev board silently reverted a
-# branch build to the stable release — `updaterd`'s cross-boot health gate, correctly, since a bench
-# board with no servo power can never report healthy — and nothing said so. Every command afterwards
-# ran against code nobody had asked for, and the symptom was a feature that "did not work".
-#
-# So the two facts worth having before typing anything are on screen at login: the release actually
-# live, and whether the last update stuck.
-#
-# An motd drop-in rather than /etc/profile.d: it runs once per ssh login rather than per shell, it is
-# the mechanism the image already uses for this kind of thing, and a slow or broken robotctl there
-# cannot wedge an interactive shell.
-#
-# Exits 0 on every path, always. A banner that fails must never be the reason a login is noisy or
-# slow — that is how people start disabling motd.
-install_login_banner() {
-    if [ ! -d /etc/update-motd.d ]; then
-        # No motd machinery on this image. Not worth building one for a banner.
-        return 0
-    fi
-
-    cat > /etc/update-motd.d/40-robot <<'BANNER'
-#!/bin/sh
-# What this robot is running, and whether it is working. Installed by scripts/install.sh.
-command -v robotctl >/dev/null 2>&1 || exit 0
-
-live="$(readlink /opt/robot/daemon/current 2>/dev/null | sed 's|releases/||')"
-[ -n "$live" ] || exit 0
-
-# First line only: `robotctl health` leads with the whole-robot verdict, and the detail below it
-# belongs to someone who has decided to look.
-verdict="$(robotctl health 2>/dev/null | head -1 | sed 's/^robot *//')"
-[ -n "$verdict" ] || verdict="not answering"
-
-printf '\nrobot   %s — %s\n' "$live" "$verdict"
-
-# The rollback that prompted this banner. Grepped rather than parsed: there is no jq on this image,
-# and the only question is whether the last attempt ended that way.
-if robotctl update status 2>/dev/null | grep -q rolled_back; then
-    printf '        the last update was ROLLED BACK — robotctl update status\n'
-fi
-exit 0
-BANNER
-    chmod 755 /etc/update-motd.d/40-robot
-    say "wrote /etc/update-motd.d/40-robot, so a login says what is running"
-}
-
-# The robot's name beside the hostname in the prompt: `microduck@radxa-zero3 (coincoin):~$`.
-#
-# Every board flashed from one image says `microduck@radxa-zero3`, so three ssh windows to
-# three ducks are three identical prompts — and a command typed into the wrong one is exactly
-# the failure the per-board *name* exists to prevent (configd/src/identity.rs). The prompt is
-# where an operator looks before typing; put the name there.
-#
-# A profile.d snippet rather than editing anyone's .bashrc: it needs no per-user provisioning
-# and an update replaces it cleanly. The wrinkle is ordering — ~/.bashrc sets PS1 *after*
-# /etc/profile.d runs, so the snippet cannot edit PS1 directly; it hooks PROMPT_COMMAND and
-# injects the name at the first prompt instead, when PS1 has settled.
-install_name_prompt() {
-    if [ ! -d /etc/profile.d ]; then
-        # Not the image we know. A prompt nicety is not worth creating login machinery for.
-        return 0
-    fi
-
-    cat > /etc/profile.d/robot-name-prompt.sh <<'PROMPT'
-# The robot's name beside the hostname in the prompt. Installed by scripts/install.sh.
-#
-# Prompt surgery below is bash syntax, and /etc/profile.d is also read by plain sh.
-[ -n "$BASH_VERSION" ] || return 0
-
-# The same name the robot advertises over BLE: configd's store where someone has renamed it,
-# else `duck-xxxx` derived exactly as configd derives it — the first four hex characters of
-# the SoC serial's SHA-256 (configd/src/identity.rs says why it is not the Bluetooth address).
-# Read from the file rather than asked of configd, so the prompt works while daemons are down
-# — which is much of what anyone is ssh'd in to deal with.
-_robot_name="$(sed -n 's/.*"name": *"\(.*\)".*/\1/p' /var/lib/robot/config/config.json 2>/dev/null)"
-if [ -z "$_robot_name" ] && [ -r /proc/device-tree/serial-number ]; then
-    _robot_serial="$(tr '\0' '\n' < /proc/device-tree/serial-number 2>/dev/null | head -n 1)"
-    [ -n "$_robot_serial" ] && _robot_name="duck-$(printf '%s' "$_robot_serial" | sha256sum | cut -c1-4)"
-fi
-unset _robot_serial
-
-# A name reaches prompt expansion, where $(...) and backticks *execute*. configd only strips
-# control characters, so strip the rest here.
-_robot_name="$(printf '%s' "$_robot_name" | tr -d '\\$`')"
-
-if [ -n "$_robot_name" ]; then
-    # Global substitution, not first-match: the xterm-title prefix Debian's .bashrc builds
-    # contains its own \h before the visible one, and naming the window too is a feature —
-    # it is the other place an operator tells sessions apart.
-    _robot_name_inject() {
-        case "$PS1" in *"($_robot_name)"*) return ;; esac
-        PS1="${PS1//\\h/\\h ($_robot_name)}"
-    }
-    PROMPT_COMMAND="_robot_name_inject${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
-fi
-PROMPT
-    chmod 644 /etc/profile.d/robot-name-prompt.sh
-    say "wrote /etc/profile.d/robot-name-prompt.sh, so the prompt names the duck"
-}
-
-install_completions() {
-    if [ ! -d /etc/bash_completion.d ]; then
-        # No bash-completion on this image. Not worth installing a directory nothing reads.
-        return 0
-    fi
-    cat > /etc/bash_completion.d/robotctl <<'EOF'
-# Generated by the robot daemon installer. Asks robotctl for its own completions, so this
-# file never needs regenerating when an update changes the command tree.
-#
-# `eval` rather than `source <(robotctl …)`: process substitution is not reliable in bash
-# 3.2, and stderr is discarded so a rolled-back release that predates `robotctl
-# completions` leaves the shell with no completions rather than a usage error on every
-# login.
-if command -v robotctl >/dev/null 2>&1; then
-    eval "$(robotctl completions bash 2>/dev/null)"
-fi
-EOF
-    chmod 644 /etc/bash_completion.d/robotctl
-}
 
 verify_install() {
     say "verifying"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -721,6 +721,14 @@ install_units() {
         fi
     done
 
+    # The login-shell files: bash completions, the motd banner, and the robot's name in the
+    # prompt.
+    #
+    # Before adding a fourth line here, read `docs/design/updater-design.md` §9.1. This script
+    # runs once, on a board being set up, so a step only it performs is a step that every board
+    # provisioned earlier never gets. And the update path cannot reach this file — `install.sh`
+    # is not in the artifact — so anything that must also arrive by update belongs in a
+    # `scripts/setup-*.sh` that this script and a hook both run.
     install_completions
     install_login_banner
     install_name_prompt

--- a/scripts/rkaiq-modinfo-shim.c
+++ b/scripts/rkaiq-modinfo-shim.c
@@ -16,9 +16,12 @@
  * reads for IQ file selection.
  *
  * Build:   gcc -shared -fPIC -O2 -o rkaiq_modinfo_shim.so rkaiq-modinfo-shim.c -ldl
- * Install: see scripts/setup-rkaiq.sh, which builds it on the board — the
- *          struct size it probes for is a property of the running kernel, so a
- *          binary built anywhere else would be guessing. The systemd drop-in
+ * Install: see scripts/setup-rkaiq.sh, which builds it on the board because it
+ *          must be aarch64 — and for no other reason. The struct size is a
+ *          property of the running kernel, but this probes for it at *runtime*
+ *          on the first intercepted ioctl, so the object does not depend on the
+ *          kernel it was compiled against and setup-rkaiq.sh only rebuilds it
+ *          when the source changes. The systemd drop-in
  *          sets LD_PRELOAD for the rkaiq_3A service alone; nothing else on the
  *          board has this ioctl intercepted.
  *

--- a/scripts/setup-login.sh
+++ b/scripts/setup-login.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# The login-shell files: what an operator sees, and can type, the moment they ssh in — the
+# `robotctl` completions, a banner naming the release actually live, and the robot's own name in
+# the prompt.
+#
+# **A script rather than three functions in `install.sh`, because `install.sh` runs once.** It sets
+# up a board and is never seen again, and the update path cannot reach it — it is not in the
+# artifact. All three of these were added to `install.sh` alone, so none of them is on any board
+# that has only ever updated: `docs/design/updater-design.md` §9.1 in its fourth shape, found by
+# ssh'ing to a robot whose release contained the prompt feature and getting the stock prompt.
+# `install.sh` and `hooks/postinstall` both run this now, which is the shape `setup-gstreamer.sh`
+# already had.
+#
+# Idempotent, and meant to be run on every update: each step rewrites its file, which is what
+# makes a board provisioned two months ago end up with what a board provisioned today has.
+#
+# Nothing here is needed for the robot to run. A board with no /etc/profile.d, no motd machinery
+# or no bash-completion skips that step; `hooks/postinstall` treats a failure as cosmetic, because
+# a shell prompt is not worth rolling an update back for.
+set -eu
+
+say() { printf 'setup-login: %s\n' "$*"; }
+
+# What the robot is running, and whether it is working, printed at every ssh login.
+#
+# This exists because of a specific failure that cost an afternoon: a dev board silently reverted a
+# branch build to the stable release — `updaterd`'s cross-boot health gate, correctly, since a bench
+# board with no servo power can never report healthy — and nothing said so. Every command afterwards
+# ran against code nobody had asked for, and the symptom was a feature that "did not work".
+#
+# So the two facts worth having before typing anything are on screen at login: the release actually
+# live, and whether the last update stuck.
+#
+# An motd drop-in rather than /etc/profile.d: it runs once per ssh login rather than per shell, it is
+# the mechanism the image already uses for this kind of thing, and a slow or broken robotctl there
+# cannot wedge an interactive shell.
+#
+# Exits 0 on every path, always. A banner that fails must never be the reason a login is noisy or
+# slow — that is how people start disabling motd.
+install_login_banner() {
+    if [ ! -d /etc/update-motd.d ]; then
+        # No motd machinery on this image. Not worth building one for a banner.
+        return 0
+    fi
+
+    cat > /etc/update-motd.d/40-robot <<'BANNER'
+#!/bin/sh
+# What this robot is running, and whether it is working. Installed by scripts/install.sh.
+command -v robotctl >/dev/null 2>&1 || exit 0
+
+live="$(readlink /opt/robot/daemon/current 2>/dev/null | sed 's|releases/||')"
+[ -n "$live" ] || exit 0
+
+# First line only: `robotctl health` leads with the whole-robot verdict, and the detail below it
+# belongs to someone who has decided to look.
+verdict="$(robotctl health 2>/dev/null | head -1 | sed 's/^robot *//')"
+[ -n "$verdict" ] || verdict="not answering"
+
+printf '\nrobot   %s — %s\n' "$live" "$verdict"
+
+# The rollback that prompted this banner. Grepped rather than parsed: there is no jq on this image,
+# and the only question is whether the last attempt ended that way.
+if robotctl update status 2>/dev/null | grep -q rolled_back; then
+    printf '        the last update was ROLLED BACK — robotctl update status\n'
+fi
+exit 0
+BANNER
+    chmod 755 /etc/update-motd.d/40-robot
+    say "wrote /etc/update-motd.d/40-robot, so a login says what is running"
+}
+
+# The robot's name beside the hostname in the prompt: `microduck@radxa-zero3 (coincoin):~$`.
+#
+# Every board flashed from one image says `microduck@radxa-zero3`, so three ssh windows to
+# three ducks are three identical prompts — and a command typed into the wrong one is exactly
+# the failure the per-board *name* exists to prevent (configd/src/identity.rs). The prompt is
+# where an operator looks before typing; put the name there.
+#
+# A profile.d snippet rather than editing anyone's .bashrc: it needs no per-user provisioning
+# and an update replaces it cleanly. The wrinkle is ordering — ~/.bashrc sets PS1 *after*
+# /etc/profile.d runs, so the snippet cannot edit PS1 directly; it hooks PROMPT_COMMAND and
+# injects the name at the first prompt instead, when PS1 has settled.
+install_name_prompt() {
+    if [ ! -d /etc/profile.d ]; then
+        # Not the image we know. A prompt nicety is not worth creating login machinery for.
+        return 0
+    fi
+
+    cat > /etc/profile.d/robot-name-prompt.sh <<'PROMPT'
+# The robot's name beside the hostname in the prompt. Installed by scripts/install.sh.
+#
+# Prompt surgery below is bash syntax, and /etc/profile.d is also read by plain sh.
+[ -n "$BASH_VERSION" ] || return 0
+
+# The same name the robot advertises over BLE: configd's store where someone has renamed it,
+# else `duck-xxxx` derived exactly as configd derives it — the first four hex characters of
+# the SoC serial's SHA-256 (configd/src/identity.rs says why it is not the Bluetooth address).
+# Read from the file rather than asked of configd, so the prompt works while daemons are down
+# — which is much of what anyone is ssh'd in to deal with.
+_robot_name="$(sed -n 's/.*"name": *"\(.*\)".*/\1/p' /var/lib/robot/config/config.json 2>/dev/null)"
+if [ -z "$_robot_name" ] && [ -r /proc/device-tree/serial-number ]; then
+    _robot_serial="$(tr '\0' '\n' < /proc/device-tree/serial-number 2>/dev/null | head -n 1)"
+    [ -n "$_robot_serial" ] && _robot_name="duck-$(printf '%s' "$_robot_serial" | sha256sum | cut -c1-4)"
+fi
+unset _robot_serial
+
+# A name reaches prompt expansion, where $(...) and backticks *execute*. configd only strips
+# control characters, so strip the rest here.
+_robot_name="$(printf '%s' "$_robot_name" | tr -d '\\$`')"
+
+if [ -n "$_robot_name" ]; then
+    # Global substitution, not first-match: the xterm-title prefix Debian's .bashrc builds
+    # contains its own \h before the visible one, and naming the window too is a feature —
+    # it is the other place an operator tells sessions apart.
+    _robot_name_inject() {
+        case "$PS1" in *"($_robot_name)"*) return ;; esac
+        PS1="${PS1//\\h/\\h ($_robot_name)}"
+    }
+    PROMPT_COMMAND="_robot_name_inject${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+fi
+PROMPT
+    chmod 644 /etc/profile.d/robot-name-prompt.sh
+    say "wrote /etc/profile.d/robot-name-prompt.sh, so the prompt names the duck"
+}
+
+# Tab-completion for `robotctl`, so an operator on a board they are debugging over a flaky
+# ssh link types `update apply` rather than remembering it.
+#
+# A *loader* rather than a generated snapshot: it asks the live binary for its completions
+# at shell start, so after an update adds a subcommand the completions describe the release
+# now installed, with no reinstall step and nothing for a rollback to leave behind. The cost
+# is one process per interactive bash — the same shape `bash-completion` itself uses for
+# dynamic completers.
+#
+# Written by hand rather than shipped in the artifact for the same reason: the artifact
+# would then have to carry a file whose only content is this indirection.
+install_completions() {
+    if [ ! -d /etc/bash_completion.d ]; then
+        # No bash-completion on this image. Not worth installing a directory nothing reads.
+        return 0
+    fi
+    cat > /etc/bash_completion.d/robotctl <<'EOF'
+# Generated by the robot daemon installer. Asks robotctl for its own completions, so this
+# file never needs regenerating when an update changes the command tree.
+#
+# `eval` rather than `source <(robotctl …)`: process substitution is not reliable in bash
+# 3.2, and stderr is discarded so a rolled-back release that predates `robotctl
+# completions` leaves the shell with no completions rather than a usage error on every
+# login.
+if command -v robotctl >/dev/null 2>&1; then
+    eval "$(robotctl completions bash 2>/dev/null)"
+fi
+EOF
+    chmod 644 /etc/bash_completion.d/robotctl
+}
+
+install_completions
+install_login_banner
+install_name_prompt

--- a/scripts/setup-rkaiq.sh
+++ b/scripts/setup-rkaiq.sh
@@ -201,9 +201,25 @@ if ! command -v gcc >/dev/null 2>&1; then
         || die "could not install gcc, so the shim cannot be built"
 fi
 
-say "building the ioctl shim"
-gcc -shared -fPIC -O2 -o "$SHIM_SO" "$SHIM_SRC" -ldl \
-    || die "could not build ${SHIM_SRC}"
+# Only when there is something to build. `hooks/preinstall` runs this script on every update, so
+# an unconditional `gcc` is a compile on every release for ever on a board that already has the
+# shim — the cost updater-design.md §9.1 says a hook step may not have. The built source is kept
+# beside the object, the way `setup-npu.sh` keeps its `.dts`, and a release that changes the C
+# file rebuilds because the copy no longer matches.
+#
+# Keyed on the source alone, and not on `uname -r`, because the shim does not depend on the
+# kernel it was built against: it brute-forces the kernel's struct size at *runtime*, once, on
+# the first intercepted ioctl. It is built on the board because it must be aarch64, which is the
+# only reason.
+SHIM_BUILT_SRC=/usr/local/lib/rkaiq-modinfo-shim.c
+if [ -f "$SHIM_SO" ] && cmp -s "$SHIM_SRC" "$SHIM_BUILT_SRC"; then
+    say "the ioctl shim is current"
+else
+    say "building the ioctl shim"
+    gcc -shared -fPIC -O2 -o "$SHIM_SO" "$SHIM_SRC" -ldl \
+        || die "could not build ${SHIM_SRC}"
+    install -m 644 "$SHIM_SRC" "$SHIM_BUILT_SRC"
+fi
 
 # ── the sensor-mode pin ───────────────────────────────────────────────────────
 #

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -981,6 +981,146 @@ mod tests {
         }
     }
 
+    /// `install_*` steps a hook performs too, and where it does it.
+    const ALSO_ON_UPDATE: [(&str, &str); 1] = [(
+        "install_units",
+        "hooks/postinstall installs, enables and starts every unit the release ships. Not the \
+         journald drop-in and not the robotctl symlink, which the hook deliberately leaves alone \
+         — board-test.sh pins that asymmetry, and it is the one thing here §9.1 does not cover",
+    )];
+
+    /// `install_*` steps only a fresh install performs, and why a board that only updates does
+    /// not need them. Each of these is a decision belonging to the board rather than to a
+    /// release, which is the only reason a release may leave it alone.
+    const FIRST_INSTALL_ONLY: [(&str, &str); 3] = [
+        (
+            "install_config",
+            "/etc/robot/*.toml belongs to the board: install.sh will not overwrite an existing \
+             updater.toml, and an update must not either",
+        ),
+        (
+            "install_dev_key",
+            "a trust anchor is the operator's decision. A release that installed trusted keys \
+             would be granting itself trust",
+        ),
+        (
+            "install_token_dropin",
+            "the fetch credential is supplied by whoever runs the install and is never in an \
+             artifact; a customer robot never has one at all",
+        ),
+    ];
+
+    /// Every step `install.sh` performs on a board is performed on an updated board too.
+    ///
+    /// This is the direction `docs/design/updater-design.md` §9.1 is about, and the one nothing
+    /// watched. `every_script_the_hooks_run_is_packaged` above checks that a script a hook
+    /// *already names* ships; it cannot notice a step no hook names at all. That is the mistake,
+    /// four times: units left where systemd never looks, a GStreamer stack only provisioning
+    /// installed, a `setup-npu.sh` packaged beside its model and never called, and a
+    /// `/etc/profile.d` snippet that sat in `install.sh` alone while every board in the fleet
+    /// updated past it. The fourth went unnoticed for a month because it is cosmetic — the
+    /// robot works, the prompt is just wrong — which is the argument for a test rather than for
+    /// a rule people are supposed to remember.
+    ///
+    /// Two halves, because the step can be missing in two shapes: a function `install.sh` runs
+    /// and no hook does, and a shared `setup-*.sh` only `install.sh` calls.
+    ///
+    /// This is a forcing function, not a proof. An author can satisfy it by adding a name to
+    /// `FIRST_INSTALL_ONLY` — but they have to write down why an already-provisioned board does
+    /// not need the thing they just added, and every one of the four would have failed at that
+    /// sentence.
+    #[test]
+    fn every_install_sh_step_reaches_an_updated_board() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask/ has a parent");
+        let install = std::fs::read_to_string(root.join("scripts/install.sh"))
+            .expect("scripts/install.sh must exist");
+
+        // ── half one: every `install_*` step is accounted for ──
+        //
+        // Call sites, not definitions: a function that is defined and never called does nothing
+        // to a board. `    install_foo` on a line of its own is how this script calls one.
+        let mut called: Vec<&str> = install
+            .lines()
+            .filter_map(|line| {
+                let name = line.trim();
+                let indented = line.starts_with(' ') || line.starts_with('\t');
+                (indented
+                    && name.starts_with("install_")
+                    && !name.contains(|c: char| !(c.is_ascii_lowercase() || c == '_')))
+                .then_some(name)
+            })
+            .collect();
+        called.sort();
+        called.dedup();
+        assert!(
+            !called.is_empty(),
+            "no install_* call sites found in install.sh; this test is watching nothing"
+        );
+
+        let mut accounted: Vec<&str> = ALSO_ON_UPDATE
+            .iter()
+            .chain(FIRST_INSTALL_ONLY.iter())
+            .map(|(name, _)| *name)
+            .collect();
+        accounted.sort();
+
+        for name in &called {
+            assert!(
+                accounted.contains(name),
+                "install.sh calls {name}, and nothing says whether an already-provisioned board \
+                 ever gets it.\n\
+                 Read docs/design/updater-design.md §9.1. Then either move the step into a \
+                 scripts/setup-*.sh that hooks/postinstall runs too — which is what \
+                 setup-login.sh is — or add {name} to FIRST_INSTALL_ONLY here with the reason a \
+                 board that only updates does not need it."
+            );
+        }
+        for name in &accounted {
+            assert!(
+                called.contains(name),
+                "{name} is listed here but install.sh no longer calls it; drop the entry"
+            );
+        }
+
+        // ── half two: a shared setup script both paths run ──
+        //
+        // `install.sh` runs one out of the installed release, as `current/scripts/setup-x.sh`.
+        // Matching that exact form and not the bare name on purpose: the script also *names*
+        // setup-board.sh in a message telling an operator to go run it, which is not the same
+        // thing as running it.
+        let mut shared: Vec<String> = Vec::new();
+        for (_, rest) in install
+            .split("current/scripts/setup-")
+            .skip(1)
+            .map(|r| ("", r))
+        {
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || "._-".contains(*c))
+                .collect();
+            if name.ends_with(".sh") {
+                shared.push(format!("scripts/setup-{name}"));
+            }
+        }
+        shared.sort();
+        shared.dedup();
+
+        let hooks: String = ["hooks/preinstall.in", "hooks/postinstall"]
+            .iter()
+            .map(|h| std::fs::read_to_string(root.join(h)).unwrap_or_else(|e| panic!("{h}: {e}")))
+            .collect();
+        for script in &shared {
+            assert!(
+                hooks.contains(&format!("script={script}")),
+                "install.sh runs {script} out of the release and no hook does. A board that only \
+                 updates never gets it — see docs/design/updater-design.md §9.1. Add \
+                 `script={script}` to hooks/postinstall."
+            );
+        }
+    }
+
     /// Every policy file in `policies/` must be packaged, at every packaging site.
     ///
     /// The `--include` list exists in three copies (the two workflows and `dev-push.sh`), and


### PR DESCRIPTION
The robot's name never appeared in the prompt on a board that had been updating since August. `scripts/install.sh` writes the `/etc/profile.d` snippet, the motd banner and the `robotctl` completions, and nothing else does — `install.sh` runs once, at provisioning, and is not in the artifact, so no hook could run it even if one tried. The board had the banner and the completions from 19 August and no snippet, because the snippet landed on the 26th.

That is `updater-design.md` §9.1 for the fourth time, in a shape that had gone unnoticed for a month because it is cosmetic: the robot works, the prompt is just wrong.

## The docs first

§9.1 was written the day after this instance merged and would not have caught it, for two reasons that are both about the docs rather than the rule.

**It had one inbound link, from the paragraph above it.** Every pointer in the tree — `hooks/postinstall`, `updater/src/engine.rs`, `updater/src/robot.rs`, four design docs, the docs index — went to `install-path-gap.md`, a closed retrospective that then forwards to §9.1. Nobody editing `install.sh` was ever on the first hop. The hooks, `CONTRIBUTING.md` and the index now name the rule, and the retrospective says plainly that it is the story and §9.1 is the rule.

**And "needs" is a judgement that let this case through.** A snippet naming the robot is not something a release *needs*. §9.1 now asks the mechanical question instead — does `scripts/install.sh` write this file or run this command — and is retitled to match. The fourth instance is written down, including the way it looked correct while it was being written: `install_completions` and `install_login_banner` sit on the two lines above and have the same gap, so the surrounding code read as the pattern.

## The fix

`scripts/setup-login.sh` is the three functions moved whole. `install.sh` runs it out of the installed release, `hooks/postinstall` runs it on every update. Idempotent, and never fatal — a shell prompt is not worth rolling an update back for.

## The test

`every_install_sh_step_reaches_an_updated_board` reads `install.sh`'s call sites and fails unless each is either performed by a hook too or written down, with a reason, as something only a fresh install does. Its second half fails if `install.sh` runs a `setup-*.sh` out of the release that no hook names. Both halves were confirmed to fail by breaking them.

A forcing function, not a proof — the escape hatch is a line in a table. But all four instances would have had to argue for that line, and none of them could have.

`board-test.sh` deletes the three files before the postinstall-alone run and asserts the hook restores them, and drives the prompt snippet rather than checking it exists: it hooks `PROMPT_COMMAND` and rewrites `PS1` at the first prompt, and that indirection is the half that silently does nothing when it is wrong.

## Still open

`hooks/postinstall` installs units but not the journald drop-in and not the `robotctl` symlink. That asymmetry is deliberate and `board-test.sh` pins it, so it is untouched here — but it is the one thing left that §9.1 does not cover, and it is now named in the test's accounting rather than only in a comment.

## Checks

`cargo test -p xtask` passes, clippy clean. `board-test.sh` needs Docker and did not run locally; the prompt snippet itself was driven by hand — it injects into a stock `PS1` and into Debian's xterm-title prefix, is idempotent across repeated `PROMPT_COMMAND` firings, and a name containing `$(...)` and backticks comes out inert.

After this merges, the board gets the prompt from the next ordinary update. No manual step.