### PR TITLE
Shutdown must not stand the robot back up, and quack opens the beak

### DIFF
--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -558,7 +558,7 @@ robotctl quack
 
 The loudest way to tell ducks apart: every robot's voice bank is generated from its SoC
 serial (`sounds ensure-bank`, run by every release install), so the robot that answers — in
-a voice that is only its own — is the one you're SSH'd into. A robot with no voice — audio
+a voice that is only its own, beak open — is the one you're SSH'd into. A robot with no voice — audio
 off, or no bank — says so instead of printing 🦆, so silence always means the wrong duck.
 The robot also greets when `robotd` comes up, pecks goodbye before powering off, and — if you
 ask it to — coos when the mic hears its head being scratched. That one is off by default in

--- a/robotd/src/chorale.rs
+++ b/robotd/src/chorale.rs
@@ -542,7 +542,7 @@ impl Chorale {
         // holding the beat, and two beacons carrying a piece would be two conductors.
         let idle = self.beacon(proto::ChoraleBeacon::IDLE, self.heartbeat(now), Vec::new());
         let advertise = self.publish(Some(idle), true);
-        let singing = position.and_then(|at| self.my_part(&roster).map(|part| (part, at)));
+        let singing = self.my_part(&roster).zip(position);
         Tick {
             advertise,
             joining: singing.is_none(),
@@ -630,7 +630,6 @@ pub fn head_expression(beats: f64, reach: f64) -> [f64; 4] {
     ]
 }
 
-#[cfg(test)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -1832,11 +1832,13 @@ async fn control_loop<T: RobotIo>(
         // still-set `enabled` flag wins — `request_relax` clears that flag, and reading the request
         // first means the order cannot invert.
         match intents.take_power_request() {
-            // The power-off has been asked for and torque is off. Standing the robot up now would
-            // hand the poweroff a robot mid-ramp, stiff, which is the outcome the sit exists to
-            // avoid.
-            Some(intents::PowerRequest::Init) if powered_off => {
-                tracing::warn!("robot.init ignored: the robot is powering off")
+            // Shutdown owns the robot: sitting, or already cutting power. Standing the robot
+            // up now would hand the poweroff a robot mid-ramp, stiff, which is the outcome
+            // the sit exists to avoid. `init` during the sit is also how the duck stood
+            // back up — the sequence went limp and the same tick (or the next `robot.init`)
+            // ramped it home. #159.
+            Some(intents::PowerRequest::Init) if powered_off || shutdown_sit.is_some() => {
+                tracing::warn!("robot.init ignored: shutdown is in progress")
             }
             Some(intents::PowerRequest::Init) => match (bringup, sensors.as_ref()) {
                 // Unlike `enable`, this needs no policy: "stand up" is a reasonable thing to ask of
@@ -2336,7 +2338,9 @@ async fn control_loop<T: RobotIo>(
         // of it — so without the guard, the very tick that cut torque for the poweroff turned it
         // back on and started ramping the robot to home. Seen on the robot as "sits, stands back
         // up, switches off", or when the poweroff was quicker, "sits, switches off, stiff".
+        // Same while the sit is still in flight: `powered_off` is not set yet. #159.
         if !powered_off
+            && shutdown_sit.is_none()
             && let (Bringup::Limp, true, true, Some(sensors)) = (
                 bringup,
                 snapshot.enabled,
@@ -2823,12 +2827,28 @@ async fn control_loop<T: RobotIo>(
             }
         }
 
-        // The mouth is not part of any policy; the intent is the only thing that moves it.
+        // The mouth is not part of any policy. The pad's analog triggers already write
+        // `snapshot.mouth`; a one-shot (`robotctl quack`, the greet, a peck) has no
+        // trigger, so the player says how open the beak should be while it calls.
+        //
         // Only while driving — a held or homing robot keeps whatever its hold pose says, so
-        // a restart cannot snap a mouth.
-        if driving && theremin_state.is_none() && chorale_state.is_none() {
-            targets[duck_control::model::MOUTH_INDEX] =
-                duck_control::model::mouth_target(snapshot.mouth);
+        // a restart cannot snap a mouth. A CLI quack on a sitting-but-torqued robot is the
+        // exception: that is how you tell which duck answered when several are in earshot,
+        // and gating on `driving` made the visible half silently absent, the same way it
+        // did for the theremin.
+        let quack_open = voice.as_mut().map(sound::Sound::quack_mouth).unwrap_or(0.0);
+        if theremin_state.is_none() && chorale_state.is_none() {
+            if driving {
+                targets[duck_control::model::MOUTH_INDEX] =
+                    duck_control::model::mouth_target(snapshot.mouth.max(quack_open));
+            } else if quack_open > 0.0
+                && snapshot.enabled
+                && bringup == Bringup::Ready
+                && !powered_off
+            {
+                targets[duck_control::model::MOUTH_INDEX] =
+                    duck_control::model::mouth_target(quack_open);
+            }
         }
 
         match safety.apply(targets, hold, gain) {

--- a/robotd/src/sound.rs
+++ b/robotd/src/sound.rs
@@ -52,6 +52,15 @@ const SYNTH_BLOCK: usize = sounds::SR as usize / 100;
 /// this number — see the module docs for why it is not the ride's 250 ms.
 const SYNTH_LEAD_S: f64 = 0.03;
 
+/// How long the beak stays open around a one-shot. A chirp is ~200 ms; the servo is
+/// slower, so a hold that ended with the wav would barely move. Long enough to read as a
+/// quack from across the room, short enough not to leave the beak hanging.
+const QUACK_MOUTH_HOLD: Duration = Duration::from_millis(450);
+
+/// How open the beak goes for a one-shot. Fully open: `robotctl quack` is how you tell
+/// ducks apart in a group, and a half-open beak is easy to miss.
+const QUACK_MOUTH_OPEN: f64 = 1.0;
+
 /// How loud one voice of an ensemble sings.
 ///
 /// Under full scale, and not for headroom: **four ducks in a room sum acoustically.** The offline
@@ -194,6 +203,9 @@ pub struct Sound {
     /// theremin and the rendered wavs are the same duck. `None` until first asked for;
     /// `Some(None)` once it has been asked for and there is no seed to be had.
     personality: Option<Option<Personality>>,
+    /// Beak stays open until this instant while a one-shot plays. The wav is shorter
+    /// than the servo's travel, so the hold is a duration, not `aplay`'s lifetime.
+    oneshot_mouth_until: Option<Instant>,
 }
 
 impl Sound {
@@ -208,6 +220,27 @@ impl Sound {
             live: None,
             singing: None,
             personality: None,
+            oneshot_mouth_until: None,
+        }
+    }
+
+    /// How open the beak should be for a one-shot that is in flight.
+    ///
+    /// The pad already opens the mouth via the analog triggers; `robotctl quack` has no
+    /// trigger, so this is the visible half of that call. Zero unless a chirp/greet/peck
+    /// (anything that went through [`Self::play`]) is still being shown, and never while a
+    /// ride/theremin/chorale owns the PCM — those own the mouth themselves.
+    pub fn quack_mouth(&mut self) -> f64 {
+        if self.ride != Ride::Off {
+            self.oneshot_mouth_until = None;
+            return 0.0;
+        }
+        match self.oneshot_mouth_until {
+            Some(until) if Instant::now() < until => QUACK_MOUTH_OPEN,
+            _ => {
+                self.oneshot_mouth_until = None;
+                0.0
+            }
         }
     }
 
@@ -243,6 +276,7 @@ impl Sound {
         }
         self.singing = None;
         self.ride = Ride::Off;
+        self.oneshot_mouth_until = None;
         if let Some(mut child) = self.child.take()
             && let Ok(None) = child.try_wait()
         {
@@ -302,6 +336,12 @@ impl Sound {
             }
             return;
         };
+        // The visual half of the call, even if `aplay` then fails: a quiet speaker is
+        // still a duck you can pick out by the beak. Not on the blocking goodbye peck —
+        // torque is about to go and there is no tick left to close it.
+        if !blocking {
+            self.oneshot_mouth_until = Some(Instant::now() + QUACK_MOUTH_HOLD);
+        }
         let child = Command::new("aplay")
             .args(["-q", "-D", &self.device])
             .arg(&wav)
@@ -897,6 +937,41 @@ mod tests {
         sound.wheee(WheeeHold::Released);
         assert!(sound.child.is_none());
         assert_eq!(sound.ride, Ride::Off);
+        assert_eq!(
+            sound.quack_mouth(),
+            0.0,
+            "a missing bank must not flap the beak"
+        );
+    }
+
+    /// A one-shot opens the beak even if `aplay` cannot run: `robotctl quack` is how you
+    /// tell ducks apart, and a quiet speaker is still a duck you can pick out visually.
+    #[test]
+    fn a_one_shot_opens_the_beak() {
+        let dir = std::env::temp_dir().join(format!("sound-quack-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("chirp")).unwrap();
+        std::fs::write(dir.join("chirp/a.wav"), b"RIFF").unwrap();
+        let mut sound = Sound::new(dir.clone(), "null".into());
+        sound.play("chirp", false);
+        assert_eq!(sound.quack_mouth(), 1.0);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A wheee ride owns the mouth via the analog trigger; a one-shot skipped because the
+    /// ride has the PCM must not steal it.
+    #[test]
+    fn a_ride_does_not_open_the_beak_for_a_skipped_one_shot() {
+        let dir = std::env::temp_dir().join(format!("sound-ride-mouth-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("wheee")).unwrap();
+        std::fs::create_dir_all(dir.join("chirp")).unwrap();
+        std::fs::write(dir.join("chirp/a.wav"), b"RIFF").unwrap();
+        let mut sound = Sound::new(dir.clone(), "null".into());
+        sound.wheee(WheeeHold::Held);
+        assert_eq!(sound.ride, Ride::Riding);
+        sound.play("chirp", false);
+        assert_eq!(sound.quack_mouth(), 0.0);
+        sound.wheee(WheeeHold::Released);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// A bank whose `wheee/` holds no triads (a half-rendered `ensure-bank`, or a bank from


### PR DESCRIPTION
Fixes #159 and #153.

Prevent a completed shutdown from re-enabling torque through the same tick's stale enable snapshot. Ignore `robot.init` while shutdown is in progress or power is off, skip enable-driven bring-up during that sequence and set `Bringup::Limp` on the no-sit power-off path.

`robotctl quack` now holds the beak open for 450 ms, including when audio playback fails. It preserves the blocking goodbye behavior and avoids taking over while ride, theremin or chorale owns the PCM. The mouth can move while sitting but torqued.

Motor-gain tuning is unchanged: policy.gain remains 200 with I/D at zero.

Also remove a duplicate `#[cfg(test)]` attribute that failed strict Clippy.

## Test plan

- [x] `cargo test -p robotd`: 99 unit tests and 7 updater_gate tests passed, including shutdown/init and one-shot beak regressions.
- [x] `RUSTFLAGS="-D warnings" cargo clippy -p robotd --all-targets`
- [ ] On a real duck: shutdown sits and stays down; init cannot stand it up before a new power-on.
- [ ] On a torqued robot: `robotctl quack` opens the beak and plays the call.

The tested shutdown path has no policy and powers off immediately. The sit-with-policy path requires ONNX and remains unvalidated.

Codex assisted with this description.
