### PR TITLE
Remote access: a robot can belong to a Hugging Face account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -329,6 +329,26 @@ fn permits(call: &proto::Call) -> bool {
         // The transport is the gate here, not the credential.
         PolicyFetch(_) | PolicyInstall(_) => true,
 
+        // ── the account, which BLE is the right transport for ────────────────
+        //
+        // Signing the robot in to a Hugging Face account is what makes it reachable from outside
+        // the LAN at all, and this is the transport that should carry it — for the reason
+        // `remote-webrtc.md` §4 gives about BLE generally: it is PIN-bonded, and ten metres of
+        // radio range means whoever tapped the button is in the room with the robot.
+        //
+        // It also happens to be the *only* transport that can do it on a robot fresh out of a
+        // box. A duck with no wifi has no console to open and no LAN to open it from, and BLE is
+        // already how such a robot is given a network — so a wizard that joins the wifi and then
+        // signs the robot in is one flow on one transport, which is what the mini's app does.
+        //
+        // The code the flow produces has to be *read by a person*, so the reply carrying it is
+        // the point: this call sends about eighty bytes back, well inside what framing chunks,
+        // and needs no link at all while the user is off approving it — see
+        // `duck_ipc_proto::API_VERSION`'s v21 note on why `login` answers with a code and not
+        // with a token. That is what makes an iPhone dropping the GATT link mid-flow a
+        // non-event rather than a lost login.
+        AccountLogin(_) | AccountStatus | AccountLogout => true,
+
         // Power to the joints. A phone button that drops the robot on the floor is not one to
         // offer, and `robot.init` is its counterpart: standing a robot up moves every joint at once,
         // which wants the person doing it to be looking at the robot rather than at a screen. Both
@@ -457,6 +477,13 @@ mod tests {
                 // the download, the shape gate at load, the clamps, the fall reflex.
                 proto::method::POLICY_INSTALL,
                 proto::method::POLICY_FETCH,
+                // Binding the robot to a Hugging Face account, and unbinding it. Provisioning,
+                // like the two below it and for the same reason: a robot out of a box has no
+                // network, so it has no console and no LAN to open one from, and this is the
+                // transport that reaches it. Physical presence is not stretched either — the
+                // person approving the code is holding the phone that is bonded to the robot.
+                proto::method::ACCOUNT_LOGIN,
+                proto::method::ACCOUNT_LOGOUT,
                 proto::method::NET_CONNECT,
                 proto::method::NET_FORGET,
                 proto::method::SYSTEM_SET_NAME,

--- a/deploy/updater.toml
+++ b/deploy/updater.toml
@@ -59,6 +59,15 @@ auto_apply = "mandatory"
 # narrow the claim is: "btd may relay an update request from the app", not "anything in the
 # robot group may replace the firmware".
 #
+# `mediad` is listed for the mutating calls its route table permits: `account.login` and
+# `account.logout` — a console page is where somebody signs a robot in — and `policy.install` and
+# `policy.fetch`, which were routed to WebRTC without this line and therefore answered
+# PERMISSION_DENIED, so the console could offer a Hub browser whose install button could not work. The claim is exactly as narrow, and it is held narrow by
+# a test rather than by this comment: `mediad::route`'s
+# `only_these_mutating_calls_are_reachable_over_webrtc` names every mutating method that
+# transport may carry, so routing a new one has to change that list deliberately. Nothing here
+# grants `mediad` the update path — `update.apply` is refused on that side.
+#
 # By NAME, not by uid: systemd-sysusers allocates dynamically, so a number written here would
 # be right on one board and wrong on the next. `allow_uids`/`allow_gids` still exist for a
 # bench override, and a test asserts the shipped config uses neither.
@@ -67,7 +76,7 @@ auto_apply = "mandatory"
 # a process as far as *talking* to updaterd; granting it change authority too would collapse
 # the two layers into one, and anything that could read status could replace the firmware.
 # There is a test for that as well.
-allow_users = ["btd"]
+allow_users = ["btd", "mediad"]
 
 
 # ── daemon ────────────────────────────────────────────────────────────────────

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ own the mechanism is the bug.
 | [`app-path-design.md`](design/app-path-design.md) | `btd` and `configd` — how a phone configures a robot over BLE. |
 | [`remote-webrtc.md`](design/remote-webrtc.md) | WebRTC sessions, signalling, and the control channel — how a peer drives and observes the robot. |
 | [`webrtc-console.md`](design/webrtc-console.md) | The WebRTC client: serving it from the robot, finding the robot, and what the page should be. |
+| [`remote-access-design.md`](design/remote-access-design.md) | Reaching a duck from outside the LAN: the Hugging Face account, the device flow, and the bridge to a rendezvous service. |
 | [`boot-recovery-net.md`](design/boot-recovery-net.md) | Falling back to golden when the release that booted cannot start its daemons. |
 
 ## `project/` — you are running the project

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -7,24 +7,31 @@ shape — a bridge from a rendezvous service to the signalling server already ru
 and it is right about the shape. This page owns the two things that shape needs and does not have:
 a **credential that names an account**, and a **service to present it to**.
 
-**Nothing here is built.** What is *established*, by probing the live services rather than by
-reading about them:
+**Built so far** (2026-09-02): §2 — the account. `account.login`, `account.status` and
+`account.logout` are served by `updaterd` and reachable locally, over BLE and over a WebRTC
+datachannel; `robotctl account login` prints a code and waits, `duckctl account login` prints one
+and hangs up. The credential lands in `/etc/robot/hf-token` and renews itself. Nothing consumes it
+yet — that is §3, and it is the next slice.
 
-- **Hugging Face implements the OAuth device grant.** Its discovery document advertises
-  `device_authorization_endpoint: https://huggingface.co/oauth/device` and
-  `urn:ietf:params:oauth:grant-type:device_code` among `grant_types_supported`. A full round trip
-  short of the user's click works today: the endpoint returns a `user_code`, a `verification_uri` of
-  `https://hf.co/oauth/device` and `expires_in: 300`, and polling `/oauth/token` answers
-  `authorization_pending`. §2.2 has the transcript.
-- **The client has to be public.** The device endpoint refuses the `reachy_mini` client id
-  (`71146982-…`) with `invalid_client`: "if you want to use the device code flow without client
-  secret authentication, delete the secret from the oauth app to make it public". §2.3.
-- **The `reachy_mini` rendezvous Space is live and gated.** `pollen-robotics-reachy-mini-central.hf.space`
-  serves a status dashboard anonymously; `/events` and `/api/robot-status` answer **401** without a
-  token. Its *repository* is private, so nobody here can read the server. §4.
-- **Its wire is not the gst signalling protocol on a WebSocket.** It is the same JSON envelopes over
-  **HTTP** — SSE inbound, `POST` outbound — with per-hop peer and session ids. This corrects a claim
-  in `remote-webrtc.md` §7; §3.2 says what it costs.
+What is **established** about the services this depends on, by probing them rather than by reading
+about them:
+
+- **Hugging Face implements the OAuth device grant**, and `huggingface_hub` ships a **first-party
+  public client** for it (`DEVICE_CODE_OAUTH_CLIENT_ID`), so this needs no OAuth app registered
+  anywhere. §2.3.
+- **A token lasts 30 days**, comes with a refresh token, and **that refresh token rotates on every
+  refresh**. §2.7 is what that costs.
+- **The token carries every scope Hugging Face grants** — `write-repos`, `manage-repos`, `jobs`,
+  `read-billing` — because the first-party client takes no `scope` parameter. §2.4, and it is the
+  one thing here that should change before a duck ships.
+- **`/oauth/userinfo` answers with the identity in one round trip**, so nothing decodes a JWT.
+- **The `reachy_mini` rendezvous Space is live and gated.**
+  `pollen-robotics-reachy-mini-central.hf.space` serves a status dashboard anonymously; `/events`
+  and `/api/robot-status` answer **401** without a token. Its *repository* is private, so nobody
+  here can read the server. §4.
+- **Its wire is not the gst signalling protocol on a WebSocket.** It is the same JSON envelopes
+  over **HTTP** — SSE inbound, `POST` outbound — with per-hop peer and session ids. This corrects
+  a claim in `remote-webrtc.md` §7; §3.2 says what it costs.
 
 ## 1. What has to be true for a duck to be reachable
 
@@ -45,11 +52,16 @@ service too was made the other way for this reason, and §3.1 is where it costs 
 
 ## 2. The account is an OAuth device flow against Hugging Face
 
-### 2.1 Why the device grant, and not the flow `reachy_mini` runs
+### 2.1 Why the device grant, which is also where `reachy_mini` ended up
 
-`reachy_mini` uses authorization code + PKCE with the redirect URI pointed back at the robot's own
-HTTP server: `http://reachy-mini.local:8000/api/hf-auth/oauth/callback`, or `localhost` for the
-tethered variant (`apps/sources/hf_auth.py`). It works, and three costs come with it:
+`reachy_mini` has **both**. It started with authorization code + PKCE, pointing the redirect URI
+back at the robot's own HTTP server — `http://reachy-mini.local:8000/api/hf-auth/oauth/callback`,
+or `localhost` for the tethered variant — and added a device-code flow later, described in its own
+source as "refresh-capable, redirect-free login", which is what its mobile app's setup wizard uses
+now. Its reasons are the two below. Worth knowing that this is not a difference of opinion: it is
+the same conclusion reached twice, from different directions.
+
+Three costs come with the redirect flow:
 
 - **A registered redirect URI per hostname.** The app has exactly one, which is why the mobile app
   carries a loopback HTTP bridge that catches HF's callback on `127.0.0.1:8000` and rewrites it as a
@@ -64,72 +76,129 @@ tethered variant (`apps/sources/hf_auth.py`). It works, and three costs come wit
 The device grant inverts that: the robot asks HF for a code, says *"open hf.co/oauth/device and type
 M8HJ-FMGN"*, and polls until somebody has. No redirect URI, no hostname, no requirement that the
 authorising device can reach the robot at all — a phone on cellular is fine. It is the flow specified
-for a device with no browser and no keyboard, which is what a duck is.
+for a device with no browser and no keyboard, which is what a duck is. It is also the only one of the
+two that yields a **refresh token**, which is what keeps a robot reachable past its first month
+(§2.7).
 
 The cost, stated plainly: somebody types eight characters. That is the whole of it, and it is smaller
 than the mDNS dependency it removes.
 
-### 2.2 The flow, and the transcript that proves it
+**Three invariants inherited from `reachy_mini`'s wizard**, none of which is about Python and all of
+which were learned the expensive way:
+
+- **Lead with the code, and never open a browser by yourself.** HF sends no
+  `verification_uri_complete` and its device page asks the user to *type* the code — auto-switching
+  to Safari hid the code before anyone could read it. Offer "copy the code and open Hugging Face" as
+  one action and keep the code on screen. `robotctl account login` prints the code on its own line
+  and nothing else; `duckctl` prints it after the reply.
+- **The client going away mid-flow is expected, not an error.** Opening the HF page backgrounds a
+  phone app, and iOS then tears the GATT link down. By that point the transport has done its job:
+  the daemon is polling and the client comes back to `status`. This is why `login` answers with a
+  code rather than a token, and it is the property `robotctl`'s wait loop is careful to not be
+  load-bearing for.
+- **Appearing on the rendezvous is the only real success signal.** A stored token means the *login*
+  worked, not that the robot is reachable — their wizard treats "a robot with my hardware id is in
+  the listing" as done and everything else as recoverable. §3 has to make that check available
+  here, and `account.status` reporting relay state is where it will go.
+
+### 2.2 The flow, and the transcript it was built from
 
 ```
 POST https://huggingface.co/oauth/device
-     client_id=<duck client>&scope=openid profile
+     client_id=26be6b09-91c5-47da-9861-d2d2bb7a7e36
 
-  → {"device_code":"96e6e116-…","user_code":"M8HJ-FMGN",
+  → {"device_code":"41ad39ae-…","user_code":"A6MY-0314",
      "verification_uri":"https://hf.co/oauth/device","expires_in":300}
 
 POST https://huggingface.co/oauth/token
      grant_type=urn:ietf:params:oauth:grant-type:device_code
-     &client_id=<duck client>&device_code=96e6e116-…
+     &client_id=26be6b09-…&device_code=41ad39ae-…
 
-  → HTTP 400 {"error":"authorization_pending", …}   until the user approves
+  → HTTP 400 {"error":"authorization_pending"}      until somebody approves it
+  → {"access_token":"…","refresh_token":"…","expires_in":2591999,
+     "token_type":"bearer","id_token":"…","scope":"manage-repos write-repos …"}
+
+GET  https://huggingface.co/oauth/userinfo   Authorization: Bearer <access token>
+  → {"name":"Rouanet","preferred_username":"PierreRouanet","orgs":[…], …}
 ```
 
-Three details the response fixes, and each is a decision we do not have to make:
+No `scope` is sent, because the first-party client does not take one (§2.4). Five things this
+answers, each of which is a decision nobody has to make now:
 
-- **No `verification_uri_complete`.** There is no QR-able URL that carries the code, so the code has
-  to be *read by a person* — which means displaying it is the **client's** job, not the daemon's
-  (§2.6). A robot with no screen cannot show it.
-- **No `interval`.** RFC 8628's default of 5 s applies, and `slow_down` has to be honoured if it ever
-  arrives.
-- **`expires_in: 300`.** Five minutes, which is short enough that the client must show a countdown
-  and long enough that nobody hurries.
+- **No `verification_uri_complete`.** There is no URL carrying the code, so the code has to be
+  *read by a person* — which makes displaying it the **client's** job, not the daemon's. The
+  `?user_code=` variant is synthesised on the robot the way `huggingface_hub` does it, for a
+  client that wants one copy-and-open button, and §2.1's first invariant says lead with the code
+  anyway.
+- **No `interval`.** RFC 8628's five seconds applies, and `slow_down` adds five more.
+- **`expires_in: 300`** on the *code*. Five minutes: long enough not to hurry, short enough that a
+  client should show what is left, which is why `account.status` counts it down rather than
+  repeating the original number.
+- **`expires_in: 2591999`** on the *token*, with a `refresh_token`. §2.7.
+- **`/oauth/userinfo` gives the identity in one round trip** — `preferred_username` is the handle
+  and `name` is a display name that can be anything, so the handle is what is stored and shown.
+  The alternative was decoding the `id_token`, which is a JWT parser and a JWKS fetch for the same
+  string.
 
-### 2.3 The OAuth client is a decision — **open**
+### 2.3 The OAuth client is Hugging Face's own — **closed**
 
-Three ways to get a `client_id`, and only one of them is a good idea:
+`huggingface_hub` ships a **first-party public device-code client**, `DEVICE_CODE_OAUTH_CLIENT_ID`
+= `26be6b09-91c5-47da-9861-d2d2bb7a7e36`, which is what `hf auth login` uses. It is public — no
+secret, so nothing needs baking into a release beyond a public identifier — and it needs no OAuth
+app registered anywhere. `updater::account::CLIENT_ID` is that constant, and it is the whole of
+what this decision came to.
 
-- **Register one public app in the `pollen-robotics` org, no secret, device grant enabled.** One
-  stable id baked into the release, revocable in one place, and the only thing on the robot is a
-  public identifier. **Recommended.** It needs somebody with org admin to create it and hand back
-  the id; that is the one thing in this page nobody here can do.
-- **Reuse `reachy_mini`'s `71146982-…`.** Blocked, not merely inelegant: it is a confidential client,
-  so the device endpoint demands Basic auth with its secret. Baking that secret into every duck's
-  release makes it not a secret, and deleting it from the app to make it public would change the
-  security posture of the mini's flow to suit ours.
-- **Dynamic registration.** `POST https://huggingface.co/oauth/register` is unauthenticated and
-  honours `token_endpoint_auth_method: "none"`, so a robot could mint its own public client at first
-  login with no admin involvement at all. It works — that is how the transcript above was obtained.
-  Rejected as the plan: a client per robot (or per release) is a fleet of identities nobody can
-  enumerate or revoke, and it looks like abuse at scale. Worth knowing as the escape hatch if the org
-  route is slow, since it means the design is not *blocked* on an admin.
+Two alternatives, recorded because the first one looks obvious and is blocked:
 
-### 2.4 Scopes: `openid profile read-repos`, and deliberately not more
+- **`reachy_mini`'s own app** (`71146982-…`) is a **confidential** client, so the device endpoint
+  refuses it — *"if you want to use the device code flow without client secret authentication,
+  delete the secret from the oauth app to make it public"*. Baking that secret into every duck
+  makes it not a secret, and making the app public would change the mini's posture to suit us.
+- **Dynamic registration.** `POST /oauth/register` is unauthenticated and honours
+  `token_endpoint_auth_method: "none"`, so a robot could mint its own public client at first login.
+  It works. Pointless now, and a client per robot would be a fleet of identities nobody can
+  enumerate or revoke.
 
-The rendezvous needs to know *who* the token belongs to, which is `openid profile`. `read-repos` is
-one scope further and buys something real: `policy install` reaching a **private** policy repo, from
-the same token file, with no new mechanism (`policy-channel-design.md` §7).
+### 2.4 The scopes are not ours to choose, and that is the thing to fix before shipping
 
-`reachy_mini` asks for `openid profile read-repos write-repos manage-repos inference-api`, because
-its robot installs apps and pushes artifacts. **Do not copy that list.** A duck holds this token
-unattended, on a board that can be lost or given away; a credential that can *push* to the owner's
-repositories is a much worse thing to lose than one that can read them. If a future feature needs to
-write, it is a scope change with a re-login, which is a day's work — where a robot that has been able
-to write all along is not recoverable.
+The first-party client takes **no `scope` parameter**, and the token it issues carries everything
+Hugging Face grants:
+
+```
+manage-repos write-repos read-repos gated-repos contribute-repos write-collections
+read-collections openid write-discussions inference-api jobs webhooks read-billing read-mcp
+```
+
+A duck therefore holds a credential that can **push to its owner's repositories, start Jobs and
+read their billing** — for something whose entire purpose is proving an identity to a rendezvous
+service. Every Reachy Mini in the field is in the same position; that is context, not a defence.
+
+What the account actually needs is `openid profile`, plus `read-repos` for one real thing:
+`policy.install` reaching a **private** policy repo from the same token file, with no new
+mechanism (`policy-channel-design.md` §7).
+
+**So the narrow version is a Pollen-owned public device-code client with
+`openid profile read-repos`** — one constant in `account.rs` and one click by somebody with HF org
+admin. It is not blocking: the flow works today and a scope change is a re-login. It is worth
+doing before a duck goes home with anybody, because the failure mode is asymmetric — a robot that
+has been able to write all along cannot be un-done, while a robot that needs a wider scope later
+just asks for one.
 
 ### 2.5 Where the token lives, and who writes it
 
-`/etc/robot/hf-token`, `root:robot`, `0640`.
+`/etc/robot/hf-token`, `root:robot`, `0640`. JSON: the access token, the refresh token, an
+absolute `expires_at` (the response gives a duration, and a duration means nothing after a reboot)
+and the username, so `account.status` answers with no network at all — a robot that is offline
+still knows who it belongs to.
+
+**Written `0600` and relaxed to `0640` after the group is set**, rather than through
+`fsutil::write_atomic` like everything else this daemon writes. That helper does not set a mode,
+and a token that lands `0644` and is chmodded a moment later is world-readable for that moment —
+the kind of window that is invisible in testing and permanent in a `ps`-and-`cat` afterwards.
+`account::write_private` is the same rename dance with the temp file opened `0600` from the start,
+and a test asserts the landed file gives "others" nothing. On a board with no `robot` group — a
+developer's laptop, a half-provisioned board — it stays root-only and says so once, rather than
+guessing.
 
 **Not in `robotd.toml`.** Every mechanism that exists for that file is wrong for a secret:
 `robotctl configure --list` prints what a robot changes, `policy-channel-design.md`'s full-screen
@@ -143,43 +212,88 @@ behalf, already runs as `root`, and already has a namespace of calls that write 
 daemon that answers `system.info` would be a new kind of thing for it. `mediad` must not own it: it
 runs as `User=mediad` under `ProtectHome=yes`, and it is the process a remote peer talks to.
 
-**`mediad` reads it** — on each connect attempt, plus a slow poll (30 s) while it has none, which is
-also its `waiting for token` state. No cross-daemon notification: `reachy_mini` has a
+**`mediad` will read it** — on each connect attempt, plus a slow poll (30 s) while it has none,
+which is also its `waiting for token` state. Not built: nothing consumes the credential until §3
+exists. No cross-daemon notification: `reachy_mini` has a
 `notify_token_change` call from its auth router into its relay, and re-reading the file on the
 reconnect that is going to happen anyway makes it unnecessary. The cost is that a fresh login takes
 up to a poll interval to become a live producer, which nobody can perceive.
 
 ### 2.6 The calls, and which transports may reach them
 
-`account.login`, `account.status`, `account.logout` on `updaterd`. `login` starts the flow and returns
-`verification_uri`, `user_code` and `expires_in`; progress is a notification, the way `update.*`
-already pushes progress, so a client that reconnects can resubscribe (`duck-ipc-proto`'s rule).
+`account.login`, `account.status` and `account.logout`, on `updaterd` — for `policy.*`'s reasons
+exactly: it is the daemon with a network stack, `robotctl` must not link one (it is on the
+recovery path), and the credential it stores is also what would reach a private Hub repo, which is
+already this daemon's job. `configd` owns *config*, not credentials, and has no HTTP client.
+`mediad` must not own it: it runs unprivileged under `ProtectHome=yes`, and it is the process a
+remote peer talks to.
 
-**`account.login` is the highest-authority call on the robot, and it is worth saying why.** Whoever
-completes it binds the robot to *their* Hugging Face account and thereby gets remote access to its
-camera and its control channel from anywhere. Nothing else in the API hands the robot to a stranger;
-`robot.shutdown` merely stops it.
+**`login` answers with a code and hands the waiting to the daemon.** There is no progress
+notification and no long-held connection; a client polls `status`. That is not a simplification,
+it is the requirement — see §2.1's second invariant.
 
-So it is **local and BLE only, refused over WebRTC** — the same table `route.rs` already keeps, with
-the same reasoning `system.setPairingPin` is refused by: BLE is the authenticated transport, and ten
-metres of radio means whoever ran it is in the room (`remote-webrtc.md` §4). `account.status` is safe
-everywhere and useful everywhere — a client wants to say "signed in as *someone*, relay connected".
-`account.logout` moves the same boundary as `login` and goes with it.
+**All three are routed to all three transports**: local, BLE and a WebRTC datachannel. BLE matters
+most and is the easy call — it is the only transport that reaches a robot fresh out of a box,
+which has no network, hence no console and no LAN to open one from, and it is where a setup wizard
+already lives. Locally it is `robotctl`, which is how a developer does anything.
 
-### 2.7 Whether the token expires is the one unknown that matters — **open**
+**WebRTC is the one worth arguing about, and it is worth writing down rather than assuming.** The
+console is the obvious place to put a "sign in" button — a page with the robot already on screen
+— and the alternative is ssh or a phone. Against that: this is the one call on that transport
+whose effect is **durable in a way nothing else there is**. Everything else a LAN peer may do is
+bounded by the session; `account.login` converts *having been on the wifi once* into remote access
+that outlives being there. §4 of `remote-webrtc.md` accepts that anyone on the network has the
+robot and its camera. It did not consider anyone on the network having them from another continent
+next month.
 
-HF advertises `refresh_token` in `grant_types_supported`, and what the token response actually carries
-— `expires_in`, `refresh_token`, or neither — cannot be known without one real authorization, which
-needs a human click. It decides a real piece of work:
+Three things make that acceptable rather than merely permitted:
 
-- **No expiry** → store the access token, and §2.5 is finished.
-- **Expiry** → store the refresh token too, refresh ahead of time, and handle a refresh that fails as
-  "signed out" rather than as an error nobody sees. That is a scheduler and a second secret.
+- **A robot that already belongs to somebody refuses.** `account.login` without `force` answers
+  `INVALID_PARAMS` naming the account, so a LAN peer cannot silently take a robot from its owner —
+  it has to say so, and a well-behaved client has to ask a person first.
+- **It is visible.** `account.status` names the account, from any transport, with no
+  authorisation at all. "Which account does this robot belong to" is a question anybody can ask.
+- **It is revocable** — `account.logout` from anywhere, and revoking the grant on Hugging Face,
+  which no robot-side gate could offer.
 
-`reachy_mini` stores only the access token, at `~/.cache/huggingface/token`, and its robots stay
-reachable — evidence that long-lived tokens are at least possible, not proof about the device grant's.
-**Answer this before writing §2.5's storage**, because "one string in a file" and "two strings plus a
-clock" are different designs and the cheap one is only correct if the answer is no.
+**One consequence that lives in another file, and it found a bug.** `account.login` and
+`account.logout` are `Call::is_mutating`, which is what `updaterd` authorises against a peer's
+uid, so `mediad` had to be added to `allow_users` in `deploy/updater.toml` alongside `btd`. That
+grants `mediad` exactly what its route table permits and nothing more — but the two files now have
+to agree, so `mediad::route`'s `only_these_mutating_calls_are_reachable_over_webrtc` names every
+mutating method that transport may carry, and routing a new one has to change that list on
+purpose. `btd` has had the same test since BLE could apply an update.
+
+Writing it down immediately turned up two methods nobody had noticed were broken:
+**`policy.install` and `policy.fetch` were routed to WebRTC while `mediad` was not in
+`allow_users`**, so `updaterd` answered them `PERMISSION_DENIED` — the console could offer a Hub
+browser whose install button could not work. The `allow_users` line added here for the account
+fixes them too. That is the argument for a named list over a counted one: the list is where a
+transport's authority and a config file's grants are forced to agree out loud.
+
+### 2.7 The token expires in 30 days, and the refresh token rotates — **closed**
+
+A device-code token comes back as `expires_in: 2591999` — thirty days — with a `refresh_token`,
+and refreshing **rotates** it: the answer carries a *new* refresh token and the old one is spent.
+So the store is two strings plus a clock, and there are three consequences worth naming.
+
+**A robot that is simply left on must renew itself.** `updater::account::maintain` wakes every six
+hours and refreshes anything with under a week left — three-quarters of the way through the
+token's life, leaving a week of retries for a board whose network is marginal. It is spawned
+unconditionally, unlike the update scheduler, because a robot with update checks switched off
+still has an account that stops working after a month.
+
+**Rotation leaves one window that cannot be closed.** Between "Hugging Face issued a new pair" and
+"the new pair is on disk", the old refresh token is already dead. A power cut in that window
+leaves a robot holding a credential HF will not renew. No write ordering fixes it — the rotation
+happened on their side — so it is handled rather than prevented: the write is atomic (a reader
+sees the old pair or the new one, never half of one), the failure surfaces in
+`account.status`'s `last_error`, and the fix is signing in again. Renewing a week early is what
+makes that a nuisance rather than an outage.
+
+**A robot switched off for more than thirty days comes back needing a login**, and no margin can
+save it. `account.token_expires_in` goes negative, which is how a client says so rather than
+leaving somebody to discover it when the robot fails to appear.
 
 ## 3. The bridge
 
@@ -279,29 +393,31 @@ service authenticated both ends, and after this page that argument gets *stronge
 has proved account ownership, where a LAN peer has proved only that it is on the wifi. The robot can
 tell them apart by source address (§7 notes it), and nothing yet acts on the difference. Keep it true.
 
-## 4. Which rendezvous — **open**
+## 4. The rendezvous is the one `reachy_mini` uses — **decided**
 
-`pollen-robotics-reachy-mini-central.hf.space` is live, and what a robot needs from it is small:
-`GET /events` (SSE, Bearer), `POST /send` (Bearer), `GET /api/robot-status`. Its `meta` is free-form,
-so a duck registers with whatever identifies it — `producer.rs` already assembles exactly the fields a
-listing wants (name, serial, release, `api_version`), which is what `webrtc-console.md` §5 predicted
-the rendezvous would need.
+`pollen-robotics-reachy-mini-central.hf.space`, the Space the mini's fleet already registers
+with. Decided rather than derived: it costs no backend work, it is proven under real robots, and
+the whole of this page becomes a client-side project.
 
-**Reusing it** costs no backend work, is proven under a fleet of real robots, and makes the whole of
-this page a client-side project. Against that: we do not own its deploys, its lease and session
-gating were written around a robot with a different lock model, a duck appears in whatever lists a
-user's robots (a feature or a bug depending on intent), and **its repository is private** — so nobody
-on this side can read the server they depend on, which is how §3.2's protocol surprise happened at all.
+What a robot needs from it is small: `GET /events` (SSE, `Authorization: Bearer <hf token>`),
+`POST /send` (same), and `GET /api/robot-status` to ask whether it is still listed. Its `meta` is
+free-form, so a duck registers with whatever identifies it — and `producer.rs` already assembles
+exactly the fields a listing wants (name, serial, release, `api_version`), which is what
+`webrtc-console.md` §5 predicted the rendezvous would need. A `kind` of `microduck` goes in the
+same structure, so a client that lists a user's robots can tell a duck from a mini without
+opening a session.
 
-**Our own instance** is a Space and a couple of hundred lines: we own the lease policy, the eviction
-sweeper and the deploy schedule, and the duck's identity model is ours. Against that: a second service
-to run and watch, duplicating something that exists and works.
+Three things follow from reusing it, and they are costs rather than objections:
 
-**Recommendation: reuse for the first proof, and decide on the answer to §5.** The service URL is one
-config key — `reachy_mini` keeps it in an env var for exactly this reason — so moving later costs a
-line. What actually couples us is not the relay, it is the client: if the client is a page we publish,
-the service stays a rendezvous and reuse is nearly free; if the client is somebody else's app, we are
-inside their product and should own neither the Space nor the decision alone.
+- **We do not own its deploys.** A change there can break remote access on ducks, and nobody here
+  would have reviewed it. The mitigation is that the URL is one constant — `reachy_mini` keeps it
+  in an env var for this reason — so moving to our own instance is a line, not a project.
+- **Its repository is private**, so nobody on this side can read the server they depend on. That
+  is how §3.2's protocol surprise came to be a surprise at all: the wire had to be reverse-read
+  from the client. Read access would be worth having even with the decision made.
+- **Its lease, eviction and session gating were written around a robot with a different lock
+  model** — `RobotAppLock`, local app versus remote session. A duck has no app, so §3.4 takes its
+  reconnect behaviour and leaves that part.
 
 ## 5. The client, and where it is served — **open**
 
@@ -350,22 +466,30 @@ that argument; it adds the one thing §4 could not name, which is **when the bin
 performs it**:
 
 - Before `account.login`, a duck is unreachable from outside the LAN. There is nothing to attack.
-- After it, one account owns it, and `account.login`/`account.logout` are the calls that can move that
-  ownership — hence BLE-and-local only (§2.6). A remote peer that could re-bind the robot to its own
-  account would be the one call able to take the robot away from its owner.
+- After it, one account owns it, and `account.login`/`account.logout` are the calls that can move
+  that ownership. They are routed to every transport, including WebRTC, and §2.6 is the argument
+  for that plus the three properties that make it hold — a robot already signed in refuses, the
+  binding is readable by anybody, and it is revocable from more places than the robot.
+- **A remote peer re-binding the robot is a narrower risk than it looks**, and it is worth being
+  precise about why: only clients of the account the robot *currently* belongs to can reach it
+  remotely at all, so a remote `account.login` is the owner's own client. The exposure that is
+  real is the LAN one, and that is what `force` exists for.
 - A robot that changes hands must be logged out. That is the same list as the pairing PIN and the
   calibration — a hand-over process, in M6 — and this is one more item on it, worth adding while the
   list is still being written rather than after a second-hand duck streams to a stranger.
 - The token is a bearer credential in a file, so a stolen board yields it. The answer is §2.4's
-  read-only scopes, not encryption: a robot has to read this file unattended at boot, so anything it
-  can decrypt without a human is something the thief can decrypt too.
+  read-only scopes, not encryption: a robot has to read this file unattended at boot, so anything
+  it can decrypt without a human is something the thief can decrypt too. Which is the sharpest
+  argument for narrowing the scopes — as it stands, a stolen duck yields a token that can write to
+  its owner's repositories.
 
 ## 8. Order of work
 
 Five slices, and the first two are independently useful and need no client:
 
-1. **`account login`** — the device flow, the token file, `account status`. `updaterd`. Verifiable on
-   its own: it prints the Hugging Face username. Answers §2.7 the moment it first succeeds.
+1. **`account login`** — the device flow, the token file, `account status`. `updaterd`. **Done**:
+   three calls, three transports, two CLIs, and a token that renews itself. Verifiable on its own,
+   which is what made it the first slice: it prints the Hugging Face username.
 2. **The relay, registering only** — producer registration, the negotiated heartbeat, reconnect and
    backoff, the split-brain poll. `mediad`. Verifiable with no client at all: the service's dashboard
    counts a producer and `/api/robot-status` lists the duck.
@@ -378,10 +502,13 @@ Five slices, and the first two are independently useful and need no client:
 
 | | needs |
 |---|---|
-| §2.3 the OAuth client id | one public app in the `pollen-robotics` HF org, no secret, device grant — created by somebody with org admin |
-| §2.7 token expiry | one real authorization, then read the token response. A click |
-| §4 which rendezvous | read access to the Space's repository, **or** the decision to stand up our own |
-| §5 where the client is served | follows §4, and is the decision that actually couples us to a service |
+| §2.4 the scope breadth | one public device-code client in the `pollen-robotics` HF org with `openid profile read-repos`, created by somebody with org admin. Not blocking — a scope change is a re-login — and it should not ship without it |
+| §4 read access to the Space | the rendezvous is decided; its source is a private repo, and depending on a server nobody here can read is how §3.2 happened |
+| §5 where the client is served | follows the shape of §3, and is the decision that actually couples us to a service |
+
+Closed since this page was written: the OAuth client (§2.3 — Hugging Face ships one), whether the
+token expires (§2.7 — thirty days, with a rotating refresh token), and which rendezvous to use
+(§4 — the mini's).
 
 ## 10. Not doing
 

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -272,6 +272,16 @@ Three things make that acceptable rather than merely permitted:
 - **It is revocable** — `account.logout` from anywhere, and revoking the grant on Hugging Face,
   which no robot-side gate could offer.
 
+  Worth being exact about the first one, because it is weaker than it sounds: **`logout` deletes
+  the robot's copy and revokes nothing.** The robot stops being a producer, which is the effect
+  somebody signing out is after — but the access token it held stays valid at Hugging Face until
+  it expires, up to thirty days, for anything that already read the file. The credential is
+  `0640 root:robot`, so "anything" means root or `mediad` on that board; a stolen board is the
+  case that matters, and for that the answer is the account's connected-apps page on hf.co, not a
+  call here. Sending a revocation from the robot is a candidate for §9 and deliberately not in
+  this slice: it needs the endpoint checked against the first-party client rather than assumed,
+  and a `logout` that failed because the network was down must still forget the token locally.
+
 **One consequence that lives in another file, and it found a bug.** `account.login` and
 `account.logout` are `Call::is_mutating`, which is what `updaterd` authorises against a peer's
 uid, so `mediad` had to be added to `allow_users` in `deploy/updater.toml` alongside `btd`. That
@@ -568,6 +578,7 @@ Five slices, and the first two are independently useful and need no client:
 |---|---|
 | §2.4 the scope breadth | one public device-code client in the `pollen-robotics` HF org with `openid profile read-repos`, created by somebody with org admin. Not blocking — a scope change is a re-login — and it should not ship without it |
 | §5 where the client is served | follows the shape of §3, and is the decision that actually couples us to a service |
+| §2.6 `logout` revokes nothing | whether Hugging Face accepts a revocation for the first-party device-code client, checked rather than assumed. Not blocking — signing out stops the robot being reachable, and a stolen board is answered on hf.co — but it is the difference between "forgotten" and "revoked" |
 
 Closed since this page was written: the OAuth client (§2.3 — Hugging Face ships one), whether the
 token expires (§2.7 — thirty days, with a rotating refresh token), which rendezvous to use (§4 —

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -85,11 +85,24 @@ than the mDNS dependency it removes.
 **Three invariants inherited from `reachy_mini`'s wizard**, none of which is about Python and all of
 which were learned the expensive way:
 
-- **Lead with the code, and never open a browser by yourself.** HF sends no
-  `verification_uri_complete` and its device page asks the user to *type* the code — auto-switching
-  to Safari hid the code before anyone could read it. Offer "copy the code and open Hugging Face" as
-  one action and keep the code on screen. `robotctl account login` prints the code on its own line
-  and nothing else; `duckctl` prints it after the reply.
+- **Lead with the code. Whether to open a browser is a property of the surface, not a rule.** The
+  mini's app learned that auto-switching to Safari hid the code before anyone could read it — but
+  that is a *phone*: the browser replaces the only screen and backgrounds the app, so the code is
+  gone. A terminal keeps it in the scrollback, and the same reasoning gives three different
+  answers here:
+
+  - `robotctl account login` opens nothing, because it runs **on the robot**, which has no
+    display. It prints the code and waits.
+  - `duckctl account login` prints the code and *then* opens the page, because it runs on your
+    own machine — where `duckctl open` already launches a browser. `--no-open` suppresses it, and
+    so does stderr not being a terminal, because a script that opens a browser window on whoever
+    runs it is a surprise. A browser that will not launch is a warning appended to the code, never
+    an error replacing it.
+  - A phone app keeps the mini's rule as written, for the mini's reason.
+
+  What makes opening worth anything is `verification_uri_complete`: HF sends none, so the robot
+  synthesises the `?user_code=` form, and Hugging Face preserves that parameter across its own
+  login redirect — so the code is filled in even for a browser that was not signed in yet.
 - **The client going away mid-flow is expected, not an error.** Opening the HF page backgrounds a
   phone app, and iOS then tears the GATT link down. By that point the transport has done its job:
   the daemon is polling and the client comes back to `status`. This is why `login` answers with a

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -171,6 +171,20 @@ progress" is what `BUSY` says elsewhere and it would send that person looking in
 `account.status` carries the code, so a client that lost track of one rejoins it rather than
 starting another.
 
+**A refusal has to name a way through it, and `force` is that way here too.** A code nobody is
+going to approve — the usual case, somebody started a login and walked off — otherwise holds the
+robot for five minutes, and the only remedy was `logout`, which destroys a working credential to
+clear a pending one. `force` already means "replace what this robot belongs to"; replacing an
+*attempt* at it is the same permission in a smaller size.
+
+**What that costs is that an abandoned flow is still holding a live device code**, and Hugging
+Face will approve it if somebody gets round to it. The flow lives in a task that outlives the call
+which started it, so this is equally true of `logout`: sign a robot out with a code in the air and
+an approval a minute later would sign it back in on its own. Each flow therefore carries the
+generation it was started with and checks that it is still the current one — before the store is
+touched and again after, because the write awaits — so a superseded login keeps its code and
+drops its answer. That is also what makes `logout` able to promise what it says.
+
 ### 2.3 The OAuth client is Hugging Face's own — **closed**
 
 `huggingface_hub` ships a **first-party public device-code client**, `DEVICE_CODE_OAUTH_CLIENT_ID`

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -156,6 +156,19 @@ answers, each of which is a decision nobody has to make now:
   The alternative was decoding the `id_token`, which is a JWT parser and a JWKS fetch for the same
   string.
 
+  **It is the last call and the least important one, so it cannot be allowed to fail the login.**
+  By the time it runs, somebody has typed a code into a phone; discarding the token because a
+  proxy answered 502 would make them do the whole flow again for a label. So the record is stored
+  with no name, `account.status` answers `unknown` rather than "signed out", and the next
+  `maintain` pass fills it in — the network that failed is the one this board is expected to have.
+
+**One login at a time, and the guard covers the round trip rather than the check before it.** Two
+callers arriving together — a console page and a phone, which is a normal thing to happen during
+setup — would otherwise both be handed a code, and the store would keep whichever approval landed
+last while somebody read the other code and watched it do nothing. The second caller gets
+`BUSY` while the first is in flight; `account.status` carries the code, so a client that lost
+track of one rejoins it rather than starting another.
+
 ### 2.3 The OAuth client is Hugging Face's own — **closed**
 
 `huggingface_hub` ships a **first-party public device-code client**, `DEVICE_CODE_OAUTH_CLIENT_ID`

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -1,0 +1,396 @@
+# Remote access — an account, and a rendezvous behind it
+
+Status: draft · Date: 2026-09-02 · Owner: pierre
+
+How a duck is reached from outside the LAN. [`remote-webrtc.md`](remote-webrtc.md) §7 states the
+shape — a bridge from a rendezvous service to the signalling server already running on the robot —
+and it is right about the shape. This page owns the two things that shape needs and does not have:
+a **credential that names an account**, and a **service to present it to**.
+
+**Nothing here is built.** What is *established*, by probing the live services rather than by
+reading about them:
+
+- **Hugging Face implements the OAuth device grant.** Its discovery document advertises
+  `device_authorization_endpoint: https://huggingface.co/oauth/device` and
+  `urn:ietf:params:oauth:grant-type:device_code` among `grant_types_supported`. A full round trip
+  short of the user's click works today: the endpoint returns a `user_code`, a `verification_uri` of
+  `https://hf.co/oauth/device` and `expires_in: 300`, and polling `/oauth/token` answers
+  `authorization_pending`. §2.2 has the transcript.
+- **The client has to be public.** The device endpoint refuses the `reachy_mini` client id
+  (`71146982-…`) with `invalid_client`: "if you want to use the device code flow without client
+  secret authentication, delete the secret from the oauth app to make it public". §2.3.
+- **The `reachy_mini` rendezvous Space is live and gated.** `pollen-robotics-reachy-mini-central.hf.space`
+  serves a status dashboard anonymously; `/events` and `/api/robot-status` answer **401** without a
+  token. Its *repository* is private, so nobody here can read the server. §4.
+- **Its wire is not the gst signalling protocol on a WebSocket.** It is the same JSON envelopes over
+  **HTTP** — SSE inbound, `POST` outbound — with per-hop peer and session ids. This corrects a claim
+  in `remote-webrtc.md` §7; §3.2 says what it costs.
+
+## 1. What has to be true for a duck to be reachable
+
+Four things, and the robot has none of them:
+
+1. a credential that names an account the robot belongs to (§2);
+2. a service the robot reaches **outward**, which shows a robot only to its owner (§4);
+3. a bridge from that service to `ws://127.0.0.1:8443` (§3);
+4. a client that speaks the service's wire, served from somewhere the client can reach (§5).
+
+Plus NAT traversal, which is a property of the media path rather than of any of the above (§6).
+
+One invariant constrains all four, and it is not negotiable here: **local mode must not come to
+depend on any of it.** `architecture.md`'s first invariant is that local recovery stays independent,
+and `remote-webrtc.md` §7 extends it to media — if the service is down, a LAN client still connects.
+Every choice below that could have been made more simply by routing local sessions through the
+service too was made the other way for this reason, and §3.1 is where it costs something.
+
+## 2. The account is an OAuth device flow against Hugging Face
+
+### 2.1 Why the device grant, and not the flow `reachy_mini` runs
+
+`reachy_mini` uses authorization code + PKCE with the redirect URI pointed back at the robot's own
+HTTP server: `http://reachy-mini.local:8000/api/hf-auth/oauth/callback`, or `localhost` for the
+tethered variant (`apps/sources/hf_auth.py`). It works, and three costs come with it:
+
+- **A registered redirect URI per hostname.** The app has exactly one, which is why the mobile app
+  carries a loopback HTTP bridge that catches HF's callback on `127.0.0.1:8000` and rewrites it as a
+  302 onto a custom `reachymini://` scheme — a whole component whose stated purpose is avoiding an
+  HF-side config change (`features/auth/oauthLoopback.ts`).
+- **The browser must be able to resolve and reach the robot.** The callback is a URL *on the robot*.
+  So logging in requires being on the robot's network, with mDNS working, which is the same class of
+  problem `webrtc-console.md` §2 spends a section on for a page.
+- **It is a browser flow on a device with no browser.** The robot is not the party that authenticates;
+  it merely hosts the landing pad.
+
+The device grant inverts that: the robot asks HF for a code, says *"open hf.co/oauth/device and type
+M8HJ-FMGN"*, and polls until somebody has. No redirect URI, no hostname, no requirement that the
+authorising device can reach the robot at all — a phone on cellular is fine. It is the flow specified
+for a device with no browser and no keyboard, which is what a duck is.
+
+The cost, stated plainly: somebody types eight characters. That is the whole of it, and it is smaller
+than the mDNS dependency it removes.
+
+### 2.2 The flow, and the transcript that proves it
+
+```
+POST https://huggingface.co/oauth/device
+     client_id=<duck client>&scope=openid profile
+
+  → {"device_code":"96e6e116-…","user_code":"M8HJ-FMGN",
+     "verification_uri":"https://hf.co/oauth/device","expires_in":300}
+
+POST https://huggingface.co/oauth/token
+     grant_type=urn:ietf:params:oauth:grant-type:device_code
+     &client_id=<duck client>&device_code=96e6e116-…
+
+  → HTTP 400 {"error":"authorization_pending", …}   until the user approves
+```
+
+Three details the response fixes, and each is a decision we do not have to make:
+
+- **No `verification_uri_complete`.** There is no QR-able URL that carries the code, so the code has
+  to be *read by a person* — which means displaying it is the **client's** job, not the daemon's
+  (§2.6). A robot with no screen cannot show it.
+- **No `interval`.** RFC 8628's default of 5 s applies, and `slow_down` has to be honoured if it ever
+  arrives.
+- **`expires_in: 300`.** Five minutes, which is short enough that the client must show a countdown
+  and long enough that nobody hurries.
+
+### 2.3 The OAuth client is a decision — **open**
+
+Three ways to get a `client_id`, and only one of them is a good idea:
+
+- **Register one public app in the `pollen-robotics` org, no secret, device grant enabled.** One
+  stable id baked into the release, revocable in one place, and the only thing on the robot is a
+  public identifier. **Recommended.** It needs somebody with org admin to create it and hand back
+  the id; that is the one thing in this page nobody here can do.
+- **Reuse `reachy_mini`'s `71146982-…`.** Blocked, not merely inelegant: it is a confidential client,
+  so the device endpoint demands Basic auth with its secret. Baking that secret into every duck's
+  release makes it not a secret, and deleting it from the app to make it public would change the
+  security posture of the mini's flow to suit ours.
+- **Dynamic registration.** `POST https://huggingface.co/oauth/register` is unauthenticated and
+  honours `token_endpoint_auth_method: "none"`, so a robot could mint its own public client at first
+  login with no admin involvement at all. It works — that is how the transcript above was obtained.
+  Rejected as the plan: a client per robot (or per release) is a fleet of identities nobody can
+  enumerate or revoke, and it looks like abuse at scale. Worth knowing as the escape hatch if the org
+  route is slow, since it means the design is not *blocked* on an admin.
+
+### 2.4 Scopes: `openid profile read-repos`, and deliberately not more
+
+The rendezvous needs to know *who* the token belongs to, which is `openid profile`. `read-repos` is
+one scope further and buys something real: `policy install` reaching a **private** policy repo, from
+the same token file, with no new mechanism (`policy-channel-design.md` §7).
+
+`reachy_mini` asks for `openid profile read-repos write-repos manage-repos inference-api`, because
+its robot installs apps and pushes artifacts. **Do not copy that list.** A duck holds this token
+unattended, on a board that can be lost or given away; a credential that can *push* to the owner's
+repositories is a much worse thing to lose than one that can read them. If a future feature needs to
+write, it is a scope change with a re-login, which is a day's work — where a robot that has been able
+to write all along is not recoverable.
+
+### 2.5 Where the token lives, and who writes it
+
+`/etc/robot/hf-token`, `root:robot`, `0640`.
+
+**Not in `robotd.toml`.** Every mechanism that exists for that file is wrong for a secret:
+`robotctl configure --list` prints what a robot changes, `policy-channel-design.md`'s full-screen
+editor shows the file, and "what has been changed on this robot" is a report we now generate. A
+bearer token would be in all three outputs. Its own file, with its own mode, is the whole of the
+protection it gets — and §7 says why that is enough.
+
+**`updaterd` owns it.** It already has the HTTP client, already reaches the network on the robot's
+behalf, already runs as `root`, and already has a namespace of calls that write system state
+(`policy.*`). `configd` owns *config*, has no HTTP client, and adding outward network egress to the
+daemon that answers `system.info` would be a new kind of thing for it. `mediad` must not own it: it
+runs as `User=mediad` under `ProtectHome=yes`, and it is the process a remote peer talks to.
+
+**`mediad` reads it** — on each connect attempt, plus a slow poll (30 s) while it has none, which is
+also its `waiting for token` state. No cross-daemon notification: `reachy_mini` has a
+`notify_token_change` call from its auth router into its relay, and re-reading the file on the
+reconnect that is going to happen anyway makes it unnecessary. The cost is that a fresh login takes
+up to a poll interval to become a live producer, which nobody can perceive.
+
+### 2.6 The calls, and which transports may reach them
+
+`account.login`, `account.status`, `account.logout` on `updaterd`. `login` starts the flow and returns
+`verification_uri`, `user_code` and `expires_in`; progress is a notification, the way `update.*`
+already pushes progress, so a client that reconnects can resubscribe (`duck-ipc-proto`'s rule).
+
+**`account.login` is the highest-authority call on the robot, and it is worth saying why.** Whoever
+completes it binds the robot to *their* Hugging Face account and thereby gets remote access to its
+camera and its control channel from anywhere. Nothing else in the API hands the robot to a stranger;
+`robot.shutdown` merely stops it.
+
+So it is **local and BLE only, refused over WebRTC** — the same table `route.rs` already keeps, with
+the same reasoning `system.setPairingPin` is refused by: BLE is the authenticated transport, and ten
+metres of radio means whoever ran it is in the room (`remote-webrtc.md` §4). `account.status` is safe
+everywhere and useful everywhere — a client wants to say "signed in as *someone*, relay connected".
+`account.logout` moves the same boundary as `login` and goes with it.
+
+### 2.7 Whether the token expires is the one unknown that matters — **open**
+
+HF advertises `refresh_token` in `grant_types_supported`, and what the token response actually carries
+— `expires_in`, `refresh_token`, or neither — cannot be known without one real authorization, which
+needs a human click. It decides a real piece of work:
+
+- **No expiry** → store the access token, and §2.5 is finished.
+- **Expiry** → store the refresh token too, refresh ahead of time, and handle a refresh that fails as
+  "signed out" rather than as an error nobody sees. That is a scheduler and a second secret.
+
+`reachy_mini` stores only the access token, at `~/.cache/huggingface/token`, and its robots stay
+reachable — evidence that long-lived tokens are at least possible, not proof about the device grant's.
+**Answer this before writing §2.5's storage**, because "one string in a file" and "two strings plus a
+clock" are different designs and the cheap one is only correct if the answer is no.
+
+## 3. The bridge
+
+### 3.1 A listener on loopback, not a signaller inside `webrtcsink`
+
+`webrtcsink` takes a custom signaller (the `Signallable` interface), so the temptation is to implement
+one that speaks the rendezvous wire directly: one hop fewer, no id translation, no local WebSocket
+client. **Rejected**, for a reason that is structural rather than aesthetic: one `webrtcsink` has one
+signaller. Pointing it at the service means local sessions go through the service too — which breaks
+§1's invariant — and keeping both means a second `webrtcsink` off the tee, which means encoding the
+same frames twice on a board where the encoder is the budget.
+
+So the bridge is what `remote-webrtc.md` §7 describes, and what `reachy_mini` runs:
+
+```
+  rendezvous  ──SSE──►  relay task  ──ws──►  127.0.0.1:8443  ◄──ws──  webrtcsink
+  (HTTP)      ◄─POST──  (in mediad)  ◄──ws──  signalling server      (the producer)
+```
+
+The relay registers with the service as a **`producer`** and with the local server as a
+**`listener`** — the roles are inverted on the two sides, because to the service it *is* the robot and
+to the pipeline it is a peer asking for a session.
+
+### 3.2 What it translates, and the correction to §7
+
+§7 says "the bridge parses nothing. It proxies the gst signalling protocol, which is the same protocol
+a LAN client speaks." The payloads — SDP and ICE — are indeed opaque and stay that way. The envelope
+is not, in three ways:
+
+| | local side | rendezvous side |
+|---|---|---|
+| transport | WebSocket | SSE inbound, `POST /send` outbound |
+| auth | none (§4 of `remote-webrtc.md`) | `Authorization: Bearer <hf token>` |
+| ids | its own `peerId`, its own `sessionId` | different ones, per hop |
+| our role | `listener` | `producer` |
+
+So the bridge keeps a session table both ways and rewrites `sessionId` on every `peer` message. That
+is where `reachy_mini`'s relay has needed most of its scar tissue (§3.4), and it is the honest
+description: **a translator with an opaque payload**, not a relay. The payoff §7 claims for
+`webrtcsink` over `webrtcbin` survives — the protocol still exists rather than being invented, and the
+translation is a table rather than a parser — but "proxies, parses nothing" should stop being said.
+
+### 3.3 The lease, and why the heartbeat is not optional
+
+The service evicts a producer that has sent nothing for `LEASE_SECONDS`, whatever its socket looks
+like. That is not defensive over-engineering on its part: a half-open TCP connection — wifi yanked,
+NAT rebinding, a sleeping captive portal — absorbs server-pushed keepalives silently for minutes,
+during which the robot believes it is reachable and is not.
+
+So the relay re-emits `setPeerStatus` periodically, at a cadence **negotiated from the welcome**:
+`recommended_heartbeat_interval_seconds` if offered, else `lease_seconds / 3`, else 5 s — clamped to
+[1 s, 60 s] so a misconfigured service can neither ask for a request storm nor talk us into a cadence
+slower than our own eviction. That ladder is `reachy_mini`'s and it is right; the clamp is the part
+worth copying most.
+
+### 3.4 The failure modes are already known, which is the main reason to read their relay
+
+Four, each cheap to build in now and expensive to rediscover:
+
+- **Split-brain.** The SSE stream is healthy and the service no longer lists us — a `setPeerStatus`
+  round trip cancelled mid-flight leaves exactly this. Nothing in the connection notices. Their
+  answer: poll `/api/robot-status` every 30 s, and force a reconnect after two consecutive misses.
+- **Concurrent sessions.** The service is supposed to gate them; enforce one at a time on the robot
+  anyway, and refuse with an `endSession` carrying a *reason* rather than by silence. A second peer
+  driving the same robot is `remote-webrtc.md` §9's interleaving bug with two remote writers instead
+  of a pad and a peer.
+- **Ordering at registration.** Register as a producer *before* reporting `connected`, or every
+  observer — a status call, a page, a person — sees "remote access enabled" while the service does not
+  yet know the robot exists.
+- **Backoff with jitter, capped.** 5 s growing to 60 s, plus ~10%. A fleet reconnecting in lockstep
+  after a service restart is a self-inflicted outage.
+
+What we do **not** copy is their `RobotAppLock`: it arbitrates a local *app* against a remote session,
+and a duck has no app. `remote-webrtc.md` §9 owns the equivalent question here (a pad and a peer both
+writing intents) and defers it deliberately; a second remote peer is the same gap, not a new one.
+
+### 3.5 It is a task in `mediad`, in a module with no GStreamer in it
+
+Not a new unit. A `relayd` would need its own copy of the producer identity, its own config, its own
+restart story, and it would still be useless without `mediad` running — three new moving parts to
+isolate a task that is a websocket, an HTTP client and a hash map.
+
+It goes where `session.rs` went, and for the same reason: **transport-agnostic on purpose**, so it is
+testable on a laptop against a fake service and a fake local server. That is what made the control
+channel testable without a board and it is worth twice as much here, because every failure in §3.4 is
+a timing failure that no manual test on hardware will reproduce on demand.
+
+One inherited rule: nothing in a GStreamer signal handler may panic (`pipeline.rs`'s header, and the
+process abort that taught it). The relay never touches one — but it will want to *reach* the pipeline
+eventually, and that is the boundary to keep clean.
+
+### 3.6 What a bridged peer may call: exactly what a LAN peer may
+
+The session is the same `webrtcsink` session and `route.rs` is the same table. This is deliberate and
+it is also the part worth re-examining once it works: §4 argues the robot needs no gate because the
+service authenticated both ends, and after this page that argument gets *stronger* — a bridged peer
+has proved account ownership, where a LAN peer has proved only that it is on the wifi. The robot can
+tell them apart by source address (§7 notes it), and nothing yet acts on the difference. Keep it true.
+
+## 4. Which rendezvous — **open**
+
+`pollen-robotics-reachy-mini-central.hf.space` is live, and what a robot needs from it is small:
+`GET /events` (SSE, Bearer), `POST /send` (Bearer), `GET /api/robot-status`. Its `meta` is free-form,
+so a duck registers with whatever identifies it — `producer.rs` already assembles exactly the fields a
+listing wants (name, serial, release, `api_version`), which is what `webrtc-console.md` §5 predicted
+the rendezvous would need.
+
+**Reusing it** costs no backend work, is proven under a fleet of real robots, and makes the whole of
+this page a client-side project. Against that: we do not own its deploys, its lease and session
+gating were written around a robot with a different lock model, a duck appears in whatever lists a
+user's robots (a feature or a bug depending on intent), and **its repository is private** — so nobody
+on this side can read the server they depend on, which is how §3.2's protocol surprise happened at all.
+
+**Our own instance** is a Space and a couple of hundred lines: we own the lease policy, the eviction
+sweeper and the deploy schedule, and the duck's identity model is ours. Against that: a second service
+to run and watch, duplicating something that exists and works.
+
+**Recommendation: reuse for the first proof, and decide on the answer to §5.** The service URL is one
+config key — `reachy_mini` keeps it in an env var for exactly this reason — so moving later costs a
+line. What actually couples us is not the relay, it is the client: if the client is a page we publish,
+the service stays a rendezvous and reuse is nearly free; if the client is somebody else's app, we are
+inside their product and should own neither the Space nor the decision alone.
+
+## 5. The client, and where it is served — **open**
+
+The console is `include_str!`'d into `mediad` and served by the robot (`webrtc-console.md` §1), which
+works because the client is on the LAN. **A remote client cannot fetch a page from a robot it cannot
+reach**, so remote needs the page hosted off-robot *and* a second signalling transport in it.
+
+Three ways:
+
+- **The same file, published by CI to GitHub Pages**, with the transport chosen by the URL it is given.
+  One page, two hosts, still no build step — the constraint `webrtc-console.md` §8 defends survives.
+  The service stays a rendezvous and nothing about the client lives in it.
+- **The service serves the page.** One host and one deploy, at the cost of putting the client inside a
+  service we may not own; a page in a private repo is a page nobody here can edit.
+- **No client yet.** Prove login and the relay with the service's own dashboard, `/api/robot-status`
+  and `duckctl` — which needs no page at all, and is the whole of slices 1 and 2 in §8.
+
+**Recommendation: the third, then the first.** The proof that the token path and the lease work needs
+no UI, and deferring the hosting decision by a slice costs nothing.
+
+One thing to know before that page is written: `EventSource` **cannot set headers**, so a browser
+speaking the service's SSE wire must either put the token in the query string — which is what
+`reachy-mini-js` does, and what puts a bearer token into Space access logs and every proxy in between
+— or read the stream with `fetch` and parse SSE by hand. The robot relay uses a header and is right to
+(`central_signaling_relay.py` says so in as many words). The page should too, which makes it `fetch`
+plus a few lines of line-splitting rather than one browser API.
+
+## 6. NAT: decide the STUN server, defer TURN
+
+`webrtcsink` defaults its `stun-server` to a public Google address. LAN sessions need none, so nothing
+has exercised it — and the moment remote works, **a duck's reachability quietly depends on a third
+party we do not run**. Set the property rather than inherit it, for the same reason
+`remote-webrtc.md` §0 sets `congestion-control` to the value that is already the default: the day
+upstream changes it should not be the day every robot's connectivity changes with it.
+
+TURN is what makes symmetric NAT and CGNAT work at all, and it relays the *whole* session's media at
+somebody's expense. Not in the first slice, and `remote-webrtc.md` §11 is right that the decision
+belongs with whoever runs the rendezvous rather than with the daemon.
+
+## 7. Authorisation, restated now that there is an account
+
+§4 of `remote-webrtc.md` argues the robot needs no gate of its own because a bridged session was
+authenticated twice before it arrived — the client to the service, the robot outward with a token —
+and that the trust therefore *moved* into the service rather than vanishing. This page does not change
+that argument; it adds the one thing §4 could not name, which is **when the binding happens and who
+performs it**:
+
+- Before `account.login`, a duck is unreachable from outside the LAN. There is nothing to attack.
+- After it, one account owns it, and `account.login`/`account.logout` are the calls that can move that
+  ownership — hence BLE-and-local only (§2.6). A remote peer that could re-bind the robot to its own
+  account would be the one call able to take the robot away from its owner.
+- A robot that changes hands must be logged out. That is the same list as the pairing PIN and the
+  calibration — a hand-over process, in M6 — and this is one more item on it, worth adding while the
+  list is still being written rather than after a second-hand duck streams to a stranger.
+- The token is a bearer credential in a file, so a stolen board yields it. The answer is §2.4's
+  read-only scopes, not encryption: a robot has to read this file unattended at boot, so anything it
+  can decrypt without a human is something the thief can decrypt too.
+
+## 8. Order of work
+
+Five slices, and the first two are independently useful and need no client:
+
+1. **`account login`** — the device flow, the token file, `account status`. `updaterd`. Verifiable on
+   its own: it prints the Hugging Face username. Answers §2.7 the moment it first succeeds.
+2. **The relay, registering only** — producer registration, the negotiated heartbeat, reconnect and
+   backoff, the split-brain poll. `mediad`. Verifiable with no client at all: the service's dashboard
+   counts a producer and `/api/robot-status` lists the duck.
+3. **Session translation** — a remote consumer gets video and the `control` channel. The first slice
+   that needs something to connect *with*.
+4. **The client, hosted.** §5.
+5. **STUN decided; TURN if a real network needs it.** §6.
+
+## 9. What is open, and who can close it
+
+| | needs |
+|---|---|
+| §2.3 the OAuth client id | one public app in the `pollen-robotics` HF org, no secret, device grant — created by somebody with org admin |
+| §2.7 token expiry | one real authorization, then read the token response. A click |
+| §4 which rendezvous | read access to the Space's repository, **or** the decision to stand up our own |
+| §5 where the client is served | follows §4, and is the decision that actually couples us to a service |
+
+## 10. Not doing
+
+- **The `teleop` datachannel.** `remote-webrtc.md` §6 owns it; a remote session makes head-of-line
+  blocking more visible, not more urgent.
+- **`update.*` mutations over a remote session.** §8 of `remote-webrtc.md` says what it will take, and
+  the answer is a client that survives the restart rather than anything here.
+- **Multi-peer.** One media session at a time, as before.
+- **Per-session consent.** An M5 item, orthogonal to this page and made more pointed by it: a stream
+  that can be started from another continent is the case `architecture.md` §7 was written for.
+- **A duck-specific mobile app.** #107 designs one and M6 owns the phone spike. This page's client
+  question (§5) is deliberately answerable without it.

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -25,13 +25,12 @@ about them:
   `read-billing` — because the first-party client takes no `scope` parameter. §2.4, and it is the
   one thing here that should change before a duck ships.
 - **`/oauth/userinfo` answers with the identity in one round trip**, so nothing decodes a JWT.
-- **The `reachy_mini` rendezvous Space is live and gated.**
-  `pollen-robotics-reachy-mini-central.hf.space` serves a status dashboard anonymously; `/events`
-  and `/api/robot-status` answer **401** without a token. Its *repository* is private, so nobody
-  here can read the server. §4.
+- **The rendezvous is ours**, and it is `pollen-robotics/reachy_mini_central` — a FastAPI app in
+  a Space, readable and changeable by us. Everything §3 and §4 say about it below is read off that
+  server rather than inferred from a client.
 - **Its wire is not the gst signalling protocol on a WebSocket.** It is the same JSON envelopes
-  over **HTTP** — SSE inbound, `POST` outbound — with per-hop peer and session ids. This corrects
-  a claim in `remote-webrtc.md` §7; §3.2 says what it costs.
+  over **HTTP** — SSE inbound, `POST` outbound, `Authorization: Bearer` — with per-hop peer and
+  session ids. This corrects a claim in `remote-webrtc.md` §7; §3.2 says what it costs.
 
 ## 1. What has to be true for a duck to be reachable
 
@@ -343,11 +342,21 @@ like. That is not defensive over-engineering on its part: a half-open TCP connec
 NAT rebinding, a sleeping captive portal — absorbs server-pushed keepalives silently for minutes,
 during which the robot believes it is reachable and is not.
 
-So the relay re-emits `setPeerStatus` periodically, at a cadence **negotiated from the welcome**:
-`recommended_heartbeat_interval_seconds` if offered, else `lease_seconds / 3`, else 5 s — clamped to
-[1 s, 60 s] so a misconfigured service can neither ask for a request storm nor talk us into a cadence
-slower than our own eviction. That ladder is `reachy_mini`'s and it is right; the clamp is the part
-worth copying most.
+The numbers, from the server rather than from a guess: `PRODUCER_LEASE_SECONDS` is **30**, and
+the SSE welcome advertises `recommended_heartbeat_interval_seconds: 10.0`. The lease is keyed
+*only* on inbound `POST /send` — a healthy-looking SSE stream refreshes nothing.
+
+So the relay re-emits `setPeerStatus` at the cadence the welcome names, falling back to 5 s and
+clamped to [1 s, 60 s] so a misconfigured service can neither ask for a request storm nor talk us
+into a cadence slower than our own eviction. `reachy_mini`'s ladder has a middle rung —
+`lease_seconds / 3` — for a server that publishes the lease but not the cadence. **This server
+publishes no `lease_seconds`**, so that rung is unreachable here; it is not worth reproducing a
+negotiation step for a field nothing sends.
+
+**The SSE side has its own keepalive to size against.** After 30 s with nothing to deliver the
+server emits an `event: ping`, whose only job is to stop the HTTP/2 proxy in front of the Space
+from killing an idle connection. A read timeout on our side therefore has to be comfortably more
+than 30 s — `reachy_mini` uses 60, which is two missed pings, and that is the number to take.
 
 ### 3.4 The failure modes are already known, which is the main reason to read their relay
 
@@ -356,10 +365,12 @@ Four, each cheap to build in now and expensive to rediscover:
 - **Split-brain.** The SSE stream is healthy and the service no longer lists us — a `setPeerStatus`
   round trip cancelled mid-flight leaves exactly this. Nothing in the connection notices. Their
   answer: poll `/api/robot-status` every 30 s, and force a reconnect after two consecutive misses.
-- **Concurrent sessions.** The service is supposed to gate them; enforce one at a time on the robot
-  anyway, and refuse with an `endSession` carrying a *reason* rather than by silence. A second peer
-  driving the same robot is `remote-webrtc.md` §9's interleaving bug with two remote writers instead
-  of a pad and a peer.
+- **Concurrent sessions.** The server does gate this — `handle_start_session` answers
+  `sessionRejected` with `reason: "robot_busy"` and the `activeApp` that holds it, and pushes a
+  `sessionStateChanged` to the owner's other devices so their UI flips inside the round trip. So
+  the robot-side gate is belt-and-braces rather than a workaround, and it should stay: a second
+  peer driving the same robot is `remote-webrtc.md` §9's interleaving bug with two remote writers
+  instead of a pad and a peer, and that is a bad enough outcome to check twice.
 - **Ordering at registration.** Register as a producer *before* reporting `connected`, or every
   observer — a status call, a page, a person — sees "remote access enabled" while the service does not
   yet know the robot exists.
@@ -393,6 +404,33 @@ service authenticated both ends, and after this page that argument gets *stronge
 has proved account ownership, where a LAN peer has proved only that it is on the wifi. The robot can
 tell them apart by source address (§7 notes it), and nothing yet acts on the difference. Keep it true.
 
+### 3.7 What a duck has to call itself, and it is not free-form after all
+
+`meta` is free-form to the *protocol*, but the server reads two keys out of it, so a duck that
+fills it in arbitrarily gets subtly wrong behaviour rather than a clear failure:
+
+- **`hardware_id`** (or `install_id`) is the **stable-identity key**. On `setPeerStatus` the server
+  looks for another producer of the *same user* carrying the same value and evicts the older one —
+  ending its session if it had one. It exists because a re-flashed daemon, a duplicated SD card or
+  a stale tray process would otherwise show up as a second robot forever.
+
+  So a duck **must** put something stable there, and the obvious candidate already exists:
+  `producer.rs` reads the SoC serial for the local `meta`, which is exactly "stable per physical
+  robot across reinstalls and renames". Leaving the key out means a robot that reconnects with a
+  fresh token is listed twice; putting the *name* there means renaming a robot forks its identity.
+- **`name`** is what the listing shows a person, and the consumer's `name` is what the server
+  reports back as `activeApp` to the owner's other devices. `transport` (`"wifi"` / `"usb"`) is a
+  mini-ism a duck can leave alone; a `kind` of `microduck` is what lets one client list both
+  families without opening a session.
+
+**And a hazard that belongs in the provisioning path, not here: peers are keyed by token.**
+`get_or_create_peer` is a `token -> peer_id` map, and a second SSE connection on the same token
+supersedes the first. Two robots sharing one token therefore take turns being reachable, and
+neither is broken in a way that looks like a bug. Each duck runs its own device flow, so each gets
+its own token — *unless* an image is cloned with `/etc/robot/hf-token` in it, which is exactly what
+this project's flashing path does with everything else in `/etc/robot`. Whatever produces a golden
+image has to exclude that file, and this is the note that says why.
+
 ## 4. The rendezvous is the one `reachy_mini` uses — **decided**
 
 `pollen-robotics-reachy-mini-central.hf.space`, the Space the mini's fleet already registers
@@ -407,17 +445,22 @@ exactly the fields a listing wants (name, serial, release, `api_version`), which
 same structure, so a client that lists a user's robots can tell a duck from a mini without
 opening a session.
 
-Three things follow from reusing it, and they are costs rather than objections:
+**We own it**, which is what makes this reuse rather than a dependency: `pollen-robotics/reachy_mini_central`
+is a FastAPI app in a Space, and it can be read and changed on this side. Two things follow:
 
-- **We do not own its deploys.** A change there can break remote access on ducks, and nobody here
-  would have reviewed it. The mitigation is that the URL is one constant — `reachy_mini` keeps it
-  in an env var for this reason — so moving to our own instance is a line, not a project.
-- **Its repository is private**, so nobody on this side can read the server they depend on. That
-  is how §3.2's protocol surprise came to be a surprise at all: the wire had to be reverse-read
-  from the client. Read access would be worth having even with the decision made.
-- **Its lease, eviction and session gating were written around a robot with a different lock
-  model** — `RobotAppLock`, local app versus remote session. A duck has no app, so §3.4 takes its
-  reconnect behaviour and leaves that part.
+- **The protocol is a fact, not a guess.** Every number in §3 — the 30 s lease keyed on `POST /send`,
+  the 10 s advertised cadence, the 30 s SSE ping, the `sessionRejected` gate, the `hardware_id`
+  eviction — is read off `app.py`. An earlier version of this page said the repository was private;
+  that was a wrong-name 401 mistaken for a permissions error, and the wire was reverse-read from
+  the client for no reason.
+- **A duck-shaped need is a pull request, not a fork.** If ducks want a different lease, a `kind`
+  filter on the listing, or an eviction rule that does not assume one robot per token, those are
+  changes to a server we maintain. Which also means the reverse: a change made there for the mini
+  can break ducks, and after this page there is a second family of robots on it.
+
+The one thing that does not transfer is its **lock model** — `RobotAppLock`, local app versus
+remote session, which the mini's relay gates incoming sessions on. A duck has no app, so §3.4
+takes the reconnect behaviour and leaves that part.
 
 ## 5. The client, and where it is served — **open**
 
@@ -438,12 +481,16 @@ Three ways:
 **Recommendation: the third, then the first.** The proof that the token path and the lease work needs
 no UI, and deferring the hosting decision by a slice costs nothing.
 
-One thing to know before that page is written: `EventSource` **cannot set headers**, so a browser
-speaking the service's SSE wire must either put the token in the query string — which is what
-`reachy-mini-js` does, and what puts a bearer token into Space access logs and every proxy in between
-— or read the stream with `fetch` and parse SSE by hand. The robot relay uses a header and is right to
-(`central_signaling_relay.py` says so in as many words). The page should too, which makes it `fetch`
-plus a few lines of line-splitting rather than one browser API.
+One thing to know before that page is written, and it is settled rather than a preference:
+`EventSource` **cannot set headers**, so a browser speaking the SSE wire must either put the token
+in the query string or read the stream with `fetch` and split SSE by hand. `reachy-mini-js` does
+the former. **The server is removing it** — `_resolve_hf_token` accepts `?token=` only as a
+transitional fallback, logs a deprecation warning per client IP, and says in its own docstring that
+the query form goes once the known clients ship the header. A bearer token in a query string is
+also a bearer token in the Space's access log and in every proxy in between.
+
+So the page is `fetch` plus a few lines of line-splitting, not one browser API — and it should be
+written that way first rather than written twice.
 
 ## 6. NAT: decide the STUN server, defer TURN
 
@@ -503,12 +550,16 @@ Five slices, and the first two are independently useful and need no client:
 | | needs |
 |---|---|
 | §2.4 the scope breadth | one public device-code client in the `pollen-robotics` HF org with `openid profile read-repos`, created by somebody with org admin. Not blocking — a scope change is a re-login — and it should not ship without it |
-| §4 read access to the Space | the rendezvous is decided; its source is a private repo, and depending on a server nobody here can read is how §3.2 happened |
 | §5 where the client is served | follows the shape of §3, and is the decision that actually couples us to a service |
 
 Closed since this page was written: the OAuth client (§2.3 — Hugging Face ships one), whether the
-token expires (§2.7 — thirty days, with a rotating refresh token), and which rendezvous to use
-(§4 — the mini's).
+token expires (§2.7 — thirty days, with a rotating refresh token), which rendezvous to use (§4 —
+the mini's), and whether we can read it (§4 — we maintain it; the "private repo" in an earlier
+draft was a wrong-name 401).
+
+One item this page created rather than closed: **a golden image must not carry
+`/etc/robot/hf-token`**, because peers are keyed by token and two robots sharing one take turns
+being reachable. §3.7. That belongs to whoever owns the flashing path.
 
 ## 10. Not doing
 

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -166,8 +166,10 @@ answers, each of which is a decision nobody has to make now:
 callers arriving together — a console page and a phone, which is a normal thing to happen during
 setup — would otherwise both be handed a code, and the store would keep whichever approval landed
 last while somebody read the other code and watched it do nothing. The second caller gets
-`BUSY` while the first is in flight; `account.status` carries the code, so a client that lost
-track of one rejoins it rather than starting another.
+`BUSY` while the first is in flight — with its own message, because "another update is already in
+progress" is what `BUSY` says elsewhere and it would send that person looking in the wrong place.
+`account.status` carries the code, so a client that lost track of one rejoins it rather than
+starting another.
 
 ### 2.3 The OAuth client is Hugging Face's own — **closed**
 

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -100,9 +100,13 @@ which were learned the expensive way:
     an error replacing it.
   - A phone app keeps the mini's rule as written, for the mini's reason.
 
-  What makes opening worth anything is `verification_uri_complete`: HF sends none, so the robot
-  synthesises the `?user_code=` form, and Hugging Face preserves that parameter across its own
-  login redirect — so the code is filled in even for a browser that was not signed in yet.
+  **What opening buys is the navigation, not the typing.** An earlier version of this section
+  claimed the robot could hand over a URL with the code in it, on the strength of a note in the
+  mini's setup docs saying `huggingface_hub` synthesises a `?user_code=` form. It does not — it
+  falls back to `verification_uri` unchanged — and HF's device page ignores the parameter, which a
+  browser confirmed after this shipped. `verification_uri_complete` is therefore the plain page
+  today, and stays in the reply only because a server that starts sending a real one is then used
+  without a wire change.
 - **The client going away mid-flow is expected, not an error.** Opening the HF page backgrounds a
   phone app, and iOS then tears the GATT link down. By that point the transport has done its job:
   the daemon is polling and the client comes back to `status`. This is why `login` answers with a
@@ -137,11 +141,11 @@ GET  https://huggingface.co/oauth/userinfo   Authorization: Bearer <access token
 No `scope` is sent, because the first-party client does not take one (§2.4). Five things this
 answers, each of which is a decision nobody has to make now:
 
-- **No `verification_uri_complete`.** There is no URL carrying the code, so the code has to be
-  *read by a person* — which makes displaying it the **client's** job, not the daemon's. The
-  `?user_code=` variant is synthesised on the robot the way `huggingface_hub` does it, for a
-  client that wants one copy-and-open button, and §2.1's first invariant says lead with the code
-  anyway.
+- **No `verification_uri_complete`, and no way to synthesise one.** There is no URL that carries
+  the code — HF's device page ignores `?user_code=` — so the code has to be *read by a person*,
+  which makes displaying it the **client's** job rather than the daemon's. The field is passed
+  through as the plain `verification_uri` so that a server which later sends a real one needs no
+  change here.
 - **No `interval`.** RFC 8628's five seconds applies, and `slow_down` adds five more.
 - **`expires_in: 300`** on the *code*. Five minutes: long enough not to hurry, short enough that a
   client should show what is left, which is why `account.status` counts it down rather than

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -370,9 +370,15 @@ Two properties follow, and both are the reason for this shape:
 
 - **Local mode never depends on the bridge.** If the rendezvous service is down, a LAN client still
   connects. Invariant 1 in `architecture.md` — local recovery stays independent — extends to media.
-- **The bridge parses nothing.** It proxies the gst signalling protocol, which is the same protocol
-  a LAN client speaks. That is the concrete payoff for using `webrtcsink` rather than `webrtcbin`:
-  the protocol already exists, so the bridge is a relay rather than a translator.
+- **The bridge invents no protocol.** The envelopes are the gst signalling protocol's, which is what
+  a LAN client already speaks, so the payload — SDP and ICE — passes through opaque. That is the
+  concrete payoff for using `webrtcsink` rather than `webrtcbin`.
+
+  It does **not** follow that the bridge is a pure relay, and this bullet used to say it was.
+  `reachy_mini`'s rendezvous carries those envelopes over HTTP — SSE inbound, `POST` outbound —
+  rather than over a WebSocket, and peer and session ids are per-hop. So the bridge rewrites the
+  envelope and keeps a session table both ways: a translator with an opaque payload.
+  [`remote-access-design.md`](remote-access-design.md) §3.2 has the two sides side by side.
 
 - **The bridge authenticates, so the robot does not have to.** The relay connects *outward* holding
   an account token, and the service shows a client only the robots its account owns — so a bridged
@@ -383,9 +389,11 @@ Two properties follow, and both are the reason for this shape:
   on the difference. Nothing is foreclosed if that stops being true.
 
 `reachy_mini` runs exactly this arrangement against a Hugging Face Space, with the robot
-registering as a `producer` and the Space keeping a TTL lease refreshed by a heartbeat. Whether we
-adopt that service, and how a robot is bound to an account, is out of scope here and stays out
-until local mode works.
+registering as a `producer` and the Space keeping a TTL lease refreshed by a heartbeat. Local mode
+works now, so the two questions this section left open — whether we adopt that service, and how a
+robot is bound to an account — are open no longer for want of asking:
+[`remote-access-design.md`](remote-access-design.md) owns both, and the account is a Hugging Face
+OAuth **device** flow rather than the redirect flow `reachy_mini` uses (§2.1 for why).
 
 ### The signalling protocol, for whoever writes the bridge
 

--- a/docs/design/remote-webrtc.md
+++ b/docs/design/remote-webrtc.md
@@ -307,6 +307,13 @@ out:
 - **`update.*` mutations.** For now only, and for a different reason than the PIN: applying an
   update restarts `mediad` and drops the session. Wanted later; §8 is what it will take.
 
+And one category came *in* that is worth naming here rather than only in the route table:
+**`account.*`**, the calls that bind this robot to a Hugging Face account. They are the first
+mutating calls this transport carries, and the console is where somebody would sign a robot in.
+It is also the only thing here whose effect outlives the session in the way an account does —
+[`remote-access-design.md`](remote-access-design.md) §2.6 is the argument and the three
+properties that make it hold, and `mediad::route` carries the short version.
+
 ### Replies are not correlated, deliberately
 
 `btd` forwards whatever a socket emits without parsing it, and has a test pinning that: a

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -138,7 +138,10 @@ through `rkaiq`.
 **Three things keep it open.**
 
 **Outside the LAN.** The same design with a rendezvous service and TURN in front (§7),
-deliberately built second.
+deliberately built second. [`remote-access-design.md`](../design/remote-access-design.md) now owns
+it: a Hugging Face account reached by the OAuth device flow, and a bridge from a rendezvous Space to
+the signalling server already on the robot. Four decisions in its §9 gate the work, and two of them
+are somebody else's click.
 
 **The SDK, and a small Python client.** §5.3 designs it as WebSocket plus snapshot: the same
 JSON-RPC, no media stack, `get_frame` returning a JPEG, a few dozen lines — and `mediad`'s

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -139,9 +139,18 @@ through `rkaiq`.
 
 **Outside the LAN.** The same design with a rendezvous service and TURN in front (§7),
 deliberately built second. [`remote-access-design.md`](../design/remote-access-design.md) now owns
-it: a Hugging Face account reached by the OAuth device flow, and a bridge from a rendezvous Space to
-the signalling server already on the robot. Four decisions in its §9 gate the work, and two of them
-are somebody else's click.
+it: a Hugging Face account reached by the OAuth device flow, and a bridge from the rendezvous Space
+the mini's fleet already uses to the signalling server already on the robot.
+
+The **account** is built and is the first half — `robotctl account login` prints a code, somebody
+approves it at hf.co/oauth/device, and the robot holds a credential it renews itself; the same
+three calls work over BLE, which is the only transport a robot with no wifi has, and over a
+datachannel. Nothing consumes the credential yet: the **bridge** is next, and it is where the
+rendezvous Space's protocol turns out to be HTTP rather than the WebSocket a LAN client speaks.
+
+One thing to fix before a duck ships with this: the token carries every scope Hugging Face grants,
+because the first-party device-code client takes no `scope` parameter. Narrowing it to
+`openid profile read-repos` is a public OAuth app in the org and one constant.
 
 **The SDK, and a small Python client.** §5.3 designs it as WebSocket plus snapshot: the same
 JSON-RPC, no media stack, `get_frame` returning a JPEG, a few dozen lines — and `mediad`'s

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -792,6 +792,9 @@ A robot that is already signed in refuses, and names the account:
 sudo robotctl account login --force
 ```
 
+The same flag abandons a code that is still waiting for approval — the case where somebody started
+a login and walked away. The old code stops working; approving it after that does nothing.
+
 The token lasts thirty days and the robot renews it on its own. A robot switched off for longer
 than that comes back needing `login` again, which `account status` says in as many words.
 

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -754,6 +754,47 @@ Joining a network **disconnects the robot from the one it is on**, so an ssh ses
 drop. That is the operation working. A scan takes a few seconds — it waits for the radio to sweep
 rather than returning the previous scan's results.
 
+### The Hugging Face account (`updaterd`)
+
+Signing the robot in is what will let you reach it from outside its own network. Nothing else
+needs it yet.
+
+```
+sudo robotctl account login
+```
+
+That prints a code. Open <https://hf.co/oauth/device> on any device, type the code, and the
+command finishes:
+
+```
+Open https://hf.co/oauth/device and enter this code:
+
+    A6MY-0314
+
+Waiting for approval…
+Signed in as PierreRouanet.
+```
+
+```
+robotctl account status
+```
+
+```
+sudo robotctl account logout
+```
+
+Ctrl-C while it is waiting costs nothing — the robot keeps polling, and `account status` says
+whether it was approved. The code is good for five minutes; after that, run `login` again.
+
+A robot that is already signed in refuses, and names the account:
+
+```
+sudo robotctl account login --force
+```
+
+The token lasts thirty days and the robot renews it on its own. A robot switched off for longer
+than that comes back needing `login` again, which `account status` says in as many words.
+
 ### Identity and power (`configd`)
 
 ```

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -333,6 +333,29 @@ duckctl --name <robot-name> update watch
 It prints where the update in flight has got to and then everything that follows. It never receives
 a reply, so it ends with Ctrl-C.
 
+## The Hugging Face account
+
+```
+duckctl account login
+```
+
+Prints a code to approve at <https://hf.co/oauth/device>. **The robot does the waiting**, so this
+tool disconnects as soon as it has printed the code — approve it from anywhere, then:
+
+```
+duckctl account status
+```
+
+```
+duckctl account logout
+```
+
+This is the one thing that works on a robot that has never seen a network: no wifi means no
+console and no LAN, and Bluetooth is what is left. Signing in over BLE is the same flow the setup
+wizard runs.
+
+A robot already signed in refuses and names the account. `--force` replaces it.
+
 ## Policies and skills
 
 What each slot runs, and which skills this robot has:

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -339,9 +339,10 @@ a reply, so it ends with Ctrl-C.
 duckctl account login
 ```
 
-Prints a code and opens <https://hf.co/oauth/device> with it already filled in. **The robot does
-the waiting**, so this tool disconnects as soon as it has printed the code — approve it in the
-browser it opened, or from any other device, then:
+Prints a code and opens <https://hf.co/oauth/device>, where you type it — Hugging Face's device
+page does not accept a code in the URL, so opening saves the navigation and not the typing. **The
+robot does the waiting**, so this tool disconnects as soon as it has printed the code — approve it
+in the browser it opened, or from any other device, then:
 
 ```
 duckctl account status

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -339,8 +339,9 @@ a reply, so it ends with Ctrl-C.
 duckctl account login
 ```
 
-Prints a code to approve at <https://hf.co/oauth/device>. **The robot does the waiting**, so this
-tool disconnects as soon as it has printed the code — approve it from anywhere, then:
+Prints a code and opens <https://hf.co/oauth/device> with it already filled in. **The robot does
+the waiting**, so this tool disconnects as soon as it has printed the code — approve it in the
+browser it opened, or from any other device, then:
 
 ```
 duckctl account status
@@ -353,6 +354,13 @@ duckctl account logout
 This is the one thing that works on a robot that has never seen a network: no wifi means no
 console and no LAN, and Bluetooth is what is left. Signing in over BLE is the same flow the setup
 wizard runs.
+
+```
+duckctl account login --no-open
+```
+
+for the code and the URL without a browser — which is also what you get automatically when the
+output is not a terminal, so a script launches nothing.
 
 A robot already signed in refuses and names the account. `--force` replaces it.
 

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -363,7 +363,8 @@ duckctl account login --no-open
 for the code and the URL without a browser — which is also what you get automatically when the
 output is not a terminal, so a script launches nothing.
 
-A robot already signed in refuses and names the account. `--force` replaces it.
+A robot already signed in refuses and names the account, and so does one still waiting for a code
+to be approved. `--force` replaces either — the abandoned code stops working.
 
 ## Policies and skills
 

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -2289,12 +2289,18 @@ pub struct AccountLoginResult {
     pub user_code: String,
     /// Where they type it.
     pub verification_uri: String,
-    /// The same page with the code already in the query string.
+    /// RFC 8628's "page that needs no code typed into it", when a server sends one.
     ///
-    /// Hugging Face does not send this, so the robot synthesises it the way `huggingface_hub`
-    /// does, and a client should still **lead with the code and never open a browser by itself**.
-    /// The mini's app learned this the expensive way: auto-switching to Safari hid the code before
-    /// the user could read it, and the page asks them to type it anyway.
+    /// **Hugging Face does not, and today this is `verification_uri` unchanged.** An earlier
+    /// version of the robot appended `?user_code=`; HF's device page ignores the parameter and
+    /// prefills nothing, so that URL read as a promise the page then broke. The field stays
+    /// because it is the protocol's — a server that starts sending a real one is used with no
+    /// wire change — which means a client must treat it as "somewhere to send them", not as
+    /// "the code is handled".
+    ///
+    /// So whatever this says, a client **leads with the code and never opens a browser by
+    /// itself**. The mini's app learned that the expensive way: auto-switching to Safari hid the
+    /// code before the user could read it, and the page asks them to type it anyway.
     pub verification_uri_complete: String,
     /// How long the code is good for. In [`AccountStatusResult`] this is what is *left*.
     pub expires_in: u64,

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -2267,10 +2267,17 @@ pub struct PolicySearchParams {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AccountLoginParams {
-    /// Sign in even though this robot already belongs to an account.
+    /// Sign in even though this robot already belongs to an account, or is already waiting for
+    /// a code to be approved.
     ///
     /// Without it, a robot that is already signed in refuses with [`code::INVALID_PARAMS`] naming
-    /// the account it belongs to. That is not ceremony: `account.login` is routed to BLE and to a
+    /// the account it belongs to, and one with a live code refuses with [`code::BUSY`]. The
+    /// second is the same permission as the first in a smaller size — replacing an *attempt* at
+    /// belonging to somebody — and it is the only way out of a code nobody is going to approve
+    /// that does not mean signing the robot out or waiting five minutes for it to expire.
+    ///
+    /// A superseded login is inert: it keeps its device code, and if Hugging Face approves it
+    /// later the answer is dropped rather than written. That is not ceremony: `account.login` is routed to BLE and to a
     /// datachannel, so on a LAN anybody who can reach the robot can start one — and a login that
     /// silently replaced the owner would convert "was on the wifi once" into remote access that
     /// outlives being there. Taking a robot from its owner should require saying so.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -162,6 +162,27 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// [`code::METHOD_NOT_FOUND`] naming it, which is the designed skew behaviour rather than a
 /// handshake refusal.
 ///
+/// # v22 — `account.*`
+///
+/// A robot can belong to a Hugging Face account, which is the thing that has to be true before it
+/// can be reached from outside its own LAN: the robot's relay proves to a rendezvous service that
+/// it belongs to an account, the service shows a client only its own robots, and those two
+/// together are the authorisation a bridged session arrives with. Nothing about the *robot's* own
+/// gate changes — there still is not one — see `docs/design/remote-access-design.md` §7.
+///
+/// Additive as methods, and `updaterd` serves them for the reasons `policy.*` is there: it is the
+/// daemon with a network stack, and the credential it stores is also what would reach a private
+/// Hub repo. An older `updaterd` answers [`code::METHOD_NOT_FOUND`] naming the method, which is
+/// the designed skew behaviour rather than a handshake refusal.
+///
+/// **`account.login` answers with a code rather than with a token**, and that shape is not an
+/// implementation detail: the flow is RFC 8628, so somebody has to read a short code and approve
+/// it in a browser, and the client that showed them the code may well be gone by the time they
+/// do — a phone that opens a browser backgrounds itself, and iOS then tears the GATT link down.
+/// So `login` returns immediately, `updaterd` owns the waiting, and `status` is what a client
+/// comes back to. A login that reported success by holding the connection open would work on a
+/// laptop and fail on the device it is for.
+///
 /// # v21 — `robot.skills`, `robot.setSkill`, `robot.removeSkill`
 ///
 /// The last thing in the policy path a terminal on the robot could reach and nothing else could.
@@ -237,7 +258,7 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// An older `robotd` answers either with [`code::METHOD_NOT_FOUND`] naming the method, which is
 /// the designed skew behaviour and not a handshake refusal. See
 /// `docs/design/policy-channel-design.md` §8.
-pub const API_VERSION: u32 = 21;
+pub const API_VERSION: u32 = 22;
 
 /// The observation width every policy this robot family runs is built against.
 ///
@@ -543,6 +564,25 @@ pub mod method {
     /// Search the Hub for policies.
     pub const POLICY_SEARCH: &str = "policy.search";
 
+    // ── account.* ────────────────────────────────────────────────────────────
+    //
+    // Which Hugging Face account this robot belongs to. Served by `updaterd` for `policy.*`'s
+    // reasons exactly — it is the daemon with a network stack, and `robotctl` must not link one —
+    // and because the credential it stores is also what reaches a *private* Hub repo, which is
+    // already this daemon's job.
+    //
+    // The account is what makes a robot reachable from outside the LAN: the relay proves the robot
+    // belongs to an account, the rendezvous service shows a client only its own robots, and the
+    // pair of those is the authorisation a bridged session arrives with.
+    // `docs/design/remote-access-design.md` §2.
+
+    /// Begin an OAuth device-code login. Answers immediately with a code to show somebody.
+    pub const ACCOUNT_LOGIN: &str = "account.login";
+    /// Which account this robot belongs to, and whether a login is in flight.
+    pub const ACCOUNT_STATUS: &str = "account.status";
+    /// Forget the account. The robot stops being reachable from outside the LAN.
+    pub const ACCOUNT_LOGOUT: &str = "account.logout";
+
     /// Turn the connection into a stream of [`ROBOT_STATE`] notifications.
     pub const ROBOT_SUBSCRIBE: &str = "robot.subscribe";
     /// Server → client. Never carries an `id`.
@@ -796,6 +836,14 @@ pub enum Call {
     PolicyFetch(PolicyFetchParams),
     /// Search the Hub; see [`method::POLICY_SEARCH`].
     PolicySearch(PolicySearchParams),
+
+    // ── account.* ────────────────────────────────────────────────────────────
+    /// Start a device-code login; see [`method::ACCOUNT_LOGIN`].
+    AccountLogin(AccountLoginParams),
+    /// Who this robot belongs to; see [`method::ACCOUNT_STATUS`].
+    AccountStatus,
+    /// Forget the account; see [`method::ACCOUNT_LOGOUT`].
+    AccountLogout,
     RobotSubscribe(SubscribeParams),
     // ── net.* ────────────────────────────────────────────────────────────────
     NetStatus,
@@ -934,6 +982,9 @@ impl Call {
             Call::PolicyInstall(_) => method::POLICY_INSTALL,
             Call::PolicyFetch(_) => method::POLICY_FETCH,
             Call::PolicySearch(_) => method::POLICY_SEARCH,
+            Call::AccountLogin(_) => method::ACCOUNT_LOGIN,
+            Call::AccountStatus => method::ACCOUNT_STATUS,
+            Call::AccountLogout => method::ACCOUNT_LOGOUT,
             Call::RobotSubscribe(_) => method::ROBOT_SUBSCRIBE,
             Call::NetStatus => method::NET_STATUS,
             Call::NetScan => method::NET_SCAN,
@@ -993,6 +1044,14 @@ impl Call {
                 // replacing the official set. `policy.search` and `policy.fetch`'s read-only
                 // cousins stay ungated — asking what exists changes nothing.
                 | Call::PolicyFetch(_)
+                // Signing the robot in binds it to a Hugging Face account, and signing it out
+                // takes it away again. That is the most consequential pair here by one measure
+                // nothing else in this list shares: it decides who can reach the robot *from
+                // outside the building*, and it outlives every session and every reboot.
+                // `account.status` is a read and stays ungated — a support engineer should be
+                // able to ask which account a robot thinks it belongs to.
+                | Call::AccountLogin(_)
+                | Call::AccountLogout
         )
     }
 
@@ -1045,6 +1104,16 @@ impl Call {
             // `fetch` downloads one file and `search` is a single query; both are bounded and
             // neither streams.
             Call::PolicyFetch(_) | Call::PolicySearch(_) => (Updater, Prompt),
+            // `login` is one HTTP round trip to Hugging Face and answers with the code to
+            // show somebody; the *waiting* happens in a task `updaterd` owns, not on this
+            // connection, so it is `Slow` for the round trip rather than `Stream` for the login.
+            // That is the whole reason `login` returns a code instead of a token: a client that
+            // backgrounds itself while its user reads the code — which is what a phone does when
+            // it opens a browser — must be able to come back and ask `status`.
+            Call::AccountLogin(_) => (Updater, Slow),
+            // Both read or write local state only. `status` is asked on a poll while a login is
+            // in flight, so it must not queue behind anything.
+            Call::AccountStatus | Call::AccountLogout => (Updater, Prompt),
             // Owns its connection until the peer goes away and never reads another request.
             Call::Subscribe => (Updater, Stream),
 
@@ -1178,6 +1247,7 @@ impl Call {
             Call::PolicyInstall(p) => encode(p),
             Call::PolicyFetch(p) => encode(p),
             Call::PolicySearch(p) => encode(p),
+            Call::AccountLogin(p) => encode(p),
             Call::RobotSound(p) => encode(p),
             Call::RobotTheremin(p) => encode(p),
             Call::RobotChorale(p) => encode(p),
@@ -1207,6 +1277,8 @@ impl Call {
             | Call::RobotPolicies
             | Call::RobotReloadPolicies
             | Call::PolicyCheck
+            | Call::AccountStatus
+            | Call::AccountLogout
             | Call::RobotMode => Value::Object(serde_json::Map::new()),
             Call::NetStatus
             | Call::NetScan
@@ -1277,6 +1349,9 @@ impl Call {
             method::POLICY_INSTALL => Call::PolicyInstall(decode(params)?),
             method::POLICY_FETCH => Call::PolicyFetch(decode(params)?),
             method::POLICY_SEARCH => Call::PolicySearch(decode(params)?),
+            method::ACCOUNT_LOGIN => Call::AccountLogin(decode(params)?),
+            method::ACCOUNT_STATUS => Call::AccountStatus,
+            method::ACCOUNT_LOGOUT => Call::AccountLogout,
             method::ROBOT_SUBSCRIBE => Call::RobotSubscribe(decode(params)?),
             method::NET_STATUS => Call::NetStatus,
             method::NET_SCAN => Call::NetScan,
@@ -1432,6 +1507,9 @@ pub mod test_support {
             Call::PolicySearch(PolicySearchParams {
                 query: "microduck".into(),
             }),
+            Call::AccountLogin(AccountLoginParams { force: false }),
+            Call::AccountStatus,
+            Call::AccountLogout,
             Call::RobotLoadPolicy(LoadPolicyParams {
                 slot: Some("walk".into()),
                 path: Some("/var/lib/robot/policies/bouncy.onnx".into()),
@@ -2183,6 +2261,86 @@ pub struct PolicyFetchResult {
 #[serde(default, deny_unknown_fields)]
 pub struct PolicySearchParams {
     pub query: String,
+}
+
+/// What to pass [`Call::AccountLogin`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountLoginParams {
+    /// Sign in even though this robot already belongs to an account.
+    ///
+    /// Without it, a robot that is already signed in refuses with [`code::INVALID_PARAMS`] naming
+    /// the account it belongs to. That is not ceremony: `account.login` is routed to BLE and to a
+    /// datachannel, so on a LAN anybody who can reach the robot can start one — and a login that
+    /// silently replaced the owner would convert "was on the wifi once" into remote access that
+    /// outlives being there. Taking a robot from its owner should require saying so.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Answer to [`Call::AccountLogin`], and the `login` member of [`AccountStatusResult`].
+///
+/// RFC 8628: show `user_code` to a person, send them to `verification_uri`, and poll
+/// [`Call::AccountStatus`] until it says who signed in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountLoginResult {
+    /// The short code somebody types. Display it prominently — see the note on
+    /// `verification_uri_complete`.
+    pub user_code: String,
+    /// Where they type it.
+    pub verification_uri: String,
+    /// The same page with the code already in the query string.
+    ///
+    /// Hugging Face does not send this, so the robot synthesises it the way `huggingface_hub`
+    /// does, and a client should still **lead with the code and never open a browser by itself**.
+    /// The mini's app learned this the expensive way: auto-switching to Safari hid the code before
+    /// the user could read it, and the page asks them to type it anyway.
+    pub verification_uri_complete: String,
+    /// How long the code is good for. In [`AccountStatusResult`] this is what is *left*.
+    pub expires_in: u64,
+    /// How often the robot polls Hugging Face, in seconds. Informational — the robot does the
+    /// polling. A client polls [`Call::AccountStatus`] at whatever rate suits it.
+    pub interval: u64,
+}
+
+/// Answer to [`Call::AccountStatus`].
+///
+/// Three independent facts rather than one state, because they genuinely are: a `force` login can
+/// be in flight while the robot still belongs to the previous account, and a login that failed
+/// leaves both the previous account and a reason.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountStatusResult {
+    /// Who this robot belongs to. `None` means it belongs to nobody and cannot be reached from
+    /// outside its LAN.
+    pub account: Option<Account>,
+    /// A login in flight, with the code still to be approved and the time it has left.
+    pub login: Option<AccountLoginResult>,
+    /// Why the last login attempt failed, when one did and nothing has superseded it.
+    pub last_error: Option<String>,
+}
+
+/// The account a robot belongs to, in [`AccountStatusResult`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Account {
+    /// The Hugging Face username, as `/oauth/userinfo` reports it. What to show a person.
+    pub username: String,
+    /// Seconds until the stored access token expires, negative once it has.
+    ///
+    /// Present so a client can say "signed in, but this robot has not been online in a month"
+    /// rather than only discovering it when the robot stops appearing. The robot refreshes on its
+    /// own well before this reaches zero; it going negative means the robot could not.
+    pub token_expires_in: i64,
+    /// Whether a refresh token is stored, so an expiring access token can be renewed without
+    /// anybody signing in again.
+    pub refreshable: bool,
+}
+
+/// Answer to [`Call::AccountLogout`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountLogoutResult {
+    /// Who it was signed in as, or `None` if it was not signed in at all — so a client can tell
+    /// "signed out" from "there was nothing to sign out of" without asking first.
+    pub was: Option<String>,
 }
 
 /// Answer to [`Call::PolicySearch`].
@@ -4418,7 +4576,7 @@ mod tests {
     fn every_call_covers_every_variant() {
         assert_eq!(
             every_call().len(),
-            58,
+            61,
             "a Call variant was added or removed — update every_call() and this count"
         );
     }
@@ -4632,6 +4790,12 @@ mod tests {
                 // list: asking what exists is inspection, and support has to be able to ask it
                 // on a robot it may not change.
                 method::POLICY_FETCH,
+                // Binding the robot to an account, and unbinding it. On this list for a reason
+                // none of the others share: it decides who can reach the robot from outside the
+                // building, and it survives every reboot. `account.status` must stay off it —
+                // which account a robot thinks it belongs to is the first thing support asks.
+                method::ACCOUNT_LOGIN,
+                method::ACCOUNT_LOGOUT,
                 method::NET_CONNECT,
                 method::NET_FORGET,
                 method::SYSTEM_SET_NAME,

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -911,8 +911,14 @@ enum Pad {
 /// `duckctl account …` — the account half of `robotctl account`, over the radio.
 #[derive(Subcommand, Debug)]
 enum Account {
-    /// Start a login, and print the code to approve.
+    /// Start a login, and open the page to approve it on.
     Login {
+        /// Print the code and the URL, and open nothing.
+        ///
+        /// Also the automatic behaviour when stderr is not a terminal, so a script does not
+        /// launch a browser on somebody's desktop.
+        #[arg(long)]
+        no_open: bool,
         /// Sign in even though this robot already belongs to an account.
         #[arg(long)]
         force: bool,
@@ -1791,7 +1797,7 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         // outbound HTTP round trip rather than a local read — the same budget `policy load` gets
         // for the same reason. What it does *not* wait for is the approval: that is the whole
         // shape of the flow, and it is why this tool can disconnect immediately afterwards.
-        Command::Account(Account::Login { force }) => (
+        Command::Account(Account::Login { force, .. }) => (
             proto::method::ACCOUNT_LOGIN,
             serde_json::json!({ "force": force }),
             SLOW_REPLY_TIMEOUT,
@@ -2077,24 +2083,62 @@ fn progress_line(params: &serde_json::Value) -> String {
 /// never restarts mid-flight — `btd` may be the transport it arrived over — so both are restarted
 /// about five seconds *after* the reply goes out (`docs/design/restart-order.md` §1). Every client
 /// has to expect that, and a phone app should show it as a step rather than an error.
-/// What to do with the code `account.login` just answered with.
+/// Show the code `account.login` just answered with, and open the page to approve it on.
 ///
 /// The reply is JSON like every other, and this is the one call where the *human* next step is
 /// not obvious from it: a code and a URL mean nothing until somebody is told to go and type them.
 /// Printed as a note rather than instead of the JSON, so `--verbose` and piping still behave.
+///
+/// **The code is printed before the browser opens, and that order is the whole of the caution
+/// here.** `remote-access-design.md` §2.1 inherits an invariant from the mini's phone app — never
+/// open a browser by yourself — and it is about a phone: the browser replaces the only screen and
+/// backgrounds the app, so a code shown a moment earlier is gone before it is read. A terminal
+/// does not have that problem, the code stays in the scrollback, and this tool already launches a
+/// browser for `duckctl open`. So it opens — after printing, so a failure to open leaves the code
+/// on screen rather than an error where the instructions should have been.
+///
+/// It opens `verification_uri_complete`, which carries `?user_code=` and saves typing the code at
+/// all. Hugging Face preserves that parameter across its own login redirect, so it survives a
+/// browser that is not signed in yet.
 fn account_note(command: &Command, reply: &serde_json::Value) -> Option<String> {
-    if !matches!(command, Command::Account(Account::Login { .. })) {
-        return None;
-    }
+    use std::io::IsTerminal;
+
+    let no_open = match command {
+        Command::Account(Account::Login { no_open, .. }) => *no_open,
+        _ => return None,
+    };
     let result = reply.get("result")?;
     let code = result["user_code"].as_str()?;
     let uri = result["verification_uri"].as_str()?;
     let minutes = result["expires_in"].as_u64().unwrap_or(0) / 60;
-    Some(format!(
+
+    let mut note = format!(
         "\nOpen {uri} and enter this code:\n\n    {code}\n\n\
          You have about {minutes} minutes. The robot is doing the waiting, so this tool can \
          disconnect now — `duckctl account status` says whether it worked."
-    ))
+    );
+
+    // Not a terminal means a script, and a script that opens a browser window on whoever runs it
+    // is a surprise rather than a convenience.
+    if no_open || !std::io::stderr().is_terminal() {
+        return Some(note);
+    }
+
+    let complete = result["verification_uri_complete"]
+        .as_str()
+        .unwrap_or(uri)
+        .to_string();
+    match webbrowser::open(&complete) {
+        Ok(()) => note.push_str(&format!("\n\nOpened {complete}")),
+        // A warning, never a failure: the login has started, the code is valid for minutes, and
+        // the terminal above says everything needed to finish it by hand. This is the opposite of
+        // `duckctl open`, where opening the browser *is* the command and failing it is the result.
+        Err(e) => note.push_str(&format!(
+            "\n\nCould not open a browser ({e}) — the URL and code above still work. \
+             `--no-open` skips this."
+        )),
+    }
+    Some(note)
 }
 
 fn restart_note(command: &Command, reply: &serde_json::Value) -> Option<&'static str> {
@@ -2338,6 +2382,78 @@ mod tests {
         let (line, _) = request_line(&cli.command).expect("a request");
         assert!(line.contains(r#""method":"system.setName""#), "{line}");
         assert!(line.contains(r#""name":"leduckpierre""#), "{line}");
+    }
+
+    /// `account login` sends `force` as the robot's route table expects it.
+    #[test]
+    fn a_forced_login_says_so_on_the_wire() {
+        let cli = Cli::try_parse_from(["duckctl", "account", "login", "--force"])
+            .expect("the login form parses");
+        let (line, _) = request_line(&cli.command).expect("a request");
+        assert!(line.contains(r#""method":"account.login""#), "{line}");
+        assert!(line.contains(r#""force":true"#), "{line}");
+
+        let cli = Cli::try_parse_from(["duckctl", "account", "login"]).expect("parses");
+        let (line, _) = request_line(&cli.command).expect("a request");
+        assert!(line.contains(r#""force":false"#), "{line}");
+    }
+
+    /// The code and the URL reach the terminal, and `--no-open` opens nothing.
+    ///
+    /// The assertion that matters is the *order*: the code is in the note whether or not a
+    /// browser could be launched, because a login whose instructions were replaced by an error
+    /// message is a login nobody can finish by hand. `remote-access-design.md` §2.1.
+    #[test]
+    fn a_login_note_carries_the_code_without_opening_anything() {
+        let cli =
+            Cli::try_parse_from(["duckctl", "account", "login", "--no-open"]).expect("parses");
+        let reply = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "user_code": "A6MY-0314",
+                "verification_uri": "https://hf.co/oauth/device",
+                "verification_uri_complete": "https://hf.co/oauth/device?user_code=A6MY-0314",
+                "expires_in": 300,
+                "interval": 5
+            }
+        });
+
+        let note = account_note(&cli.command, &reply).expect("a note for a login");
+        assert!(note.contains("A6MY-0314"), "the code: {note}");
+        assert!(
+            note.contains("https://hf.co/oauth/device"),
+            "where to type it: {note}"
+        );
+        assert!(
+            note.contains("about 5 minutes"),
+            "how long it is good for: {note}"
+        );
+        assert!(
+            !note.contains("Opened"),
+            "--no-open must not launch a browser: {note}"
+        );
+        assert!(
+            note.contains("duckctl account status"),
+            "the note has to say how to find out whether it worked: {note}"
+        );
+    }
+
+    /// Every other command gets no login note, including the two next to it in the namespace.
+    #[test]
+    fn only_a_login_gets_the_code_note() {
+        let reply = serde_json::json!({ "result": { "account": null } });
+        for args in [
+            vec!["duckctl", "account", "status"],
+            vec!["duckctl", "account", "logout"],
+            vec!["duckctl", "info"],
+        ] {
+            let cli = Cli::try_parse_from(&args).expect("parses");
+            assert!(
+                account_note(&cli.command, &reply).is_none(),
+                "{args:?} must get no login note"
+            );
+        }
     }
 
     /// The point of the whole thing: a robot named by nobody who is typing. The environment has to

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -913,7 +913,8 @@ enum Account {
         /// launch a browser on somebody's desktop.
         #[arg(long)]
         no_open: bool,
-        /// Sign in even though this robot already belongs to an account.
+        /// Sign in even though this robot already belongs to an account, or is already
+        /// waiting for a code to be approved.
         #[arg(long)]
         force: bool,
     },

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -902,12 +902,6 @@ enum Pad {
     },
 }
 
-/// The policy commands, named as `robotctl policy` names them.
-///
-/// Same words in the same order as on the robot, for the reason [`Update`] gives. What is missing
-/// against `robotctl` is the Hub: `policy.check`, `policy.install` and `policy.search` are not
-/// served over this transport — they reach the network on the robot's behalf and write to the
-/// eMMC — so `load` here takes a path to a file already on the robot, never `org/repo`.
 /// `duckctl account …` — the account half of `robotctl account`, over the radio.
 #[derive(Subcommand, Debug)]
 enum Account {
@@ -929,6 +923,12 @@ enum Account {
     Logout,
 }
 
+/// The policy commands, named as `robotctl policy` names them.
+///
+/// Same words in the same order as on the robot, for the reason [`Update`] gives. What is missing
+/// against `robotctl` is the Hub: `policy.check`, `policy.install` and `policy.search` are not
+/// served over this transport — they reach the network on the robot's behalf and write to the
+/// eMMC — so `load` here takes a path to a file already on the robot, never `org/repo`.
 #[derive(Subcommand)]
 enum Policy {
     /// What each slot is running, from where, and which skills this robot has.
@@ -2097,9 +2097,9 @@ fn progress_line(params: &serde_json::Value) -> String {
 /// browser for `duckctl open`. So it opens — after printing, so a failure to open leaves the code
 /// on screen rather than an error where the instructions should have been.
 ///
-/// It opens `verification_uri_complete`, which carries `?user_code=` and saves typing the code at
-/// all. Hugging Face preserves that parameter across its own login redirect, so it survives a
-/// browser that is not signed in yet.
+/// It opens `verification_uri_complete`, which for Hugging Face is the plain device page: they
+/// send no complete URI and their page ignores a `?user_code=` query, so what opening buys is the
+/// navigation and not the typing. The code above it is still the part that matters.
 fn account_note(command: &Command, reply: &serde_json::Value) -> Option<String> {
     use std::io::IsTerminal;
 
@@ -2413,7 +2413,9 @@ mod tests {
             "result": {
                 "user_code": "A6MY-0314",
                 "verification_uri": "https://hf.co/oauth/device",
-                "verification_uri_complete": "https://hf.co/oauth/device?user_code=A6MY-0314",
+                // The plain URI, which is what the robot sends for Hugging Face: no complete
+                // one comes back and their page prefills nothing from a query.
+                "verification_uri_complete": "https://hf.co/oauth/device",
                 "expires_in": 300,
                 "interval": 5
             }

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -847,6 +847,15 @@ enum Command {
         #[arg(value_name = "SKILL")]
         skill: String,
     },
+    /// The Hugging Face account this robot belongs to.
+    ///
+    /// Signing in over Bluetooth is what a robot fresh out of a box needs: it has no network, so
+    /// it has no console and no LAN to open one from. `login` prints a short code to approve on
+    /// huggingface.co from any device — this tool does not have to stay connected while you do,
+    /// which is the point of the flow. `status` afterwards says whether it worked.
+    #[command(subcommand)]
+    Account(Account),
+
     /// What each policy slot is running, and what to run instead.
     #[command(subcommand)]
     Policy(Policy),
@@ -899,6 +908,21 @@ enum Pad {
 /// against `robotctl` is the Hub: `policy.check`, `policy.install` and `policy.search` are not
 /// served over this transport — they reach the network on the robot's behalf and write to the
 /// eMMC — so `load` here takes a path to a file already on the robot, never `org/repo`.
+/// `duckctl account …` — the account half of `robotctl account`, over the radio.
+#[derive(Subcommand, Debug)]
+enum Account {
+    /// Start a login, and print the code to approve.
+    Login {
+        /// Sign in even though this robot already belongs to an account.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Which account this robot belongs to, and whether a login is waiting for approval.
+    Status,
+    /// Forget the account.
+    Logout,
+}
+
 #[derive(Subcommand)]
 enum Policy {
     /// What each slot is running, from where, and which skills this robot has.
@@ -1506,6 +1530,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(note) = restart_note(&cli.command, &value) {
                     eprintln!("{note}");
                 }
+                if let Some(note) = account_note(&cli.command, &value) {
+                    eprintln!("{note}");
+                }
                 Ok(())
             };
         }
@@ -1758,6 +1785,25 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         Command::Do { skill } => (
             proto::method::ROBOT_DO,
             serde_json::json!({ "skill": skill }),
+            REPLY_TIMEOUT,
+        ),
+        // The robot asks Hugging Face for a device code before it answers, so this is one
+        // outbound HTTP round trip rather than a local read — the same budget `policy load` gets
+        // for the same reason. What it does *not* wait for is the approval: that is the whole
+        // shape of the flow, and it is why this tool can disconnect immediately afterwards.
+        Command::Account(Account::Login { force }) => (
+            proto::method::ACCOUNT_LOGIN,
+            serde_json::json!({ "force": force }),
+            SLOW_REPLY_TIMEOUT,
+        ),
+        Command::Account(Account::Status) => (
+            proto::method::ACCOUNT_STATUS,
+            serde_json::json!({}),
+            REPLY_TIMEOUT,
+        ),
+        Command::Account(Account::Logout) => (
+            proto::method::ACCOUNT_LOGOUT,
+            serde_json::json!({}),
             REPLY_TIMEOUT,
         ),
         Command::Policy(Policy::List) => (
@@ -2031,6 +2077,26 @@ fn progress_line(params: &serde_json::Value) -> String {
 /// never restarts mid-flight — `btd` may be the transport it arrived over — so both are restarted
 /// about five seconds *after* the reply goes out (`docs/design/restart-order.md` §1). Every client
 /// has to expect that, and a phone app should show it as a step rather than an error.
+/// What to do with the code `account.login` just answered with.
+///
+/// The reply is JSON like every other, and this is the one call where the *human* next step is
+/// not obvious from it: a code and a URL mean nothing until somebody is told to go and type them.
+/// Printed as a note rather than instead of the JSON, so `--verbose` and piping still behave.
+fn account_note(command: &Command, reply: &serde_json::Value) -> Option<String> {
+    if !matches!(command, Command::Account(Account::Login { .. })) {
+        return None;
+    }
+    let result = reply.get("result")?;
+    let code = result["user_code"].as_str()?;
+    let uri = result["verification_uri"].as_str()?;
+    let minutes = result["expires_in"].as_u64().unwrap_or(0) / 60;
+    Some(format!(
+        "\nOpen {uri} and enter this code:\n\n    {code}\n\n\
+         You have about {minutes} minutes. The robot is doing the waiting, so this tool can \
+         disconnect now — `duckctl account status` says whether it worked."
+    ))
+}
+
 fn restart_note(command: &Command, reply: &serde_json::Value) -> Option<&'static str> {
     let component = match command {
         Command::Update(

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -159,6 +159,37 @@ fn permits(call: &proto::Call) -> bool {
         // neighbour can already replace with `robot.loadPolicy`.
         PolicyFetch(_) | PolicyInstall(_) => true,
 
+        // ── the account, permitted, and this one is worth reading ────────────
+        //
+        // The console is the obvious place to sign a robot in from: it is a page with the robot
+        // already on screen, and the alternative is ssh or a phone. So `account.*` is routed
+        // here.
+        //
+        // **It is also the largest thing this transport grants, and by a different measure than
+        // anything above.** Everything else on this list is bounded by the session: a LAN peer
+        // drives the robot while it is on the wifi, and stops when it leaves. `account.login`
+        // converts being on the wifi *once* into remote access that outlives being there — the
+        // one call here whose effect is durable in that particular way. §4 accepts that anyone
+        // on the network has the robot and its camera; it did not consider anyone on the network
+        // having them from another continent next month.
+        //
+        // Three things make that acceptable rather than merely permitted, and they are the
+        // reason this is a paragraph and not a line:
+        //
+        // - **A robot that already belongs to somebody refuses.** `account.login` without
+        //   `force` answers with the account it belongs to (`Error::AlreadySignedIn`), so a LAN
+        //   peer cannot silently take a robot from its owner — it has to say so.
+        // - **It is visible.** `account.status` names the account, from any transport, without
+        //   authorisation. A robot signed in to a stranger is a question anybody can ask.
+        // - **It is revocable**, by `account.logout` here or on the robot, and by revoking the
+        //   grant on Hugging Face — which no robot-side gate could offer.
+        //
+        // What it is *not* is a reason to route `policy.fetch` after all: that one reaches the
+        // network to put a stranger's weights in charge of fifteen servos, where this reaches it
+        // to prove an identity. Same "the robot touches the network on a peer's behalf", very
+        // different thing arriving.
+        AccountLogin(_) | AccountStatus | AccountLogout => true,
+
         // ── the streams BLE pointed here ────────────────────────────────────
         //
         // `pad.input` exists to measure the cadence of its own delivery, and `btd` refuses it
@@ -306,6 +337,64 @@ mod tests {
                 call.method()
             );
         }
+    }
+
+    /// Exactly which **mutating** calls a WebRTC peer may make, named one by one.
+    ///
+    /// `btd` has had this test since BLE could apply an update; `mediad` did not need one while
+    /// nothing mutating was routed here, and `account.login` is what changed that. It is the same
+    /// boundary and it deserves the same shape of guard: spelled out rather than counted, so
+    /// routing a new mutating method has to change this line and say why in the commit.
+    ///
+    /// The reason a *list* matters more here than the `permits` table alone is that
+    /// `Call::is_mutating` is also what `updaterd` authorises against, and `deploy/updater.toml`
+    /// names `mediad` in `allow_users` — so anything both mutating *and* permitted here is a call
+    /// a LAN peer can get `updaterd` to perform. That is two files agreeing, and this is the test
+    /// that notices when they stop.
+    #[test]
+    fn only_these_mutating_calls_are_reachable_over_webrtc() {
+        let mutating_and_permitted: Vec<&str> = proto::test_support::every_call()
+            .iter()
+            .filter(|call| call.is_mutating() && permits(call))
+            .map(proto::Call::method)
+            .collect();
+
+        assert_eq!(
+            mutating_and_permitted,
+            // In `every_call()`'s order, which is the enum's — the list is a set, and sorting
+            // it by hand would be a second thing to get right.
+            vec![
+                // Powering the robot off. Routed since this transport existed: it drops the
+                // session and leaves nothing mid-transition, which is what you offer a robot
+                // that is misbehaving in front of you.
+                proto::method::ROBOT_SHUTDOWN,
+                // Installing a policy set, and fetching a stranger's policy. Permitted by the
+                // table above — and **this test is how they were found to be broken**. They are
+                // mutating, they were routed here, and `mediad` was not in `allow_users`, so
+                // `updaterd` answered PERMISSION_DENIED: the console could offer a Hub browser
+                // whose install button could not work. Adding `mediad` there for `account.login`
+                // fixed them by accident, which is the sort of accident a named list turns into
+                // a decision.
+                proto::method::POLICY_INSTALL,
+                proto::method::POLICY_FETCH,
+                // Binding this robot to a Hugging Face account, and unbinding it. The argument
+                // is in the table above — briefly: the console is where somebody would sign a
+                // robot in, a robot that already belongs to somebody refuses without `force`,
+                // and `account.status` makes the answer visible to anyone who asks.
+                proto::method::ACCOUNT_LOGIN,
+                proto::method::ACCOUNT_LOGOUT,
+                // Renaming it. The console shows the name in its header, so the place to change
+                // it is the place it is wrong.
+                proto::method::SYSTEM_SET_NAME,
+                // Rebooting it, for `robot.shutdown`'s reason.
+                proto::method::SYSTEM_REBOOT,
+                // Forgetting a gamepad. `pad.pair` is refused — it needs a pad in the room in a
+                // fifteen-second window, which a remote peer cannot satisfy — but unbonding one
+                // is a thing you do *because* the pad is not there.
+                proto::method::PAD_FORGET,
+            ],
+            "a mutating call was routed to WebRTC; is `deploy/updater.toml` still narrow enough?"
+        );
     }
 
     /// The two calls that must never reach a network transport, whatever else changes.

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -182,7 +182,9 @@ fn permits(call: &proto::Call) -> bool {
         // - **It is visible.** `account.status` names the account, from any transport, without
         //   authorisation. A robot signed in to a stranger is a question anybody can ask.
         // - **It is revocable**, by `account.logout` here or on the robot, and by revoking the
-        //   grant on Hugging Face — which no robot-side gate could offer.
+        //   grant on Hugging Face — which no robot-side gate could offer. `logout` forgets the
+        //   credential rather than revoking it, so the token stays live at HF until it expires;
+        //   `remote-access-design.md` §2.6 is exact about that.
         //
         // What it is *not* is a reason to route `policy.fetch` after all: that one reaches the
         // network to put a stranger's weights in charge of fifteen servos, where this reaches it

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -225,6 +225,23 @@ enum Namespace {
         command: UpdateCommand,
     },
 
+    /// The Hugging Face account this robot belongs to.
+    ///
+    /// A robot on a LAN needs no account: the console is a URL on the same wifi. An account is
+    /// what lets a robot be reached from *outside* the LAN — it is how a rendezvous service knows
+    /// which robots are yours.
+    ///
+    /// Signing in is a device-code flow: this prints a short code, somebody approves it on
+    /// huggingface.co from any device, and the robot picks up the token. No browser on the robot
+    /// and no callback URL, so it works over ssh and it works from a phone.
+    ///
+    /// `docs/design/remote-access-design.md` §2.
+    #[command(subcommand_required = true, arg_required_else_help = true)]
+    Account {
+        #[command(subcommand)]
+        command: AccountCommand,
+    },
+
     /// Which `.onnx` runs in which slot — try a policy, and put it back.
     ///
     /// Slots are `walk`, `stand`, `sitstand`, `ground_pick`, `kick_left`, `kick_right` and
@@ -805,6 +822,35 @@ enum PadCommand {
     /// this robot no longer has and the bond is refused.
     Forget {
         mac: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// `robotctl account …`
+#[derive(Subcommand, Debug)]
+enum AccountCommand {
+    /// Sign this robot in to a Hugging Face account.
+    Login {
+        /// Print the code and exit instead of waiting for it to be approved.
+        ///
+        /// The robot keeps polling either way — the waiting is `updaterd`'s, not this process's
+        /// — so `account status` picks up where this left off. Ctrl-C does the same thing.
+        #[arg(long)]
+        no_wait: bool,
+        /// Sign in even though this robot already belongs to an account.
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Which account this robot belongs to.
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Forget the account. The robot stops being reachable from outside the LAN.
+    Logout {
         #[arg(long)]
         json: bool,
     },
@@ -2187,6 +2233,166 @@ fn result_of(response: proto::Response) -> Result<serde_json::Value, Failure> {
         return Err(Failure::from_rpc(error));
     }
     Ok(response.result.unwrap_or(serde_json::Value::Null))
+}
+
+/// `robotctl account` — the Hugging Face account this robot belongs to.
+///
+/// `updaterd`'s, for `policy.*`'s reason: it is the daemon with a network stack, and this binary
+/// deliberately does not link one — it is on the recovery path.
+fn run_account(socket: &Path, command: AccountCommand) -> Result<(), Failure> {
+    let mut client = Client::connect_to("updaterd", socket)?;
+    client.hello()?;
+
+    match command {
+        AccountCommand::Status { json } => {
+            let result = result_of(client.call(&proto::Call::AccountStatus)?)?;
+            if json {
+                println!("{}", compact(&result));
+                return Ok(());
+            }
+            print!("{}", render_account(&decode(&result)?));
+            Ok(())
+        }
+        AccountCommand::Logout { json } => {
+            let result = result_of(client.call(&proto::Call::AccountLogout)?)?;
+            if json {
+                println!("{}", compact(&result));
+                return Ok(());
+            }
+            let done: proto::AccountLogoutResult = decode(&result)?;
+            match done.was {
+                Some(username) => println!(
+                    "signed out {username}\n  \
+                     this robot is no longer reachable from outside its own network"
+                ),
+                None => println!("this robot was not signed in to anything"),
+            }
+            Ok(())
+        }
+        AccountCommand::Login {
+            no_wait,
+            force,
+            json,
+        } => {
+            let result = result_of(client.call(&proto::Call::AccountLogin(
+                proto::AccountLoginParams { force },
+            ))?)?;
+            if json {
+                println!("{}", compact(&result));
+                return Ok(());
+            }
+            let login: proto::AccountLoginResult = decode(&result)?;
+
+            // The code first and alone, because that is the one thing the next thirty seconds
+            // depend on somebody reading. The mini's app learned the expensive version of this
+            // lesson — it opened a browser and the code scrolled away underneath it.
+            println!("Open {} and enter this code:\n", login.verification_uri);
+            println!("    {}\n", login.user_code);
+
+            if no_wait {
+                println!(
+                    "The robot is waiting for it — `robotctl account status` says whether it \
+                     has been approved."
+                );
+                return Ok(());
+            }
+            wait_for_login(&mut client, login.expires_in)
+        }
+    }
+}
+
+/// Poll `account.status` until the login resolves, and say what happened.
+///
+/// **Nothing here is load-bearing for the login itself.** `updaterd` is doing the polling; this
+/// only watches. So Ctrl-C is free, and so is losing the terminal — which is the property that
+/// makes the same call work from a phone that backgrounds itself.
+fn wait_for_login(client: &mut Client, expires_in: u64) -> Result<(), Failure> {
+    /// Slower than the robot's own poll of Hugging Face, because this is a second-hand view of
+    /// it: a tighter loop would only ask `updaterd` the same question between its answers.
+    const EVERY: std::time::Duration = std::time::Duration::from_secs(3);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(expires_in);
+    eprintln!("Waiting for approval…");
+    loop {
+        std::thread::sleep(EVERY);
+        let status: proto::AccountStatusResult =
+            decode(&result_of(client.call(&proto::Call::AccountStatus)?)?)?;
+
+        if let Some(account) = &status.account
+            && status.login.is_none()
+        {
+            println!("Signed in as {}.", account.username);
+            return Ok(());
+        }
+        if let Some(error) = &status.last_error {
+            return Err(Failure::new(
+                exit::FAILED,
+                format!("the login did not complete: {error}"),
+            ));
+        }
+        // `login` gone with no account and no error is a robot that was signed out from
+        // somewhere else mid-flow. Rare, and better named than waited out.
+        if status.login.is_none() && status.account.is_none() {
+            return Err(Failure::new(
+                exit::FAILED,
+                "the login is no longer in flight, and this robot is signed in to nothing"
+                    .to_string(),
+            ));
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(Failure::new(
+                exit::FAILED,
+                "the code expired before it was approved — run `account login` again".to_string(),
+            ));
+        }
+    }
+}
+
+/// `account status` for a person.
+fn render_account(status: &proto::AccountStatusResult) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    match &status.account {
+        None => out.push_str(
+            "not signed in\n  \
+             this robot is reachable on its own network only. `robotctl account login` changes \
+             that\n",
+        ),
+        Some(account) => {
+            let _ = writeln!(out, "signed in as {}", account.username);
+            // A token's remaining life is only worth a line when it is short or gone: the
+            // ordinary answer is "twenty-nine days", which nobody asked about.
+            let days = account.token_expires_in / 86_400;
+            if account.token_expires_in <= 0 {
+                let _ = writeln!(
+                    out,
+                    "  the stored token has expired{}",
+                    if account.refreshable {
+                        " and the robot could not renew it — sign in again"
+                    } else {
+                        " and there is nothing to renew it with — sign in again"
+                    }
+                );
+            } else if days < 3 {
+                let _ = writeln!(out, "  the token expires in under {} days", days + 1);
+            }
+        }
+    }
+
+    if let Some(login) = &status.login {
+        let _ = writeln!(
+            out,
+            "a login is waiting for approval: enter {} at {} ({} minutes left)",
+            login.user_code,
+            login.verification_uri,
+            login.expires_in / 60
+        );
+    }
+    if let Some(error) = &status.last_error {
+        let _ = writeln!(out, "last login attempt: {error}");
+    }
+    out
 }
 
 /// Ask `configd` one question and print the answer.
@@ -4163,6 +4369,9 @@ fn run(cli: Cli) -> Result<(), Failure> {
                 return run_pad_bindings(&cli.robot_socket, &cli.pad_config, command);
             }
             return run_pad(&cli.config_socket, command);
+        }
+        Namespace::Account { command } => {
+            return run_account(&cli.socket, command);
         }
         Namespace::Policy { command, file } => {
             return run_policy(&cli.robot_socket, &cli.socket, &file, command);

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -838,7 +838,11 @@ enum AccountCommand {
         /// — so `account status` picks up where this left off. Ctrl-C does the same thing.
         #[arg(long)]
         no_wait: bool,
-        /// Sign in even though this robot already belongs to an account.
+        /// Sign in even though this robot already belongs to an account, or is already
+        /// waiting for a code to be approved.
+        ///
+        /// The second is how to abandon a code nobody is going to approve: the login that was
+        /// waiting is dropped, and an approval that arrives for it afterwards is ignored.
         #[arg(long)]
         force: bool,
         #[arg(long)]

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -60,7 +60,9 @@ tar = "0.4.46"
 zstd = "0.13.3"
 toml = "1.1.3"
 futures-util = "0.3.33"
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "json", "stream", "http2", "charset"] }
+# `form` is for `account.rs`: OAuth token endpoints take `application/x-www-form-urlencoded`
+# bodies, not JSON, and RFC 8628 is no exception. It pulls in `serde_urlencoded` and nothing else.
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "json", "stream", "http2", "charset", "form"] }
 
 [dev-dependencies]
 test-support = { path = "../test-support" }

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -496,8 +496,18 @@ pub struct Account {
     /// mutating a variable the whole process shares.
     endpoint: String,
     /// `Mutex` rather than a channel because there is at most one login at a time and both
-    /// `login` and `status` need to see it; the lock is held for a field read.
+    /// `login` and `status` need to see it; the lock is held for a field read, and deliberately
+    /// never across a network call — `status` is polled *while* a login is in flight, so
+    /// anything that made it queue behind an HTTP round trip would make a wizard look stuck.
     pending: Mutex<Option<Pending>>,
+    /// Held for the whole of starting a login, which the one above cannot be.
+    ///
+    /// Two callers arriving together both read `pending` as empty, both ask Hugging Face for a
+    /// code, and both spawn a poller: the store then holds whichever approval landed last, which
+    /// is neither predictable nor explicable to whoever was reading the other code. The window is
+    /// the round trip to `/oauth/device`, so the guard has to cover it — and it is its own lock
+    /// rather than `pending` because `status` must not wait on that round trip.
+    starting: Mutex<()>,
     last_error: Mutex<Option<String>>,
 }
 
@@ -517,6 +527,7 @@ impl Account {
             store,
             endpoint,
             pending: Mutex::new(None),
+            starting: Mutex::new(()),
             last_error: Mutex::new(None),
         }
     }
@@ -539,8 +550,12 @@ impl Account {
             let who = stored.username.unwrap_or_else(|| "another account".into());
             return Err(Error::AlreadySignedIn(who));
         }
-        // One login at a time. A second one would race the first's write and leave whichever
-        // finished last, which is not a thing a caller can predict or a user can understand.
+
+        // One login at a time, and the gate has to hold across the round trip below rather than
+        // only across the check — see [`Self::starting`] for what two of them leave behind.
+        // `try_lock`, so the second caller is told `Busy` now instead of queueing behind
+        // somebody else's twenty-second timeout and then starting a login nobody is waiting for.
+        let _starting = self.starting.try_lock().map_err(|_| Error::Busy)?;
         {
             let pending = self.pending.lock().await;
             if let Some(pending) = pending.as_ref()
@@ -615,6 +630,7 @@ impl Account {
         *self.pending.lock().await = None;
         match result {
             Ok(username) => {
+                let username = username.unwrap_or_else(|| "an account it cannot name yet".into());
                 tracing::info!(%username, "this robot now belongs to a Hugging Face account");
                 *self.last_error.lock().await = None;
             }
@@ -625,21 +641,36 @@ impl Account {
         }
     }
 
-    /// Store a fresh token, and return the username it belongs to.
+    /// Store a fresh token, and return the username it belongs to if the name could be had.
     ///
     /// The username is asked for *before* the write and stored with it, so `status` never needs
     /// the network — and a robot that is offline still knows who it belongs to.
+    ///
+    /// **A failure to read the name must not lose the token.** By this point somebody has
+    /// approved a code on their phone; throwing the credential away because `/oauth/userinfo`
+    /// answered a 502 would make them do the whole flow again for a field that is a label. So
+    /// the name is optional: the record lands either way, `status` says `unknown` until it is
+    /// known, and [`maintain`] fills it in within six hours — see [`Self::name_if_unknown`].
     async fn persist(
         &self,
         client: &reqwest::Client,
         token: TokenResponse,
-    ) -> Result<String, Error> {
-        let username = userinfo(client, &self.endpoint, &token.access_token).await?;
+    ) -> Result<Option<String>, Error> {
+        let username = match userinfo(client, &self.endpoint, &token.access_token).await {
+            Ok(username) => Some(username),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "signed in, but could not read the account name; storing the token anyway"
+                );
+                None
+            }
+        };
         self.store.save(&Stored {
             access_token: token.access_token,
             refresh_token: token.refresh_token,
             expires_at: token.expires_in.map(|s| now_secs() + s as i64),
-            username: Some(username.clone()),
+            username: username.clone(),
         })?;
         Ok(username)
     }
@@ -719,6 +750,28 @@ impl Account {
         })?;
         Ok(true)
     }
+
+    /// Ask who the token belongs to, when the stored record cannot say.
+    ///
+    /// Only ever the case after a login whose `/oauth/userinfo` call failed — [`Self::persist`]
+    /// keeps the token in that case rather than losing it over a label. Left alone,
+    /// `account.status` would answer `unknown` until somebody signed in again; this is what makes
+    /// it answer properly on the next [`maintain`] pass instead. Returns `true` when it wrote a
+    /// name.
+    pub async fn name_if_unknown(&self) -> Result<bool, Error> {
+        let Some(stored) = self.store.load() else {
+            return Ok(false);
+        };
+        if stored.username.is_some() {
+            return Ok(false);
+        }
+        let username = userinfo(&http::client()?, &self.endpoint, &stored.access_token).await?;
+        self.store.save(&Stored {
+            username: Some(username),
+            ..stored
+        })?;
+        Ok(true)
+    }
 }
 
 /// Keep the token fresh for as long as this process runs.
@@ -738,6 +791,15 @@ pub async fn maintain(account: std::sync::Arc<Account>) {
                 tracing::warn!(%why, "could not renew the account token");
                 *account.last_error.lock().await = Some(why);
             }
+        }
+        // A missing name is cosmetic, so its failure stays in the journal rather than going to
+        // `last_error`: that field answers "why did remote access stop", and this did not stop
+        // it. Nothing happens here at all on the overwhelmingly common path — the name is only
+        // absent after a login that could not reach `/oauth/userinfo`.
+        match account.name_if_unknown().await {
+            Ok(true) => tracing::info!("filled in the account name a login could not read"),
+            Ok(false) => {}
+            Err(e) => tracing::debug!(error = %e, "still cannot read the account name"),
         }
         tokio::time::sleep(MAINTAIN_INTERVAL).await;
     }
@@ -1027,8 +1089,11 @@ mod tests {
     struct FakeHf {
         base: String,
         /// Every `grant_type` the token endpoint was asked for, in order. Empty for a fake that
-        /// only serves `/oauth/device`.
+        /// does not serve `/oauth/token`.
         grants: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        /// How many times the route under test was asked, for the tests where *once* is the
+        /// property rather than the answer.
+        hits: std::sync::Arc<std::sync::atomic::AtomicUsize>,
         _task: tokio::task::JoinHandle<()>,
     }
 
@@ -1036,9 +1101,19 @@ mod tests {
         fn grants(&self) -> Vec<String> {
             self.grants.lock().unwrap().clone()
         }
+
+        fn hits(&self) -> usize {
+            self.hits.load(std::sync::atomic::Ordering::SeqCst)
+        }
     }
 
-    async fn serve(app: axum::Router, grants: std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> FakeHf {
+    #[derive(Default)]
+    struct Records {
+        grants: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        hits: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    async fn serve(app: axum::Router, records: Records) -> FakeHf {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base = format!("http://{}", listener.local_addr().unwrap());
         let task = tokio::spawn(async move {
@@ -1046,7 +1121,8 @@ mod tests {
         });
         FakeHf {
             base,
-            grants,
+            grants: records.grants,
+            hits: records.hits,
             _task: task,
         }
     }
@@ -1058,7 +1134,7 @@ mod tests {
             "/oauth/device",
             post(move || async move { ([("content-type", "application/json")], device_response) }),
         );
-        serve(app, Default::default()).await
+        serve(app, Records::default()).await
     }
 
     /// A stand-in for the token endpoint alone, which is all a refresh touches.
@@ -1068,8 +1144,8 @@ mod tests {
     async fn fake_hf_token(answer: &'static str) -> FakeHf {
         use axum::routing::post;
 
-        let grants: std::sync::Arc<std::sync::Mutex<Vec<String>>> = Default::default();
-        let seen = std::sync::Arc::clone(&grants);
+        let records = Records::default();
+        let seen = std::sync::Arc::clone(&records.grants);
         let app = axum::Router::new().route(
             "/oauth/token",
             post(
@@ -1086,7 +1162,132 @@ mod tests {
                 },
             ),
         );
-        serve(app, grants).await
+        serve(app, records).await
+    }
+
+    /// A stand-in for `/oauth/userinfo` alone, answering with whatever status is asked for.
+    async fn fake_hf_userinfo(answer: &'static str, status: u16) -> FakeHf {
+        use axum::routing::get;
+
+        let code = axum::http::StatusCode::from_u16(status).unwrap();
+        let app = axum::Router::new().route(
+            "/oauth/userinfo",
+            get(move || async move { (code, [("content-type", "application/json")], answer) }),
+        );
+        serve(app, Records::default()).await
+    }
+
+    /// A device endpoint that takes its time, and counts how often it was asked.
+    ///
+    /// The delay is the point: the window two logins race for is exactly this round trip, so a
+    /// fake that answered instantly would leave the test passing for the wrong reason.
+    async fn fake_hf_slow_device() -> FakeHf {
+        use axum::routing::post;
+
+        let records = Records::default();
+        let hits = std::sync::Arc::clone(&records.hits);
+        let app = axum::Router::new().route(
+            "/oauth/device",
+            post(move || {
+                let hits = std::sync::Arc::clone(&hits);
+                async move {
+                    hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    (
+                        [("content-type", "application/json")],
+                        r#"{"device_code":"device-abc","user_code":"A6MY-0314",
+                            "verification_uri":"https://hf.co/oauth/device",
+                            "expires_in":60,"interval":1}"#,
+                    )
+                }
+            }),
+        );
+        serve(app, records).await
+    }
+
+    /// Two logins arriving together: one starts, the other is told the robot is busy.
+    ///
+    /// The guard has to cover the round trip to `/oauth/device`, not just the check before it —
+    /// two codes handed out means two pollers, and the store then holds whichever approval landed
+    /// last while somebody stares at the other code wondering why it did nothing.
+    #[tokio::test]
+    async fn two_logins_at_once_do_not_both_reach_hugging_face() {
+        let dir = tempfile::tempdir().unwrap();
+        let hf = fake_hf_slow_device().await;
+        let account = std::sync::Arc::new(Account::with_endpoint(store_in(&dir), hf.base.clone()));
+
+        let (first, second) = tokio::join!(account.login(false), account.login(false));
+
+        let outcomes = [first, second];
+        assert_eq!(
+            outcomes.iter().filter(|r| r.is_ok()).count(),
+            1,
+            "exactly one login starts: {outcomes:?}"
+        );
+        let refusal = outcomes
+            .iter()
+            .find_map(|r| r.as_ref().err())
+            .expect("the other is refused");
+        assert!(
+            matches!(refusal, Error::Busy),
+            "and refused as busy, which is a state that passes: {refusal:?}"
+        );
+        assert_eq!(
+            hf.hits(),
+            1,
+            "one device code asked for, so there is only one code to read"
+        );
+    }
+
+    /// An approved token is not thrown away because `/oauth/userinfo` failed.
+    ///
+    /// By the time this runs somebody has typed a code into a phone. Losing the credential over
+    /// the *label* would make them do all of it again, and on the board this is for — one whose
+    /// network is the reason the call failed — quite possibly twice. So the name is optional, and
+    /// the next `maintain` pass is what fills it in.
+    #[tokio::test]
+    async fn an_approved_token_survives_a_userinfo_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let approved = || TokenResponse {
+            access_token: "approved".into(),
+            refresh_token: Some("refresh-1".into()),
+            expires_in: Some(2_591_999),
+        };
+
+        let broken = fake_hf_userinfo("<html>502 Bad Gateway</html>", 502).await;
+        let account = Account::with_endpoint(store.clone(), broken.base.clone());
+        let named = account
+            .persist(&http::client().unwrap(), approved())
+            .await
+            .expect("a name that cannot be read is not a failed login");
+        assert!(named.is_none());
+
+        let stored = store.load().expect("the credential is on disk regardless");
+        assert_eq!(stored.access_token, "approved");
+        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-1"));
+        assert!(stored.username.is_none(), "the name is what is missing");
+        assert_eq!(
+            account.status().await.account.unwrap().username,
+            "unknown",
+            "a client is told the robot belongs to somebody it cannot name, not that it is \
+             signed out"
+        );
+
+        // And the next pass names it, without touching the credential.
+        let working = fake_hf_userinfo(r#"{"preferred_username":"PierreRouanet"}"#, 200).await;
+        let account = Account::with_endpoint(store.clone(), working.base.clone());
+        assert!(account.name_if_unknown().await.unwrap());
+        let stored = store.load().unwrap();
+        assert_eq!(stored.username.as_deref(), Some("PierreRouanet"));
+        assert_eq!(
+            stored.access_token, "approved",
+            "the backfill writes the name and nothing else"
+        );
+        assert!(
+            !account.name_if_unknown().await.unwrap(),
+            "and asks nobody once it knows — this runs every six hours forever"
+        );
     }
 
     /// A token near the end of its life is renewed, and **the rotated refresh token replaces the

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -555,13 +555,16 @@ impl Account {
         // only across the check — see [`Self::starting`] for what two of them leave behind.
         // `try_lock`, so the second caller is told `Busy` now instead of queueing behind
         // somebody else's twenty-second timeout and then starting a login nobody is waiting for.
-        let _starting = self.starting.try_lock().map_err(|_| Error::Busy)?;
+        let _starting = self
+            .starting
+            .try_lock()
+            .map_err(|_| Error::LoginInFlight)?;
         {
             let pending = self.pending.lock().await;
             if let Some(pending) = pending.as_ref()
                 && pending.deadline > SystemTime::now()
             {
-                return Err(Error::Busy);
+                return Err(Error::LoginInFlight);
             }
         }
 
@@ -1229,8 +1232,13 @@ mod tests {
             .find_map(|r| r.as_ref().err())
             .expect("the other is refused");
         assert!(
-            matches!(refusal, Error::Busy),
+            matches!(refusal, Error::LoginInFlight),
             "and refused as busy, which is a state that passes: {refusal:?}"
+        );
+        assert_eq!(refusal.code(), crate::proto::code::BUSY, "retryable");
+        assert!(
+            refusal.to_string().contains("account status"),
+            "and it says where the code that already exists can be read: {refusal}"
         );
         assert_eq!(
             hf.hits(),

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -21,11 +21,11 @@
 //!   process owns, and a client comes back to [`Account::status`]. A login that reported success
 //!   by holding the connection open would work from a laptop and fail from the device it is for:
 //!   a phone that opens a browser backgrounds itself, and iOS tears the GATT link down.
-//! - **The client displays the code and must not open a browser by itself.** HF sends no
-//!   `verification_uri_complete`, and its device page asks the user to type the code — the mini's
-//!   app found that auto-switching to Safari hid the code before anyone could read it. We
-//!   synthesise the `?user_code=` variant the way `huggingface_hub` does, for a client that wants
-//!   a "copy and open" button, and lead with the code.
+//! - **The client displays the code, and the code has to be typed.** HF sends no
+//!   `verification_uri_complete` and its device page prefills nothing, so no URL carries the code
+//!   — which makes showing it the client's whole job. Whether a client also *opens* the page
+//!   depends on what it is: `remote-access-design.md` §2.1 has three answers, for a robot, a
+//!   terminal and a phone.
 //! - **A token expires in 30 days and its refresh token rotates.** So [`maintain`] renews well
 //!   before expiry, and the store is written atomically — see [`Store::save`] for the one window
 //!   that cannot be closed.
@@ -321,16 +321,23 @@ pub async fn request_device_code(
         ))
     })?;
 
-    // HF sends neither `interval` nor `verification_uri_complete`, so both are synthesised here
-    // — the same normalisation `huggingface_hub` does, in the same place, so nothing downstream
-    // has to know which fields a server bothered with.
-    let verification_uri_complete = raw.verification_uri_complete.unwrap_or_else(|| {
-        format!(
-            "{}?user_code={}",
-            raw.verification_uri,
-            urlencode(&raw.user_code)
-        )
-    });
+    // HF sends neither `interval` nor `verification_uri_complete`, so both are defaulted here —
+    // the same normalisation `huggingface_hub` does, in the same place, so nothing downstream has
+    // to know which fields a server bothered with.
+    //
+    // **The fallback is the plain URI, and the code still has to be typed.** An earlier version
+    // of this appended `?user_code=`, on the strength of a claim in `reachy_mini`'s setup notes
+    // that `huggingface_hub` synthesises that form. It does not — it falls back to
+    // `verification_uri` unchanged — and Hugging Face's device page ignores the parameter: it
+    // survives the login redirect and prefills nothing, which was confirmed in a browser. A URL
+    // carrying a query the other end drops is worse than no query, because it reads like a
+    // promise the page then breaks.
+    //
+    // The field stays because it is the protocol's, and a server that starts sending a real one
+    // is then used without a change here.
+    let verification_uri_complete = raw
+        .verification_uri_complete
+        .unwrap_or_else(|| raw.verification_uri.clone());
     Ok(DeviceCode {
         device_code: raw.device_code,
         user_code: raw.user_code,
@@ -739,21 +746,6 @@ fn now_secs() -> i64 {
         .unwrap_or(0)
 }
 
-/// Percent-encode the few characters a user code could contain that a query string cares about.
-///
-/// HF's codes are `ABCD-1234`, so this is defensive rather than load-bearing — and small enough
-/// that it is not worth a dependency for.
-fn urlencode(s: &str) -> String {
-    s.bytes()
-        .map(|b| match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                (b as char).to_string()
-            }
-            other => format!("%{other:02X}"),
-        })
-        .collect()
-}
-
 /// Write via a temp file and rename, with the temp file created `0600` from the start.
 ///
 /// `fsutil::write_atomic` is the same dance without the mode, and this cannot use it: a token
@@ -947,9 +939,9 @@ mod tests {
             "RFC 8628's fallback, because HF sends no interval"
         );
         assert_eq!(
-            code.verification_uri_complete, "https://hf.co/oauth/device?user_code=A6MY-0314",
-            "the `?user_code=` variant huggingface_hub synthesises, for a client that offers a \
-             single copy-and-open button"
+            code.verification_uri_complete, "https://hf.co/oauth/device",
+            "the plain URI when the server sends none — HF's device page ignores a `?user_code=` \
+             query, so inventing one would promise a prefill that does not happen"
         );
     }
 
@@ -1035,13 +1027,6 @@ mod tests {
             })
             .unwrap();
         assert!(!account.refresh_if_due().await.unwrap());
-    }
-
-    /// Percent-encoding, which only matters if HF ever changes what a user code looks like.
-    #[test]
-    fn a_user_code_is_safe_in_a_query_string() {
-        assert_eq!(urlencode("A6MY-0314"), "A6MY-0314");
-        assert_eq!(urlencode("a b&c"), "a%20b%26c");
     }
 
     /// A one-route stand-in for huggingface.co.

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -1,0 +1,1067 @@
+//! Which Hugging Face account this robot belongs to.
+//!
+//! A duck on a LAN needs no account: `mediad` serves the console, a browser on the same wifi
+//! reaches it, and nothing here is involved. An account is what makes a robot reachable from
+//! *outside* the LAN — the relay proves to a rendezvous service that this robot belongs to an
+//! account, the service shows a client only its own robots, and the pair of those is the
+//! authorisation a bridged session arrives with. `docs/design/remote-access-design.md` owns that
+//! argument; this module owns the credential.
+//!
+//! # The flow is RFC 8628, because the robot has no browser
+//!
+//! `reachy_mini` started with authorization code + PKCE and HF's callback pointed at a URL on the
+//! robot, which needs a redirect URI registered per hostname and a browser that can resolve the
+//! robot. A duck asks Hugging Face for a code instead, says *"type `M8HJ-FMGN` at
+//! hf.co/oauth/device"*, and polls. The phone that approves it need not be able to reach the
+//! robot at all.
+//!
+//! Three consequences shape the code below:
+//!
+//! - **[`Account::login`] returns a code, not a token.** The waiting happens in a task this
+//!   process owns, and a client comes back to [`Account::status`]. A login that reported success
+//!   by holding the connection open would work from a laptop and fail from the device it is for:
+//!   a phone that opens a browser backgrounds itself, and iOS tears the GATT link down.
+//! - **The client displays the code and must not open a browser by itself.** HF sends no
+//!   `verification_uri_complete`, and its device page asks the user to type the code — the mini's
+//!   app found that auto-switching to Safari hid the code before anyone could read it. We
+//!   synthesise the `?user_code=` variant the way `huggingface_hub` does, for a client that wants
+//!   a "copy and open" button, and lead with the code.
+//! - **A token expires in 30 days and its refresh token rotates.** So [`maintain`] renews well
+//!   before expiry, and the store is written atomically — see [`Store::save`] for the one window
+//!   that cannot be closed.
+//!
+//! # The client id is Hugging Face's own, and that is a decision to revisit
+//!
+//! [`CLIENT_ID`] is the first-party device-code client `huggingface_hub` ships, so this needs no
+//! OAuth app registered anywhere and works on a robot that has never met Pollen. What comes back
+//! is a token with **every scope HF grants** — `write-repos`, `manage-repos`, `jobs`,
+//! `read-billing` — because that client takes no `scope` parameter. A duck therefore holds a
+//! credential that can push to its owner's repositories, which is worse than it needs to be for
+//! something whose whole job is proving an identity to a rendezvous service.
+//!
+//! The alternative is a public device-code client registered to `pollen-robotics` with
+//! `openid profile read-repos`, which is one constant here and one click by an org admin. Worth
+//! doing before a duck ships; not worth blocking on now. `remote-access-design.md` §2.4.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::Error;
+use crate::proto;
+use crate::source::http;
+
+/// Hugging Face's first-party device-code OAuth client.
+///
+/// `huggingface_hub`'s `DEVICE_CODE_OAUTH_CLIENT_ID`, which is what `hf auth login` uses. Public
+/// — no secret, and none can be sent: HF refuses the device grant for a *confidential* client
+/// unless it is given the secret, which is why `reachy_mini`'s own OAuth app cannot be used here.
+///
+/// See the module header for what this costs in scopes and what replaces it.
+pub const CLIENT_ID: &str = "26be6b09-91c5-47da-9861-d2d2bb7a7e36";
+
+/// Hugging Face, overridable so tests can point the whole flow at a local server.
+///
+/// `HF_ENDPOINT` is the variable `huggingface_hub` itself reads, so a board pointed at a mirror
+/// for one reason is pointed at it for all of them.
+fn endpoint() -> String {
+    std::env::var("HF_ENDPOINT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://huggingface.co".to_string())
+}
+
+/// Where the credential lives.
+///
+/// **Not in `robotd.toml`.** Every mechanism that exists for that file is wrong for a secret:
+/// `robotctl configure --list` prints what a robot changes, the config editor shows the whole
+/// file, and "what was changed on this robot" is a report we generate. A bearer token would be in
+/// all three.
+pub const DEFAULT_PATH: &str = "/etc/robot/hf-token";
+
+/// The group that may read the token file.
+///
+/// `mediad` runs as `User=mediad` with `SupplementaryGroups=robot`, and it is the process that
+/// needs the token — it is the one holding the relay. `updaterd` runs as root and writes it. So
+/// the file is `root:robot` and `0640`: readable by the daemons that belong to this robot, and by
+/// nothing else with a login on the board.
+const TOKEN_GROUP: &str = "robot";
+
+/// How long an HTTP round trip to Hugging Face gets.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// RFC 8628's fallback when the server sends no `interval`. HF sends none.
+const DEFAULT_POLL_INTERVAL: u64 = 5;
+
+/// RFC 8628 requires `expires_in`; defaulted defensively so a poll loop stays bounded.
+const DEFAULT_EXPIRES_IN: u64 = 900;
+
+/// How often [`maintain`] wakes to look at the token's remaining life.
+const MAINTAIN_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Renew a token with less than this left.
+///
+/// HF issues 30 days, so this refreshes at three-quarters of the way through the token's life and
+/// leaves a week of retries. A robot switched off for longer than the whole 30 days cannot be
+/// saved by any margin — it comes back needing a login, which [`proto::Account::token_expires_in`]
+/// going negative is how a client says so.
+const REFRESH_WHEN_UNDER: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+// ── the stored credential ────────────────────────────────────────────────────
+
+/// What is on disk.
+///
+/// The shape mirrors what the token endpoint returns, plus the two things it does not: an
+/// absolute expiry (the response gives a duration, and a duration is meaningless after a reboot)
+/// and the username, so [`Account::status`] answers without a network round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Stored {
+    pub access_token: String,
+    /// Absent when HF issues none, which would make the token unrenewable rather than broken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    /// Unix seconds. Absent means "HF did not say", which is treated as not expiring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+    /// As `/oauth/userinfo` reported it at login.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+
+impl Stored {
+    /// Seconds until the access token expires; negative once it has. `i64::MAX` when unknown.
+    fn expires_in(&self) -> i64 {
+        match self.expires_at {
+            None => i64::MAX,
+            Some(at) => at.saturating_sub(now_secs()),
+        }
+    }
+}
+
+/// The token file, and the two operations anything has on it.
+#[derive(Debug, Clone)]
+pub struct Store {
+    path: PathBuf,
+}
+
+impl Store {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// What is stored, or `None` when the robot belongs to nobody.
+    ///
+    /// A file that will not parse is `None` with a warning rather than an error: the recovery for
+    /// a corrupt credential is signing in again, and a daemon that refuses to start — or a status
+    /// call that fails — because of one would make that harder rather than safer.
+    pub fn load(&self) -> Option<Stored> {
+        let bytes = std::fs::read(&self.path).ok()?;
+        match serde_json::from_slice::<Stored>(&bytes) {
+            Ok(stored) => Some(stored),
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    error = %e,
+                    "the stored account credential does not parse; treating this robot as signed out"
+                );
+                None
+            }
+        }
+    }
+
+    /// Replace the credential, atomically, readable only by root and the `robot` group.
+    ///
+    /// **The one window this cannot close.** HF rotates the refresh token on every refresh, so
+    /// between "HF issued a new pair" and "the new pair is on disk" the old refresh token is
+    /// already dead. A power cut in that window leaves a robot holding a credential HF will not
+    /// renew, and no ordering here fixes it — the rotation happened on their side. It surfaces as
+    /// a refresh failure in [`proto::AccountStatusResult::last_error`] and is fixed by signing in
+    /// again, which is why [`maintain`] starts trying a week early rather than on the last day.
+    pub fn save(&self, stored: &Stored) -> Result<(), Error> {
+        let bytes = serde_json::to_vec_pretty(stored).map_err(|e| Error::Io {
+            path: self.path.clone(),
+            source: std::io::Error::other(e),
+        })?;
+
+        // Written 0600 first and relaxed to 0640 after the group is set, so the file is never
+        // group-readable while it is owned by root's default group.
+        write_private(&self.path, &bytes)?;
+        if let Some(gid) = group_id(TOKEN_GROUP) {
+            set_group(&self.path, gid)?;
+            set_mode(&self.path, 0o640)?;
+        } else {
+            // No `robot` group means a developer's laptop or a half-provisioned board. Root can
+            // still read it, so a login is not lost; `mediad` will not be able to, and saying so
+            // once is better than a relay that cannot explain why it has no token.
+            tracing::warn!(
+                group = TOKEN_GROUP,
+                path = %self.path.display(),
+                "no such group, so the token stays root-only — mediad will not be able to read it"
+            );
+        }
+        Ok(())
+    }
+
+    /// Forget the credential. Returns who it belonged to, if anyone.
+    pub fn clear(&self) -> Result<Option<String>, Error> {
+        let was = self.load().and_then(|s| s.username);
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(was),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(Error::Io {
+                path: self.path.clone(),
+                source: e,
+            }),
+        }
+    }
+}
+
+// ── the Hugging Face half ────────────────────────────────────────────────────
+
+/// A started device authorization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceCode {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+/// What `POST /oauth/device` answers, before normalisation.
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    verification_uri_complete: Option<String>,
+    expires_in: Option<u64>,
+    interval: Option<u64>,
+}
+
+/// What `POST /oauth/token` answers on success.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[serde(default)]
+    pub expires_in: Option<u64>,
+}
+
+/// What `POST /oauth/token` answers while nobody has approved yet.
+#[derive(Debug, Deserialize)]
+struct OAuthError {
+    error: String,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// One poll of the token endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Poll {
+    /// Nobody has approved it yet.
+    Pending,
+    /// The server wants a longer interval. RFC 8628 §3.5: add five seconds.
+    SlowDown,
+    /// Approved.
+    Token(Box<TokenResponse>),
+    /// The user said no, or the code ran out. Either way, start again.
+    Refused(String),
+    /// Anything inconclusive — a 5xx, a proxy's error page, a network blip. **Not** a failure:
+    /// RFC 8628 §3.5 says keep polling until the code expires, and the deadline bounds the wait.
+    Inconclusive(String),
+}
+
+impl PartialEq for TokenResponse {
+    fn eq(&self, other: &Self) -> bool {
+        self.access_token == other.access_token
+            && self.refresh_token == other.refresh_token
+            && self.expires_in == other.expires_in
+    }
+}
+impl Eq for TokenResponse {}
+
+/// Ask Hugging Face to start a device authorization.
+pub async fn request_device_code(
+    client: &reqwest::Client,
+    base: &str,
+) -> Result<DeviceCode, Error> {
+    let url = format!("{base}/oauth/device");
+    let response = client
+        .post(&url)
+        .timeout(HTTP_TIMEOUT)
+        .form(&[("client_id", CLIENT_ID)])
+        .send()
+        .await
+        .map_err(|e| Error::Network(format!("POST {url}: {e}")))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| Error::Network(format!("reading {url}: {e}")))?;
+    if !status.is_success() {
+        return Err(Error::Network(format!(
+            "POST {url}: HTTP {status}: {}",
+            body.chars().take(300).collect::<String>()
+        )));
+    }
+
+    let raw: DeviceCodeResponse = serde_json::from_str(&body).map_err(|e| {
+        Error::Network(format!(
+            "POST {url}: could not parse the device code response: {e}"
+        ))
+    })?;
+
+    // HF sends neither `interval` nor `verification_uri_complete`, so both are synthesised here
+    // — the same normalisation `huggingface_hub` does, in the same place, so nothing downstream
+    // has to know which fields a server bothered with.
+    let verification_uri_complete = raw.verification_uri_complete.unwrap_or_else(|| {
+        format!(
+            "{}?user_code={}",
+            raw.verification_uri,
+            urlencode(&raw.user_code)
+        )
+    });
+    Ok(DeviceCode {
+        device_code: raw.device_code,
+        user_code: raw.user_code,
+        verification_uri: raw.verification_uri,
+        verification_uri_complete,
+        expires_in: raw.expires_in.unwrap_or(DEFAULT_EXPIRES_IN),
+        interval: raw.interval.unwrap_or(DEFAULT_POLL_INTERVAL),
+    })
+}
+
+/// Poll the token endpoint once.
+pub async fn poll_token(client: &reqwest::Client, base: &str, device_code: &str) -> Poll {
+    let url = format!("{base}/oauth/token");
+    let response = client
+        .post(&url)
+        .timeout(HTTP_TIMEOUT)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("client_id", CLIENT_ID),
+            ("device_code", device_code),
+        ])
+        .send()
+        .await;
+
+    let response = match response {
+        Ok(response) => response,
+        Err(e) => return Poll::Inconclusive(format!("POST {url}: {e}")),
+    };
+    // A 5xx is a Hugging Face problem, not an answer about this login.
+    if response.status().is_server_error() {
+        return Poll::Inconclusive(format!("POST {url}: HTTP {}", response.status()));
+    }
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(e) => return Poll::Inconclusive(format!("reading {url}: {e}")),
+    };
+
+    if let Ok(token) = serde_json::from_str::<TokenResponse>(&body) {
+        return Poll::Token(Box::new(token));
+    }
+    match serde_json::from_str::<OAuthError>(&body) {
+        Ok(err) => classify(&err),
+        // JSON without an `error` member, or not JSON at all: a gateway's error page. Transient.
+        Err(_) => Poll::Inconclusive(format!(
+            "POST {url}: unexpected answer: {}",
+            body.chars().take(200).collect::<String>()
+        )),
+    }
+}
+
+/// Which OAuth errors end a login and which are the login working normally.
+fn classify(err: &OAuthError) -> Poll {
+    let detail = err
+        .error_description
+        .clone()
+        .unwrap_or_else(|| err.error.clone());
+    match err.error.as_str() {
+        "authorization_pending" => Poll::Pending,
+        "slow_down" => Poll::SlowDown,
+        "expired_token" => Poll::Refused(
+            "the code expired before it was approved — start the login again".to_string(),
+        ),
+        "access_denied" => Poll::Refused("the login was refused on Hugging Face".to_string()),
+        // An OAuth error we do not know is still an answer about this login rather than a blip:
+        // `invalid_client` and `invalid_grant` will not fix themselves by being asked again.
+        other => Poll::Refused(format!("Hugging Face said {other}: {detail}")),
+    }
+}
+
+/// Exchange a refresh token for a new pair. HF rotates the refresh token, so the answer's is the
+/// one to keep.
+pub async fn refresh(
+    client: &reqwest::Client,
+    base: &str,
+    refresh_token: &str,
+) -> Result<TokenResponse, Error> {
+    let url = format!("{base}/oauth/token");
+    let response = client
+        .post(&url)
+        .timeout(HTTP_TIMEOUT)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", CLIENT_ID),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await
+        .map_err(|e| Error::Network(format!("POST {url}: {e}")))?;
+    let body = response
+        .text()
+        .await
+        .map_err(|e| Error::Network(format!("reading {url}: {e}")))?;
+    serde_json::from_str::<TokenResponse>(&body).map_err(|_| {
+        let detail = serde_json::from_str::<OAuthError>(&body)
+            .map(|e| format!("{}: {}", e.error, e.error_description.unwrap_or_default()))
+            .unwrap_or_else(|_| body.chars().take(200).collect());
+        Error::Network(format!("could not refresh the account token: {detail}"))
+    })
+}
+
+/// Who a token belongs to.
+///
+/// `/oauth/userinfo` rather than decoding the `id_token`: one round trip against an endpoint that
+/// is part of the flow already, versus a JWT parser and a JWKS fetch for the same string.
+pub async fn userinfo(
+    client: &reqwest::Client,
+    base: &str,
+    access_token: &str,
+) -> Result<String, Error> {
+    #[derive(Deserialize)]
+    struct UserInfo {
+        /// The handle — `PierreRouanet`. `name` is the display name and can be anything.
+        preferred_username: Option<String>,
+        name: Option<String>,
+    }
+
+    let url = format!("{base}/oauth/userinfo");
+    let response = client
+        .get(&url)
+        .timeout(HTTP_TIMEOUT)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| Error::Network(format!("GET {url}: {e}")))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| Error::Network(format!("reading {url}: {e}")))?;
+    if !status.is_success() {
+        return Err(Error::Network(format!("GET {url}: HTTP {status}")));
+    }
+    let info: UserInfo = serde_json::from_str(&body)
+        .map_err(|e| Error::Network(format!("GET {url}: could not parse the answer: {e}")))?;
+    info.preferred_username
+        .or(info.name)
+        .ok_or_else(|| Error::Network(format!("GET {url}: no username in the answer")))
+}
+
+// ── what `updaterd` serves ───────────────────────────────────────────────────
+
+/// A login in flight.
+#[derive(Debug, Clone)]
+struct Pending {
+    login: proto::AccountLoginResult,
+    /// When the code stops being good for anything, so `status` can count down.
+    deadline: SystemTime,
+}
+
+/// The account, as the three `account.*` calls see it.
+#[derive(Debug)]
+pub struct Account {
+    store: Store,
+    /// Where Hugging Face is. Read once at construction rather than per call, so nothing below
+    /// this struct reads the environment — which is what lets a test serve a fake one without
+    /// mutating a variable the whole process shares.
+    endpoint: String,
+    /// `Mutex` rather than a channel because there is at most one login at a time and both
+    /// `login` and `status` need to see it; the lock is held for a field read.
+    pending: Mutex<Option<Pending>>,
+    last_error: Mutex<Option<String>>,
+}
+
+impl Account {
+    /// Infallible, so a daemon whose TLS stack will not build still starts and still answers
+    /// `account.status` — which is how anybody finds out. The HTTP client is built per operation
+    /// instead: `status` and `logout` need none at all, and the one operation that polls in a
+    /// loop wants a client that lives exactly as long as the loop.
+    pub fn new(store: Store) -> Self {
+        Self::with_endpoint(store, endpoint())
+    }
+
+    /// As [`Self::new`], against a named endpoint. For tests, and for a board pointed at a
+    /// mirror by something other than `HF_ENDPOINT`.
+    pub fn with_endpoint(store: Store, endpoint: String) -> Self {
+        Self {
+            store,
+            endpoint,
+            pending: Mutex::new(None),
+            last_error: Mutex::new(None),
+        }
+    }
+
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
+
+    /// Start a device-code login, and answer with the code to show somebody.
+    ///
+    /// The polling runs in a task this returns without waiting for. `force` is what it takes to
+    /// replace an account the robot already belongs to — see [`proto::AccountLoginParams::force`].
+    pub async fn login(
+        self: &std::sync::Arc<Self>,
+        force: bool,
+    ) -> Result<proto::AccountLoginResult, Error> {
+        if let Some(stored) = self.store.load()
+            && !force
+        {
+            let who = stored.username.unwrap_or_else(|| "another account".into());
+            return Err(Error::AlreadySignedIn(who));
+        }
+        // One login at a time. A second one would race the first's write and leave whichever
+        // finished last, which is not a thing a caller can predict or a user can understand.
+        {
+            let pending = self.pending.lock().await;
+            if let Some(pending) = pending.as_ref()
+                && pending.deadline > SystemTime::now()
+            {
+                return Err(Error::Busy);
+            }
+        }
+
+        let client = http::client()?;
+        let code = request_device_code(&client, &self.endpoint).await?;
+        let login = proto::AccountLoginResult {
+            user_code: code.user_code.clone(),
+            verification_uri: code.verification_uri.clone(),
+            verification_uri_complete: code.verification_uri_complete.clone(),
+            expires_in: code.expires_in,
+            interval: code.interval,
+        };
+        *self.pending.lock().await = Some(Pending {
+            login: login.clone(),
+            deadline: SystemTime::now() + Duration::from_secs(code.expires_in),
+        });
+        *self.last_error.lock().await = None;
+
+        tracing::info!(
+            user_code = %code.user_code,
+            uri = %code.verification_uri,
+            expires_in = code.expires_in,
+            "account login started; waiting for approval"
+        );
+
+        let this = std::sync::Arc::clone(self);
+        tokio::spawn(async move { this.wait_for_approval(client, code).await });
+        Ok(login)
+    }
+
+    /// Poll Hugging Face until the code is approved, refused, or out of time.
+    async fn wait_for_approval(&self, client: reqwest::Client, code: DeviceCode) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(code.expires_in);
+        let mut interval = Duration::from_secs(code.interval.max(1));
+
+        let outcome = loop {
+            tokio::time::sleep(interval).await;
+            if tokio::time::Instant::now() >= deadline {
+                break Err("the code expired before it was approved".to_string());
+            }
+            match poll_token(&client, &self.endpoint, &code.device_code).await {
+                Poll::Pending => continue,
+                Poll::SlowDown => {
+                    interval += Duration::from_secs(5);
+                    continue;
+                }
+                // Logged rather than surfaced: a 502 from a proxy is not news about this login,
+                // and RFC 8628 says to keep asking until the code expires.
+                Poll::Inconclusive(why) => {
+                    tracing::debug!(%why, "inconclusive poll; still waiting");
+                    continue;
+                }
+                Poll::Refused(why) => break Err(why),
+                Poll::Token(token) => break Ok(*token),
+            }
+        };
+
+        let result = match outcome {
+            Err(why) => Err(why),
+            Ok(token) => self
+                .persist(&client, token)
+                .await
+                .map_err(|e| e.to_string()),
+        };
+
+        *self.pending.lock().await = None;
+        match result {
+            Ok(username) => {
+                tracing::info!(%username, "this robot now belongs to a Hugging Face account");
+                *self.last_error.lock().await = None;
+            }
+            Err(why) => {
+                tracing::warn!(%why, "account login did not complete");
+                *self.last_error.lock().await = Some(why);
+            }
+        }
+    }
+
+    /// Store a fresh token, and return the username it belongs to.
+    ///
+    /// The username is asked for *before* the write and stored with it, so `status` never needs
+    /// the network — and a robot that is offline still knows who it belongs to.
+    async fn persist(
+        &self,
+        client: &reqwest::Client,
+        token: TokenResponse,
+    ) -> Result<String, Error> {
+        let username = userinfo(client, &self.endpoint, &token.access_token).await?;
+        self.store.save(&Stored {
+            access_token: token.access_token,
+            refresh_token: token.refresh_token,
+            expires_at: token.expires_in.map(|s| now_secs() + s as i64),
+            username: Some(username.clone()),
+        })?;
+        Ok(username)
+    }
+
+    /// Who this robot belongs to, and whether a login is in flight.
+    pub async fn status(&self) -> proto::AccountStatusResult {
+        let account = self.store.load().map(|stored| proto::Account {
+            username: stored
+                .username
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+            token_expires_in: stored.expires_in(),
+            refreshable: stored.refresh_token.is_some(),
+        });
+
+        // The code's remaining life rather than its original one: a client polling this wants a
+        // countdown, and `expires_in` is documented as what is *left* here.
+        let login = self.pending.lock().await.as_ref().and_then(|pending| {
+            let left = pending
+                .deadline
+                .duration_since(SystemTime::now())
+                .ok()?
+                .as_secs();
+            Some(proto::AccountLoginResult {
+                expires_in: left,
+                ..pending.login.clone()
+            })
+        });
+
+        proto::AccountStatusResult {
+            account,
+            login,
+            last_error: self.last_error.lock().await.clone(),
+        }
+    }
+
+    /// Forget the account. A login in flight is abandoned with it.
+    pub async fn logout(&self) -> Result<proto::AccountLogoutResult, Error> {
+        let was = self.store.clear()?;
+        *self.pending.lock().await = None;
+        *self.last_error.lock().await = None;
+        if let Some(username) = &was {
+            tracing::info!(%username, "this robot no longer belongs to a Hugging Face account");
+        }
+        Ok(proto::AccountLogoutResult { was })
+    }
+
+    /// Renew the token before it expires. One pass; [`maintain`] is the loop.
+    ///
+    /// Returns `true` when it wrote a new token. Does nothing when the robot is signed out, when
+    /// there is no refresh token, or when there is plenty of time left.
+    pub async fn refresh_if_due(&self) -> Result<bool, Error> {
+        let Some(stored) = self.store.load() else {
+            return Ok(false);
+        };
+        let Some(refresh_token) = stored.refresh_token.clone() else {
+            return Ok(false);
+        };
+        if stored.expires_in() > REFRESH_WHEN_UNDER.as_secs() as i64 {
+            return Ok(false);
+        }
+
+        let token = refresh(&http::client()?, &self.endpoint, &refresh_token).await?;
+        // Keep the username rather than re-asking: a refresh cannot change who the token belongs
+        // to, and this path runs unattended on a board whose network may be marginal.
+        self.store.save(&Stored {
+            access_token: token.access_token,
+            refresh_token: token.refresh_token,
+            expires_at: token.expires_in.map(|s| now_secs() + s as i64),
+            username: stored.username,
+        })?;
+        Ok(true)
+    }
+}
+
+/// Keep the token fresh for as long as this process runs.
+///
+/// Spawned once at startup. It is a slow loop on purpose: the thing it guards against is a robot
+/// that has been on for a month, and the cost of asking too often is a request to Hugging Face
+/// that answers "not yet".
+pub async fn maintain(account: std::sync::Arc<Account>) {
+    loop {
+        match account.refresh_if_due().await {
+            Ok(true) => tracing::info!("renewed the account token"),
+            Ok(false) => {}
+            // Not fatal and not silent: a week of retries is left, and `account.status` carries
+            // the reason for anyone asking why remote access stopped.
+            Err(e) => {
+                let why = e.to_string();
+                tracing::warn!(%why, "could not renew the account token");
+                *account.last_error.lock().await = Some(why);
+            }
+        }
+        tokio::time::sleep(MAINTAIN_INTERVAL).await;
+    }
+}
+
+// ── small things ─────────────────────────────────────────────────────────────
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Percent-encode the few characters a user code could contain that a query string cares about.
+///
+/// HF's codes are `ABCD-1234`, so this is defensive rather than load-bearing — and small enough
+/// that it is not worth a dependency for.
+fn urlencode(s: &str) -> String {
+    s.bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (b as char).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
+}
+
+/// Write via a temp file and rename, with the temp file created `0600` from the start.
+///
+/// `fsutil::write_atomic` is the same dance without the mode, and this cannot use it: a token
+/// written `0644` and chmodded afterwards is world-readable for the moment in between, which is
+/// exactly the kind of window that is invisible in testing and permanent in a log.
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), Error> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let tmp = path.with_extension("tmp");
+    let io = |source: std::io::Error, path: &Path| Error::Io {
+        path: path.to_path_buf(),
+        source,
+    };
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .map_err(|e| io(e, &tmp))?;
+        file.write_all(bytes).map_err(|e| io(e, &tmp))?;
+        file.sync_all().map_err(|e| io(e, &tmp))?;
+    }
+    std::fs::rename(&tmp, path).map_err(|e| io(e, path))?;
+    crate::fsutil::fsync_parent(path)
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<(), Error> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| Error::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+/// The gid of a group by name, or `None` if there is no such group.
+fn group_id(name: &str) -> Option<u32> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    // SAFETY: `getgrnam` takes a NUL-terminated string and returns a pointer into a static
+    // buffer or NULL. We read the one field we need before anything else can call it again.
+    let entry = unsafe { libc::getgrnam(cname.as_ptr()) };
+    if entry.is_null() {
+        return None;
+    }
+    Some(unsafe { (*entry).gr_gid })
+}
+
+fn set_group(path: &Path, gid: u32) -> Result<(), Error> {
+    use std::os::unix::ffi::OsStrExt;
+    let cpath = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| Error::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::other("path contains a NUL"),
+    })?;
+    // SAFETY: both pointers are valid for the call; `-1` as the uid leaves the owner alone.
+    let rc = unsafe { libc::chown(cpath.as_ptr(), u32::MAX, gid) };
+    if rc != 0 {
+        return Err(Error::Io {
+            path: path.to_path_buf(),
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_in(dir: &tempfile::TempDir) -> Store {
+        Store::new(dir.path().join("hf-token"))
+    }
+
+    fn token(access: &str) -> Stored {
+        Stored {
+            access_token: access.to_string(),
+            refresh_token: Some("refresh-1".into()),
+            expires_at: Some(now_secs() + 30 * 24 * 60 * 60),
+            username: Some("PierreRouanet".into()),
+        }
+    }
+
+    /// The store is a file, and the file survives being replaced.
+    #[test]
+    fn a_credential_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+
+        assert!(store.load().is_none(), "nothing stored yet");
+        store.save(&token("first")).unwrap();
+        assert_eq!(store.load().unwrap().access_token, "first");
+
+        store.save(&token("second")).unwrap();
+        assert_eq!(store.load().unwrap().access_token, "second");
+        assert_eq!(
+            store.clear().unwrap(),
+            Some("PierreRouanet".to_string()),
+            "clear reports who it forgot, so a CLI can say so"
+        );
+        assert!(store.load().is_none());
+        assert_eq!(
+            store.clear().unwrap(),
+            None,
+            "clearing nothing is not an error — `logout` twice is not a failure"
+        );
+    }
+
+    /// **A token must never be world-readable, at any point.**
+    ///
+    /// The mode is checked on the file that lands, and the temp file it was written through is
+    /// checked by construction: `write_private` opens it `0600` rather than chmodding afterwards,
+    /// which is the window this test cannot see and the reason the helper exists.
+    #[test]
+    fn the_token_file_is_not_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        store.save(&token("secret")).unwrap();
+
+        let mode = std::fs::metadata(store.path())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode & 0o007,
+            0,
+            "the token file is readable by other users: {mode:o}"
+        );
+        // 0640 on a board with a `robot` group, 0600 without one — a developer's laptop has no
+        // such group, and the test has to pass in both places.
+        assert!(mode == 0o600 || mode == 0o640, "unexpected mode {mode:o}");
+        assert!(
+            !dir.path().join("hf-token.tmp").exists(),
+            "the temp file must not be left behind holding a copy of the token"
+        );
+    }
+
+    /// A file somebody edited by hand reads as "signed out", not as a broken daemon.
+    #[test]
+    fn a_corrupt_credential_is_signed_out_rather_than_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        std::fs::write(store.path(), b"{ this is not json").unwrap();
+        assert!(store.load().is_none());
+    }
+
+    /// Which OAuth errors end a login, and which are it working normally.
+    ///
+    /// The two in the middle are the ones worth pinning: treating `slow_down` as a failure would
+    /// abandon a login that was about to succeed, and treating `expired_token` as transient would
+    /// poll a dead code until the deadline.
+    #[test]
+    fn oauth_errors_are_classified() {
+        let of = |error: &str| {
+            classify(&OAuthError {
+                error: error.to_string(),
+                error_description: None,
+            })
+        };
+        assert_eq!(of("authorization_pending"), Poll::Pending);
+        assert_eq!(of("slow_down"), Poll::SlowDown);
+        assert!(matches!(of("expired_token"), Poll::Refused(_)));
+        assert!(matches!(of("access_denied"), Poll::Refused(_)));
+        // An error we have never seen is still an answer about this login: `invalid_client` will
+        // not fix itself by being asked again, and polling it for five minutes hides the cause.
+        assert!(matches!(of("invalid_client"), Poll::Refused(_)));
+    }
+
+    /// Hugging Face sends neither `interval` nor `verification_uri_complete`. Both are
+    /// synthesised here so nothing downstream has to know that.
+    #[tokio::test]
+    async fn a_device_code_response_is_normalised() {
+        // Exactly what huggingface.co answered on 2026-09-02, field for field.
+        let server = fake_hf(
+            r#"{"device_code":"41ad39ae","user_code":"A6MY-0314",
+                "verification_uri":"https://hf.co/oauth/device","expires_in":300}"#,
+        )
+        .await;
+
+        let code = request_device_code(&http::client().unwrap(), &server.base)
+            .await
+            .unwrap();
+
+        assert_eq!(code.user_code, "A6MY-0314");
+        assert_eq!(code.expires_in, 300);
+        assert_eq!(
+            code.interval, DEFAULT_POLL_INTERVAL,
+            "RFC 8628's fallback, because HF sends no interval"
+        );
+        assert_eq!(
+            code.verification_uri_complete, "https://hf.co/oauth/device?user_code=A6MY-0314",
+            "the `?user_code=` variant huggingface_hub synthesises, for a client that offers a \
+             single copy-and-open button"
+        );
+    }
+
+    /// A robot that already belongs to somebody refuses without `force`, and says who.
+    ///
+    /// The check is before any network call, which is what makes this testable offline — and is
+    /// also the behaviour that matters: a login that reached Hugging Face first would have burned
+    /// a device code to arrive at the same refusal.
+    #[tokio::test]
+    async fn signing_in_over_an_existing_account_is_refused_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        store.save(&token("already-here")).unwrap();
+
+        let account = std::sync::Arc::new(Account::new(store));
+        let error = account.login(false).await.expect_err("must refuse");
+        assert!(
+            matches!(&error, Error::AlreadySignedIn(who) if who == "PierreRouanet"),
+            "{error:?}"
+        );
+        assert_eq!(
+            error.code(),
+            crate::proto::code::INVALID_PARAMS,
+            "the fix is a parameter, and a client should be able to tell that from the code"
+        );
+        assert!(
+            error.to_string().contains("--force"),
+            "the message must name the way past it: {error}"
+        );
+    }
+
+    /// `status` on a robot that belongs to nobody, which is every robot out of the box.
+    #[tokio::test]
+    async fn status_of_a_robot_that_belongs_to_nobody() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = Account::new(store_in(&dir));
+        let status = account.status().await;
+        assert!(status.account.is_none());
+        assert!(status.login.is_none());
+        assert!(status.last_error.is_none());
+    }
+
+    /// `status` reports the account from disk, with no network call.
+    #[tokio::test]
+    async fn status_names_the_account_without_asking_anybody() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        store.save(&token("stored")).unwrap();
+
+        let status = Account::new(store).status().await;
+        let account = status.account.expect("signed in");
+        assert_eq!(account.username, "PierreRouanet");
+        assert!(account.refreshable, "a refresh token was stored");
+        assert!(
+            account.token_expires_in > 29 * 24 * 60 * 60,
+            "about thirty days: {}",
+            account.token_expires_in
+        );
+    }
+
+    /// A token with a month left is not renewed, and a robot with no token is not renewed either.
+    ///
+    /// Both are the "do nothing" case and both would otherwise be an HTTP request on every tick
+    /// of [`maintain`] — on a board whose network may not be there.
+    #[tokio::test]
+    async fn a_fresh_token_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let account = Account::new(store.clone());
+
+        assert!(!account.refresh_if_due().await.unwrap(), "signed out");
+
+        store.save(&token("fresh")).unwrap();
+        assert!(!account.refresh_if_due().await.unwrap(), "plenty of time");
+
+        // No refresh token: nothing to renew with, and it must not be an error — the robot is
+        // signed in and working, it just cannot renew unattended.
+        store
+            .save(&Stored {
+                refresh_token: None,
+                expires_at: Some(now_secs() + 60),
+                ..token("expiring")
+            })
+            .unwrap();
+        assert!(!account.refresh_if_due().await.unwrap());
+    }
+
+    /// Percent-encoding, which only matters if HF ever changes what a user code looks like.
+    #[test]
+    fn a_user_code_is_safe_in_a_query_string() {
+        assert_eq!(urlencode("A6MY-0314"), "A6MY-0314");
+        assert_eq!(urlencode("a b&c"), "a%20b%26c");
+    }
+
+    /// A one-route stand-in for huggingface.co.
+    struct FakeHf {
+        base: String,
+        _task: tokio::task::JoinHandle<()>,
+    }
+
+    async fn fake_hf(device_response: &'static str) -> FakeHf {
+        use axum::routing::post;
+
+        let app = axum::Router::new().route(
+            "/oauth/device",
+            post(move || async move { ([("content-type", "application/json")], device_response) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        FakeHf { base, _task: task }
+    }
+}

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -192,7 +192,7 @@ impl Store {
         // Written 0600 first and relaxed to 0640 after the group is set, so the file is never
         // group-readable while it is owned by root's default group.
         write_private(&self.path, &bytes)?;
-        if let Some(gid) = group_id(TOKEN_GROUP) {
+        if let Some(gid) = crate::unix::group_id(TOKEN_GROUP) {
             set_group(&self.path, gid)?;
             set_mode(&self.path, 0o640)?;
         } else {
@@ -677,6 +677,12 @@ impl Account {
     }
 
     /// Forget the account. A login in flight is abandoned with it.
+    ///
+    /// **Forgets rather than revokes.** The file goes, so the robot stops being able to prove it
+    /// belongs to anybody, which is what signing out is for. The token itself stays valid at
+    /// Hugging Face until it expires — up to thirty days — for anything that read the file while
+    /// it was there. `remote-access-design.md` §2.6 says why that is where the line is and what
+    /// closing it would take.
     pub async fn logout(&self) -> Result<proto::AccountLogoutResult, Error> {
         let was = self.store.clear()?;
         *self.pending.lock().await = None;
@@ -781,18 +787,6 @@ fn set_mode(path: &Path, mode: u32) -> Result<(), Error> {
         path: path.to_path_buf(),
         source: e,
     })
-}
-
-/// The gid of a group by name, or `None` if there is no such group.
-fn group_id(name: &str) -> Option<u32> {
-    let cname = std::ffi::CString::new(name).ok()?;
-    // SAFETY: `getgrnam` takes a NUL-terminated string and returns a pointer into a static
-    // buffer or NULL. We read the one field we need before anything else can call it again.
-    let entry = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if entry.is_null() {
-        return None;
-    }
-    Some(unsafe { (*entry).gr_gid })
 }
 
 fn set_group(path: &Path, gid: u32) -> Result<(), Error> {
@@ -1032,7 +1026,29 @@ mod tests {
     /// A one-route stand-in for huggingface.co.
     struct FakeHf {
         base: String,
+        /// Every `grant_type` the token endpoint was asked for, in order. Empty for a fake that
+        /// only serves `/oauth/device`.
+        grants: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
         _task: tokio::task::JoinHandle<()>,
+    }
+
+    impl FakeHf {
+        fn grants(&self) -> Vec<String> {
+            self.grants.lock().unwrap().clone()
+        }
+    }
+
+    async fn serve(app: axum::Router, grants: std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> FakeHf {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        FakeHf {
+            base,
+            grants,
+            _task: task,
+        }
     }
 
     async fn fake_hf(device_response: &'static str) -> FakeHf {
@@ -1042,11 +1058,147 @@ mod tests {
             "/oauth/device",
             post(move || async move { ([("content-type", "application/json")], device_response) }),
         );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let base = format!("http://{}", listener.local_addr().unwrap());
-        let task = tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-        FakeHf { base, _task: task }
+        serve(app, Default::default()).await
+    }
+
+    /// A stand-in for the token endpoint alone, which is all a refresh touches.
+    ///
+    /// It records the `grant_type` it was asked for, because a refresh sent as a device-code
+    /// grant would be refused by Hugging Face and by nobody here.
+    async fn fake_hf_token(answer: &'static str) -> FakeHf {
+        use axum::routing::post;
+
+        let grants: std::sync::Arc<std::sync::Mutex<Vec<String>>> = Default::default();
+        let seen = std::sync::Arc::clone(&grants);
+        let app = axum::Router::new().route(
+            "/oauth/token",
+            post(
+                move |axum::extract::Form(form): axum::extract::Form<
+                    std::collections::HashMap<String, String>,
+                >| {
+                    let seen = std::sync::Arc::clone(&seen);
+                    async move {
+                        seen.lock()
+                            .unwrap()
+                            .push(form.get("grant_type").cloned().unwrap_or_default());
+                        ([("content-type", "application/json")], answer)
+                    }
+                },
+            ),
+        );
+        serve(app, grants).await
+    }
+
+    /// A token near the end of its life is renewed, and **the rotated refresh token replaces the
+    /// one that was spent**.
+    ///
+    /// The rotation is the part worth a test rather than a comment: Hugging Face spends the old
+    /// refresh token on every refresh, so storing the one already on disk — the obvious mistake,
+    /// since the rest of the record is carried over — leaves a robot that renews exactly once and
+    /// then quietly stops being reachable. `remote-access-design.md` §2.7.
+    #[tokio::test]
+    async fn a_due_token_is_renewed_and_the_rotation_lands_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        // Six days left: inside `REFRESH_WHEN_UNDER`, which is how a board with a marginal
+        // network gets a week of retries instead of one last day.
+        store
+            .save(&Stored {
+                expires_at: Some(now_secs() + 6 * 24 * 60 * 60),
+                ..token("spent")
+            })
+            .unwrap();
+
+        let hf = fake_hf_token(
+            r#"{"access_token":"renewed","refresh_token":"refresh-2","expires_in":2591999}"#,
+        )
+        .await;
+        let account = Account::with_endpoint(store.clone(), hf.base.clone());
+
+        assert!(
+            account.refresh_if_due().await.unwrap(),
+            "a token with six days left is due"
+        );
+
+        let stored = store.load().unwrap();
+        assert_eq!(stored.access_token, "renewed");
+        assert_eq!(
+            stored.refresh_token.as_deref(),
+            Some("refresh-2"),
+            "the answer's refresh token, not the one it was traded for"
+        );
+        assert_eq!(
+            stored.username.as_deref(),
+            Some("PierreRouanet"),
+            "kept rather than re-asked: a refresh cannot change who a token belongs to, and this              path runs unattended"
+        );
+        assert!(
+            stored.expires_in() > 29 * 24 * 60 * 60,
+            "the new expiry is absolute and thirty days out: {}",
+            stored.expires_in()
+        );
+        assert_eq!(
+            hf.grants(),
+            vec!["refresh_token".to_string()],
+            "one refresh, sent as a refresh"
+        );
+
+        // And now it is not due again, which is what stops `maintain` renewing on every tick.
+        assert!(!account.refresh_if_due().await.unwrap());
+        assert_eq!(hf.grants().len(), 1, "no second round trip");
+    }
+
+    /// A refresh Hugging Face refuses leaves the credential alone and says so in `status`.
+    ///
+    /// This is the visible half of the window §2.7 says cannot be closed: once the old refresh
+    /// token is spent, no ordering here can recover it, so what the code owes is (a) not making
+    /// it worse by writing a half-record and (b) telling somebody. `maintain` is what turns the
+    /// error into an answer a client can read, so it is driven here rather than trusted.
+    #[tokio::test]
+    async fn a_refused_refresh_is_left_alone_and_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        store
+            .save(&Stored {
+                expires_at: Some(now_secs() + 60 * 60),
+                ..token("spent")
+            })
+            .unwrap();
+
+        let hf = fake_hf_token(
+            r#"{"error":"invalid_grant","error_description":"refresh token is expired"}"#,
+        )
+        .await;
+        let account = std::sync::Arc::new(Account::with_endpoint(store.clone(), hf.base.clone()));
+
+        let error = account
+            .refresh_if_due()
+            .await
+            .expect_err("a refused refresh is an error");
+        assert!(
+            error.to_string().contains("invalid_grant"),
+            "the reason has to survive to the surface: {error}"
+        );
+        assert_eq!(
+            store.load().unwrap().access_token,
+            "spent",
+            "the stored credential is untouched — an hour of access left is worth more than a              record half-replaced by a failed refresh"
+        );
+
+        let task = tokio::spawn(maintain(std::sync::Arc::clone(&account)));
+        let mut reported = None;
+        for _ in 0..200 {
+            if let Some(why) = account.status().await.last_error {
+                reported = Some(why);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        task.abort();
+        let reported = reported.expect("`maintain` must put the failure where a client can see it");
+        assert!(
+            reported.contains("invalid_grant"),
+            "`account.status` is where somebody asks why remote access stopped: {reported}"
+        );
     }
 }

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -500,6 +500,16 @@ pub struct Account {
     /// never across a network call — `status` is polled *while* a login is in flight, so
     /// anything that made it queue behind an HTTP round trip would make a wizard look stuck.
     pending: Mutex<Option<Pending>>,
+    /// Which login is the current one.
+    ///
+    /// A flow lives in a spawned task that outlives the call that started it, and two things can
+    /// happen to it while it waits: `--force` starts another, or `logout` says the robot belongs
+    /// to nobody. In both cases the old task is still holding a device code Hugging Face will
+    /// happily approve, and without this it would write that approval to the store — a robot
+    /// signed back in a minute after being signed out, or signed in as the account somebody just
+    /// replaced. Each flow carries the number it was started with and does nothing at all if it
+    /// is no longer the current one.
+    generation: std::sync::atomic::AtomicU64,
     /// Held for the whole of starting a login, which the one above cannot be.
     ///
     /// Two callers arriving together both read `pending` as empty, both ask Hugging Face for a
@@ -527,6 +537,7 @@ impl Account {
             store,
             endpoint,
             pending: Mutex::new(None),
+            generation: std::sync::atomic::AtomicU64::new(0),
             starting: Mutex::new(()),
             last_error: Mutex::new(None),
         }
@@ -553,13 +564,18 @@ impl Account {
 
         // One login at a time, and the gate has to hold across the round trip below rather than
         // only across the check — see [`Self::starting`] for what two of them leave behind.
-        // `try_lock`, so the second caller is told `Busy` now instead of queueing behind
-        // somebody else's twenty-second timeout and then starting a login nobody is waiting for.
+        // `try_lock`, so the second caller is told so now instead of queueing behind somebody
+        // else's twenty-second timeout and then starting a login nobody is waiting for.
         let _starting = self
             .starting
             .try_lock()
             .map_err(|_| Error::LoginInFlight)?;
-        {
+        // A code that is still good refuses a second login — **unless `force`**. Without that
+        // exception the only ways out of a code nobody is going to approve are waiting five
+        // minutes and `logout`, and `logout` throws away a working credential to clear a
+        // *pending* one, which is a remedy worse than the problem. `force` already means "replace
+        // what this robot belongs to"; replacing an attempt at it is the smaller version.
+        if !force {
             let pending = self.pending.lock().await;
             if let Some(pending) = pending.as_ref()
                 && pending.deadline > SystemTime::now()
@@ -577,6 +593,12 @@ impl Account {
             expires_in: code.expires_in,
             interval: code.interval,
         };
+        // Claimed before the old flow can be told it has been replaced, so there is no instant
+        // in which two tasks both believe they are current.
+        let generation = self
+            .generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
         *self.pending.lock().await = Some(Pending {
             login: login.clone(),
             deadline: SystemTime::now() + Duration::from_secs(code.expires_in),
@@ -591,12 +613,17 @@ impl Account {
         );
 
         let this = std::sync::Arc::clone(self);
-        tokio::spawn(async move { this.wait_for_approval(client, code).await });
+        tokio::spawn(async move { this.wait_for_approval(client, code, generation).await });
         Ok(login)
     }
 
     /// Poll Hugging Face until the code is approved, refused, or out of time.
-    async fn wait_for_approval(&self, client: reqwest::Client, code: DeviceCode) {
+    async fn wait_for_approval(
+        &self,
+        client: reqwest::Client,
+        code: DeviceCode,
+        generation: u64,
+    ) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(code.expires_in);
         let mut interval = Duration::from_secs(code.interval.max(1));
 
@@ -622,6 +649,18 @@ impl Account {
             }
         };
 
+        // Superseded, and therefore silent: a `--force` login replaced this one, or `logout`
+        // said the robot belongs to nobody. Either way an approval that arrives now is an answer
+        // to a question that has been withdrawn, and writing it would sign the robot into the
+        // account somebody just replaced or out of. Checked *before* the store is touched.
+        if !self.is_current(generation) {
+            tracing::info!(
+                user_code = %code.user_code,
+                "a login was superseded before it finished; dropping its result"
+            );
+            return;
+        }
+
         let result = match outcome {
             Err(why) => Err(why),
             Ok(token) => self
@@ -629,6 +668,14 @@ impl Account {
                 .await
                 .map_err(|e| e.to_string()),
         };
+
+        // And again after it, because `persist` awaits: a `logout` landing during the write is
+        // the same withdrawal, and the record it left behind has to go with it.
+        if !self.is_current(generation) {
+            let _ = self.store.clear();
+            tracing::info!("a login completed after being superseded; its token was discarded");
+            return;
+        }
 
         *self.pending.lock().await = None;
         match result {
@@ -642,6 +689,11 @@ impl Account {
                 *self.last_error.lock().await = Some(why);
             }
         }
+    }
+
+    /// Whether the flow started as `generation` is still the one this robot is waiting on.
+    fn is_current(&self, generation: u64) -> bool {
+        self.generation.load(std::sync::atomic::Ordering::SeqCst) == generation
     }
 
     /// Store a fresh token, and return the username it belongs to if the name could be had.
@@ -718,6 +770,10 @@ impl Account {
     /// it was there. `remote-access-design.md` §2.6 says why that is where the line is and what
     /// closing it would take.
     pub async fn logout(&self) -> Result<proto::AccountLogoutResult, Error> {
+        // Before the file goes, so a flow that approves during this call sees itself superseded
+        // rather than writing a token into a robot that has just been signed out.
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let was = self.store.clear()?;
         *self.pending.lock().await = None;
         *self.last_error.lock().await = None;
@@ -1245,6 +1301,120 @@ mod tests {
             1,
             "one device code asked for, so there is only one code to read"
         );
+    }
+
+    /// A whole fake Hugging Face: a device code, a token, and a name.
+    ///
+    /// `approve_after` is how many `authorization_pending` answers to give first; `0` approves on
+    /// the first poll, which is what the tests about *abandoning* a login want — the approval has
+    /// to land while the test is still watching.
+    async fn fake_hf_full(approve_after: usize) -> FakeHf {
+        use axum::routing::{get, post};
+
+        let records = Records::default();
+        let polls = std::sync::Arc::clone(&records.hits);
+        let app = axum::Router::new()
+            .route(
+                "/oauth/device",
+                post(|| async {
+                    (
+                        [("content-type", "application/json")],
+                        r#"{"device_code":"device-abc","user_code":"A6MY-0314",
+                            "verification_uri":"https://hf.co/oauth/device",
+                            "expires_in":60,"interval":1}"#,
+                    )
+                }),
+            )
+            .route(
+                "/oauth/token",
+                post(move || {
+                    let polls = std::sync::Arc::clone(&polls);
+                    async move {
+                        let n = polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let body = if n < approve_after {
+                            r#"{"error":"authorization_pending"}"#
+                        } else {
+                            r#"{"access_token":"approved","refresh_token":"refresh-1",
+                                "expires_in":2591999}"#
+                        };
+                        ([("content-type", "application/json")], body)
+                    }
+                }),
+            )
+            .route(
+                "/oauth/userinfo",
+                get(|| async {
+                    (
+                        [("content-type", "application/json")],
+                        r#"{"preferred_username":"PierreRouanet"}"#,
+                    )
+                }),
+            );
+        serve(app, records).await
+    }
+
+    /// `--force` abandons a code nobody is going to approve.
+    ///
+    /// Without this the only ways past a live code are waiting five minutes and `logout`, and
+    /// `logout` destroys a working credential to clear a *pending* one. The refusal has to name a
+    /// way through it, and this is that way.
+    #[tokio::test]
+    async fn force_replaces_a_login_that_is_still_waiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let hf = fake_hf_slow_device().await;
+        let account = std::sync::Arc::new(Account::with_endpoint(store_in(&dir), hf.base.clone()));
+
+        let first = account.login(false).await.expect("the first login starts");
+        assert_eq!(hf.hits(), 1);
+
+        let refused = account
+            .login(false)
+            .await
+            .expect_err("a live code refuses a second login");
+        assert!(matches!(refused, Error::LoginInFlight), "{refused:?}");
+        assert!(
+            refused.to_string().contains("--force"),
+            "and says how to get past itself: {refused}"
+        );
+
+        account.login(true).await.expect("`force` gets past it");
+        assert_eq!(hf.hits(), 2, "a new code was asked for");
+        let waiting = account.status().await.login.expect("one login is in flight");
+        assert_eq!(
+            waiting.user_code, first.user_code,
+            "this fake answers with one code, so what is pinned here is that `status` describes \
+             the current login and not a stale one"
+        );
+    }
+
+    /// An approval that lands after `logout` is dropped, not written.
+    ///
+    /// The flow lives in a task that outlives the call that started it, so signing out while a
+    /// code is live leaves somebody able to approve it a minute later. Writing that would sign
+    /// the robot back in on its own, which is the one thing `logout` has to be able to promise it
+    /// will not do.
+    #[tokio::test]
+    async fn a_login_approved_after_logout_is_discarded() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let hf = fake_hf_full(0).await;
+        let account =
+            std::sync::Arc::new(Account::with_endpoint(store.clone(), hf.base.clone()));
+
+        account.login(false).await.expect("a login starts");
+        account.logout().await.expect("and is signed out under it");
+
+        // The fake approves on the first poll, one second in. Well past that, and nothing has
+        // been written: the flow saw itself superseded before it touched the store.
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+        assert!(hf.hits() >= 1, "the abandoned flow did reach the token endpoint");
+        assert!(
+            store.load().is_none(),
+            "a robot signed out must stay signed out"
+        );
+        let status = account.status().await;
+        assert!(status.account.is_none());
+        assert!(status.login.is_none());
     }
 
     /// An approved token is not thrown away because `/oauth/userinfo` failed.

--- a/updater/src/account.rs
+++ b/updater/src/account.rs
@@ -566,10 +566,7 @@ impl Account {
         // only across the check — see [`Self::starting`] for what two of them leave behind.
         // `try_lock`, so the second caller is told so now instead of queueing behind somebody
         // else's twenty-second timeout and then starting a login nobody is waiting for.
-        let _starting = self
-            .starting
-            .try_lock()
-            .map_err(|_| Error::LoginInFlight)?;
+        let _starting = self.starting.try_lock().map_err(|_| Error::LoginInFlight)?;
         // A code that is still good refuses a second login — **unless `force`**. Without that
         // exception the only ways out of a code nobody is going to approve are waiting five
         // minutes and `logout`, and `logout` throws away a working credential to clear a
@@ -618,12 +615,7 @@ impl Account {
     }
 
     /// Poll Hugging Face until the code is approved, refused, or out of time.
-    async fn wait_for_approval(
-        &self,
-        client: reqwest::Client,
-        code: DeviceCode,
-        generation: u64,
-    ) {
+    async fn wait_for_approval(&self, client: reqwest::Client, code: DeviceCode, generation: u64) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(code.expires_in);
         let mut interval = Duration::from_secs(code.interval.max(1));
 
@@ -1379,7 +1371,11 @@ mod tests {
 
         account.login(true).await.expect("`force` gets past it");
         assert_eq!(hf.hits(), 2, "a new code was asked for");
-        let waiting = account.status().await.login.expect("one login is in flight");
+        let waiting = account
+            .status()
+            .await
+            .login
+            .expect("one login is in flight");
         assert_eq!(
             waiting.user_code, first.user_code,
             "this fake answers with one code, so what is pinned here is that `status` describes \
@@ -1398,8 +1394,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(&dir);
         let hf = fake_hf_full(0).await;
-        let account =
-            std::sync::Arc::new(Account::with_endpoint(store.clone(), hf.base.clone()));
+        let account = std::sync::Arc::new(Account::with_endpoint(store.clone(), hf.base.clone()));
 
         account.login(false).await.expect("a login starts");
         account.logout().await.expect("and is signed out under it");
@@ -1407,7 +1402,10 @@ mod tests {
         // The fake approves on the first poll, one second in. Well past that, and nothing has
         // been written: the flow saw itself superseded before it touched the store.
         tokio::time::sleep(Duration::from_millis(2_500)).await;
-        assert!(hf.hits() >= 1, "the abandoned flow did reach the token endpoint");
+        assert!(
+            hf.hits() >= 1,
+            "the abandoned flow did reach the token endpoint"
+        );
         assert!(
             store.load().is_none(),
             "a robot signed out must stay signed out"

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -617,6 +617,23 @@ mod tests {
             "btd must be able to relay an update request from the app: {:?}",
             config.allow_users
         );
+        // And mediad, for the mutating calls its route table permits: `account.login`, and
+        // `policy.install`/`policy.fetch`, which were routed to WebRTC before this line existed
+        // and so answered PERMISSION_DENIED. Asserted rather than assumed because the failure is
+        // silent in the worst way — a button that reads as a broken feature rather than as a
+        // missing line in a config file.
+        assert!(
+            config.allow_users.iter().any(|u| u == "mediad"),
+            "mediad must be able to sign the robot in to an account: {:?}",
+            config.allow_users
+        );
+        // Neither entry may become a *group*: the two above are services, and the layering
+        // argument above is about exactly that distinction.
+        assert!(
+            config.allow_groups.is_empty(),
+            "change authority is granted to named services, not to groups: {:?}",
+            config.allow_groups
+        );
         assert_ne!(
             config.auto_apply,
             AutoApply::All,

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -18,7 +18,7 @@
 //! trigger an update or a rollback, so it is created `0o660`, group-owned, and every
 //! mutating request is logged with the caller's uid/pid from `SO_PEERCRED`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -120,6 +120,13 @@ pub struct Server {
 
     /// Test-only override of the owning uid; `None` means "read it from the socket".
     forced_owner_uid: Option<u32>,
+
+    /// Which Hugging Face account this robot belongs to.
+    ///
+    /// Not part of the engine: it shares nothing with an update but the network stack, and it
+    /// must stay answerable *during* one — `account.status` is polled while a login is in
+    /// flight, and queueing that behind a download would make a wizard look stuck.
+    account: Arc<crate::account::Account>,
 }
 
 impl Server {
@@ -139,7 +146,24 @@ impl Server {
             allow_uids,
             allow_gids,
             forced_owner_uid: None,
+            account: Arc::new(crate::account::Account::new(crate::account::Store::new(
+                crate::account::DEFAULT_PATH,
+            ))),
         }
+    }
+
+    /// Point the account at a token file and a Hugging Face of your choosing.
+    ///
+    /// Only for tests, and it is not optional there: [`Self::with_policy`] uses
+    /// [`crate::account::DEFAULT_PATH`], and a test that ran against it would read — or on a
+    /// developer's machine try to write — the real robot's credential.
+    #[doc(hidden)]
+    pub fn with_account_for_test(mut self, token_path: PathBuf, endpoint: String) -> Self {
+        self.account = Arc::new(crate::account::Account::with_endpoint(
+            crate::account::Store::new(token_path),
+            endpoint,
+        ));
+        self
     }
 
     /// Build a server with an explicit owning uid.
@@ -239,6 +263,15 @@ impl Server {
     /// therefore inherit the bypass and lose the protection: exactly the wrong half of
     /// each. It also needs the same engine mutex and progress plumbing as a
     /// client-triggered update.
+    /// Keep the account token from expiring under a robot that is simply left on.
+    ///
+    /// Separate from [`Self::spawn_periodic_checks`] because it is unconditional: that one is
+    /// off unless a `check_interval` is configured, and a robot with update checks disabled
+    /// still has an account that stops working after thirty days.
+    pub fn spawn_account_maintenance(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(crate::account::maintain(Arc::clone(&self.account)))
+    }
+
     pub fn spawn_periodic_checks(
         self: &Arc<Self>,
         interval: Duration,
@@ -602,6 +635,23 @@ impl Server {
                     Err(e) => Response::err(Some(id), e.to_rpc_error()),
                 }
             }
+            // ── account.* ───────────────────────────────────────────────────────
+            //
+            // None of the three touches the engine, so none takes its lock: a login is an HTTP
+            // round trip and a file, and both are outside every release directory. That is also
+            // what makes `status` answerable during an update, which it has to be.
+            Call::AccountLogin(params) => {
+                match Arc::clone(&self.account).login(params.force).await {
+                    Ok(login) => Response::ok(Some(id), &login),
+                    Err(e) => Response::err(Some(id), e.to_rpc_error()),
+                }
+            }
+            Call::AccountStatus => Response::ok(Some(id), &self.account.status().await),
+            Call::AccountLogout => match self.account.logout().await {
+                Ok(result) => Response::ok(Some(id), &result),
+                Err(e) => Response::err(Some(id), e.to_rpc_error()),
+            },
+
             // Read-only and no engine lock: asking the Hub what exists changes nothing here.
             Call::PolicySearch(params) => match crate::policy::search(&params.query).await {
                 Ok(result) => Response::ok(Some(id), &result),

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -263,15 +263,6 @@ impl Server {
     /// therefore inherit the bypass and lose the protection: exactly the wrong half of
     /// each. It also needs the same engine mutex and progress plumbing as a
     /// client-triggered update.
-    /// Keep the account token from expiring under a robot that is simply left on.
-    ///
-    /// Separate from [`Self::spawn_periodic_checks`] because it is unconditional: that one is
-    /// off unless a `check_interval` is configured, and a robot with update checks disabled
-    /// still has an account that stops working after thirty days.
-    pub fn spawn_account_maintenance(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(crate::account::maintain(Arc::clone(&self.account)))
-    }
-
     pub fn spawn_periodic_checks(
         self: &Arc<Self>,
         interval: Duration,
@@ -288,6 +279,15 @@ impl Server {
                 tokio::time::sleep(interval).await;
             }
         })
+    }
+
+    /// Keep the account token from expiring under a robot that is simply left on.
+    ///
+    /// Separate from [`Self::spawn_periodic_checks`] because it is unconditional: that one is
+    /// off unless a `check_interval` is configured, and a robot with update checks disabled
+    /// still has an account that stops working after thirty days.
+    pub fn spawn_account_maintenance(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(crate::account::maintain(Arc::clone(&self.account)))
     }
 
     /// One pass of the scheduler. Exposed so tests can drive it without waiting for

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -123,7 +123,10 @@ pub enum Error {
     /// both pointed at the same robot, and telling that person an *update* is in progress sends
     /// them looking in the wrong place. What they need is that a code is already out and where to
     /// read it.
-    #[error("a login is already waiting for approval — `account status` has the code")]
+    #[error(
+        "a login is already waiting for approval — `account status` has the code, or --force to \
+         start a new one"
+    )]
     LoginInFlight,
 
     /// `account.login` on a robot that already belongs to somebody, without `--force`.

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -116,6 +116,16 @@ pub enum Error {
     #[error("another update is already in progress")]
     Busy,
 
+    /// A second `account.login` while one is still waiting for approval.
+    ///
+    /// Shares [`code::BUSY`] with the update above — a client should retry or wait either way —
+    /// but not its message: two logins collide during setup, when a console page and a phone are
+    /// both pointed at the same robot, and telling that person an *update* is in progress sends
+    /// them looking in the wrong place. What they need is that a code is already out and where to
+    /// read it.
+    #[error("a login is already waiting for approval — `account status` has the code")]
+    LoginInFlight,
+
     /// `account.login` on a robot that already belongs to somebody, without `--force`.
     ///
     /// A refusal rather than a silent replacement, because this call is routed to BLE and to a
@@ -240,7 +250,7 @@ impl Error {
             // target is older than what is installed" — and what a person needs is the message.
             // A new code would be an `API_VERSION` bump for a refusal no client branches on.
             Error::StagingBehind { .. } => code::WOULD_DOWNGRADE,
-            Error::Busy => code::BUSY,
+            Error::Busy | Error::LoginInFlight => code::BUSY,
             // The request is well-formed and refused because of what it did not say, which is
             // what `INVALID_PARAMS` is: passing `force` is the fix, and it is a parameter.
             Error::AlreadySignedIn(_) => code::INVALID_PARAMS,

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -52,6 +52,8 @@ pub mod source;
 mod spawn;
 pub mod store;
 pub mod transcript;
+/// Names to numbers, for the two lookups this crate makes against the user database.
+pub mod unix;
 pub mod verify;
 
 use std::path::PathBuf;

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -29,6 +29,9 @@
 //! - **No hardware capability matrix.** v1 targets one hardware configuration
 //!   (§5.6).
 
+/// Which Hugging Face account this robot belongs to — the credential a remote session needs
+/// before it can exist. `docs/design/remote-access-design.md` §2.
+pub mod account;
 pub mod config;
 pub mod engine;
 pub mod faults;
@@ -110,6 +113,19 @@ pub enum Error {
 
     #[error("another update is already in progress")]
     Busy,
+
+    /// `account.login` on a robot that already belongs to somebody, without `--force`.
+    ///
+    /// A refusal rather than a silent replacement, because this call is routed to BLE and to a
+    /// datachannel: on a LAN, anybody who can reach the robot can start a login, and one that
+    /// quietly rebound the robot would turn "was on the wifi" into remote access that outlives
+    /// being there. The message names the account and the flag, because the legitimate case —
+    /// a robot changing hands — is common enough to deserve the instruction rather than a hunt.
+    #[error(
+        "this robot already belongs to {0}. Sign that account out first, or pass --force to \
+         replace it"
+    )]
+    AlreadySignedIn(String),
 
     #[error("config error: {0}")]
     Config(String),
@@ -223,6 +239,9 @@ impl Error {
             // A new code would be an `API_VERSION` bump for a refusal no client branches on.
             Error::StagingBehind { .. } => code::WOULD_DOWNGRADE,
             Error::Busy => code::BUSY,
+            // The request is well-formed and refused because of what it did not say, which is
+            // what `INVALID_PARAMS` is: passing `force` is the fix, and it is a parameter.
+            Error::AlreadySignedIn(_) => code::INVALID_PARAMS,
             Error::Network(_) => code::NETWORK,
             // Shares the network code rather than adding one, for the reason `StagingBehind`
             // shares the downgrade code above — with a second reason here. To a client this is

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -158,46 +158,46 @@ async fn robot_is_answering(robot: &dyn updater::robot::RobotClient) -> bool {
     )
 }
 
-/// A user name to a uid, and a group name to a gid.
+/// A user name to a uid, and a group name to a gid — with a line in the journal either way.
 ///
 /// `SO_PEERCRED` reports numbers, so a name has to become one somewhere. Doing it here, once at
 /// startup, is what lets `deploy/updater.toml` name `btd` and stay correct on a board where
 /// `systemd-sysusers` allocated a different uid.
 ///
-/// Duplicated in `configd`, deliberately: the obvious shared home would be `duck-ipc-proto`, and
-/// that crate is types only — every service speaks it, including the ones on the recovery path,
-/// so it may not grow a libc dependency for the convenience of two callers.
+/// The lookup itself is [`updater::unix`], which `account.rs` also uses for the token file's
+/// group. What is left here is the logging, and that is the part worth keeping local: these two
+/// lines are how you find out from the journal that a board's `allow_users` entry resolved to
+/// nothing, which looks exactly like a permissions bug from the client's end.
 fn resolve_uid(name: &str) -> Option<u32> {
-    let cname = std::ffi::CString::new(name).ok()?;
-    // Safety: `getpwnam` takes a NUL-terminated string and returns a pointer into a static
-    // buffer, or null. Read immediately; nothing is retained.
-    let entry = unsafe { libc::getpwnam(cname.as_ptr()) };
-    if entry.is_null() {
-        tracing::warn!(
-            user = name,
-            "no such user; it cannot change this robot's software"
-        );
-        return None;
+    match updater::unix::user_id(name) {
+        None => {
+            tracing::warn!(
+                user = name,
+                "no such user; it cannot change this robot's software"
+            );
+            None
+        }
+        Some(uid) => {
+            tracing::info!(user = name, uid, "may change this robot's software");
+            Some(uid)
+        }
     }
-    let uid = unsafe { (*entry).pw_uid };
-    tracing::info!(user = name, uid, "may change this robot's software");
-    Some(uid)
 }
 
 fn resolve_gid(name: &str) -> Option<u32> {
-    let cname = std::ffi::CString::new(name).ok()?;
-    // Safety: as above, for the group database.
-    let entry = unsafe { libc::getgrnam(cname.as_ptr()) };
-    if entry.is_null() {
-        tracing::warn!(
-            group = name,
-            "no such group; it cannot change this robot's software"
-        );
-        return None;
+    match updater::unix::group_id(name) {
+        None => {
+            tracing::warn!(
+                group = name,
+                "no such group; it cannot change this robot's software"
+            );
+            None
+        }
+        Some(gid) => {
+            tracing::info!(group = name, gid, "may change this robot's software");
+            Some(gid)
+        }
     }
-    let gid = unsafe { (*entry).gr_gid };
-    tracing::info!(group = name, gid, "may change this robot's software");
-    Some(gid)
 }
 
 #[tokio::main]

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -611,6 +611,11 @@ async fn serve(args: Args) -> ExitCode {
     ));
     let socket = args.socket.clone();
 
+    // Unconditional, unlike the update scheduler below: a Hugging Face token lasts thirty days
+    // and its refresh token rotates, so a robot that is on for a month loses remote access
+    // unless something renews it. `docs/design/remote-access-design.md` §2.7.
+    server.spawn_account_maintenance();
+
     // The scheduler is what makes `min_supported` effective: without it the floor is
     // inert, because a robot only learns of it when someone opens the app.
     match check_interval {

--- a/updater/src/unix.rs
+++ b/updater/src/unix.rs
@@ -1,0 +1,55 @@
+//! Names to numbers: the two lookups this crate needs from the user database.
+//!
+//! Everything in this crate that cares about identity is configured by **name** —
+//! `deploy/updater.toml` names `btd` and `mediad` in `allow_users`, and the account token is
+//! group-owned by `robot` — because `systemd-sysusers` allocates dynamically and a number written
+//! down is right on one board and wrong on the next. `SO_PEERCRED` and `chown(2)` deal in
+//! numbers, so the translation has to happen somewhere, and doing it here means one SAFETY
+//! argument rather than one per caller.
+//!
+//! Not shared with `configd`, `padd` and `tof`, which have their own copies: the obvious common
+//! home is `duck-ipc-proto`, and that crate is types only — every service speaks it, including
+//! the ones on the recovery path, so it may not grow a libc dependency for the convenience of a
+//! few callers. Within *this* crate there is no such excuse, which is why the lib and the binary
+//! share these rather than each keeping a copy.
+
+/// The uid of a user by name, or `None` if there is no such user.
+pub fn user_id(name: &str) -> Option<u32> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    // SAFETY: `getpwnam` takes a NUL-terminated string and returns a pointer into a static
+    // buffer, or null. The one field we need is read immediately and nothing is retained, so
+    // the next caller overwriting that buffer cannot be observed here.
+    let entry = unsafe { libc::getpwnam(cname.as_ptr()) };
+    if entry.is_null() {
+        return None;
+    }
+    Some(unsafe { (*entry).pw_uid })
+}
+
+/// The gid of a group by name, or `None` if there is no such group.
+pub fn group_id(name: &str) -> Option<u32> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    // SAFETY: as [`user_id`], for the group database.
+    let entry = unsafe { libc::getgrnam(cname.as_ptr()) };
+    if entry.is_null() {
+        return None;
+    }
+    Some(unsafe { (*entry).gr_gid })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `root` and `root`/`wheel` are the only names portable enough to assert on, and the
+    /// property worth pinning is the other half anyway: a name that does not exist is `None`
+    /// rather than a panic or a zero — `0` is root, so a lookup that returned it on failure
+    /// would hand the wrong caller everything.
+    #[test]
+    fn a_name_that_does_not_exist_is_none() {
+        assert_eq!(user_id("no-such-user-exists-here"), None);
+        assert_eq!(group_id("no-such-group-exists-here"), None);
+        assert_eq!(user_id("root\0with-a-nul"), None, "a NUL is not a name");
+        assert_eq!(user_id("root"), Some(0), "root is uid 0 everywhere");
+    }
+}

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -1145,3 +1145,293 @@ async fn an_allowed_uid_may_mutate() {
     assert!(response.error.is_none(), "{:?}", response.error);
     assert_eq!(fx.live_version().as_deref(), Some("1.0.0"));
 }
+
+// ── account.* ────────────────────────────────────────────────────────────────
+//
+// The login is a device-code flow, so the interesting property is not "the call works" but the
+// *shape* it works in: `account.login` answers with a code and hands the waiting to the daemon,
+// and a client that goes away — which is what a phone does when it opens a browser — comes back
+// to `account.status` to find out what happened. These drive that over a real socket against a
+// stand-in for huggingface.co, because every part of it that can be wrong is in the wiring
+// between the three.
+
+/// A stand-in for huggingface.co: a device code, then pending, then a token.
+///
+/// One state machine rather than a fixed script, so a test observes the same sequence a real
+/// login does — including the `authorization_pending` the robot has to keep polling through.
+struct FakeHub {
+    base: String,
+    polls: Arc<std::sync::atomic::AtomicUsize>,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl FakeHub {
+    /// `approve_after` is how many `authorization_pending` answers to give before the token.
+    async fn start(approve_after: usize) -> Self {
+        use axum::extract::Form;
+        use axum::routing::{get, post};
+
+        let polls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = Arc::clone(&polls);
+
+        let app = axum::Router::new()
+            .route(
+                "/oauth/device",
+                // Hugging Face sends no `verification_uri_complete`, so this does not either —
+                // synthesising it is part of what these tests cover. It *does* send an
+                // `interval` HF omits, and only to keep the suite quick: the robot sleeps one
+                // interval before its first poll, so the real five seconds would make every
+                // login test five seconds long. That HF's omission falls back to five is pinned
+                // in `account::tests::a_device_code_response_is_normalised`, where it costs
+                // nothing.
+                post(|| async {
+                    axum::Json(serde_json::json!({
+                        "device_code": "device-abc",
+                        "user_code": "A6MY-0314",
+                        "verification_uri": "https://hf.co/oauth/device",
+                        "expires_in": 300,
+                        "interval": 1
+                    }))
+                }),
+            )
+            .route(
+                "/oauth/token",
+                post(
+                    move |Form(form): Form<std::collections::HashMap<String, String>>| {
+                        let counter = Arc::clone(&counter);
+                        async move {
+                            assert_eq!(
+                                form.get("client_id").map(String::as_str),
+                                Some(updater::account::CLIENT_ID),
+                                "the device flow must identify itself as the public client"
+                            );
+                            let n = counter.fetch_add(1, Ordering::SeqCst);
+                            if n < approve_after {
+                                return axum::Json(serde_json::json!({
+                                    "error": "authorization_pending"
+                                }));
+                            }
+                            axum::Json(serde_json::json!({
+                                "access_token": "an-access-token",
+                                "refresh_token": "a-refresh-token",
+                                "expires_in": 2_591_999u64,
+                                "token_type": "bearer"
+                            }))
+                        }
+                    },
+                ),
+            )
+            .route(
+                "/oauth/userinfo",
+                get(|| async {
+                    axum::Json(serde_json::json!({
+                        "name": "Rouanet",
+                        "preferred_username": "PierreRouanet"
+                    }))
+                }),
+            );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            base,
+            polls,
+            _task: task,
+        }
+    }
+}
+
+/// Serve with the account pointed at a temp file and a fake hub.
+async fn serve_with_account(fx: &Harness, hub: &FakeHub) -> (PathBuf, tokio::task::JoinHandle<()>) {
+    let token_path = fx.root.join("etc/robot/hf-token");
+    std::fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+    let server = Arc::new(
+        Server::new(fx.engine(true, Faults::none()))
+            .with_account_for_test(token_path.clone(), hub.base.clone()),
+    );
+    let handle = fx.serve_with(server).await;
+    (token_path, handle)
+}
+
+/// The whole flow: a code comes back, the daemon polls, and the token lands on disk.
+///
+/// The three assertions that matter are ordered as a client experiences them — the code arrives
+/// *before* anyone has approved anything, the account appears without the client asking Hugging
+/// Face anything itself, and what is written is a credential that can be renewed.
+#[tokio::test]
+async fn a_device_code_login_completes_without_the_client_waiting() {
+    let fx = Harness::new();
+    let hub = FakeHub::start(2).await;
+    let (token_path, _server) = serve_with_account(&fx, &hub).await;
+
+    let mut client = Client::connect(&fx.socket).await;
+    client.hello().await;
+
+    // 1. `login` answers immediately, with something to show a person.
+    let response = client
+        .call(method::ACCOUNT_LOGIN, serde_json::json!({}))
+        .await;
+    assert!(response.error.is_none(), "{:?}", response.error);
+    let result = response.result.unwrap();
+    assert_eq!(result["user_code"], "A6MY-0314");
+    assert_eq!(result["verification_uri"], "https://hf.co/oauth/device");
+    assert_eq!(
+        result["verification_uri_complete"], "https://hf.co/oauth/device?user_code=A6MY-0314",
+        "synthesised, because Hugging Face sends none"
+    );
+    assert_eq!(
+        result["interval"], 1,
+        "the server's interval, passed through for a client that wants to show a countdown"
+    );
+    assert!(
+        !token_path.exists(),
+        "nothing is stored until somebody approves it"
+    );
+
+    // A second client, because the first one is allowed to have gone away by now — this is the
+    // property the whole shape exists for.
+    let mut watcher = Client::connect(&fx.socket).await;
+    watcher.hello().await;
+
+    // While it is in flight, `status` carries the code so a client that reconnected can show it
+    // again rather than starting a second login.
+    let pending = watcher
+        .call(method::ACCOUNT_STATUS, serde_json::json!({}))
+        .await;
+    let pending = pending.result.unwrap();
+    assert_eq!(pending["login"]["user_code"], "A6MY-0314");
+    assert!(pending["account"].is_null(), "not signed in yet");
+
+    // 2. The daemon is doing the polling. `FakeHub` approves on the third ask, and the interval
+    // is five seconds, so this is the one place the test has to wait for real time.
+    let signed_in = loop {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let status = watcher
+            .call(method::ACCOUNT_STATUS, serde_json::json!({}))
+            .await
+            .result
+            .unwrap();
+        if !status["account"].is_null() {
+            break status;
+        }
+        assert!(
+            status["last_error"].is_null(),
+            "the login failed: {status:?}"
+        );
+    };
+
+    assert_eq!(signed_in["account"]["username"], "PierreRouanet");
+    assert!(
+        signed_in["login"].is_null(),
+        "the pending login is cleared once it resolves"
+    );
+    assert_eq!(
+        signed_in["account"]["refreshable"], true,
+        "a refresh token came back, so the robot can renew this itself"
+    );
+    assert!(
+        hub.polls.load(Ordering::SeqCst) >= 3,
+        "the daemon must have polled through the pending answers"
+    );
+
+    // 3. What is on disk is the pair, not just the access token: a 30-day token with no way to
+    // renew it is a robot that silently stops being reachable next month.
+    let stored: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&token_path).unwrap()).unwrap();
+    assert_eq!(stored["access_token"], "an-access-token");
+    assert_eq!(stored["refresh_token"], "a-refresh-token");
+    assert_eq!(stored["username"], "PierreRouanet");
+    assert!(stored["expires_at"].as_i64().unwrap() > 0);
+
+    // And signing out forgets it, naming who it was — which is what lets a robot change hands.
+    let out = client
+        .call(method::ACCOUNT_LOGOUT, serde_json::json!({}))
+        .await
+        .result
+        .unwrap();
+    assert_eq!(out["was"], "PierreRouanet");
+    assert!(!token_path.exists(), "the credential is gone from disk");
+}
+
+/// A robot that already belongs to somebody refuses, by name, and does not start a login.
+///
+/// `INVALID_PARAMS` rather than a generic failure because the fix is a parameter, and a client
+/// should be able to offer "replace it?" without parsing English.
+#[tokio::test]
+async fn a_second_login_needs_force() {
+    let fx = Harness::new();
+    let hub = FakeHub::start(0).await;
+    let (token_path, _server) = serve_with_account(&fx, &hub).await;
+
+    let mut client = Client::connect(&fx.socket).await;
+    client.hello().await;
+    client
+        .call(method::ACCOUNT_LOGIN, serde_json::json!({}))
+        .await;
+    // Wait for the first login to land, since that is what the second one collides with.
+    for _ in 0..100 {
+        if token_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(token_path.exists(), "the first login did not complete");
+    let polls_after_first = hub.polls.load(Ordering::SeqCst);
+
+    let refused = client
+        .call(method::ACCOUNT_LOGIN, serde_json::json!({}))
+        .await;
+    let error = refused.error.expect("must refuse");
+    assert_eq!(error.code, proto::code::INVALID_PARAMS);
+    assert!(
+        error.message.contains("PierreRouanet") && error.message.contains("--force"),
+        "the refusal must name the account and the way past it: {}",
+        error.message
+    );
+    assert_eq!(
+        hub.polls.load(Ordering::SeqCst),
+        polls_after_first,
+        "the refusal must come before anything reaches Hugging Face — a device code burned to \
+         arrive at the same answer is a code somebody might have been typing"
+    );
+
+    // With `force`, it starts.
+    let forced = client
+        .call(method::ACCOUNT_LOGIN, serde_json::json!({ "force": true }))
+        .await;
+    assert!(forced.error.is_none(), "{:?}", forced.error);
+    assert_eq!(forced.result.unwrap()["user_code"], "A6MY-0314");
+}
+
+/// `account.status` is a read, so it answers without the privilege the other two need.
+///
+/// The gate is `Call::is_mutating`, which this test exists to pin from the outside: a support
+/// engineer has to be able to ask which account a robot thinks it belongs to.
+#[tokio::test]
+async fn status_is_not_a_privileged_call() {
+    let fx = Harness::new();
+    let hub = FakeHub::start(0).await;
+    let (_token_path, _server) = serve_with_account(&fx, &hub).await;
+
+    // A server whose owning uid is nobody's, so every mutating call is denied.
+    assert!(
+        !proto::Call::AccountStatus.is_mutating(),
+        "account.status must never require change authority"
+    );
+    assert!(
+        proto::Call::AccountLogin(proto::AccountLoginParams { force: false }).is_mutating()
+            && proto::Call::AccountLogout.is_mutating(),
+        "binding a robot to an account, and unbinding it, must both be authorised"
+    );
+
+    let mut client = Client::connect(&fx.socket).await;
+    client.hello().await;
+    let status = client
+        .call(method::ACCOUNT_STATUS, serde_json::json!({}))
+        .await;
+    assert!(status.error.is_none(), "{:?}", status.error);
+    assert!(status.result.unwrap()["account"].is_null());
+}

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -1178,7 +1178,7 @@ impl FakeHub {
             .route(
                 "/oauth/device",
                 // Hugging Face sends no `verification_uri_complete`, so this does not either —
-                // synthesising it is part of what these tests cover. It *does* send an
+                // what falls out of that is part of what these tests cover. It *does* send an
                 // `interval` HF omits, and only to keep the suite quick: the robot sleeps one
                 // interval before its first poll, so the real five seconds would make every
                 // login test five seconds long. That HF's omission falls back to five is pinned
@@ -1279,8 +1279,9 @@ async fn a_device_code_login_completes_without_the_client_waiting() {
     assert_eq!(result["user_code"], "A6MY-0314");
     assert_eq!(result["verification_uri"], "https://hf.co/oauth/device");
     assert_eq!(
-        result["verification_uri_complete"], "https://hf.co/oauth/device?user_code=A6MY-0314",
-        "synthesised, because Hugging Face sends none"
+        result["verification_uri_complete"], "https://hf.co/oauth/device",
+        "the plain URI, because Hugging Face sends no complete one and its device page ignores a \
+         `?user_code=` query — so no URL carries the code and a client has to show it"
     );
     assert_eq!(
         result["interval"], 1,

--- a/updater/tests/ipc.rs
+++ b/updater/tests/ipc.rs
@@ -1246,12 +1246,27 @@ impl FakeHub {
 
 /// Serve with the account pointed at a temp file and a fake hub.
 async fn serve_with_account(fx: &Harness, hub: &FakeHub) -> (PathBuf, tokio::task::JoinHandle<()>) {
+    serve_with_account_as(fx, hub, None).await
+}
+
+/// As [`serve_with_account`], with an owning uid the test process is not.
+///
+/// `None` means the ordinary case: the socket's owner is whoever ran the test, so mutating calls
+/// are authorised. `Some(uid)` is how a test asks what an *unlisted* peer sees, which for
+/// `account.*` is the whole point of one call being a read.
+async fn serve_with_account_as(
+    fx: &Harness,
+    hub: &FakeHub,
+    owner_uid: Option<u32>,
+) -> (PathBuf, tokio::task::JoinHandle<()>) {
     let token_path = fx.root.join("etc/robot/hf-token");
     std::fs::create_dir_all(token_path.parent().unwrap()).unwrap();
-    let server = Arc::new(
-        Server::new(fx.engine(true, Faults::none()))
-            .with_account_for_test(token_path.clone(), hub.base.clone()),
-    );
+    let engine = fx.engine(true, Faults::none());
+    let server = match owner_uid {
+        None => Server::new(engine),
+        Some(uid) => Server::with_policy_for_test(engine, uid, Vec::new(), Vec::new()),
+    };
+    let server = Arc::new(server.with_account_for_test(token_path.clone(), hub.base.clone()));
     let handle = fx.serve_with(server).await;
     (token_path, handle)
 }
@@ -1306,23 +1321,28 @@ async fn a_device_code_login_completes_without_the_client_waiting() {
     assert_eq!(pending["login"]["user_code"], "A6MY-0314");
     assert!(pending["account"].is_null(), "not signed in yet");
 
-    // 2. The daemon is doing the polling. `FakeHub` approves on the third ask, and the interval
-    // is five seconds, so this is the one place the test has to wait for real time.
-    let signed_in = loop {
+    // 2. The daemon is doing the polling. `FakeHub` approves on the third ask and answers with a
+    // one-second interval, so this is the one place the test has to wait for real time — a few
+    // seconds of it. Bounded rather than a bare loop: a login that never lands should fail here
+    // saying so, not hang until whatever is running the suite gives up on it.
+    let mut signed_in = None;
+    for _ in 0..100 {
         tokio::time::sleep(Duration::from_millis(200)).await;
         let status = watcher
             .call(method::ACCOUNT_STATUS, serde_json::json!({}))
             .await
             .result
             .unwrap();
-        if !status["account"].is_null() {
-            break status;
-        }
         assert!(
             status["last_error"].is_null(),
             "the login failed: {status:?}"
         );
-    };
+        if !status["account"].is_null() {
+            signed_in = Some(status);
+            break;
+        }
+    }
+    let signed_in = signed_in.expect("the login never completed");
 
     assert_eq!(signed_in["account"]["username"], "PierreRouanet");
     assert!(
@@ -1409,15 +1429,18 @@ async fn a_second_login_needs_force() {
 
 /// `account.status` is a read, so it answers without the privilege the other two need.
 ///
-/// The gate is `Call::is_mutating`, which this test exists to pin from the outside: a support
-/// engineer has to be able to ask which account a robot thinks it belongs to.
+/// The gate is `Call::is_mutating`, and this drives it from the outside against a server whose
+/// owning uid the test process is not: `login` and `logout` are refused, and `status` still
+/// answers. Both halves matter — a support engineer has to be able to ask which account a robot
+/// thinks it belongs to, and nobody who merely reached the socket may rebind it.
 #[tokio::test]
 async fn status_is_not_a_privileged_call() {
     let fx = Harness::new();
     let hub = FakeHub::start(0).await;
-    let (_token_path, _server) = serve_with_account(&fx, &hub).await;
+    // Owner uid set to something the test process is not, and no allowances — the shape
+    // `an_unlisted_peer_cannot_mutate` uses for the update calls.
+    let (token_path, _server) = serve_with_account_as(&fx, &hub, Some(u32::MAX)).await;
 
-    // A server whose owning uid is nobody's, so every mutating call is denied.
     assert!(
         !proto::Call::AccountStatus.is_mutating(),
         "account.status must never require change authority"
@@ -1430,6 +1453,27 @@ async fn status_is_not_a_privileged_call() {
 
     let mut client = Client::connect(&fx.socket).await;
     client.hello().await;
+
+    for (method, params) in [
+        (method::ACCOUNT_LOGIN, serde_json::json!({})),
+        (method::ACCOUNT_LOGOUT, serde_json::json!({})),
+    ] {
+        let error = client
+            .call(method, params)
+            .await
+            .error
+            .unwrap_or_else(|| panic!("{method} should be denied"));
+        assert_eq!(
+            error.code,
+            proto::code::PERMISSION_DENIED,
+            "{method}: {error:?}"
+        );
+    }
+    assert!(
+        !token_path.exists(),
+        "a denied login must not have reached Hugging Face, let alone stored anything"
+    );
+
     let status = client
         .call(method::ACCOUNT_STATUS, serde_json::json!({}))
         .await;


### PR DESCRIPTION
A duck on a LAN needs no account. Reaching one from outside does, and this is that
half: a robot can belong to a Hugging Face account, signed in from a terminal, a
phone over Bluetooth, or the console page. Nothing consumes the credential yet —
the relay is next, and this is what it needed to exist.

`remote-webrtc.md` §7 has said since it was written that the remote path is a bridge
to the signalling server already on the robot, and that whether we adopt the
rendezvous Space and how a robot is bound to an account were out of scope "until
local mode works". Local mode works.

## What a person can do now

```
sudo robotctl account login      # prints a code; approve it anywhere; Ctrl-C is free
sudo robotctl account login --force   # replaces an account, or a code nobody will approve
robotctl account status
sudo robotctl account logout

duckctl account login            # the same, over BLE — the only transport a robot
duckctl account status           # with no wifi has
```

```
$ sudo robotctl account login
Open https://hf.co/oauth/device and enter this code:

    A6MY-0314

Waiting for approval…
Signed in as PierreRouanet.
```

## The flow is RFC 8628, and the shape is the requirement

`login` asks Hugging Face for a device code and answers **with the code, not a token**.
`updaterd` polls; a client comes back to `status`. That is not a convenience: a phone
that opens a browser to show somebody the code backgrounds itself, and iOS then tears
the GATT link down. A login that reported success by holding a connection open would
work from a laptop and fail from the device it is for.

Hugging Face ships a **first-party public device-code client**, which `reachy_mini`'s
own device flow uses, so this registers no OAuth app anywhere.

Three invariants inherited from the mini's setup wizard, none of them about Python:
lead with the code and never auto-open a browser (auto-switching to Safari hid the
code before users could read it); a transport drop mid-flow is expected, not an error;
and appearing on the rendezvous — not a stored token — is the only real success signal.

## Two things running the flow against the real service changed

**A token lasts 30 days and its refresh token rotates.** So the store is two strings
plus an absolute expiry, `maintain` renews at a week left rather than on the last day,
and the one window rotation leaves open — HF issued a new pair, the board lost power
before the write — is named in `Store::save` and surfaces in `status`, because no write
ordering can close it. A robot off for more than thirty days comes back needing a
login, which `token_expires_in` going negative is how a client says.

**The token carries every scope HF grants**: `write-repos`, `manage-repos`, `jobs`,
`read-billing`. That client takes no `scope` parameter. A duck holding a credential
that can push to its owner's repositories is worse than it needs to be for something
whose job is proving an identity — and a stolen board yields it. The fix is a public
device-code app in the org with `openid profile read-repos`: one constant in
`account.rs`, one click in HF. **Not blocking** — the flow works today and a scope
change is a re-login — but it should not ship without it. §2.4.

## Two things a login has to survive, which only using it turned up

**A code nobody is going to approve held the robot for five minutes.** Somebody starts a
login and walks off; every login after that is refused, and the only remedies were waiting
it out and `logout` — which destroys a working credential to clear a pending one. `--force`
covers it now, and the refusal names the flag rather than only saying where to read the
code that is stuck.

**An abandoned flow was still holding a live device code.** The flow lives in a task that
outlives the call that started it, so this was already true of `logout`: sign a robot out
with a code in the air, approve it a minute later, and the robot signed itself back in —
writing a token into a robot whose owner believed it belonged to nobody. Each flow now
carries the generation it started with and drops its answer unless it is still the current
one, checked before the write and again after it, because the write awaits and a `logout`
can land inside it.

## Where the credential lives

`/etc/robot/hf-token`, `root:robot`, `0640`. `updaterd` owns it for `policy.*`'s
reasons — it is the daemon with a network stack, `robotctl` must not link one, and the
same credential is what reaches a private Hub repo. `mediad` will read it and must not
own it: unprivileged, `ProtectHome=yes`, and it is the process a remote peer talks to.

**Not in `robotd.toml`**, deliberately: `configure --list`, the config editor and the
"what changed on this robot" report would all print it.

**Written `0600` and relaxed after the group is set**, rather than through
`fsutil::write_atomic`, which sets no mode — a token that lands `0644` and is chmodded
a moment later is world-readable for that moment, which is invisible in testing and
permanent in whatever read it. A test asserts the landed file gives "others" nothing.

## Routing it to WebRTC is the decision worth reading

`account.login` is the first **mutating** call that transport carries, and the only
one there whose effect outlives the session the way an account does: it converts having
been on the wifi *once* into remote access that outlives being there. `remote-webrtc.md`
§4 accepts that anyone on the network has the robot and its camera; it did not consider
anyone on the network having them from another continent next month.

Permitted anyway — the console is where somebody would sign a robot in, and the
alternative is ssh — with three properties that make it hold, argued in
`mediad/src/route.rs`:

- a robot that already belongs to somebody **refuses by name** (`--force` to replace),
  so a LAN peer cannot silently take a robot from its owner;
- it is **visible**: `account.status` names the account from any transport with no
  authorisation at all;
- it is **revocable** from more places than the robot, including HF itself — though
  `logout` forgets the credential rather than revoking it, so the token stays live at HF
  until it expires. §2.6 is exact about that, and §9 carries what closing it needs.

It also means `mediad` needed `allow_users` in `updater.toml`, and that grants more than
the account: `allow_users` gates the *caller*, not the method, so `updaterd` will perform
any mutating call `mediad` makes — `update.apply` included. What stops a remote peer is
`mediad`'s route table refusing to relay it, which makes that table the only narrowing
there is, on the process most exposed to a stranger's traffic. Same shape `btd` has had
since BLE could apply an update, and the same answer: a named list with a test,
`only_these_mutating_calls_are_reachable_over_webrtc`. §2.6 says a per-method gate in
`updaterd` is what would make it two layers, and that not building one was a choice.

### Writing that list down found two methods nobody had noticed were broken

`policy.install` and `policy.fetch` are routed to WebRTC on this branch, and `mediad` was
not in `allow_users` — so `updaterd` answered them **PERMISSION_DENIED**. The console
could offer a Hub browser whose install button could not work. The `allow_users` line
added here for the account fixes them too, and they are now in the named list with a note
saying how they were found.

That is the argument for a named list over a counted one: it is where a transport's
authority and a config file's grants are made to agree out loud.

## The rendezvous, and what reading its source settled

Decided: `pollen-robotics/reachy_mini_central`, the Space the mini's fleet uses. **We
maintain it**, so a duck-shaped need there is a pull request rather than a fork — and
the reverse is true too, which is worth knowing now that a second family of robots is
on it.

An earlier commit in this branch said its repository was private and reverse-read the
wire from the mini's client. That was a wrong-name 401 mistaken for a permissions
error. Reading `app.py` corrected five things:

- the lease is **30 s and keyed only on inbound `POST /send`** — a healthy SSE stream
  refreshes nothing;
- the welcome advertises a 10 s cadence and **no `lease_seconds`**, so the middle rung
  of the mini relay's negotiation ladder is unreachable here;
- the SSE side **pings every 30 s of idle** to survive the Space's proxy, which is what
  a read timeout has to be sized against;
- the server **gates concurrent sessions itself** (`sessionRejected`, with the
  `activeApp` holding it), so a robot-side gate is belt-and-braces rather than a
  workaround — and it stays, because two remote writers into one intent slot is §9's
  interleaving bug;
- `meta` is free-form to the protocol and **not to the server**: it reads `hardware_id`
  as a stable-identity key and evicts an older producer of the same user carrying the
  same value. So a duck must put its SoC serial there — `producer.rs` already reads it
  — or a robot that reconnects with a fresh token is listed twice, and putting the
  *name* there would fork a robot's identity on rename.

It also corrected `remote-webrtc.md` §7, which said the bridge "parses nothing" and is
"a relay rather than a translator". The payload stays opaque; the envelope does not —
the wire is HTTP (SSE in, `POST` out) with per-hop ids.

## One hazard for whoever owns the image path

**Peers are keyed by token.** Two robots sharing one take turns being reachable, and
neither looks broken. Each duck runs its own device flow, so each has its own token —
unless an image is cloned with `/etc/robot/hf-token` in it, which is what this
project's flashing path does with everything else in `/etc/robot`. §3.7.

## Wire

`API_VERSION` **22 → 23**, additive. 22 is `robot.skills`, which landed with #191; this
branch had taken that number while the two were in flight, and the merge settled it. `account.login`, `account.status`, `account.logout` on
`updaterd`; `login` and `logout` are `is_mutating` (so uid-authorised), `status` is a
read and stays ungated — which account a robot thinks it belongs to is the first thing
support asks.

## Tested

Unit: the store's permissions and round trip, a corrupt credential reading as signed
out, the OAuth error classification (`slow_down` treated as failure would abandon a
login about to succeed), the device-code normalisation against exactly what
huggingface.co answered, and the refusals. Plus the refresh, which had no test and is
the path that runs unattended for a month: the rotated refresh token replacing the one
it was traded for, and a refusal driven through `maintain` to where `account.status`
reports it.

End to end over a real unix socket against a fake Hub that answers what HF answers:
the code arrives before anyone approves anything, a **second client** picks the flow
up (which is the property the whole shape exists for), the daemon polls through
`authorization_pending`, and what lands on disk is the pair rather than just the access
token. Plus both route tables' boundary tests.

The protocol itself was verified against the live Hugging Face endpoints.

**Run on a board** (`olducky`, Radxa Zero 3), which is where the parts no test can reach
were checked:

- `sudo robotctl account login` prints the code, waits, and reports `Signed in as
  PierreRouanet`;
- the credential lands `-rw-r----- root robot`, and `sudo -u mediad -g robot test -r`
  says the group grant works — so `mediad` will be able to read it, via the unit's
  `SupplementaryGroups=robot` rather than any `/etc/group` membership;
- `robotctl account status` answers **without `sudo`**, which is the ungated read
  working for a non-root caller on a real socket;
- the `AlreadySignedIn` refusal fires: a `login` on a robot that already belonged to
  somebody is logged as a mutating request with no `login started` after it, so no
  device code was burned to reach the refusal;
- two of the logins in the journal arrive as `uid=986`, not from a shell — the relayed
  path and the `allow_users` entry, end to end;
- a second `login` while one is waiting for approval is refused with `a login is already
  waiting for approval — account status has the code`, and no second code is issued;
- `--force` past that refusal issues a second code, and **approving the first one on
  huggingface.co afterwards does nothing**: the robot stays signed out, the forced login
  stays pending, and the journal says the flow was superseded before it finished. Same
  with `logout` in place of `--force`, which is the version that matters — a robot signed
  out must not sign itself back in when somebody approves a code a minute later.

Nothing about renewal, and that is correct: the token is thirty days out, so `maintain`
has nothing to do until the end of the month. That part rests on the tests.

## What is next, and what is still open

The relay (§3): producer registration, the negotiated heartbeat, the split-brain poll
against `/api/robot-status`. Verifiable with no client at all — the Space's dashboard
counts a producer.

Open: the scope narrowing above (§2.4, pre-ship), and where the remote console page is
served from (§5) — which is the decision that actually couples us to the service.




