### PR TITLE
robot.rebootMotors: reboot servos in place (`robotctl robot reboot-motors`, D-pad-right)

### DIFF
--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -354,7 +354,7 @@ fn permits(call: &proto::Call) -> bool {
         // offer, and `robot.init` is its counterpart: standing a robot up moves every joint at once,
         // which wants the person doing it to be looking at the robot rather than at a screen. Both
         // are `robotctl` on the robot, deliberately.
-        RobotInit | RobotRelax => false,
+        RobotInit | RobotRelax | RobotRebootMotors(_) => false,
 
         // `robot.stop` deserves its own line, because refusing it looks wrong. An emergency stop
         // in the app is exactly what someone reaches for, and §6 does say local should preempt

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -411,6 +411,7 @@ sudo robotctl robot init
 
 ```
 sudo robotctl robot relax --yes
+sudo robotctl robot reboot-motors           # every servo; or `reboot-motors 3 11` for just those. Torque off, then init / Start
 ```
 
 `init` powers the joints and ramps to the home pose over about two seconds — **it moves every joint**,
@@ -476,6 +477,7 @@ mapping is the prototype's, so muscle memory carries over:
 | **DPad-Down** | sit ↔ stand |
 | **RT / LT** | mouth (either trigger) — RT also quacks; LT rides the "wheee" while held |
 | **DPad-Up**, held 3 s | switch drive mode, walk ⇄ roller |
+| **DPad-Right** | reboot every servo: the way back from a tripped overload without pulling the battery. Torque off, then Start |
 | **Select**, held 2 s | sit down, then power off |
 
 There is no stop button: release the sticks and the robot stands, and `robotd`'s deadman stops it

--- a/duck-control/src/bus.rs
+++ b/duck-control/src/bus.rs
@@ -313,6 +313,15 @@ impl RobotIo for DynamixelIo {
         DynamixelIo::set_torque(self, on)
     }
 
+    fn reboot(&mut self, id: u8) -> Result<()> {
+        // The status packet is a courtesy the servo may not manage before it resets, so only a
+        // failure to send is an error here.
+        self.controller
+            .reboot(id)
+            .map(|_| ())
+            .map_err(|e| IoError::Bus(format!("reboot {id}: {e}")))
+    }
+
     fn set_gain(&mut self, kp: u16) -> Result<()> {
         // I and D are written too, at zero — the prototype's `--ki`/`--kd` defaults, which
         // its startup writes to every motor. These are RAM registers, so every power-up

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -134,6 +134,14 @@ pub trait RobotIo {
     /// never because a process began.
     fn set_torque(&mut self, on: bool) -> Result<()>;
 
+    /// Reboot one servo: the Protocol 2 REBOOT instruction.
+    ///
+    /// The way out of a latched hardware error — overload, overheating, electrical shock, the
+    /// `shutdown` mask — which otherwise holds torque off until the battery is pulled. The servo is
+    /// off the bus for a few hundred milliseconds and comes back with torque off and its RAM
+    /// registers, the gains among them, at their EEPROM defaults; the caller owns putting them back.
+    fn reboot(&mut self, id: u8) -> Result<()>;
+
     /// Supply voltage and case temperatures, in one extra transaction.
     ///
     /// Not part of [`Sensors`], and not on the tick's critical path: these registers sit at
@@ -191,6 +199,8 @@ pub struct FakeIo {
     /// How many times torque was written, so a test can tell "brought up once" from "written every
     /// tick" — the latter being a bus transaction per joint per tick.
     pub torque_writes: usize,
+    /// Every servo id rebooted, in order.
+    pub reboots: Vec<u8>,
 }
 
 impl Default for FakeIo {
@@ -217,6 +227,7 @@ impl FakeIo {
             track_targets: true,
             torque: None,
             torque_writes: 0,
+            reboots: Vec::new(),
         }
     }
 
@@ -281,6 +292,11 @@ impl RobotIo for FakeIo {
     fn set_torque(&mut self, on: bool) -> Result<()> {
         self.torque = Some(on);
         self.torque_writes += 1;
+        Ok(())
+    }
+
+    fn reboot(&mut self, id: u8) -> Result<()> {
+        self.reboots.push(id);
         Ok(())
     }
 

--- a/duck-control/src/safety.rs
+++ b/duck-control/src/safety.rs
@@ -167,6 +167,18 @@ impl<T: RobotIo> Safety<T> {
         self.io.set_torque(on)
     }
 
+    /// Reboot these servos, and forget the gain cache: a rebooted servo comes back at its EEPROM
+    /// gains, and a cache that still says the running gain is written would leave it there. The
+    /// next [`Self::apply`] rewrites the gains on every servo.
+    pub fn reboot_motors(&mut self, ids: &[u8]) -> Result<(), IoError> {
+        for &id in ids {
+            tracing::warn!(id, "rebooting servo");
+            self.io.reboot(id)?;
+        }
+        self.gain = None;
+        Ok(())
+    }
+
     /// The gain last written to the servos, or `None` before the first write. This is what
     /// the robot is running at, which is not always what the caller asked for.
     pub fn gain(&self) -> Option<u16> {
@@ -288,6 +300,26 @@ impl<T: RobotIo> Safety<T> {
 
 #[cfg(test)]
 mod tests {
+    /// A reboot forgets the gain cache, so the rebooted servos get their gains back on the next
+    /// apply instead of running at whatever their EEPROM says.
+    #[test]
+    fn rebooting_motors_rewrites_the_gain_on_the_next_apply() {
+        use crate::io::FakeIo;
+        use crate::model::DEFAULT_POSITION;
+        let mut s = Safety::new(FakeIo::at(DEFAULT_POSITION), SafetyConfig::default());
+        s.apply(DEFAULT_POSITION, DEFAULT_POSITION, 200).unwrap();
+        assert_eq!(s.gain(), Some(200));
+        s.reboot_motors(&[3, 11]).unwrap();
+        assert_eq!(s.io().reboots, vec![3, 11]);
+        assert_eq!(
+            s.gain(),
+            None,
+            "the gain cache must be forgotten after a reboot"
+        );
+        s.apply(DEFAULT_POSITION, DEFAULT_POSITION, 200).unwrap();
+        assert_eq!(s.gain(), Some(200));
+    }
+
     use super::*;
     use crate::imu::ImuData;
     use crate::io::FakeIo;

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -469,6 +469,12 @@ pub mod method {
     /// yield a fallen robot is commanded at, which keeps torque on. This is the register.
     pub const ROBOT_RELAX: &str = "robot.relax";
 
+    /// Reboot servos: the REBOOT instruction, which clears a latched hardware error (overload,
+    /// overheating, electrical shock) that otherwise holds torque off until the battery is pulled.
+    /// Torque is cut on every joint first and the robot is back at limp afterwards, so `robot.init`
+    /// or `robot.enable` brings it up from a known state. Discrete; send as a request.
+    pub const ROBOT_REBOOT_MOTORS: &str = "robot.rebootMotors";
+
     // ── skills ───────────────────────────────────────────────────────────────
     //
     // One-shot scripted moves, ported from `microduck_runtime`. Each swaps a dedicated
@@ -809,6 +815,8 @@ pub enum Call {
     RobotInit,
     /// Cut power to the joints. The robot collapses if nothing holds it.
     RobotRelax,
+    /// Reboot servos (all of them, or the ids named), then limp. See [`method::ROBOT_REBOOT_MOTORS`].
+    RobotRebootMotors(RebootMotorsParams),
     /// Run a one-shot skill, or toggle sit↔stand.
     RobotDo(DoParams),
     /// Standing body pose. Continuous. Send as a notification.
@@ -978,6 +986,7 @@ impl Call {
             Call::RobotEnable(_) => method::ROBOT_ENABLE,
             Call::RobotInit => method::ROBOT_INIT,
             Call::RobotRelax => method::ROBOT_RELAX,
+            Call::RobotRebootMotors(_) => method::ROBOT_REBOOT_MOTORS,
             Call::RobotDo(_) => method::ROBOT_DO,
             Call::RobotPose(_) => method::ROBOT_POSE,
             Call::RobotMouth(_) => method::ROBOT_MOUTH,
@@ -1148,6 +1157,7 @@ impl Call {
             | Call::RobotEnable(_)
             | Call::RobotInit
             | Call::RobotRelax
+            | Call::RobotRebootMotors(_)
             | Call::RobotDo(_)
             | Call::RobotPose(_)
             | Call::RobotMouth(_)
@@ -1255,6 +1265,7 @@ impl Call {
             Call::RobotLook(p) => encode(p),
             Call::RobotEnable(p) => encode(p),
             Call::RobotDo(p) => encode(p),
+            Call::RobotRebootMotors(p) => encode(p),
             Call::RobotPose(p) => encode(p),
             Call::RobotMouth(p) => encode(p),
             Call::RobotSetMode(p) => encode(p),
@@ -1345,6 +1356,7 @@ impl Call {
             method::ROBOT_ENABLE => Call::RobotEnable(decode(params)?),
             method::ROBOT_INIT => Call::RobotInit,
             method::ROBOT_RELAX => Call::RobotRelax,
+            method::ROBOT_REBOOT_MOTORS => Call::RobotRebootMotors(decode(params)?),
             method::ROBOT_DO => Call::RobotDo(decode(params)?),
             method::ROBOT_POSE => Call::RobotPose(decode(params)?),
             method::ROBOT_MOUTH => Call::RobotMouth(decode(params)?),
@@ -1492,6 +1504,7 @@ pub mod test_support {
             }),
             Call::RobotInit,
             Call::RobotRelax,
+            Call::RobotRebootMotors(RebootMotorsParams { ids: vec![3, 11] }),
             Call::RobotDo(DoParams {
                 skill: "ground_pick".into(),
             }),
@@ -2029,6 +2042,13 @@ pub struct ThereminState {
 /// The five above are still the names a stock robot answers to. An unknown one is refused with
 /// the list it does know, which is the same shape as a bad policy slot.
 pub type Skill = String;
+
+/// Which servos [`method::ROBOT_REBOOT_MOTORS`] reboots. Empty means every servo.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RebootMotorsParams {
+    pub ids: Vec<u8>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -4636,7 +4656,7 @@ mod tests {
     fn every_call_covers_every_variant() {
         assert_eq!(
             every_call().len(),
-            61,
+            62,
             "a Call variant was added or removed — update every_call() and this count"
         );
     }

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -82,7 +82,7 @@ fn permits(call: &proto::Call) -> bool {
         // camera: it is looking at the robot, which is precisely what a phone in the room over
         // Bluetooth was not. Permitted for that reason, and it would be worth revisiting if a
         // control-only session without video ever becomes a normal thing.
-        RobotEnable(_) | RobotInit | RobotRelax => true,
+        RobotEnable(_) | RobotInit | RobotRelax | RobotRebootMotors(_) => true,
 
         // `robot.stop` is permitted here and refused over BLE, and the difference is honesty
         // rather than authority. BLE's objection was that a stop button over "an unbonded,

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -309,8 +309,8 @@ fn main() -> std::process::ExitCode {
         hz = args.hz,
         roller,
         "driving — Start toggles the policy, Y head mode, B body pose, A ground pick, \
-         LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Up (3s) walk/roller, \
-         Select (2s) shutdown"
+         LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Right reboot servos, DPad-Up (3s) \
+         walk/roller, Select (2s) shutdown"
     );
 
     let period = Duration::from_secs_f64(1.0 / args.hz as f64);
@@ -364,6 +364,7 @@ fn main() -> std::process::ExitCode {
         // Which bindable buttons went down this tick, by their config name. A list rather than
         // a flag apiece, because what each one runs is config now and this loop no longer knows.
         let mut pressed: Vec<&'static str> = Vec::new();
+        let mut reboot_motors = false;
         while let Some(event) = gilrs.next_event() {
             if let gilrs::EventType::ButtonPressed(button, _) = event.event {
                 match button {
@@ -381,6 +382,9 @@ fn main() -> std::process::ExitCode {
                     Button::LeftTrigger => pressed.push("lb"),
                     Button::RightTrigger => pressed.push("rb"),
                     Button::DPadDown => pressed.push("dpad_down"),
+                    // Reboot the servos: the way back from a tripped overload without pulling
+                    // the battery.
+                    Button::DPadRight => reboot_motors = true,
                     _ => {}
                 }
             }
@@ -515,6 +519,17 @@ fn main() -> std::process::ExitCode {
         {
             tracing::error!(error = %e, "send failed");
             return std::process::ExitCode::FAILURE;
+        }
+
+        if reboot_motors {
+            tracing::warn!(
+                "DPad-Right — asking the robot to reboot its servos (robot.rebootMotors)"
+            );
+            let call = proto::Call::RobotRebootMotors(proto::RebootMotorsParams::default());
+            if let Err(e) = request(&mut stream, &mut next_id, &call) {
+                tracing::error!(error = %e, "reboot request failed");
+                return std::process::ExitCode::FAILURE;
+            }
         }
 
         // Select held two seconds: sit down, then power off. Sent once per hold — the

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -436,6 +436,19 @@ enum RobotCommand {
         json: bool,
     },
 
+    /// Reboot servos: every one of them, or only the ids given.
+    ///
+    /// The way back from a servo in hardware error (overload, overheating) without pulling the
+    /// battery. Torque goes off on every joint first, so hold the robot or have it down; the
+    /// rebooted servos come back with torque off and their gains restored on the next write.
+    /// Then `robot init` or Start.
+    RebootMotors {
+        /// Servo ids, space separated. None means all.
+        ids: Vec<u8>,
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Run a one-shot skill by name — `roulade`, `kick_left`, `ground_pick`, `sit_toggle`, or
     /// whatever else this robot has.
     ///
@@ -2601,6 +2614,10 @@ fn run_robot(socket: &Path, command: RobotCommand) -> Result<(), Failure> {
     let (call, json) = match &command {
         RobotCommand::Init { json } => (proto::Call::RobotInit, *json),
         RobotCommand::Relax { json, .. } => (proto::Call::RobotRelax, *json),
+        RobotCommand::RebootMotors { ids, json } => (
+            proto::Call::RobotRebootMotors(proto::RebootMotorsParams { ids: ids.clone() }),
+            *json,
+        ),
         RobotCommand::Do { skill, json } => (
             proto::Call::RobotDo(proto::DoParams {
                 skill: skill.clone(),
@@ -2668,6 +2685,12 @@ fn run_robot(socket: &Path, command: RobotCommand) -> Result<(), Failure> {
     match command {
         RobotCommand::Init { .. } => println!("standing up — about two seconds to the home pose"),
         RobotCommand::Relax { .. } => println!("torque off"),
+        RobotCommand::RebootMotors { ids, .. } if ids.is_empty() => {
+            println!("rebooting every servo, torque off — then `robot init` or Start")
+        }
+        RobotCommand::RebootMotors { ids, .. } => {
+            println!("rebooting servos {ids:?}, torque off — then `robot init` or Start")
+        }
         RobotCommand::Do { skill, .. } => println!("{skill:?} queued"),
         RobotCommand::Mode { .. } | RobotCommand::Look { .. } => unreachable!("answered above"),
     }

--- a/robotd/src/intents.rs
+++ b/robotd/src/intents.rs
@@ -12,8 +12,8 @@
 //! Every slot is stamped, because the loop's real question is never "what is the value" but
 //! "how old is it". That is what the deadman reads.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
 
 /// "No mode switch pending" in [`Intents::mode_switch`].
 ///
@@ -198,6 +198,9 @@ pub struct Intents {
     /// The wheee hold, as a stamped level: `padd` re-notifies while the trigger is down,
     /// and the loop reads value + age so a dead client's ride decays instead of looping.
     wheee: ArcSwap<Stamped<bool>>,
+    /// `robot.rebootMotors`, pending: the ids to reboot (empty = all). A mutex rather than an
+    /// atomic because it carries a list; the loop takes it with `try_lock`, so it can never wait.
+    reboot_motors: Mutex<Option<Vec<u8>>>,
 }
 
 /// A pending policy change, as [`Intents::request_policy_change`] took it.
@@ -282,6 +285,7 @@ impl Intents {
             mode_switch: AtomicU8::new(MODE_NONE),
             policy_change: ArcSwapOption::empty(),
             sounds: std::sync::atomic::AtomicU32::new(0),
+            reboot_motors: Mutex::new(None),
             wheee: ArcSwap::from_pointee(Stamped {
                 value: false,
                 at_us: 0,
@@ -465,6 +469,24 @@ impl Intents {
     /// Ask the loop to cut power to the joints.
     ///
     /// Also clears `enabled`: a robot that has been asked to go limp is not one the policy should
+    /// Ask the loop to reboot these servos (empty = all). Clears `enabled` for the same reason
+    /// [`Self::request_relax`] does: the robot comes back up when someone asks, not mid-reboot.
+    pub fn request_reboot_motors(&self, ids: Vec<u8>) {
+        self.enabled.store(false, Ordering::Relaxed);
+        if let Ok(mut slot) = self.reboot_motors.lock() {
+            *slot = Some(ids);
+        }
+    }
+
+    /// Take the pending reboot request, if any. Never blocks: a contended lock reads as "nothing
+    /// yet" and the request is picked up on the next tick.
+    pub fn take_reboot_motors(&self) -> Option<Vec<u8>> {
+        self.reboot_motors
+            .try_lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
+    }
+
     /// keep driving, and leaving that flag set would have the next tick bring it straight back up.
     pub fn request_relax(&self) {
         self.enabled.store(false, Ordering::Relaxed);

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -1894,6 +1894,33 @@ async fn control_loop<T: RobotIo>(
             None => {}
         }
 
+        // `robot.rebootMotors`: torque off everywhere, then REBOOT the named servos (every servo
+        // when none are named). The rebooted servos are off the bus for a few hundred milliseconds
+        // — the reads fail and the loop coasts through it — and come back with torque off and
+        // EEPROM gains; the forgotten gain cache makes the next write restore the gains, and the
+        // robot is back at limp, so the next `init` or Start brings it up like a fresh boot. Torque
+        // off first on purpose: a tripped servo is usually a leg, and a robot standing on the other
+        // leg while one reboots is not a robot to leave standing.
+        if let Some(ids) = intents.take_reboot_motors() {
+            let ids: Vec<u8> = if ids.is_empty() {
+                duck_control::model::JOINT_IDS.to_vec()
+            } else {
+                ids
+            };
+            if let Err(e) = safety.set_torque(false) {
+                tracing::warn!(error = %e, "robot.rebootMotors: torque off failed on a servo; rebooting anyway");
+            }
+            match safety.reboot_motors(&ids) {
+                Ok(()) => tracing::warn!(
+                    ?ids,
+                    "robot.rebootMotors: rebooted; init or Start brings the robot up"
+                ),
+                Err(e) => tracing::warn!(error = %e, ?ids, "robot.rebootMotors: failed part-way"),
+            }
+            bringup = Bringup::Limp;
+            was_driving = false;
+        }
+
         // One-shot skill requests, taken once per tick like the power request. They need a
         // driving robot — the prototype's buttons likewise did nothing until the policy ran.
         let requests = intents.take_skills();
@@ -4206,6 +4233,12 @@ fn dispatch(
             proto::Response::ok(Some(id), &proto::IntentResult::accepted())
         }
 
+        // Never refused: a robot with a tripped servo is exactly the one that needs it.
+        proto::Call::RobotRebootMotors(p) => {
+            intents.request_reboot_motors(p.ids.clone());
+            proto::Response::ok(Some(id), &proto::IntentResult::accepted())
+        }
+
         proto::Call::RobotHealth => proto::Response::ok(Some(id), &state.health()),
         proto::Call::RobotSafeToRestart => proto::Response::ok(Some(id), &state.safe_to_restart()),
         proto::Call::RobotModelApi => proto::Response::ok(
@@ -5406,6 +5439,9 @@ mod tests {
         }
         fn set_torque(&mut self, on: bool) -> duck_control::io::Result<()> {
             self.0.set_torque(on)
+        }
+        fn reboot(&mut self, id: u8) -> duck_control::io::Result<()> {
+            self.0.reboot(id)
         }
         fn slow_sensors(&mut self) -> duck_control::io::Result<duck_control::SlowSensors> {
             self.0.slow_sensors()
@@ -7293,6 +7329,9 @@ mod tests {
             fn set_torque(&mut self, on: bool) -> duck_control::io::Result<()> {
                 self.0.set_torque(on)
             }
+            fn reboot(&mut self, id: u8) -> duck_control::io::Result<()> {
+                self.0.reboot(id)
+            }
             fn slow_sensors(&mut self) -> duck_control::io::Result<duck_control::SlowSensors> {
                 self.0.slow_sensors()
             }
@@ -7484,6 +7523,63 @@ mod tests {
         assert!(
             !s.homed.load(Ordering::Relaxed),
             "still reporting homed after relax"
+        );
+    }
+
+    /// **`robot.rebootMotors` cuts torque, reboots the named servos and returns to limp.**
+    #[tokio::test]
+    async fn robot_reboot_motors_reboots_the_named_servos_and_returns_to_limp() {
+        let io = FakeIo::at(DEFAULT_POSITION).frozen();
+        let mut params = Params::default();
+        params.policy.enabled = false;
+        let s = Arc::new(RobotState::new(
+            &params,
+            std::path::Path::new("/test/robotd.toml"),
+            false,
+            false,
+        ));
+        let intents = Arc::new(Intents::new());
+        intents.request_init();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let loop_state = Arc::clone(&s);
+        let loop_intents = Arc::clone(&intents);
+        let handle = tokio::spawn(async move {
+            let mut io = io;
+            control_loop_probe_with(&mut io, loop_state, loop_intents, Duration::from_millis(2))
+                .await;
+            tx.send((io.torque, io.reboots.clone(), io.last_gain))
+                .unwrap();
+        });
+        while s.ticks.load(Ordering::Relaxed) < 3 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        let at = s.ticks.load(Ordering::Relaxed);
+        intents.request_reboot_motors(vec![7]);
+        while s.ticks.load(Ordering::Relaxed) < at + 4 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle.await.unwrap();
+        let (torque, reboots, last_gain) = rx.recv().unwrap();
+        assert_eq!(
+            torque,
+            Some(false),
+            "the joints must be unpowered after a reboot"
+        );
+        assert_eq!(reboots, vec![7], "only the named servo is rebooted");
+        assert_eq!(
+            last_gain,
+            Some(params.policy.gain),
+            "the gain is written again after the reboot"
+        );
+        assert!(
+            !s.homed.load(Ordering::Relaxed),
+            "still reporting homed after a reboot"
+        );
+        assert!(
+            !intents.snapshot().enabled,
+            "a reboot must stop the policy asking to drive"
         );
     }
 

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -745,6 +745,7 @@ impl Server {
             | Call::RobotEnable(_)
             | Call::RobotInit
             | Call::RobotRelax
+            | Call::RobotRebootMotors(_)
             | Call::RobotDo(_)
             | Call::RobotSound(_)
             | Call::RobotPose(_)


### PR DESCRIPTION
Closes #201.

A servo that trips its `shutdown` mask (overload, overheating, electrical shock) latches with torque off until it is rebooted or the battery is pulled. Until now the battery pull was the only way back. This adds the REBOOT instruction as an IO primitive and one intent on top of it, kept as small as I could.

## What

- `RobotIo::reboot(id)` — rustypot's REBOOT; `FakeIo` records the ids. `Safety::reboot_motors(ids)` reboots and **forgets the gain cache**: a rebooted XL330 comes back at its EEPROM gains, and a cache that still says "200 is written" would leave it there. The next `apply` rewrites the gains on every servo.
- `robot.rebootMotors { ids }` — torque off on every joint first (a tripped servo is usually a leg; a robot standing on the other one while it reboots is not a robot to leave standing), REBOOT the ids named (**all servos when the list is empty**), then back to limp. `robot.init` / Start bring it up again like a fresh boot. Refused over Bluetooth like `relax`; allowed on the console like `relax`.
- `robotctl robot reboot-motors [ID ...]` — no ids = every servo. Ids are **space separated** (the issue says commas; we discussed it and spaces are what a shell hands over naturally).
- `padd`: pressing **D-pad right** reboots every servo. (D-pad up was the first choice, but its 3 s hold already switches walk/roller.)

## Not in this PR

Reading `hardware_error_status` to reboot only the servos that tripped; a `robot.state` field for it. Both are natural follow-ups; this PR is the mechanism the issue asked for.

## Tested

- `cargo test --workspace`, `cargo clippy --workspace --all-targets` (only the two pre-existing warnings), `cargo fmt`.
- New tests: the safety layer forgets the gain after a reboot; the control loop cuts torque, reboots only the named servo, rewrites the gain and reports not-homed; the proto round-trip list.
- On a robot (0.10.0 board, binaries swapped by hand): the same mechanism, in a slightly larger form, recovered a tripped servo and Start brought the robot back up. This exact branch has not run on hardware yet.


## How to test this (on a robot)
   - **on the pad**: press **D-pad right**, or
   - **on the robot**: `sudo robotctl robot reboot-motors` (every servo) or `sudo robotctl robot reboot-motors 3 11` (only those ids, space separated).
