### PR TITLE
duck-detect: keep the c_char cast, which clippy only sees half of

### DIFF
--- a/duck-detect/src/rknn.rs
+++ b/duck-detect/src/rknn.rs
@@ -394,6 +394,12 @@ impl Drop for Model {
 }
 
 /// A NUL-terminated vendor string, without the noise.
+///
+/// the cast is needed and clippy cannot see it. `c_char` is `i8` on the x86_64 host and `u8` on
+/// the board, so on the board this is `u8 as u8` and `unnecessary_cast` fires, while taking the
+/// cast out stops the host compiling at all. lint the workspace for the board's own target, the
+/// way CONTRIBUTING asks, and `-D warnings` turns that into an error.
+#[allow(clippy::unnecessary_cast)]
 fn c_str(raw: &[c_char]) -> String {
     let bytes: Vec<u8> = raw
         .iter()


### PR DESCRIPTION
fixes #185

`c_char` is `i8` on x86_64 and `u8` on aarch64, so the cast in `c_str` is load bearing on the host and dead on the board, and clippy only ever sees one of the two. linting for the board's target turned it into an error under `-D warnings`, and removing the cast stops the host compiling.

so the cast stays and the lint is allowed on that one function, with the reason written down next to it. nothing else was touched.

checked both ways: `cargo clippy --workspace --all-targets` on aarch64 is clean, and `cargo check -p duck-detect --target x86_64-unknown-linux-gnu` still builds.
