### PR TITLE
ci: lint the scripts that run on a board, not just some of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,29 @@ jobs:
       #
       # POSIX sh, not bash: the script is piped to `sh` by the documented one-liner, and
       # a bashism would work on a dev box and fail on the board.
+      #
+      # `setup-npu.sh` and `setup-rkaiq.sh` are fetched standalone with curl, exactly like
+      # `setup-gstreamer.sh` two names to the left, and the update hook runs both. `robot-boot-check`
+      # runs on every boot. `hooks/postinstall` runs on every board on every update, which
+      # CONTRIBUTING calls the only thing that does. Each of those is the reason `robot-rescue` is on
+      # this list, and none of them was.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/setup-npu.sh scripts/setup-rkaiq.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/robot-boot-check scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh hooks/postinstall; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.
             test -x "$script"
           done
+
+      # `hooks/preinstall.in` is the same shell, checked the same way, minus the `test -x`: it is a
+      # template `xtask package` renders into the hook, so the file in the tree is not the file that
+      # runs and is not executable. The placeholders it carries are bare words to `sh`, so they
+      # parse and lint like anything else.
+      - name: Lint the preinstall template
+        run: |
+          sh -n hooks/preinstall.in
+          shellcheck --shell=sh hooks/preinstall.in
 
       # `board-test.sh` separately, because it needs different flags and was excluded for it.
       #

--- a/scripts/setup-npu.sh
+++ b/scripts/setup-npu.sh
@@ -238,7 +238,9 @@ printf '  duck-bench --model /var/tmp/duck.rknn --frames /var/tmp/frames\n'
 if [ -n "${NEEDS_REBOOT:-}" ]; then
     printf '\nREBOOT FIRST. The NPU node was just enabled and binds on the next boot:\n'
     printf '  sudo reboot\n'
+    # shellcheck disable=SC2016  # the backticks are for the reader, not the shell
     printf 'Then `dmesg | grep rknpu` should say the driver initialised.\n'
 elif [ -z "$DRIVER" ]; then
+    # shellcheck disable=SC2016  # same, and single quotes are what keeps them literal
     printf '\nExpect `rknn_init` to fail until the NPU driver is there.\n'
 fi


### PR DESCRIPTION
fixes #186

adds the five that were missing to the shellcheck loop: `setup-npu.sh`, `setup-rkaiq.sh`, `robot-boot-check`, `hooks/postinstall`, and `hooks/preinstall.in`.

the template gets its own step because it is the one file here that is not executable. `xtask package` renders it into the hook, so the file in the tree is not the file that runs and `test -x` would fail on it. its placeholders are bare words to `sh`, so it parses and lints like anything else.

`setup-npu.sh` needed two `# shellcheck disable=SC2016` lines. the backticks in those two printf strings are for the person reading the output, and the single quotes are what keeps them literal, so the warning is asking for the opposite of what the line wants. disabled in the file rather than excluded in the workflow, so the rule still applies to the rest of the script.

left off deliberately: `cross-sysroot.sh` and `systemd-test.sh`. they only ever run on a dev machine or in CI, so the argument for the rest of the list does not reach them. happy to add them if you would rather the list were simply everything.

i ran the step as written against all 17 files and it passes.
