### PR TITLE
ci: the coverage gate enforces again, and a fork's pull request stops going red for a comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,13 +285,11 @@ jobs:
       # staying over the floor no longer says so. The ratchet is the mechanism now — raise the
       # floor when the number rises, and a collapse still fails the job.
 
-      # Column 10 of the TOTAL row is line coverage. The whole table goes in the run
-      # summary, where it renders without anyone opening a log; the comment carries the
-      # number that matters.
-      - name: Report
+      # Column 10 of the TOTAL row is line coverage. The whole table goes in the run summary,
+      # where it renders without anyone opening a log, and into a file the step below posts as a
+      # comment wherever it is allowed to.
+      - name: Summary
         if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           pct() { awk '/^TOTAL/ {gsub("%","",$10); print $10}' "$1" 2>/dev/null; }
           head_pct=$(pct "$RUNNER_TEMP/head.txt")
@@ -317,6 +315,20 @@ jobs:
 
           cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
 
+      # Its own step, and skipped for a pull request from a fork. A fork's `pull_request` run
+      # gets a read-only `GITHUB_TOKEN` whatever this job's `permissions:` block asks for, so
+      # `gh pr comment` cannot post and fails with "Resource not accessible by integration
+      # (addComment)" — which turned every outside contribution red on the one step that merely
+      # decorates it, while `Coverage` above had already passed. The table is in the run summary
+      # either way; only the comment is missing, and it is a convenience, not the gate.
+      #
+      # Posting for a fork too would mean moving this into a `workflow_run` workflow, which runs
+      # with the base repository's token. That is a bigger change than a comment is worth.
+      - name: Comment
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
           # Edit the previous comment rather than adding one per push, so a long-running
           # branch does not accumulate a wall of near-identical coverage reports.
           gh pr comment "${{ github.event.number }}" --body-file "$RUNNER_TEMP/comment.md" --edit-last \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     env:
       # The floor, in one place. It is both enforced and quoted in the comment, and two copies
       # of a number are one copy and one thing to forget.
-      COVERAGE_FLOOR: 72
+      COVERAGE_FLOOR: 70
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -255,11 +255,25 @@ jobs:
       # below is set with them included, rather than hidden by widening the exclusion until
       # the number looks good.
       #
-      # The floor is a ratchet, not a target: raise it when the real number rises. It sits
-      # a few points under today's ~77% so ordinary work does not trip it, while a genuine
-      # collapse still fails. Lowering it should be a deliberate, explained commit.
+      # The floor is a ratchet, not a target: raise it when the real number rises. It sits a
+      # point under today's 71.03% so ordinary work does not trip it, while a genuine collapse
+      # still fails. Lowering it should be a deliberate, explained commit.
+      #
+      # This is that commit, for 72 -> 70. 72 was written when the number here was quoted as
+      # ~77%; line coverage has in fact been 71% since at least August, so the floor sat above
+      # the real number and every run should have been red. None were, because the status of
+      # `--fail-under-lines` was thrown away — see `set -o pipefail` below. So the floor was
+      # enforcing nothing, and the drift it existed to catch went unreported for weeks.
+      #
+      # `set -o pipefail`, because the default shell for a `run:` block is `bash -e` *without*
+      # it: the status of a pipeline is then `tee`'s, and `--fail-under-lines` exits 1 into a
+      # step that reports success. That is the whole of how the floor came to enforce nothing,
+      # and it is why the number is piped rather than written with `--output-path` — the table
+      # belongs in the log as well as the file, and now the exit code survives the pipe.
       - name: Coverage
-        run: cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines "$COVERAGE_FLOOR" | tee "$RUNNER_TEMP/head.txt"
+        run: |
+          set -o pipefail
+          cargo llvm-cov --workspace --summary-only --ignore-filename-regex '(^|/)xtask/' --fail-under-lines "$COVERAGE_FLOOR" | tee "$RUNNER_TEMP/head.txt"
 
       # There is deliberately no second run against the base branch. This job used to check
       # the base out separately and build it instrumented a second time, purely to subtract


### PR DESCRIPTION
Two faults in the `coverage` job, found while looking at why CI was red on #188.

## The floor enforced nothing

```yaml
- run: cargo llvm-cov … --fail-under-lines "$COVERAGE_FLOOR" | tee "$RUNNER_TEMP/head.txt"
```

The default shell for a `run:` block is `bash -e`, *without* `pipefail` — that only comes from writing `shell: bash` explicitly. So the pipeline's status is `tee`'s, and cargo-llvm-cov's exit code went nowhere:

```
$ /bin/bash -e -c 'false | tee /dev/null; echo "status=$?"'
status=0
```

And the gate had something to catch: line coverage is **71.03%** against a floor of **72**, and was 70.53% in August. Every coverage run for weeks should have been red. Meanwhile the comment beside the floor still read "a few points under today's ~77%".

`set -o pipefail`, and the floor moves to 70 — the deliberate, explained commit that comment asks for. 70 is a point under the real number, about 375 uncovered lines of slack.

## A fork's pull request went red for a comment it cannot post

A fork's `pull_request` run gets a read-only `GITHUB_TOKEN` regardless of the job's `permissions:` block, so `gh pr comment` fails:

```
GraphQL: Resource not accessible by integration (addComment)
```

On #188 that failed the job after `Coverage` had already passed. Every outside contribution hits it.

Reporting is now two steps: `Summary` writes the table to the run summary as before, and `Comment` posts it only when the head repository is this one. Posting for forks too would mean a `workflow_run` workflow holding the base repository's token — more machinery than a comment justifies.

## Checked

The step bodies were extracted from the workflow and run under `bash -e <file>`, the same invocation the runner uses:

- old `Coverage` body with a stub that prints the table and exits 1 → step exits **0**
- new body, same stub → step exits **1**
- `Summary` body against the real TOTAL row → `**71.03% lines** on this branch, against a floor of 70%.`

Merging this makes #188 green: its `Comment` step is skipped and its coverage number clears 70.