### PR TITLE
Four daemons were doing work nobody had asked for

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -270,6 +270,10 @@ mode = "walk"
 # coo wore thin — so this is an opt-in. The model ships in the release
 # (models/pet_detect.onnx); thresholds are the classifier's hysteresis (enter above, leave
 # below).
+#
+# The mic is read whenever [audio] is on, but the classifier only runs on audio that stands
+# out from the room: in a quiet one this costs nothing beyond the envelope the ambient-sound
+# watcher is measuring anyway.
 # pet_detect = true
 # pet_model = ".../current/models/pet_detect.onnx"
 # pet_enter_threshold = 0.95

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 | [`update-over-ble.md`](project/update-over-ble.md) | Driving the update path from a phone: what it turned up, and what rollback over a radio was decided on. |
 | [`media-bringup.md`](project/media-bringup.md) | What a Radxa Zero 3W does about video: the VPU, what MPP needs, and the two plugins that have to be built. |
 | [`pad-minimal-pairing.md`](project/pad-minimal-pairing.md) | The smallest board configuration a gamepad will bond under, found by taking one away at a time. |
+| [`idle-cpu.md`](project/idle-cpu.md) | What the daemons do when nobody is asking them to: four things that stopped, two that were measured and left alone, and what still wants a board. |
 
 ## `ideas/` — not designed yet
 

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -178,7 +178,7 @@ defaults are in [`media-bringup.md`](../project/media-bringup.md).
 ```text
                               ┌─ queue ─ mpph264enc ─ h264parse ─ webrtcsink
 capture ─ NV12 ─ capsfilter ─ tee
-                              └─ queue(leaky, 1) ─ appsink ─ latest frame
+                              └─ queue(leaky, 1) ─ appsink ─ a frame on request
 ```
 
 §5.3 wants a frame on demand for a server-side program — "it wants a frame every second or two plus
@@ -189,8 +189,21 @@ taking them off the encoded branch would mean decoding what was just encoded.
 NV12 throughout, because that is what the rkisp path emits and what `mpph264enc` accepts, so
 nothing converts anywhere. Each branch has its own `queue` — a `tee` without them runs both from
 one thread, so a slow reader would stall the video track — and the raw one is leaky and one buffer
-deep, which is the last-value-wins, non-blocking snapshot `architecture.md` §2 asks for. A stalled
-reader costs frames, never the encoder.
+deep, which is the *latest* snapshot `architecture.md` §2 asks for rather than a queue of stale
+ones. A stalled reader costs frames, never the encoder.
+
+**A frame is copied out of the appsink only when a reader has asked for one.** The readers on this
+branch want two frames a second between them — auto-exposure meters one every 500 ms, the duck
+detector looks twice a second when it is enabled at all — and a frame is 1.84 MB at 720p30.
+Capturing all thirty was 55 MB/s of memcpy and a 1.8 MB allocation thirty times a second, from
+boot, on every robot, for frames nobody read. Every buffer still reaches the appsink and is dropped
+there unread; the cost on a frame nobody wants is a relaxed load.
+
+The request is answered by the *next* capture rather than by the last one delivered. Handing back
+whatever was lying around would be cheaper again and would put the reader's own polling period into
+the measurement — an exposure loop steering on luma from half a second ago is a loop that hunts. A
+reader blocks until its frame lands, bounded by a timeout, and a camera that has stopped reaches
+the same "no frame" path it always did.
 
 The branch exists from the start rather than being added when something reads it: inserting a tee
 into a live pipeline is a materially harder problem than having one that was always there.

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -66,7 +66,7 @@ deliberately:
 
 ```text
    ┌──────────┐   robot.move / robot.head      ┌─────────────────────┐
-   │  padd    │───(notifications, 50 Hz)──────►│                     │
+   │  padd    │──(notifications, ≤50 Hz)──────►│                     │
    │ gamepad  │   robot.stop / robot.enable    │                     │
    └──────────┘───(requests, answered)────────►│                     │
                                                │   /run/robotd.sock  │

--- a/docs/project/idle-cpu.md
+++ b/docs/project/idle-cpu.md
@@ -1,0 +1,118 @@
+# What the robot does when nobody is asking it to
+
+A duck sitting on a desk with no pad connected, no viewer, and nothing driving it still runs
+five daemons. This is what they were each doing in that state, what was changed, and — for the
+two candidates that were not — the numbers that say why.
+
+Everything here is arithmetic on the code or a measurement on this machine. **Nothing in it has
+been measured on a board**, and the last section says what that would take.
+
+## What was costing something
+
+| | idle before | idle after |
+|---|---|---|
+| `mediad` raw branch | 1.84 MB copied 30×/s | copied when a reader asks — ~2×/s |
+| `tofd` frame poll | ~100 I²C reads/s | ~45 |
+| `padd`, pad connected, sticks centred | 50–100 msg/s | 10 |
+| `pet-detect`, when enabled | ~400 FFTs/s + 4 forward passes/s | none until the room makes a sound |
+
+### `mediad` copied every frame
+
+The appsink callback copied every buffer off the tee into a slot readers took the latest of.
+At 720p30 — the shipped quality, and `media.camera` defaults on — a UYVY frame is 1 280 × 720 × 2
+= 1.84 MB. The readers are auto-exposure at 2 Hz and the duck detector at 2 Hz when enabled, so
+twenty-eight of every thirty copies were made for nobody: 55 MB/s of memcpy and a 1.8 MB
+allocation thirty times a second, from boot.
+
+A reader now asks and the callback answers the *next* frame. Answering with the last one instead
+would be cheaper again and would put the reader's own polling period into the measurement — an
+exposure loop steering on half-second-old luma hunts rather than settles.
+
+### `tofd` polled a 15 Hz sensor 100 times a second
+
+`data_ready` every 10 ms across the whole 66 ms between frames: about seven I²C transactions to
+find one frame, six of them answered no. The loop now sits out the stretch in which the sensor
+cannot yet have one and polls through the rest. Frame age is unchanged — still bounded by the
+10 ms poll, which is the granularity a frame is noticed at either way.
+
+This runs on every duck with a ToF fitted whether or not anyone uses the theremin, because
+`robotd`'s depth reader subscribes at startup rather than when the instrument is picked up.
+
+### `padd` re-sent the same three zeros fifty times a second
+
+The sticks are polled, so an untouched pad produced an identical frame every tick — an encode, a
+write, a flush, and a parse on `robotd`'s side, doubled in the two modes that also send a zeroing
+`robot.move`. Identical frames are now held back, and the two intents share one write.
+
+A frame is only held back when it asks for **no motion**. That is what keeps this away from
+`[safety] deadman_ms`, a value `padd` cannot read: the deadman zeroes the twist and nothing else,
+so on a frame already commanding zero, letting it fire changes nothing — and on one commanding
+motion it would stop a robot whose stick is still held.
+
+### The petting classifier ran through silence
+
+A 1 s window of 40 log-mel bands is a hundred 512-point FFTs plus a forward pass, four times a
+second. The ambient-sound watcher beside it was already measuring the room, so the classifier now
+waits until something stands out from that floor — except while petting, where the End edge has
+to be found by inference exactly as the Start was.
+
+Off by default, so this is a cost anyone who turns it on stops paying rather than one every robot
+was paying.
+
+## What was left alone, and why
+
+### The 50 Hz bus write is not worth making conditional
+
+`safety.apply` writes sixteen goal positions every tick, including the ticks where the robot is
+parked and the targets have not moved. Making that conditional saves:
+
+- **Bus:** a Protocol 2.0 sync-write of sixteen servos is 94 bytes — 4 header, 1 broadcast id,
+  2 length, 1 instruction, 4 address/length, 16 × 5 payload, 2 CRC. At 1 Mbaud, 940 µs. The tick's
+  sync-read of seventeen devices is about 422 bytes, or 4.2 ms, so the write is a fifth of a bus
+  already at roughly a quarter utilisation on a 20 ms tick. It is not the constraint.
+- **CPU:** one `write(2)` of 94 bytes and the tty layer behind it. Call it 15 µs including the
+  completion interrupt; at 50 Hz that is **0.075% of one core**.
+
+Against that: the write is the loop's one statement guaranteeing the servos have been told where
+to be. Making it conditional means enumerating every path that can invalidate a servo's stored
+goal — a torque toggle, a brown-out, a servo rebooting itself after clearing a shutdown latch,
+`init`'s own `interpolate_to` — and being wrong means a robot that stops holding its pose in a
+case nobody thought of. Seven hundredths of a percent of a core does not buy that.
+
+The rest of an idle `robotd` tick is already lean: the ONNX step is gated on `driving`, the state
+frame is only assembled when something has subscribed, the voltage and thermal registers are read
+once a second rather than per tick, and the serial read sleeps rather than spins.
+
+### Multi-threaded tokio runtimes cost nothing to leave alone
+
+`robotd`, `configd` and `updaterd` use bare `#[tokio::main]`, which starts one worker per core —
+four each on an RK3566. Idle workers park; they do not poll. Measured with a runtime of four
+workers and four parked tasks, against a `current_thread` runtime doing the same:
+
+```text
+multi:   5 threads   0.01 s CPU at start → 0.01 s after 20 s
+current: 1 thread    0.00 s CPU at start → 0.00 s after 20 s
+```
+
+The difference is four parked threads' worth of stacks — memory, not heat. Switching flavours
+would buy none of the CPU this page is about, and would cost something real: on
+`current_thread`, a synchronous call on the async path blocks the whole runtime including the IPC
+socket, and `updaterd` has several (`engine.rs` reads a signature, writes the embedded manifest,
+and scans a unit directory inline; only the heavy verification is on `spawn_blocking`).
+
+## What still needs a board
+
+Every figure above is arithmetic on frame sizes, packet layouts and poll intervals, or a
+measurement on a developer's machine. The four changes want confirming where the heat actually
+is:
+
+- `mediad`, `tofd` and `padd` CPU before and after, from `dev-push.sh` and `top -H`. The camera
+  one should be the visible change.
+- SoC temperature at idle over ten minutes, which is the number the whole exercise is for. The
+  `videoflip` episode took this board to 97 °C and throttled it to 408 MHz, so idle headroom is
+  what decides whether a duck walks well while it is also looking at something.
+- `tofd`'s guard against a real sensor clock. The poll is anchored on each frame's arrival and
+  tolerates the sensor running 20 ms early — a 30% period error — but no VL53L8 has been watched
+  doing it.
+- That petting still starts as promptly as it did, on a robot in an ordinary room rather than a
+  silent one.

--- a/mediad/src/detect.rs
+++ b/mediad/src/detect.rs
@@ -223,7 +223,11 @@ pub fn spawn(
                     starved = 0;
                 }
 
-                let Some(frame) = frames.latest() else {
+                // Asked for rather than taken: the tee only copies a frame somebody wants, and this
+                // is the want — see [`crate::pipeline::Frames`]. `starved` now counts a tee that
+                // did not answer within the timeout, which is the same fault it always meant and a
+                // narrower one than "there was nothing there when I looked".
+                let Some(frame) = frames.next_frame() else {
                     starved += 1;
                     continue;
                 };

--- a/mediad/src/exposure.rs
+++ b/mediad/src/exposure.rs
@@ -241,7 +241,11 @@ pub fn spawn(device: String, frames: Frames, exposure_lines: u32, analogue_gain_
                     break;
                 }
 
-                let metered = frames.inspect(mean_luma);
+                // Asked for, so what gets metered is a frame captured now rather than one left
+                // over from the previous tick — [`Frames`] has why the branch works this way. The
+                // wait is bounded and lands on the same "no frame" path a camera that has not
+                // started yet does.
+                let metered = frames.inspect_next(mean_luma);
                 if metered == Some(None) && !format_logged {
                     format_logged = true;
                     // The one way a frame can arrive and be unreadable: it is not what the capture

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -13,7 +13,7 @@
 //!                                       (leaky)     │
 //!                                          │        └─ consumer-added → "control" channel
 //!                                      appsink
-//!                                     latest frame
+//!                                   a frame on request
 //! ```
 //!
 //! **The tee is on raw NV12, before the encoder**, and that placement is the point of it.
@@ -36,7 +36,11 @@
 //! branches on one thread, so a slow consumer stalls the others — here that would mean a
 //! perception consumer pausing the video track. The raw branch drops old frames rather than
 //! applying backpressure, which is the semantics `architecture.md` §2 asks for: the *latest*
-//! snapshot, non-blocking, last-value-wins. A stalled reader costs frames, never the encoder.
+//! snapshot, never a queue of stale ones. A stalled reader costs frames, never the encoder.
+//!
+//! **And the raw branch only copies a frame somebody asked for.** Every buffer reaches the appsink
+//! and nearly all of them are dropped there unread — see [`crate::pipeline::Frames`] for what that saves and why the
+//! request has to be answered by the *next* capture rather than the last one.
 //!
 //! **`webrtcsink` runs the signalling server in this process** (`run-signalling-server`, with
 //! `signalling-server-host` and `-port`), so the separate `gst-webrtc-signalling-server` binary
@@ -219,28 +223,121 @@ pub struct Frame {
     pub data: Vec<u8>,
 }
 
-/// The most recent raw frame, or none yet.
+/// A frame off the tee, handed over on request.
 ///
-/// Last-value-wins by construction: the appsink callback replaces whatever was here. A reader that
-/// is slow sees a newer frame next time rather than a queue of stale ones, which is what a
-/// perception consumer and a `get_frame` both want — and neither can slow the encoder down by
-/// being slow itself.
+/// **Asked for, not published.** Copying a frame out of the tee costs the whole frame — 1.84 MB at
+/// 720p30, the quality every robot ships at — and the branch's readers want two a second between
+/// them: the auto-exposure loop meters one every 500 ms, and the duck detector looks twice a second
+/// when it is switched on at all. Capturing all thirty meant **55 MB/s of memcpy and a 1.8 MB
+/// allocation thirty times a second, from boot, on every robot**, for twenty-eight frames nobody
+/// ever read. A reader now says when it wants one, and the appsink callback's cost on every other
+/// frame is a relaxed load and dropping the sample.
+///
+/// **A reader waits for the next frame rather than taking the last one.** The demand has to be
+/// answered by a capture that happens *after* it, or the saving would come straight back out of the
+/// picture: a reader polling every 500 ms would meter a frame captured for the previous poll, and an
+/// exposure loop steering on half-second-old luma is a loop that hunts. So the request marks the
+/// next frame, and the reader blocks until it lands — [`FRAME_TIMEOUT`] bounds that for a camera
+/// that has stopped delivering.
+///
+/// One captured frame answers every reader waiting for one: the flag is a single bit and the
+/// delivery wakes all of them, so the detector and the exposure loop asking at the same moment cost
+/// one copy between them rather than two.
 #[derive(Clone, Default)]
-pub struct Frames(Arc<Mutex<Option<Frame>>>);
+pub struct Frames(Arc<Shared>);
+
+/// The reader/callback rendezvous. [`Frames`] is the handle; this is what both ends touch.
+#[derive(Default)]
+struct Shared {
+    latest: Mutex<Latest>,
+    /// Signalled when [`Latest::generation`] moves, which is the only thing a reader waits on.
+    delivered: std::sync::Condvar,
+    /// A reader is waiting for the next frame. Read once per buffer and `Relaxed` on purpose:
+    /// nothing is published through it — the frame itself goes through `latest`, whose mutex
+    /// carries the ordering — so this only ever has to be eventually true, and it is the one thing
+    /// the callback does on a frame nobody asked for.
+    wanted: std::sync::atomic::AtomicBool,
+}
+
+#[derive(Default)]
+struct Latest {
+    frame: Option<Frame>,
+    /// Bumped on every delivery, so a reader can tell the frame it asked for from the one that was
+    /// already there. A counter rather than an `Option::take`, because two readers waiting on the
+    /// same capture must both see it.
+    generation: u64,
+}
+
+/// How long a reader waits for the frame it asked for before giving up on it.
+///
+/// Fifteen frame periods at 720p30 and seven at 720p15 — far longer than any capture hiccup, and
+/// short enough that a reader on a camera that has stopped goes back round its own loop and says so
+/// rather than parking for ever. Both readers already have a "no frame" path; this is what reaches
+/// it.
+pub const FRAME_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
 impl Frames {
-    /// Read the latest frame in place, without copying it. `None` until the first one arrives.
+    /// Ask for the next frame and read it in place, without copying it.
     ///
     /// For a reader that wants a number out of a frame rather than the frame — the auto-exposure
-    /// loop wants a mean, and cloning 1.8 MB twice a second to average 11k bytes of it is a memcpy
+    /// loop wants a mean, and copying 1.84 MB twice a second to average 11k bytes of it is a memcpy
     /// nobody needs.
-    pub fn inspect<T>(&self, read: impl FnOnce(&Frame) -> T) -> Option<T> {
-        self.0.lock().expect("frame lock").as_ref().map(read)
+    ///
+    /// `None` when no frame arrived within [`FRAME_TIMEOUT`].
+    pub fn inspect_next<T>(&self, read: impl FnOnce(&Frame) -> T) -> Option<T> {
+        self.next_capture(|frame| frame.map(read))
     }
 
-    /// The latest frame, cloned. `None` until the first one arrives.
-    pub fn latest(&self) -> Option<Frame> {
-        self.0.lock().expect("frame lock").clone()
+    /// Ask for the next frame and take a copy of it. `None` when none arrived within
+    /// [`FRAME_TIMEOUT`].
+    pub fn next_frame(&self) -> Option<Frame> {
+        self.next_capture(|frame| frame.cloned())
+    }
+
+    /// Register the demand, wait for the capture that answers it, and read what landed.
+    ///
+    /// The generation is read *before* the flag is set: a capture that lands between the two is one
+    /// this reader asked for as far as it can tell, and waiting out a whole extra frame to be
+    /// pedantic about it would only make the answer staler.
+    fn next_capture<T>(&self, read: impl FnOnce(Option<&Frame>) -> T) -> T {
+        let latest = self.0.latest.lock().expect("frame lock");
+        let seen = latest.generation;
+        self.0
+            .wanted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let (latest, _) = self
+            .0
+            .delivered
+            .wait_timeout_while(latest, FRAME_TIMEOUT, |latest| latest.generation == seen)
+            .expect("frame lock");
+        // On a timeout this is whatever the last delivery left — `None` on a camera that has never
+        // produced one, and a stale frame on one that has stopped. Reported as the timeout it is
+        // rather than as that frame: a reader told "here is a frame" cannot tell the difference,
+        // and the exposure loop steering on a frame from a minute ago is the failure this whole
+        // rendezvous exists to prevent.
+        if latest.generation == seen {
+            return read(None);
+        }
+        read(latest.frame.as_ref())
+    }
+
+    /// Whether a reader is waiting, taking the request if one is. The callback's whole cost on a
+    /// frame nobody asked for.
+    fn take_request(&self) -> bool {
+        self.0
+            .wanted
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Hand the captured frame to whoever is waiting for it.
+    fn deliver(&self, frame: Frame) {
+        let mut latest = self.0.latest.lock().expect("frame lock");
+        latest.frame = Some(frame);
+        latest.generation = latest.generation.wrapping_add(1);
+        drop(latest);
+        // Every waiter, not one: a single capture is the answer to every request outstanding when
+        // it was taken.
+        self.0.delivered.notify_all();
     }
 }
 
@@ -589,12 +686,20 @@ fn link_tee_branch(tee: &gst::Element, branch: &gst::Element) -> Result<()> {
     Ok(())
 }
 
-/// Keep [`Frames`] pointing at the most recent buffer off the raw branch.
+/// Answer a reader's request for a frame out of the raw branch, and drop every other buffer.
 fn wire_frames(appsink: &gst_app::AppSink, frames: Frames, width: u32, height: u32) {
     appsink.set_callbacks(
         gst_app::AppSinkCallbacks::builder()
             .new_sample(move |sink| {
+                // Pulled whatever happens, and *before* the request is looked at. A sample left
+                // unpulled sits in the appsink's queue holding one of the capture pool's buffers,
+                // and [`CAPTURE_BUFFERS`] is four with three the cliff — declining to copy a frame
+                // must not cost the pipeline a buffer to decline it with. Dropped at the end of
+                // this scope instead, which returns the buffer to the pool.
                 let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                if !frames.take_request() {
+                    return Ok(gst::FlowSuccess::Ok);
+                }
                 let Some(buffer) = sample.buffer() else {
                     return Ok(gst::FlowSuccess::Ok);
                 };
@@ -604,18 +709,19 @@ fn wire_frames(appsink: &gst_app::AppSink, frames: Frames, width: u32, height: u
                 // one on this branch.
                 let Ok(map) = buffer.map_readable() else {
                     // A buffer that will not map is not worth failing the pipeline over — the next
-                    // one is a frame away, and this branch is advisory by design.
+                    // one is a frame away, and this branch is advisory by design. The request has
+                    // been taken by now, so the reader waits out its timeout rather than being
+                    // answered with nothing; a map that fails twice running is a pipeline in
+                    // trouble, not a frame to retry for.
                     tracing::debug!("a raw frame would not map");
                     return Ok(gst::FlowSuccess::Ok);
                 };
-                let frame = Frame {
+                frames.deliver(Frame {
                     width,
                     height,
                     format: CAPTURE_FORMAT,
                     data: map.as_slice().to_vec(),
-                };
-                // Replaced, not queued: last-value-wins is the contract.
-                *frames.0.lock().expect("frame lock") = Some(frame);
+                });
 
                 Ok(gst::FlowSuccess::Ok)
             })
@@ -1382,6 +1488,105 @@ fn open_control_channel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A frame whose every byte is `tag`, so a test can say *which* capture came back.
+    fn frame(tag: u8) -> Frame {
+        Frame {
+            width: 4,
+            height: 2,
+            format: CAPTURE_FORMAT,
+            data: vec![tag; 16],
+        }
+    }
+
+    /// **The point of the whole rendezvous.** With nobody waiting, the callback's answer is no,
+    /// and no is what stops 1.84 MB being copied thirty times a second for readers that want two.
+    ///
+    /// A regression here is silent: the picture is identical, the detector still detects, and the
+    /// only symptom is a robot that runs hotter than it needs to.
+    #[test]
+    fn a_frame_nobody_asked_for_is_not_captured() {
+        let frames = Frames::default();
+        assert!(!frames.take_request());
+        assert!(!frames.take_request());
+    }
+
+    /// One capture answers every reader waiting for one. The request is a bit rather than a queue,
+    /// so the exposure loop and the detector asking in the same frame period cost one copy.
+    #[test]
+    fn two_readers_asking_at_once_cost_one_capture() {
+        let frames = Frames::default();
+        frames
+            .0
+            .wanted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        frames
+            .0
+            .wanted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        assert!(frames.take_request());
+        assert!(
+            !frames.take_request(),
+            "the second frame must not be captured too"
+        );
+    }
+
+    /// **A reader gets the frame captured after it asked, not the one already lying there.**
+    ///
+    /// This is what makes demand-driven capture safe for the exposure loop. Handing back the last
+    /// delivery would be cheaper still and would mean metering a frame from the previous tick — up
+    /// to half a second of dead reckoning on a control loop whose whole job is to track the light
+    /// in the room.
+    #[test]
+    fn a_reader_gets_the_capture_that_answered_it() {
+        let frames = Frames::default();
+        // What a previous reader's request left behind.
+        frames.deliver(frame(1));
+
+        let reader = {
+            let frames = frames.clone();
+            std::thread::spawn(move || frames.next_frame())
+        };
+
+        // Stand in for the appsink: wait for the request to show up, then answer it.
+        let deadline = std::time::Instant::now() + FRAME_TIMEOUT;
+        while !frames.take_request() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the reader never asked for a frame"
+            );
+            std::thread::yield_now();
+        }
+        frames.deliver(frame(2));
+
+        let got = reader.join().expect("reader thread").expect("a frame");
+        assert_eq!(
+            got.data,
+            vec![2; 16],
+            "got the stale frame, not the fresh one"
+        );
+    }
+
+    /// A camera that has stopped times out rather than handing back the frame it stopped on.
+    ///
+    /// The reader cannot tell a stale frame from a current one, so the staleness has to be the
+    /// answer. Both readers already have a "no frame" path — this is what reaches it.
+    #[test]
+    fn a_capture_that_never_comes_is_not_a_stale_frame() {
+        let frames = Frames::default();
+        frames.deliver(frame(1));
+
+        let waited = std::time::Instant::now();
+        assert!(
+            frames.next_frame().is_none(),
+            "a timeout must not be answered with the last frame"
+        );
+        assert!(
+            waited.elapsed() >= FRAME_TIMEOUT,
+            "it gave up before the timeout was out"
+        );
+    }
 
     /// A quarter turn swaps the frame's axes; a half turn does not.
     ///

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -56,8 +56,9 @@
 //!
 //! One socket, read-only, for `pad.input` and nothing else — `src/tap.rs`, and it does not make this
 //! a privileged process. It exists because `padd` is the reason a stalled radio is invisible: the
-//! sticks are *polled*, so the last known value keeps being sent at 50 Hz whether or not the pad is
-//! still talking, and every surface downstream then shows a robot with a live driver. The event
+//! sticks are *polled*, so the last known value keeps being sent — at the full rate, since a stick
+//! reading anything but centre is never held back — whether or not the pad is still talking, and
+//! every surface downstream then shows a robot with a live driver. The event
 //! stream one layer below has the evidence, so it is passed out unaltered rather than summarised.
 //! `robotctl monitor` draws it; `docs/robot/pair-a-gamepad.md` says how to read it.
 //!
@@ -108,9 +109,12 @@ struct Args {
     #[arg(long, default_value = "/run/robotd.sock")]
     socket: PathBuf,
 
-    /// How often to send intents. Matching the control rate exactly buys nothing — the loop
+    /// How often to read the pad. Matching the control rate exactly buys nothing — the loop
     /// reads the latest value once per tick — but staying at or above it keeps the added
     /// latency under one tick.
+    ///
+    /// Not quite how often intents are *sent*: a frame identical to the last one and asking
+    /// for no motion is held back, down to [`HEARTBEAT`]. See [`Continuous`].
     #[arg(long, default_value_t = 50)]
     hz: u32,
 
@@ -263,6 +267,10 @@ fn main() -> std::process::ExitCode {
     // starts the wheee ride. The prototype's threshold.
     let mut prev_rt = 0.0f64;
     let mut prev_lt = 0.0f64;
+    // The continuous intents, and the buffer this tick's are built in. Both live across
+    // ticks so a steady state neither allocates nor re-sends — see [`Continuous`].
+    let mut continuous = Continuous::default();
+    let mut frame: Vec<proto::Call> = Vec::with_capacity(2);
 
     loop {
         let tick = Instant::now();
@@ -534,8 +542,12 @@ fn main() -> std::process::ExitCode {
             }
         }
 
-        let call = match mode {
-            Mode::Drive if roller => proto::Call::RobotMove(proto::MoveParams {
+        // This tick's continuous intents, as one frame. Reused rather than built fresh:
+        // a `Vec` per tick is an allocation fifty times a second to say what the sticks
+        // were doing, which is the shape of thing this loop is meant not to do.
+        frame.clear();
+        match mode {
+            Mode::Drive if roller => frame.push(proto::Call::RobotMove(proto::MoveParams {
                 // The prototype's roller shaping: push harder than you can brake, no
                 // strafe, heading capped independently of the walking limits.
                 vx: left_y
@@ -546,8 +558,8 @@ fn main() -> std::process::ExitCode {
                     },
                 vy: 0.0,
                 vyaw: -right_x * ROLLER_YAW,
-            }),
-            Mode::Drive => proto::Call::RobotMove(proto::MoveParams {
+            })),
+            Mode::Drive => frame.push(proto::Call::RobotMove(proto::MoveParams {
                 vx: left_y
                     * if left_y >= 0.0 {
                         args.max_linear
@@ -558,38 +570,30 @@ fn main() -> std::process::ExitCode {
                 // gilrs normalises.
                 vy: -left_x * args.max_linear,
                 vyaw: -right_x * args.max_angular,
-            }),
+            })),
             Mode::Head => {
                 // The body must not keep its last velocity while the sticks are posing the
                 // head. The deadman would catch it eventually; a robot that keeps walking
                 // because you started moving its head is a bad enough surprise to be
                 // explicit about.
-                if let Err(e) = notify(
-                    &mut stream,
-                    &proto::Call::RobotMove(proto::MoveParams::default()),
-                ) {
-                    tracing::error!(error = %e, "send failed");
-                    return std::process::ExitCode::FAILURE;
-                }
+                //
+                // In the same frame as the head rather than a notification of its own: the
+                // two describe one instant, and sending them separately was two `write_all`
+                // and two `flush` syscalls a tick to say so.
+                frame.push(proto::Call::RobotMove(proto::MoveParams::default()));
                 // The prototype's alpha mapping, signs included (its head_pitch/head_yaw
                 // joint axes are inverted relative to stick direction — verified on
                 // hardware there, kept verbatim here).
-                proto::Call::RobotHead(proto::HeadParams {
+                frame.push(proto::Call::RobotHead(proto::HeadParams {
                     neck_pitch: right_y * args.max_head,
                     head_pitch: -left_y * args.max_head,
                     head_yaw: -left_x * args.max_head,
                     head_roll: right_x * args.max_head,
-                })
+                }));
             }
             Mode::BodyPose => {
-                if let Err(e) = notify(
-                    &mut stream,
-                    &proto::Call::RobotMove(proto::MoveParams::default()),
-                ) {
-                    tracing::error!(error = %e, "send failed");
-                    return std::process::ExitCode::FAILURE;
-                }
-                proto::Call::RobotPose(proto::PoseParams {
+                frame.push(proto::Call::RobotMove(proto::MoveParams::default()));
+                frame.push(proto::Call::RobotPose(proto::PoseParams {
                     z: left_y
                         * if left_y >= 0.0 {
                             BODY_MAX_Z_UP
@@ -599,11 +603,11 @@ fn main() -> std::process::ExitCode {
                     pitch: right_y * BODY_MAX_ANGLE,
                     roll: right_x * BODY_MAX_ANGLE,
                     active: true,
-                })
+                }));
             }
-        };
+        }
 
-        if let Err(e) = notify(&mut stream, &call) {
+        if let Err(e) = continuous.send(&mut stream, &frame, tick) {
             tracing::error!(error = %e, "send failed");
             return std::process::ExitCode::FAILURE;
         }
@@ -620,6 +624,85 @@ fn notify(stream: &mut UnixStream, call: &proto::Call) -> std::io::Result<()> {
     line.push(b'\n');
     stream.write_all(&line)?;
     stream.flush()
+}
+
+/// How long an unchanged frame may go unsent while the robot is being asked to stand still.
+///
+/// The sticks are *polled*, so an untouched pad re-sent the same three zeros fifty times a
+/// second — a `serde_json` encode, a `write_all`, a `flush`, and a `serde_json` parse on
+/// `robotd`'s side, a hundred messages a second in the modes that send two, to say nothing
+/// changed. Ten a second says it as well.
+///
+/// **Nothing about the robot's safety rests on this number**, which is why it can be picked
+/// for legibility rather than argued against `[safety] deadman_ms` — a value this daemon
+/// cannot read and does not know. A frame is only ever held back when it is byte-identical
+/// to the last one sent *and* asks for no motion ([`Continuous::may_hold`]); a stick that is
+/// doing anything goes out on every tick as it always did. What the heartbeat buys is the
+/// report: without it `robotd`'s twist would age past the deadman while a pad sat connected
+/// and idle, and `robot.state` would carry `limited_by: ["deadman"]` for a robot that is
+/// stationary because it was asked to be.
+const HEARTBEAT: Duration = Duration::from_millis(100);
+
+/// The continuous intents, encoded once a tick and sent when they say something new.
+#[derive(Default)]
+struct Continuous {
+    /// This tick's frame. Kept across ticks so the encode reuses its buffer.
+    line: Vec<u8>,
+    /// The bytes last put on the socket, to compare this tick's against.
+    last: Vec<u8>,
+    /// When that was. `None` until the first send, which therefore always happens.
+    at: Option<Instant>,
+}
+
+impl Continuous {
+    /// Put this tick's intents on the socket, unless they are the ones already there.
+    ///
+    /// One write for the whole frame: the calls describe a single instant, and a peer that
+    /// read half of one would be acting on a head pose without the velocity that came with
+    /// it. `robotd` splits the buffer back into lines on its own read.
+    fn send(
+        &mut self,
+        stream: &mut UnixStream,
+        calls: &[proto::Call],
+        now: Instant,
+    ) -> std::io::Result<()> {
+        self.line.clear();
+        for call in calls {
+            serde_json::to_writer(&mut self.line, &proto::Request::notify(call))?;
+            self.line.push(b'\n');
+        }
+
+        if self.line == self.last && self.may_hold(calls, now) {
+            return Ok(());
+        }
+
+        stream.write_all(&self.line)?;
+        stream.flush()?;
+        // Swapped rather than cloned: the buffer this displaces becomes next tick's
+        // scratch, so a steady state allocates nothing at all.
+        std::mem::swap(&mut self.last, &mut self.line);
+        self.at = Some(now);
+        Ok(())
+    }
+
+    /// Whether an unchanged frame may be left unsent this tick.
+    ///
+    /// Only while it asks for no velocity. The deadman zeroes the twist and nothing else, so
+    /// on a frame that already commands zero, letting it fire changes nothing about what the
+    /// robot does — and on a frame that commands motion it would stop a robot whose stick is
+    /// still held. That is the whole of the argument, and it holds whatever `deadman_ms` is
+    /// set to.
+    ///
+    /// A held stick therefore keeps sending at the full rate. That is the case where the
+    /// robot is walking and the daemon has something to say; this is about the one where it
+    /// is not and does not.
+    fn may_hold(&self, calls: &[proto::Call], now: Instant) -> bool {
+        let asks_for_motion = calls.iter().any(|call| match call {
+            proto::Call::RobotMove(p) => p.vx != 0.0 || p.vy != 0.0 || p.vyaw != 0.0,
+            _ => false,
+        });
+        !asks_for_motion && self.at.is_some_and(|at| now.duration_since(at) < HEARTBEAT)
+    }
 }
 
 /// Send a discrete intent and read its answer.
@@ -659,5 +742,181 @@ fn request(
             tracing::warn!(error = %e, raw = %answer.trim(), "unparsable answer");
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    /// A socket pair standing in for `robotd`, and what came out of it.
+    ///
+    /// Non-blocking on the reading end so a test can assert that *nothing* was sent, which
+    /// is the assertion most of these are making.
+    fn socket() -> (UnixStream, UnixStream) {
+        let (ours, theirs) = UnixStream::pair().expect("a socket pair");
+        theirs.set_nonblocking(true).expect("non-blocking");
+        (ours, theirs)
+    }
+
+    fn drain(stream: &mut UnixStream) -> String {
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 4096];
+        while let Ok(n) = stream.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..n]);
+        }
+        String::from_utf8(buffer).expect("utf-8")
+    }
+
+    fn moving() -> Vec<proto::Call> {
+        vec![proto::Call::RobotMove(proto::MoveParams {
+            vx: 0.2,
+            vy: 0.0,
+            vyaw: 0.0,
+        })]
+    }
+
+    fn still() -> Vec<proto::Call> {
+        vec![proto::Call::RobotMove(proto::MoveParams::default())]
+    }
+
+    /// The sticks are polled, so an untouched pad produces the same frame fifty times a
+    /// second. Sending it fifty times is what this stops.
+    #[test]
+    fn an_unchanged_stationary_frame_is_not_resent() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let at = Instant::now();
+
+        continuous.send(&mut ours, &still(), at).expect("first");
+        let first = drain(&mut theirs);
+        assert!(first.contains("robot.move"), "the first frame must go out");
+
+        for tick in 1..5 {
+            let now = at + Duration::from_millis(20 * tick);
+            continuous.send(&mut ours, &still(), now).expect("held");
+        }
+        assert_eq!(drain(&mut theirs), "", "an idle pad must say nothing");
+    }
+
+    /// **The safety property, and the reason the heartbeat needs no argument about
+    /// `deadman_ms`.** A stick that is asking the robot to walk is re-sent every tick
+    /// whatever the clock says, because a deadman that fires on a held stick stops a robot
+    /// somebody is driving.
+    #[test]
+    fn a_frame_that_asks_for_motion_is_always_sent() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let at = Instant::now();
+
+        continuous.send(&mut ours, &moving(), at).expect("first");
+        drain(&mut theirs);
+
+        // The same bytes, one tick later — well inside the heartbeat.
+        continuous
+            .send(&mut ours, &moving(), at + Duration::from_millis(20))
+            .expect("second");
+        assert!(
+            drain(&mut theirs).contains("robot.move"),
+            "a held stick must keep being sent"
+        );
+    }
+
+    /// The heartbeat is what keeps `robotd` from reporting a deadman on a robot that is
+    /// standing still because it was asked to.
+    #[test]
+    fn a_stationary_frame_goes_out_again_on_the_heartbeat() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let at = Instant::now();
+
+        continuous.send(&mut ours, &still(), at).expect("first");
+        drain(&mut theirs);
+
+        continuous
+            .send(
+                &mut ours,
+                &still(),
+                at + HEARTBEAT - Duration::from_millis(1),
+            )
+            .expect("held");
+        assert_eq!(drain(&mut theirs), "", "not due yet");
+
+        continuous
+            .send(&mut ours, &still(), at + HEARTBEAT)
+            .expect("heartbeat");
+        assert!(drain(&mut theirs).contains("robot.move"), "due");
+    }
+
+    /// A stick that moves is heard on the tick it moved, not on the next heartbeat.
+    #[test]
+    fn a_changed_frame_is_sent_at_once() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let at = Instant::now();
+
+        continuous.send(&mut ours, &still(), at).expect("first");
+        drain(&mut theirs);
+
+        continuous
+            .send(&mut ours, &moving(), at + Duration::from_millis(20))
+            .expect("changed");
+        assert!(
+            drain(&mut theirs).contains("robot.move"),
+            "a stick that moved must not wait for a heartbeat"
+        );
+    }
+
+    /// Head mode's two intents describe one instant and go out in one write. Split across
+    /// two, a reader could act on a head pose without the velocity that came with it.
+    #[test]
+    fn a_two_call_frame_is_one_write_and_two_lines() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let calls = vec![
+            proto::Call::RobotMove(proto::MoveParams::default()),
+            proto::Call::RobotHead(proto::HeadParams {
+                neck_pitch: 0.1,
+                head_pitch: 0.0,
+                head_yaw: 0.0,
+                head_roll: 0.0,
+            }),
+        ];
+
+        continuous
+            .send(&mut ours, &calls, Instant::now())
+            .expect("sent");
+
+        let sent = drain(&mut theirs);
+        let lines: Vec<&str> = sent.lines().collect();
+        assert_eq!(lines.len(), 2, "two intents, two lines: {sent:?}");
+        assert!(lines[0].contains("robot.move"));
+        assert!(lines[1].contains("robot.head"));
+        assert!(sent.ends_with('\n'), "every line must be terminated");
+    }
+
+    /// A head frame carries a zero velocity, so an untouched pad in head mode holds too —
+    /// which is the mode that was sending a hundred messages a second.
+    #[test]
+    fn an_untouched_pad_in_head_mode_holds_both_intents() {
+        let (mut ours, mut theirs) = socket();
+        let mut continuous = Continuous::default();
+        let at = Instant::now();
+        let calls = vec![
+            proto::Call::RobotMove(proto::MoveParams::default()),
+            proto::Call::RobotHead(proto::HeadParams::default()),
+        ];
+
+        continuous.send(&mut ours, &calls, at).expect("first");
+        drain(&mut theirs);
+
+        continuous
+            .send(&mut ours, &calls, at + Duration::from_millis(20))
+            .expect("held");
+        assert_eq!(drain(&mut theirs), "");
     }
 }

--- a/pet-detect/src/bin/detect.rs
+++ b/pet-detect/src/bin/detect.rs
@@ -67,7 +67,10 @@ fn main() -> Result<()> {
         for chunk in buf[..n].as_chunks::<2>().0 {
             i16_buf.push(i16::from_le_bytes(*chunk));
         }
-        let (events, last_p) = detector.push_samples(&i16_to_f32(&i16_buf))?;
+        // Always audible: this reads a stream somebody is analysing, and a probability per
+        // window — including the quiet ones — is the whole output. The live gate is
+        // `pet_detect::worker`'s, off the ambient floor it is already measuring.
+        let (events, last_p) = detector.push_samples(&i16_to_f32(&i16_buf), true)?;
         if let Some(p) = last_p {
             let state = if detector.is_petting() {
                 "petting"

--- a/pet-detect/src/lib.rs
+++ b/pet-detect/src/lib.rs
@@ -279,13 +279,41 @@ impl PettingDetector {
 
     /// Push samples; returns the state-change events this batch triggered and the latest
     /// inference probability (when one ran), for logging.
-    pub fn push_samples(&mut self, samples: &[f32]) -> Result<(Vec<PettingEvent>, Option<f32>)> {
+    ///
+    /// `audible` is the caller's answer to "has the room made a sound this could possibly
+    /// find petting in". False skips the window's features and inference — the expensive
+    /// part by far — while still advancing the ring and the schedule, so the audio a later
+    /// window sees is continuous and not spliced across the gap.
+    ///
+    /// **Pass `true` from a caller with no measure of the room**, which is what this did
+    /// before there was a gate: analysing a recording wants a probability for every window,
+    /// including the quiet ones. `worker::SoundSentry::audible` is the live measure.
+    pub fn push_samples(
+        &mut self,
+        samples: &[f32],
+        audible: bool,
+    ) -> Result<(Vec<PettingEvent>, Option<f32>)> {
         self.ring.extend_from_slice(samples);
         let mut events = Vec::new();
         let mut last_p = None;
 
         while self.ring.len() >= self.samples_until_infer {
             let start = self.samples_until_infer - WINDOW_SAMPLES;
+            // Advanced here rather than at the end of the body, so that *every* path out of
+            // this iteration has advanced it. The skip below is one such path, and a skip
+            // that forgot to would not be a missed inference — it would be this loop
+            // spinning on the same window until the thread is killed.
+            self.samples_until_infer += self.stride;
+
+            // Silence cannot be petting, and finding that out the honest way costs a
+            // hundred FFTs and a forward pass.
+            //
+            // Only while *not* petting. The End edge is found by inference exactly as the
+            // Start is, so a session whose room went quiet under a shut gate would never
+            // end — the robot would sit there believing it was still being stroked.
+            if !audible && !self.is_petting {
+                continue;
+            }
             let mel = self
                 .extractor
                 .log_mel(&self.ring[start..start + WINDOW_SAMPLES]);
@@ -302,8 +330,6 @@ impl PettingDetector {
                 self.is_petting = false;
                 events.push(PettingEvent::End);
             }
-
-            self.samples_until_infer += self.stride;
         }
 
         // Cap the ring at 2× window so memory stays bounded.

--- a/pet-detect/src/worker.rs
+++ b/pet-detect/src/worker.rs
@@ -35,6 +35,19 @@ pub enum SoundEvent {
 /// 32 ms at 16 kHz.
 const SENTRY_FRAME: u32 = 512;
 
+/// How long a sound keeps the classifier armed after it, in [`SENTRY_FRAME`]s.
+///
+/// **A whole window, derived rather than written down.** A sound heard now is still inside
+/// the window the classifier looks at a window from now, so anything shorter would shut the
+/// gate on audio still under examination — and a stroke is not continuous anyway, it is
+/// scratches with gaps to sit through. Rounded up, because a hold that covers all but the
+/// last 23 ms of a window covers the wrong thing.
+///
+/// Written as arithmetic on [`crate::WINDOW_SAMPLES`] because the obvious literal is wrong:
+/// a window is 16 240 samples, which is 1.015 s and *not* the 31 frames that "about a
+/// second" suggests.
+const AUDIBLE_HOLD_FRAMES: u32 = (crate::WINDOW_SAMPLES as u32).div_ceil(SENTRY_FRAME);
+
 /// RMS envelope watcher over ~32 ms frames with a slowly-adapting ambient floor. Petting
 /// sounds are loud on this mic (it's practically a contact mic for head scratches), so
 /// events are suppressed while the classifier reports petting (+1 s hangover).
@@ -51,6 +64,8 @@ struct SoundSentry {
     event_peak: f32,
     /// Frames since the last periodic floor log (~every 60 s).
     floor_log_frames: u32,
+    /// Frames left in which the room counts as having made a sound. See [`Self::audible`].
+    audible_frames: u32,
 }
 
 impl SoundSentry {
@@ -66,7 +81,28 @@ impl SoundSentry {
             petting_hold_frames: 0,
             event_peak: 0.0,
             floor_log_frames: 0,
+            audible_frames: 0,
         }
+    }
+
+    /// Whether anything in the last second stood out from the room.
+    ///
+    /// **This is what decides whether the classifier runs at all.** The petting model is
+    /// 40 log-mel bands over a second of audio — a hundred 512-point FFTs and a forward
+    /// pass, four times a second, for ever. In a quiet room every one of those returns the
+    /// same answer, and this is the cheap way to know it in advance: the sentry is already
+    /// measuring the room frame by frame, so the gate reads its floor rather than keeping a
+    /// second one that could drift from it.
+    ///
+    /// Armed by the *lower* of the sentry's two thresholds, the one that says an event has
+    /// ended rather than the one that says a clap has started. This is not deciding whether
+    /// a sound is worth reporting; it is deciding whether a pet is worth looking for, and
+    /// the two want very different margins. A stroke gentle enough to stay under three
+    /// times the ambient floor for a whole second would be missed — and would have scored
+    /// far below the 0.95 enter threshold anyway, on a mic this model was trained through
+    /// where a head scratch is loud enough to need muting.
+    fn audible(&self) -> bool {
+        self.audible_frames > 0
     }
 
     fn push(&mut self, samples: &[f32], petting: bool, out: &mut Vec<SoundEvent>) {
@@ -103,6 +139,14 @@ impl SoundSentry {
         // gain puts real claps well under an absolute guess.)
         let on_thresh = (self.floor * 6.0).max(0.002);
         let off_thresh = (self.floor * 3.0).max(0.0012);
+        // Arm the classifier, or let the arming run down. Above the event thresholds so it
+        // is decided on every frame including the ones inside an event, where the floor is
+        // frozen and a petting session is exactly what is going on.
+        if rms > off_thresh {
+            self.audible_frames = AUDIBLE_HOLD_FRAMES;
+        } else {
+            self.audible_frames = self.audible_frames.saturating_sub(1);
+        }
         if !self.in_event {
             // The ambient floor adapts only from non-event frames (τ ≈ 6 s), so sustained
             // noise (gait servos, music) raises the bar instead of spamming events.
@@ -357,7 +401,14 @@ fn pump(
             i16_buf.push(i16::from_le_bytes(*chunk));
         }
         let samples = i16_to_f32(&i16_buf);
-        let (events, _p) = detector.push_samples(&samples)?;
+        // Read before the sentry sees this batch, deliberately: the answer is a one-second
+        // hangover rather than a verdict on these 128 ms, so it spans batches and reading it
+        // one batch early costs nothing. Reading it after would mean pushing to the sentry
+        // first, and the sentry's petting mute wants the state from *after* this batch's
+        // inference — see below. Only one of the two can go first, and this is the one whose
+        // ordering does not matter.
+        let audible = sentry.audible();
+        let (events, _p) = detector.push_samples(&samples, audible)?;
         for ev in events {
             if tx.send(ev).is_err() {
                 // Receiver dropped — the daemon is shutting down.
@@ -378,4 +429,91 @@ fn pump(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One sentry frame of a constant amplitude, pushed through as the mic would deliver it.
+    fn frames(sentry: &mut SoundSentry, amplitude: f32, count: u32) {
+        let block = vec![amplitude; SENTRY_FRAME as usize];
+        let mut out = Vec::new();
+        for _ in 0..count {
+            sentry.push(&block, false, &mut out);
+        }
+    }
+
+    /// **The point of the gate.** A room with nothing happening in it never arms the
+    /// classifier, so the hundred FFTs and the forward pass never run.
+    ///
+    /// A regression is silent in exactly the way the camera one is: petting still works,
+    /// and the only symptom is a robot warmer than it needs to be.
+    #[test]
+    fn a_quiet_room_never_arms_the_classifier() {
+        let mut sentry = SoundSentry::new();
+        assert!(!sentry.audible(), "nothing has happened yet");
+
+        // Well under the 0.0012 absolute minimum the off threshold floors at.
+        frames(&mut sentry, 0.0001, 200);
+        assert!(!sentry.audible(), "silence must not arm it");
+    }
+
+    /// A sound arms it, and it stays armed across the gaps in a stroke.
+    #[test]
+    fn a_sound_arms_the_classifier_and_the_arming_outlives_it() {
+        let mut sentry = SoundSentry::new();
+
+        frames(&mut sentry, 0.05, 2);
+        assert!(sentry.audible(), "a loud frame must arm it");
+
+        // The gaps between scratches must not shut the gate mid-stroke.
+        frames(&mut sentry, 0.0001, AUDIBLE_HOLD_FRAMES - 1);
+        assert!(sentry.audible(), "the hangover must span a gap in a stroke");
+    }
+
+    /// And it lets go, or the gate would be a one-way switch and the saving would last
+    /// until the first door slammed.
+    #[test]
+    fn the_arming_runs_out_after_the_hold() {
+        let mut sentry = SoundSentry::new();
+
+        frames(&mut sentry, 0.05, 1);
+        assert!(sentry.audible());
+
+        frames(&mut sentry, 0.0001, AUDIBLE_HOLD_FRAMES);
+        assert!(!sentry.audible(), "the hold must expire");
+    }
+
+    /// The hold is at least a window wide, because a sound heard now is still inside the
+    /// window the classifier looks at a second from now.
+    #[test]
+    fn the_hold_covers_a_whole_window() {
+        let held = f64::from(AUDIBLE_HOLD_FRAMES) * f64::from(SENTRY_FRAME) / 16_000.0;
+        let window = crate::WINDOW_SAMPLES as f64 / 16_000.0;
+        assert!(
+            held >= window,
+            "{held:.2}s of hold for a {window:.2}s window"
+        );
+    }
+
+    /// The gate opens on the sentry's *lower* threshold. Tying it to the upper one would
+    /// tune "is a pet worth looking for" against "is a clap worth reporting", which are not
+    /// the same question and do not want the same margin.
+    #[test]
+    fn the_gate_opens_below_the_event_threshold() {
+        let mut sentry = SoundSentry::new();
+        let floor = sentry.floor;
+        // Between the off threshold (3x) and the on threshold (6x), and above both
+        // absolute minimums at the starting floor.
+        let between = floor * 4.5;
+        assert!(between > (floor * 3.0).max(0.0012));
+        assert!(between < (floor * 6.0).max(0.002));
+
+        frames(&mut sentry, between, 1);
+        assert!(
+            sentry.audible(),
+            "a sound too small to report is not too small to classify"
+        );
+    }
 }

--- a/tof/src/main.rs
+++ b/tof/src/main.rs
@@ -54,12 +54,29 @@ const GROUP: &str = "robot";
 /// jump in `seq` rather than a silent hole.
 const FRAME_BUFFER: usize = 32;
 
-/// How often to ask the sensor whether a frame is ready.
+/// How often to ask the sensor whether a frame is ready, once one is nearly due.
 ///
 /// One 1-byte register read, so the cost is a few hundred microseconds of bus.
 /// At 10 ms it adds at most that to a frame's age at 15 Hz (66 ms apart), which
 /// is well inside what any consumer of depth cares about.
 const POLL: Duration = Duration::from_millis(10);
+
+/// How long before a frame is due the loop starts asking for it.
+///
+/// **Asking every 10 ms for the whole period is asking six times to be told no
+/// once.** A frame is 66 ms away at 15 Hz and the sensor answers on its own
+/// clock, so the poll only has to be running as the frame lands — the rest was
+/// a hundred I²C transactions and a hundred thread wakeups a second, forever,
+/// on a daemon whose sensor produces fifteen frames in that time.
+///
+/// Two poll intervals of margin, and the anchor is the last frame's *arrival*,
+/// so the estimate can never accumulate more than one period of drift: this
+/// tolerates the sensor being 20 ms early on any given frame — a 30% period
+/// error, far past anything a hardware ranging timer does — and a sensor that
+/// is merely late is polled for exactly as long as it was before. Frame age is
+/// unchanged either way: it is still bounded by [`POLL`], because that is the
+/// granularity the frame is noticed at whichever way the loop got there.
+const POLL_GUARD: Duration = Duration::from_millis(20);
 
 /// Backoff between attempts to bring a sensor up, doubling to a cap.
 ///
@@ -184,6 +201,15 @@ async fn main() -> std::process::ExitCode {
     }
 }
 
+/// How long after one frame the sensor cannot yet have the next, at `hz`.
+///
+/// Saturating rather than clamped by hand: a rate whose period is shorter than
+/// [`POLL_GUARD`] leaves nothing to skip, and the loop then polls straight
+/// through exactly as it did before there was a guard.
+fn quiet_period(hz: u8) -> Duration {
+    Duration::from_secs_f64(1.0 / f64::from(hz.max(1))).saturating_sub(POLL_GUARD)
+}
+
 /// Bring the sensor up and stream from it, forever, with a backoff between
 /// attempts. Never returns until shutdown.
 fn sensor_loop(
@@ -198,6 +224,7 @@ fn sensor_loop(
     let mut seq = 0u64;
     let mut backoff = RETRY_MIN;
     let mut said = false;
+    let quiet = quiet_period(hz);
 
     while !shutdown.load(Ordering::Acquire) {
         match open_sensor(bus, address, hz) {
@@ -208,12 +235,31 @@ fn sensor_loop(
                 tracing::warn!(sensor = generation.as_str(), hz, "ranging");
                 status.up(generation.as_str());
 
+                // When the sensor could not possibly have a frame yet, so there
+                // is nothing to ask it until then — see [`POLL_GUARD`]. `None`
+                // before the first frame and after any poll that came up empty,
+                // both of which mean "as far as this loop knows, one is due
+                // now": the wait is only ever skipped forward by a frame that
+                // actually arrived.
+                let mut quiet_until: Option<Instant> = None;
+
                 // Stream until the sensor stops answering, then fall through to
                 // the backoff and try the whole bring-up again.
                 while !shutdown.load(Ordering::Acquire) {
+                    if let Some(until) = quiet_until.take() {
+                        // Through the sliced sleep rather than `thread::sleep`,
+                        // for the reason that helper exists: at 15 Hz this is
+                        // 47 ms and either would do, but `--hz 1` makes it most
+                        // of a second, and exit must not wait it out.
+                        sleep_unless_shutdown(
+                            until.saturating_duration_since(Instant::now()),
+                            shutdown,
+                        );
+                    }
                     match sensor.data_ready() {
                         Ok(true) => match sensor.read_frame() {
                             Ok(frame) => {
+                                quiet_until = Some(Instant::now() + quiet);
                                 seq += 1;
                                 // No subscribers is the normal state — nobody is
                                 // watching most of the time — so a send that
@@ -559,5 +605,45 @@ mod tests {
         }
         assert_eq!(backoff, RETRY_MAX);
         assert!(RETRY_MIN < RETRY_MAX);
+    }
+
+    /// **The saving, as arithmetic rather than as a claim in a comment.**
+    ///
+    /// At the shipped rate a frame used to cost seven `data_ready` reads to
+    /// find, six of them answered no. Widening [`POLL_GUARD`] until the quiet
+    /// stretch disappears would leave the loop correct and the reason for it
+    /// gone, which is exactly the change nothing else here would notice.
+    #[test]
+    fn a_frame_at_the_shipped_rate_costs_three_polls_instead_of_seven() {
+        let period = Duration::from_secs_f64(1.0 / 15.0);
+        let polls = |window: Duration| (window.as_secs_f64() / POLL.as_secs_f64()).ceil() as u32;
+
+        assert_eq!(polls(period), 7, "what polling the whole period cost");
+        // The guard's window, plus the poll that finds the frame at the end of it.
+        assert_eq!(polls(period - quiet_period(15)) + 1, 3);
+    }
+
+    /// The anchor is the last frame's arrival, so the guard only ever has to
+    /// absorb one period of drift. 20 ms of it at 15 Hz is a 30% period error —
+    /// far past anything a hardware ranging timer does.
+    #[test]
+    fn the_guard_tolerates_a_sensor_running_early() {
+        let period = Duration::from_secs_f64(1.0 / 15.0);
+        let slack = POLL_GUARD.as_secs_f64() / period.as_secs_f64();
+        assert!(slack > 0.25, "only {slack:.0}% of a period of margin");
+    }
+
+    /// A rate whose period is shorter than the guard has nothing to skip, and
+    /// must poll straight through rather than underflow into a long sleep.
+    #[test]
+    fn a_rate_faster_than_the_guard_polls_straight_through() {
+        assert_eq!(quiet_period(60), Duration::ZERO);
+        assert_eq!(quiet_period(u8::MAX), Duration::ZERO);
+    }
+
+    /// `--hz 0` is a division this must not do.
+    #[test]
+    fn a_zero_rate_is_treated_as_one_hertz() {
+        assert_eq!(quiet_period(0), Duration::from_secs(1) - POLL_GUARD);
     }
 }


### PR DESCRIPTION
A duck on a desk — no pad connected, no viewer, nothing driving it — still runs five daemons. Four of them were spending real work on that state.

| | idle before | idle after |
|---|---|---|
| `mediad` raw branch | 1.84 MB copied 30×/s | copied on request — ~2×/s |
| `tofd` frame poll | ~100 I²C reads/s | ~45 |
| `padd`, pad connected, sticks centred | 50–100 msg/s | 10 |
| `pet-detect`, when enabled | ~400 FFTs/s + 4 forward passes/s | none until the room makes a sound |

`docs/project/idle-cpu.md` has every figure and where it came from.

## The four

**`mediad` copied every frame.** The appsink callback copied each buffer off the tee into a slot readers took the latest of. At the shipped 720p30 a UYVY frame is 1.84 MB, and the readers are auto-exposure at 2 Hz plus the detector at 2 Hz when enabled — so twenty-eight of every thirty copies were made for nobody. A reader now asks and the callback answers the **next** frame; answering with the last one would put the reader's polling period into the measurement, and an exposure loop steering on half-second-old luma hunts rather than settles. `latest()`/`inspect()` are gone rather than kept beside the new pair, so there is no stale-read trap for the `get_frame` surface still to be written.

**`tofd` polled a 15 Hz sensor 100 times a second.** `data_ready` every 10 ms across the whole 66 ms between frames: seven I²C transactions to find one frame, six answered no. The loop now sits out the stretch in which the sensor cannot yet have one. Frame age is unchanged, still bounded by the 10 ms poll. The guard is two poll intervals and the anchor is each frame's *arrival*, so drift cannot accumulate past one period.

**`padd` re-sent the same three zeros fifty times a second.** Identical frames are held back and head mode's two intents share one write. A frame is only held back when it asks for **no motion** — that is what keeps this away from `[safety] deadman_ms`, a value `padd` cannot read: the deadman zeroes the twist and nothing else, so on a frame already commanding zero, letting it fire changes nothing, and on one commanding motion it would stop a robot whose stick is still held. A held stick still goes out every tick.

**The petting classifier ran through silence.** The ambient-sound watcher beside it already measures the room, so the classifier waits until something stands out from that floor — except while petting, where the End edge must be found by inference exactly as Start was. Off by default.

## Two candidates measured and left alone

**The 50 Hz bus write** is 0.075% of a core: a 94-byte sync-write against a bus at ~26% utilisation where the tick's own sync-read is four times larger. It is also the loop's one statement guaranteeing the servos have been told where to be, and making it conditional means enumerating every path that can invalidate a stored goal. Not worth it.

**The `#[tokio::main]` worker pools** are parked, not spinning — measured at 0.00 s of CPU over 20 s, same as `current_thread`. The difference is four stacks per daemon, memory rather than heat, and `current_thread` would cost something real in `updaterd`, which has synchronous file work on its async path.

Both are written up with the arithmetic so the next person to notice them finds the numbers instead of redoing them.

## State

`cargo test --workspace` green, `cargo board --bins` release cross-build clean, `fmt` and clippy clean, no new rustdoc warnings. 16 new tests; `padd` had none before.

**Nothing here has been run on a board.** Every figure is arithmetic on a packet layout or frame size, or a measurement on a laptop. The last section of `idle-cpu.md` lists what to run on hardware — the before/after CPU, idle SoC temperature, `tofd`'s guard against a real sensor clock, and that petting still starts as promptly in an ordinary room.