### PR TITLE
updater: boot recovery waits for a robot that is still starting, the way the gate does

### DIFF
--- a/updater/src/engine.rs
+++ b/updater/src/engine.rs
@@ -1706,9 +1706,12 @@ impl Engine {
             //
             // Only for a socket gate. `HealthCheck::None` has nothing to ask, and `Command` answers
             // a two-way question — there is no "degraded" in an exit status.
-            if let HealthCheck::Socket { .. } = cfg.health {
-                match self.robot.health(ROBOT_QUERY_TIMEOUT).await {
-                    crate::robot::Health::Healthy => {
+            if let HealthCheck::Socket { timeout, .. } = &cfg.health {
+                // For as long as the gate would have, and for the gate's reason: at boot this
+                // question lands while `robotd` may still be loading its policies, and the two
+                // units are not ordered. See `robot_verdict`.
+                match self.robot_verdict(*timeout).await {
+                    Some(crate::robot::Health::Healthy) => {
                         tracing::warn!(
                             component = %pending.component,
                             version = %pending.version,
@@ -1719,7 +1722,7 @@ impl Engine {
                         self.boot_counter.confirm(&pending.component)?;
                         continue;
                     }
-                    crate::robot::Health::Degraded(reason) => {
+                    Some(crate::robot::Health::Degraded(reason)) => {
                         tracing::warn!(
                             component = %pending.component,
                             version = %pending.version,
@@ -2088,6 +2091,33 @@ impl Engine {
         }
     }
 
+    /// The robot's verdict, asked for as long as `timeout` allows rather than once.
+    ///
+    /// Because `robotd` says so. Between its socket opening and its first tick it answers
+    /// "control loop has not completed a cycle yet", and the comment on that line reads:
+    /// `"Starting" is not "started". The gate polls, so it will see the transition.` Anything that
+    /// decides on this answer has to be that gate, or a robot that is merely late is a robot that
+    /// failed. Boot recovery asked once and reverted on what it heard.
+    ///
+    /// The first answer that settles the question, the last one heard when the time runs out, or
+    /// `None` when there was no time to ask at all.
+    async fn robot_verdict(&self, timeout: Duration) -> Option<crate::robot::Health> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut last = None;
+        while tokio::time::Instant::now() < deadline {
+            let verdict = self.robot.health(ROBOT_QUERY_TIMEOUT).await;
+            if matches!(
+                verdict,
+                crate::robot::Health::Healthy | crate::robot::Health::Degraded(_)
+            ) {
+                return Some(verdict);
+            }
+            last = Some(verdict);
+            tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+        }
+        last
+    }
+
     /// Wait for the new release to report healthy.
     ///
     /// A timeout is a **failure**: unproven is not healthy, or auto-rollback would
@@ -2115,38 +2145,30 @@ impl Engine {
             HealthCheck::Socket { .. } => {
                 // The socket path lives in `Config::robot_socket` and is used to build
                 // the RobotClient in `main`; here we just ask the client.
-                let deadline = tokio::time::Instant::now() + timeout;
-                let mut last = String::from("no answer");
-                while tokio::time::Instant::now() < deadline {
-                    match self.robot.health(ROBOT_QUERY_TIMEOUT).await {
-                        crate::robot::Health::Healthy => return Ok(GatePassed::Healthy),
-                        // Passes. Logged at warn, not swallowed: committing a release onto a
-                        // robot that cannot move is the right call, but nobody should have to
-                        // guess afterwards that that is what happened.
-                        crate::robot::Health::Degraded(reason) => {
-                            tracing::warn!(
-                                reason = %reason,
-                                "committing: the robot is degraded for a reason this release \
-                                 cannot have caused and a rollback cannot fix"
-                            );
-                            return Ok(GatePassed::Degraded(reason));
-                        }
-                        crate::robot::Health::Unhealthy(reason) => last = reason,
-                        // Fails, like `Unreachable`, and reads nothing like it. "unreachable"
-                        // about a robot that is serving its socket sends the reader to the wrong
-                        // half of the system for an hour; see `docs/project/install-path-gap.md`.
-                        crate::robot::Health::Incompatible(reason) => {
-                            last = format!(
-                                "answered in a shape this updaterd cannot read ({reason}) — \
-                                 the robot may be fine and the contract is what disagrees"
-                            );
-                        }
-                        crate::robot::Health::Unreachable => {
-                            last = "unreachable".into();
-                        }
+                let last = match self.robot_verdict(timeout).await {
+                    Some(crate::robot::Health::Healthy) => return Ok(GatePassed::Healthy),
+                    // Passes. Logged at warn, not swallowed: committing a release onto a
+                    // robot that cannot move is the right call, but nobody should have to
+                    // guess afterwards that that is what happened.
+                    Some(crate::robot::Health::Degraded(reason)) => {
+                        tracing::warn!(
+                            reason = %reason,
+                            "committing: the robot is degraded for a reason this release \
+                             cannot have caused and a rollback cannot fix"
+                        );
+                        return Ok(GatePassed::Degraded(reason));
                     }
-                    tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
-                }
+                    Some(crate::robot::Health::Unhealthy(reason)) => reason,
+                    // Fails, like `Unreachable`, and reads nothing like it. "unreachable"
+                    // about a robot that is serving its socket sends the reader to the wrong
+                    // half of the system for an hour; see `docs/project/install-path-gap.md`.
+                    Some(crate::robot::Health::Incompatible(reason)) => format!(
+                        "answered in a shape this updaterd cannot read ({reason}) — \
+                         the robot may be fine and the contract is what disagrees"
+                    ),
+                    Some(crate::robot::Health::Unreachable) => "unreachable".into(),
+                    None => "no answer".into(),
+                };
                 Err(Error::Health(format!(
                     "not healthy within {}s: {last}",
                     timeout.as_secs()

--- a/updater/tests/apply.rs
+++ b/updater/tests/apply.rs
@@ -88,6 +88,46 @@ impl RobotClient for DegradedRobot {
     }
 }
 
+/// A robot that is still coming up the first time it is asked, and fine after that.
+///
+/// What `robotd` answers between its socket opening and its first tick: `healthy: false`,
+/// `degraded: false`, reason "control loop has not completed a cycle yet". Its own comment on that
+/// line says the gate polls, so it will see the transition. This is the transition.
+struct StartingThenHealthy {
+    asked: std::sync::atomic::AtomicU32,
+}
+
+impl StartingThenHealthy {
+    fn new() -> Self {
+        Self {
+            asked: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RobotClient for StartingThenHealthy {
+    async fn safe_to_restart(&self, _t: std::time::Duration) -> SafeToRestart {
+        SafeToRestart::Yes
+    }
+    async fn health(&self, _t: std::time::Duration) -> Health {
+        let asked = self
+            .asked
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if asked == 0 {
+            Health::Unhealthy("control loop has not completed a cycle yet".into())
+        } else {
+            Health::Healthy
+        }
+    }
+    async fn model_api(&self, _t: std::time::Duration) -> Option<u32> {
+        Some(1)
+    }
+    async fn remote_session_active(&self, _t: std::time::Duration) -> bool {
+        false
+    }
+}
+
 #[async_trait::async_trait]
 impl RobotClient for FakeRobot {
     async fn safe_to_restart(&self, _t: std::time::Duration) -> SafeToRestart {
@@ -974,6 +1014,50 @@ async fn an_unconfirmed_trial_on_a_healthy_robot_is_committed() {
         );
     }
     assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+}
+
+/// **A robot that is still starting is not a robot that failed.**
+///
+/// `robotd` answers "control loop has not completed a cycle yet" from the moment its socket opens
+/// until its first tick, and it says on that line that the gate polls and will see the transition.
+/// The apply gate does. Boot recovery asked once, with a two second timeout, and reverted on the
+/// answer. The two daemons start under different `After=` targets and nothing orders them, so on
+/// the boot that exhausts the budget the question could land in the seconds between `robotd`
+/// opening its socket and loading its policies, and a release the robot was about to be fine on
+/// went back to the previous one with "never reported healthy" in the log.
+#[tokio::test]
+async fn an_unconfirmed_trial_waits_for_a_robot_that_is_still_starting() {
+    let fx = Fixture::new();
+    fx.publish("1.0.0", None);
+    let mut engine = fx.engine_healthy();
+    apply_latest(&mut engine).await.unwrap();
+
+    fx.publish("1.1.0", None);
+    let mut crashing = fx.engine(
+        Box::new(FakeRobot::healthy()),
+        Faults {
+            abort_after_swap: true,
+            ..Faults::none()
+        },
+        "",
+    );
+    let _ = apply_latest(&mut crashing).await;
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+
+    // First start counts. The second exhausts the budget and asks the robot, which is mid-start.
+    let mut engine = fx.engine(Box::new(StartingThenHealthy::new()), Faults::none(), "");
+    assert!(engine.recover_on_start().await.unwrap().is_empty());
+    let outcomes = engine.recover_on_start().await.unwrap();
+
+    assert!(
+        outcomes.is_empty(),
+        "a robot that had not ticked yet was treated as a failed release: {outcomes:?}"
+    );
+    assert_eq!(fx.live_version().as_deref(), Some("1.1.0"));
+    assert!(
+        !fx.pending_file_exists(),
+        "and once it answered healthy the trial is over"
+    );
 }
 
 /// And the case that prompted all of this: a bench board with no servo power.


### PR DESCRIPTION
fixes #196

the apply gate polls robotd for the whole health timeout. boot recovery asks once with a 2s timeout and reverts on whatever it hears, so a robot that's still loading its policies reads as a release that failed.

pulled the gate's polling loop into a helper and had boot recovery ask through it too.

one cost: on a boot where the trial is exhausted and robotd isn't answering at all, recovery now waits the health timeout instead of 2s before reverting. that's the wait the apply gate already does on the same question. board-test is unaffected, its fixture uses probe = none.
