### PR TITLE
btd, mediad: a restarted daemon gets the next request, not the one after

### DIFF
--- a/btd/src/upstream.rs
+++ b/btd/src/upstream.rs
@@ -153,30 +153,47 @@ impl Pool {
     }
 
     /// Send one line to `upstream` on `lane`'s connection, connecting first if needed.
+    ///
+    /// A daemon that restarted between two requests is ordinary here: `robotd` is the one an
+    /// update restarts, and `updaterd` restarts itself from a release's postinstall hook. The
+    /// connection from before the restart is still in the pool, its reader has already seen the
+    /// socket close, and the first write into it fails. Those bytes never left, so they are written
+    /// again on a fresh connection rather than reported. Reporting them told a phone that a daemon
+    /// listening on a fresh socket was not answering, once per lane, after every update. Once and
+    /// not in a loop: a daemon that is genuinely gone fails the reconnect, and that is the error
+    /// worth reporting.
     pub async fn send(&mut self, upstream: Upstream, lane: Lane, line: &str) -> io::Result<()> {
         let key = (upstream, lane);
+        let mut bytes = line.as_bytes().to_vec();
+        bytes.push(b'\n');
+
         if !self.conns.contains_key(&key) {
             let conn = self.open(upstream, lane).await?;
             self.conns.insert(key, conn);
         }
+        match self.write(key, &bytes).await {
+            Err(e) if peer_is_gone(&e) => {
+                let conn = self.open(upstream, lane).await?;
+                self.conns.insert(key, conn);
+                self.write(key, &bytes).await
+            }
+            done => done,
+        }
+    }
 
-        // Unwrap is sound: just inserted, or the contains_key above held.
+    /// One bounded write on the connection for `key`. Any failure drops that connection, so
+    /// nothing keeps writing into a dead socket. This lane's only: the others may be perfectly
+    /// alive, and a restart that broke one breaks the next write to each of them anyway.
+    async fn write(&mut self, key: (Upstream, Lane), bytes: &[u8]) -> io::Result<()> {
+        // Unwrap is sound: the caller inserted it, or `contains_key` held.
         let conn = self.conns.get_mut(&key).expect("connection present");
-
-        let mut bytes = line.as_bytes().to_vec();
-        bytes.push(b'\n');
-
         let write = async {
-            conn.write.write_all(&bytes).await?;
+            conn.write.write_all(bytes).await?;
             conn.write.flush().await
         };
         match tokio::time::timeout(WRITE_TIMEOUT, write).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
-                // A broken pipe here is ordinary — the daemon restarted. Drop the connection
-                // so the next call reconnects rather than writing into a dead socket forever.
-                // This lane's connection only: the others may be perfectly alive, and a restart
-                // that broke one breaks the next write to each of them anyway.
                 self.conns.remove(&key);
                 Err(e)
             }
@@ -231,6 +248,19 @@ impl Pool {
         tracing::debug!(upstream = ?upstream, lane = ?lane, path = %path.display(), "connected");
         Ok(Conn { write })
     }
+}
+
+/// Whether a write failed because the peer went away, rather than being slow or refusing. Only
+/// these are worth one more try, because only these mean the bytes went to a daemon that is no
+/// longer there. A timeout is a daemon that is there and stuck, and that is not retried.
+fn peer_is_gone(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::BrokenPipe
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::NotConnected
+    )
 }
 
 #[cfg(test)]
@@ -325,5 +355,65 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("configd refused"), "{err}");
+    }
+    /// The daemon restarted between two requests.
+    ///
+    /// The comment on the write path says a broken pipe is ordinary, the daemon restarted, and
+    /// the next call reconnects. It is the call *after* the next: the first write after a restart
+    /// went into the socket the old daemon closed, failed, and the phone was told the service was
+    /// not answering while it was listening on a fresh socket the whole time. The pool's own
+    /// reader had already seen the socket close and told nobody.
+    ///
+    /// On the BLE update path this is `updaterd` restarting itself from the release's postinstall
+    /// hook, and the phone's next `update.status` failing for it.
+    #[tokio::test]
+    async fn a_restarted_daemon_gets_the_next_request_not_the_one_after() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("updaterd.sock");
+        let sockets = Sockets {
+            updater: path.clone(),
+            robot: dir.path().join("robotd.sock"),
+            config: dir.path().join("configd.sock"),
+        };
+        let (replies, mut forwarded) = mpsc::channel(8);
+        let mut pool = Pool::new(sockets, replies);
+
+        let before = serve_once(
+            &path,
+            proto::Response::ok(Some(proto::Id::Number(1)), &serde_json::json!({})),
+        );
+        pool.send(
+            Upstream::Updater,
+            Lane::Prompt,
+            r#"{"jsonrpc":"2.0","id":1,"method":"update.status"}"#,
+        )
+        .await
+        .unwrap();
+        assert!(
+            forwarded.recv().await.is_some(),
+            "the first answer is forwarded"
+        );
+        // The daemon has answered and hung up: it is restarting.
+        before.await.unwrap();
+
+        // And it is back, listening on a fresh socket at the same path.
+        std::fs::remove_file(&path).unwrap();
+        let after = serve_once(
+            &path,
+            proto::Response::ok(Some(proto::Id::Number(2)), &serde_json::json!({})),
+        );
+        pool.send(
+            Upstream::Updater,
+            Lane::Prompt,
+            r#"{"jsonrpc":"2.0","id":2,"method":"update.status"}"#,
+        )
+        .await
+        .expect("a daemon that is back must get the request, not a broken pipe");
+        let request = after.await.unwrap();
+        assert!(request.contains(r#""id":2"#), "{request}");
+        assert!(
+            forwarded.recv().await.is_some(),
+            "and its answer is forwarded"
+        );
     }
 }

--- a/mediad/src/upstream.rs
+++ b/mediad/src/upstream.rs
@@ -103,6 +103,15 @@ impl Pool {
     }
 
     /// Send one line to `service` on `lane`'s connection, connecting first if needed.
+    ///
+    /// A daemon that restarted between two requests is ordinary here: `robotd` is the one an
+    /// update restarts, and `updaterd` restarts itself from a release's postinstall hook. The
+    /// connection from before the restart is still in the pool, its reader has already seen the
+    /// socket close, and the first write into it fails. Those bytes never left, so they are written
+    /// again on a fresh connection rather than reported. Reporting them told the console that a
+    /// daemon listening on a fresh socket was not answering, once per lane, after every restart.
+    /// Once and not in a loop: a daemon that is genuinely gone fails the reconnect, and that is
+    /// the error worth reporting.
     pub async fn send(
         &mut self,
         service: proto::Service,
@@ -110,25 +119,35 @@ impl Pool {
         line: &str,
     ) -> io::Result<()> {
         let key = (service, lane);
+        let mut bytes = line.as_bytes().to_vec();
+        bytes.push(b'\n');
+
         if !self.conns.contains_key(&key) {
             let conn = self.open(service, lane).await?;
             self.conns.insert(key, conn);
         }
-        let conn = self.conns.get_mut(&key).expect("just inserted");
+        match self.write(key, &bytes).await {
+            Err(e) if peer_is_gone(&e) => {
+                let conn = self.open(service, lane).await?;
+                self.conns.insert(key, conn);
+                self.write(key, &bytes).await
+            }
+            done => done,
+        }
+    }
 
-        let mut bytes = line.as_bytes().to_vec();
-        bytes.push(b'\n');
-
+    /// One bounded write on the connection for `key`. Any failure drops that connection, so
+    /// nothing keeps writing into a dead socket. Only this lane's: the others may be perfectly
+    /// alive.
+    async fn write(&mut self, key: (proto::Service, proto::Lane), bytes: &[u8]) -> io::Result<()> {
+        let conn = self.conns.get_mut(&key).expect("connection present");
         let write = async {
-            conn.write.write_all(&bytes).await?;
+            conn.write.write_all(bytes).await?;
             conn.write.flush().await
         };
         match tokio::time::timeout(WRITE_TIMEOUT, write).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => {
-                // A broken pipe here is ordinary — the daemon restarted. Drop this lane's
-                // connection so the next call reconnects rather than writing into a dead socket
-                // forever. Only this lane's: the others may be perfectly alive.
                 self.conns.remove(&key);
                 Err(e)
             }
@@ -181,5 +200,102 @@ impl Pool {
 
         tracing::debug!(service = ?service, lane = ?lane, path = %path.display(), "connected");
         Ok(Conn { write })
+    }
+}
+
+/// Whether a write failed because the peer went away, rather than being slow or refusing. Only
+/// these are worth one more try, because only these mean the bytes went to a daemon that is no
+/// longer there. A timeout is a daemon that is there and stuck, and that is not retried.
+fn peer_is_gone(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::BrokenPipe
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::NotConnected
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    /// A fake daemon that answers one request with `response` and hangs up.
+    fn serve_once(path: &Path, response: proto::Response) -> tokio::task::JoinHandle<String> {
+        let listener = tokio::net::UnixListener::bind(path).unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let request = BufReader::new(read)
+                .lines()
+                .next_line()
+                .await
+                .unwrap()
+                .unwrap();
+            let mut line = serde_json::to_vec(&response).unwrap();
+            line.push(b'\n');
+            write.write_all(&line).await.unwrap();
+            write.flush().await.unwrap();
+            request
+        })
+    }
+
+    /// The daemon restarted between two requests.
+    ///
+    /// The same pool `btd` has, with the same hole it had: the first write after a restart went
+    /// into the socket the old daemon closed, failed, and the console was told the service was
+    /// not answering while it was listening on a fresh socket the whole time.
+    #[tokio::test]
+    async fn a_restarted_daemon_gets_the_next_request_not_the_one_after() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("robotd.sock");
+        let sockets = Sockets {
+            robot: path.clone(),
+            updater: dir.path().join("updaterd.sock"),
+            config: dir.path().join("configd.sock"),
+            pad: dir.path().join("padd.sock"),
+            tof: dir.path().join("tofd.sock"),
+        };
+        let (replies, mut forwarded) = mpsc::channel(8);
+        let mut pool = Pool::new(sockets, replies);
+
+        let before = serve_once(
+            &path,
+            proto::Response::ok(Some(proto::Id::Number(1)), &serde_json::json!({})),
+        );
+        pool.send(
+            proto::Service::Robot,
+            proto::Lane::Prompt,
+            r#"{"jsonrpc":"2.0","id":1,"method":"robot.health"}"#,
+        )
+        .await
+        .unwrap();
+        assert!(
+            forwarded.recv().await.is_some(),
+            "the first answer is forwarded"
+        );
+        // The daemon has answered and hung up: it is restarting.
+        before.await.unwrap();
+
+        // And it is back, listening on a fresh socket at the same path.
+        std::fs::remove_file(&path).unwrap();
+        let after = serve_once(
+            &path,
+            proto::Response::ok(Some(proto::Id::Number(2)), &serde_json::json!({})),
+        );
+        pool.send(
+            proto::Service::Robot,
+            proto::Lane::Prompt,
+            r#"{"jsonrpc":"2.0","id":2,"method":"robot.health"}"#,
+        )
+        .await
+        .expect("a daemon that is back must get the request, not a broken pipe");
+        let request = after.await.unwrap();
+        assert!(request.contains(r#""id":2"#), "{request}");
+        assert!(
+            forwarded.recv().await.is_some(),
+            "and its answer is forwarded"
+        );
     }
 }


### PR DESCRIPTION
fixes #206

a write that fails because the peer went away is written once more on a fresh connection, in both pools. those bytes never left, so there is nothing to double up. a timeout is not retried, that is a daemon that is there and stuck, and a daemon that is genuinely gone fails the reconnect with the error that is actually true. the write itself moved into one bounded helper that drops the connection on any failure, which is what the old code did inline.

the same change in both files rather than one shared crate, because the two pools are already two copies and unifying them is a different change.

two tests, one per copy, each with a fake daemon that answers once and hangs up, then a fresh listener at the same path. both fail on main with `BrokenPipe` on the second send and pass now with the request reaching the new listener and its answer forwarded.

`cargo test -p btd`, `cargo test -p mediad`, clippy with `-D warnings` and fmt are green.
