### PR TITLE
A crash-looping daemon reported as an active one running an unknown old build

### DIFF
--- a/configd/src/units.rs
+++ b/configd/src/units.rs
@@ -131,20 +131,48 @@ async fn query(unit: &str) -> Result<proto::UnitState, String> {
         .try_into()
         .map_err(|e: zbus::zvariant::Error| e.to_string())?;
 
-    let state = match active.as_str() {
-        // `activating` counts as active: `padd` spends its first moments connecting to `robotd`, and
-        // reporting that as "not running" would make a robot mid-boot look broken.
+    // A second property on the connection and object path already in hand, so it costs one more
+    // round trip on the same bus. It buys the only distinction systemd makes between a daemon
+    // coming up and a daemon that keeps dying: both are `ActiveState=activating`.
+    let sub: String = property(&bus, &path, "org.freedesktop.systemd1.Unit", "SubState")
+        .await?
+        .try_into()
+        .map_err(|e: zbus::zvariant::Error| e.to_string())?;
+
+    Ok(state_of(&active, &sub, unit))
+}
+
+/// What one `ActiveState`/`SubState` pair means.
+///
+/// Pure, and separated from the bus call for the reason `reconcile::verdict_for` is: the mapping is
+/// the part that can be wrong, and the states worth checking are the ones a test cannot arrange —
+/// a crash loop needs a daemon that will not start, and asking systemd for one on a board means
+/// breaking the robot.
+///
+/// **`SubState` is read first**, because `auto-restart` is the answer `ActiveState` cannot give.
+/// systemd reports a unit waiting out its `RestartSec=` as `activating`, exactly as it reports one
+/// starting for the first time; taking `activating` for `Active` is what let `mediad` crash-loop on
+/// an unplugged camera flex while `robotctl health` called it active. `auto-restart-queued` is the
+/// same state one systemd version later, hence the prefix rather than an equality.
+pub fn state_of(active: &str, sub: &str, unit: &str) -> proto::UnitState {
+    if sub.starts_with("auto-restart") {
+        return proto::UnitState::Restarting;
+    }
+
+    match active {
+        // `activating` still counts as active: `padd` spends its first moments connecting to
+        // `robotd`, and reporting that as "not running" would make a robot mid-boot look broken.
+        // With `auto-restart` taken out above, that is all this arm now catches.
         "active" | "activating" | "reloading" => proto::UnitState::Active,
-        // `failed` is inactive with a reason, and the reason is in the journal rather than here.
-        // Collapsing them keeps this a status line rather than a diagnosis.
-        "inactive" | "deactivating" | "failed" => proto::UnitState::Inactive,
+        // Reported apart from `inactive`, because a daemon that could not start and a daemon
+        // somebody stopped are different news even though neither is running.
+        "failed" => proto::UnitState::Failed,
+        "inactive" | "deactivating" => proto::UnitState::Inactive,
         other => {
             tracing::warn!(state = other, unit, "unfamiliar unit state");
             proto::UnitState::Unknown
         }
-    };
-
-    Ok(state)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -168,4 +196,60 @@ async fn property(
     .map(|value| value.try_to_owned().map(Into::into))
     .map_err(|e| e.to_string())?
     .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pair a crash loop presents as, and the whole reason [`state_of`] reads `SubState`.
+    #[test]
+    fn auto_restart_is_not_active() {
+        assert_eq!(
+            state_of("activating", "auto-restart", "mediad.service"),
+            proto::UnitState::Restarting
+        );
+        // The same state on a systemd new enough to queue the job separately.
+        assert_eq!(
+            state_of("activating", "auto-restart-queued", "mediad.service"),
+            proto::UnitState::Restarting
+        );
+    }
+
+    /// A daemon coming up for the first time is `activating` too, and must keep reading as running
+    /// — `padd` is `activating` while it connects to `robotd` on every boot.
+    #[test]
+    fn starting_still_counts_as_active() {
+        assert_eq!(
+            state_of("activating", "start", "padd.service"),
+            proto::UnitState::Active
+        );
+        assert_eq!(
+            state_of("active", "running", "padd.service"),
+            proto::UnitState::Active
+        );
+    }
+
+    /// `failed` and a deliberate stop both mean "not running" and are not the same news.
+    #[test]
+    fn failed_is_not_a_stop() {
+        assert_eq!(
+            state_of("failed", "failed", "mediad.service"),
+            proto::UnitState::Failed
+        );
+        assert_eq!(
+            state_of("inactive", "dead", "padd.service"),
+            proto::UnitState::Inactive
+        );
+    }
+
+    /// An unfamiliar `ActiveState` reports "I do not know" rather than guessing at one of the
+    /// answers that would be acted on.
+    #[test]
+    fn an_unknown_state_stays_unknown() {
+        assert_eq!(
+            state_of("maintenance", "whatever", "robotd.service"),
+            proto::UnitState::Unknown
+        );
+    }
 }

--- a/docs/design/restart-order.md
+++ b/docs/design/restart-order.md
@@ -421,7 +421,9 @@ Two version numbers are legitimately different at once, and which pair it is dec
 | `updaterd` or `btd` behind the installed release, for a few seconds after an update | expected — the deferred restart has not fired yet |
 | `btd`, `robotd`, `configd`, `padd`, `mediad` or `tofd` disagreeing with `current` at all, persistently | the restart did not take effect *and* §5 did not fix it — so either `updaterd` has not restarted since, or its restart failed (journal, at `error`) |
 | `updaterd` behind it, persistently | the deferred restart never landed, and §5 will not fix this one. `robotctl update apply daemon` repairs it — it reports `already_current` with `updaterd` in `stale` and schedules the restart. `systemctl restart updaterd` is the same fix by hand; either way the journal has why it did not land |
-| any daemon reporting `build unknown (old)` | it predates the identity mechanism, so §5 leaves it alone. One update makes it answerable |
+| any daemon reporting `restarting` | it exited and systemd is bringing it back. For a few seconds after an update, that is the restart itself. Persistently, the daemon cannot start at all — `mediad` with the camera flex unplugged is the case this row exists for — and §5 leaves it alone, since a daemon that is not running has no identity to compare. `journalctl -u <name> -b` has why it exits |
+| any daemon reporting `failed` | it could not start and systemd has stopped retrying. Same journal, and unlike `stopped` nobody chose it |
+| any daemon reporting `build unknown` | it is running, and published no identity: a build predating the mechanism, or the instant between `exec` and its first line. §5 leaves it alone. One update makes an old one answerable |
 
 Ask the robot rather than inferring:
 

--- a/docs/robot/cheatsheet-dev.md
+++ b/docs/robot/cheatsheet-dev.md
@@ -80,8 +80,10 @@ robotctl health
 ```
 
 The `units` block prints one line per daemon with the release its process was launched from, and a
-warning naming the restart when that disagrees with what is installed. `build unknown (old)` means
-that daemon predates the release which taught it to say — restart it and it will answer.
+warning naming the restart when that disagrees with what is installed. `build unknown` means that
+daemon is running and published no identity — an old build, most likely; restart it and it will
+answer. `restarting` means it exited and systemd is bringing it back: ordinary for a few seconds
+after an update, and a daemon that cannot start at all if it stays that way.
 
 If a daemon is genuinely stale, restart it — this should not be necessary, so it is worth reading the
 journal for why it was:

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -161,7 +161,15 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// results are not `deny_unknown_fields`. An older `updaterd` answers `update.show` with
 /// [`code::METHOD_NOT_FOUND`] naming it, which is the designed skew behaviour rather than a
 /// handshake refusal.
-pub const API_VERSION: u32 = 16;
+/// # v17 — a unit state that can say "crash loop"
+///
+/// [`UnitState`] gains `Restarting` and `Failed`, which `system.services` can now answer with.
+/// Not additive in the way a new method is: an older client deserialising a `Vec<ServiceUnit>`
+/// rejects a member it has no variant for, and `robotctl` reads that reply with `.ok()` — so an
+/// older `robotctl` against this `configd` prints no `units` block at all rather than a wrong one.
+/// Both come out of the same release and an apply restarts both, so the skew lasts as long as the
+/// update does; a board left mid-update sees a missing block, not a lie.
+pub const API_VERSION: u32 = 17;
 
 /// The longest an update may legitimately go quiet, in seconds — the pre-install hook's ceiling.
 ///
@@ -2861,15 +2869,35 @@ pub struct Pad {
 
 /// Whether one of the robot's units is running, as systemd sees it.
 ///
-/// Named for the unit rather than for `padd`, which is where it started: the same four answers are
-/// what [`ServiceUnit`] needs about every daemon. The wire form is unchanged by that rename — these
+/// Named for the unit rather than for `padd`, which is where it started: the same answers are what
+/// [`ServiceUnit`] needs about every daemon. The wire form is unchanged by that rename — these
 /// serialise as their own names, not as the type's.
+///
+/// **`Restarting` and `Failed` are here because folding them into their neighbours made a robot
+/// with an unplugged camera report a healthy one.** `mediad` exits when it cannot build a pipeline
+/// and `Restart=always` brings it back five seconds later, forever; systemd calls that
+/// `ActiveState=activating`, `SubState=auto-restart`. Read as `Active` — which is what happened,
+/// for `padd`'s good reason about a daemon still connecting at boot — it printed as a running
+/// daemon, and because systemd deletes `RuntimeDirectory=` on every stop there was no
+/// [`Identity`] to name a build either. The whole of a crash loop reached the operator as
+/// `active · build unknown (old)`: the one explanation that could not be true, since every daemon
+/// in this workspace has published its identity since the commit that introduced it.
+///
+/// `Failed` splits out for the smaller version of the same complaint: it read as `Inactive`, which
+/// is also what a deliberate `systemctl stop` reads as, and those are not the same news.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UnitState {
     /// Running. With a connected pad, the robot is drivable.
     Active,
-    /// The unit exists and is not running. Someone stopped it, or it is failed.
+    /// Between processes: it exited and systemd is starting it again. Once for an ordinary restart,
+    /// or every `RestartSec=` for a daemon that cannot start at all — this state cannot tell those
+    /// apart, and nothing that reads it should pretend otherwise.
+    Restarting,
+    /// It could not start, and systemd has stopped trying.
+    Failed,
+    /// The unit exists and is not running, because something stopped it. A robot whose owner has no
+    /// gamepad and disabled `padd` is the ordinary case, which is why this is not a fault.
     Inactive,
     /// No such unit on this board — a release older than the one that added it.
     Absent,

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -1680,6 +1680,10 @@ fn render_units(units: &[proto::ServiceUnit], indent: usize) -> String {
         let name = unit.unit.strip_suffix(".service").unwrap_or(&unit.unit);
         let state = match unit.state {
             proto::UnitState::Active => "active",
+            // Not "active": a daemon systemd is restarting every five seconds is not one that is
+            // running, whatever its `ActiveState` says. See [`proto::UnitState::Restarting`].
+            proto::UnitState::Restarting => "restarting",
+            proto::UnitState::Failed => "failed",
             proto::UnitState::Inactive => "stopped",
             proto::UnitState::Absent => "not installed",
             proto::UnitState::Unknown => "unknown",
@@ -1701,10 +1705,21 @@ fn render_units(units: &[proto::ServiceUnit], indent: usize) -> String {
                     None => format!(" · {build}"),
                 }
             }
-            // Nothing published. For a stopped unit that is expected — systemd removes the runtime
-            // directory with the unit. For a running one it means a build too old to publish, and
-            // saying so beats inferring a version from somewhere else.
-            None if unit.state == proto::UnitState::Active => " · build unknown (old)".to_owned(),
+            // Nothing published, and what that means is the unit state's to say rather than this
+            // arm's to guess.
+            //
+            // It used to read `build unknown (old)` for anything active, which was the wrong story
+            // told confidently: systemd deletes the runtime directory holding `identity.json` on
+            // every stop, so a crash-looping daemon has none either — and a crash-looping daemon
+            // was `active` here until `Restarting` existed. `mediad` on a board with the camera
+            // flex unplugged reported `active · build unknown (old)` indefinitely, of a build from
+            // minutes earlier that publishes its identity on its first line.
+            //
+            // A restarting or failed unit says nothing about a build, because there is no running
+            // process to have one. What is left for `build unknown` is a daemon that is genuinely
+            // running and published nothing: a build predating the mechanism, or the milliseconds
+            // between `exec` and that first line.
+            None if unit.state == proto::UnitState::Active => " · build unknown".to_owned(),
             None => String::new(),
         };
         let _ = writeln!(out, "{:indent$}{name:<9} {state}{detail}", "");
@@ -1723,16 +1738,49 @@ fn render_units(units: &[proto::ServiceUnit], indent: usize) -> String {
 /// next to its name, and a robot whose owner has no gamepad and disabled `padd` should not be told
 /// off about it on every health check. A version disagreement is different: nobody chooses that, and
 /// it is invisible without being pointed at.
+///
+/// **A daemon that cannot start is warned about, and that is the same rule rather than an exception
+/// to it.** Nobody chooses a crash loop either. It is also the one thing here a `units` line cannot
+/// convey on its own: `restarting` beside a name is a word, while the fix is a journal command, and
+/// the robot this exists for is one whose camera stopped working and whose owner has no reason to
+/// suspect a daemon.
 fn unit_warnings(
     units: &[proto::ServiceUnit],
     socket_reported: &[ServiceReport],
     installed: Option<&semver::Version>,
 ) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    // Before every filter below, and before the `installed` gate, because none of them bear on
+    // this: a daemon that is not running has no release to compare, no socket to have answered,
+    // and is worth saying whether or not `updaterd` could name what is installed.
+    for unit in units {
+        let name = unit.unit.strip_suffix(".service").unwrap_or(&unit.unit);
+        match unit.state {
+            // Deliberately phrased for both readings, because this state cannot tell them apart —
+            // see [`proto::UnitState::Restarting`]. An ordinary restart shows here for a few
+            // seconds; a daemon that cannot start shows here forever, and `mediad` with `Restart=
+            // always` and `RestartSec=5s` never trips systemd's start-rate limit, so it never
+            // progresses to `failed` on its own.
+            proto::UnitState::Restarting => warnings.push(format!(
+                "{name} exited and systemd is restarting it.\n  \
+                 During an ordinary restart this shows for a few seconds. If it persists,\n  \
+                 the daemon cannot start and nothing it does is happening — for mediad that\n  \
+                 is the camera and the WebRTC control channel. The journal has why it exits:\n  \
+                 sudo journalctl -u {name} -b | tail -30"
+            )),
+            proto::UnitState::Failed => warnings.push(format!(
+                "{name} could not start and systemd has given up on it.\n  \
+                 sudo journalctl -u {name} -b | tail -30"
+            )),
+            _ => {}
+        }
+    }
+
     let Some(installed) = installed else {
-        return Vec::new();
+        return warnings;
     };
 
-    let mut warnings = Vec::new();
     for unit in units {
         let name = unit.unit.strip_suffix(".service").unwrap_or(&unit.unit);
         if socket_reported.iter().any(|service| service.name == name) {
@@ -2482,6 +2530,15 @@ fn render_pad_status(result: &serde_json::Value) -> Result<String, Failure> {
 
     let driver = match status.driver {
         proto::UnitState::Active => "active — driving whatever pad connects".to_owned(),
+        // The state that most looks like the pad's fault: the light on the controller is on, the
+        // robot ignores it, and `padd` is dying and being restarted a few seconds later. Named
+        // rather than folded into either neighbour, which is the whole point of the variant.
+        proto::UnitState::Restarting => "restarting — it keeps exiting; check:  \
+                                         sudo journalctl -u padd -b | tail -30"
+            .to_owned(),
+        proto::UnitState::Failed => "FAILED to start — check:  \
+                                     sudo journalctl -u padd -b | tail -30"
+            .to_owned(),
         proto::UnitState::Inactive => {
             "NOT running — start it:  sudo systemctl start padd".to_owned()
         }
@@ -3948,9 +4005,12 @@ mod tests {
     }
 
     /// **A daemon too old to publish an identity, which is the case that made this design possible.**
-    /// It is allowed to simply not answer: saying `unknown (old)` beats inferring a version from
-    /// somewhere else and presenting the guess as fact — and it must not read as a disagreement,
-    /// because there is no version to disagree with.
+    /// It is allowed to simply not answer: saying the build is unknown beats inferring a version
+    /// from somewhere else and presenting the guess as fact — and it must not read as a
+    /// disagreement, because there is no version to disagree with.
+    ///
+    /// It used to read `build unknown (old)`, and the parenthesis was a diagnosis this arm is in no
+    /// position to make — see the case below, which is where that wording ended up being wrong.
     #[test]
     fn a_daemon_that_published_nothing_says_so() {
         let silent = proto::ServiceUnit {
@@ -3961,8 +4021,87 @@ mod tests {
         let installed = semver::Version::parse("0.4.0").unwrap();
 
         let rendered = render_units(std::slice::from_ref(&silent), 2);
-        assert!(rendered.contains("build unknown (old)"), "{rendered}");
+        assert!(rendered.contains("build unknown"), "{rendered}");
+        assert!(!rendered.contains("(old)"), "{rendered}");
         assert!(unit_warnings(&[silent], &[], Some(&installed)).is_empty());
+    }
+
+    /// **The report a robot with an unplugged camera flex gave for as long as it stayed unplugged:
+    /// `mediad    active · build unknown (old)`.**
+    ///
+    /// Every part of it was wrong. `mediad` was crash-looping, not active; it had published an
+    /// identity minutes earlier, and systemd had deleted the runtime directory holding it on the
+    /// stop; and `(old)` named the one cause that could not apply, since `mediad` has published its
+    /// identity since the commit that introduced it. The state has to carry this, because the
+    /// missing identity file cannot.
+    #[test]
+    fn a_crash_loop_is_not_reported_as_a_running_daemon() {
+        let looping = proto::ServiceUnit {
+            unit: "mediad.service".into(),
+            state: proto::UnitState::Restarting,
+            identity: None,
+        };
+
+        let rendered = render_units(std::slice::from_ref(&looping), 2);
+        assert!(rendered.contains("mediad    restarting"), "{rendered}");
+        assert!(!rendered.contains("active"), "{rendered}");
+        // No build claim of any kind: there is no running process to have one.
+        assert!(!rendered.contains("build unknown"), "{rendered}");
+    }
+
+    /// A crash loop is warned about, unlike a stopped unit, because nobody chose it — and the
+    /// warning has to carry the journal command, which is the whole of what to do next.
+    ///
+    /// With `installed` absent, because that gate has nothing to do with this: a board whose
+    /// `updaterd` could not name the installed release still deserves to hear that its camera
+    /// daemon is dying.
+    #[test]
+    fn a_crash_loop_warns_without_needing_a_release_to_compare() {
+        let units = vec![proto::ServiceUnit {
+            unit: "mediad.service".into(),
+            state: proto::UnitState::Restarting,
+            identity: None,
+        }];
+
+        let warnings = unit_warnings(&units, &[], None);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].starts_with("mediad exited"), "{warnings:?}");
+        assert!(warnings[0].contains("journalctl -u mediad"), "{warnings:?}");
+    }
+
+    /// A daemon systemd has given up on is not a daemon somebody stopped, and the two must not
+    /// print the same word.
+    #[test]
+    fn a_failed_unit_is_not_a_stopped_one() {
+        let units = vec![proto::ServiceUnit {
+            unit: "mediad.service".into(),
+            state: proto::UnitState::Failed,
+            identity: None,
+        }];
+
+        let rendered = render_units(&units, 2);
+        assert!(rendered.contains("mediad    failed"), "{rendered}");
+        assert_eq!(unit_warnings(&units, &[], None).len(), 1);
+    }
+
+    /// A daemon that answers its own socket is still warned about when it is crash-looping. The
+    /// double-warning rule this exempts is about *version* disagreement, where the socket's answer
+    /// is the better one; a socket that answered at all did so from a process that has since died.
+    #[test]
+    fn a_crash_loop_is_warned_about_even_with_a_socket_answer() {
+        let units = vec![proto::ServiceUnit {
+            unit: "robotd.service".into(),
+            state: proto::UnitState::Restarting,
+            identity: None,
+        }];
+        let reported = vec![service("robotd", "0.4.0")];
+        let installed = semver::Version::parse("0.4.0").unwrap();
+
+        assert_eq!(
+            unit_warnings(&units, &reported, Some(&installed)).len(),
+            1,
+            "a crash loop is not the case the socket answers better"
+        );
     }
 
     /// A revision is what distinguishes two builds of one version, so the line has to carry it —


### PR DESCRIPTION
`mediad` on a board whose camera flex was unplugged exits, `Restart=always` brings it back five seconds later, and for as long as the flex stayed out `robotctl health` said:

```
  mediad    active · build unknown (old)
```

None of it was true. systemd reports a unit waiting out its `RestartSec=` as `ActiveState=activating`, which `configd` folded into `Active` for a good reason about `padd` connecting to `robotd` at boot; it deletes `RuntimeDirectory=` on every stop, so the `identity.json` the daemon publishes on its first line went with the process; and `(old)` named the one cause that cannot apply, since every daemon here has published its identity since the commit that introduced it.

## What changed

`SubState` is the distinction systemd already makes and nothing was reading — `auto-restart` is the crash loop, `activating`/`start` is the daemon coming up that the old mapping was protecting. `configd` now reads it beside `ActiveState`, in a `state_of` kept pure for the reason `reconcile::verdict_for` is: a crash loop cannot be arranged on a board without breaking the robot.

`UnitState` gains `Restarting` and `Failed`. That is what makes the bad line unrepresentable rather than reworded — with a state for it, the identity-absent arm has nothing left to guess at, and `failed` stops printing as `stopped` beside a `systemctl stop` somebody meant.

```
  mediad    restarting

! mediad exited and systemd is restarting it.
  During an ordinary restart this shows for a few seconds. If it persists,
  the daemon cannot start and nothing it does is happening — for mediad that
  is the camera and the WebRTC control channel. The journal has why it exits:
  sudo journalctl -u mediad -b | tail -30
```

`unit_warnings` names it ahead of its version checks and their gates: a daemon that is not running has no release to compare, no socket to have answered, and is worth saying whether or not `updaterd` could name what is installed. Warned about at all, unlike a stopped unit, on that function's existing rule rather than as an exception to it — nobody chooses a crash loop, and `mediad` with `RestartSec=5s` never trips systemd's start-rate limit, so it never progresses to `failed` on its own.

## Install consequence

`API_VERSION` 16 → 17. An older `robotctl` cannot deserialise a `UnitState` it has no variant for, and it reads `system.services` with `.ok()`, so it prints no `units` block rather than a wrong one. Both come out of the same release and an apply restarts both, so the skew lasts as long as the update does.

## Checked

`cargo check --workspace --all-targets`, `cargo clippy` on the three crates, and the tests for each: `duck-ipc-proto` 49, `configd` 41 (four new, on the `ActiveState`/`SubState` pairs), `robotctl` 142 (four new, on the crash-loop line and its warning). Not yet run on a board — `--ref health-names-a-crash-loop` and an unplugged flex is the check.