### PR TITLE
padd: Start once stands the robot up, Start again drives

### DIFF
--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -467,7 +467,7 @@ mapping is the prototype's, so muscle memory carries over:
 | --- | --- |
 | left stick | drive: forward/back and strafe · head: head yaw and pitch · body pose: up and crouch |
 | right stick | drive: turn · head: neck pitch and head roll · body pose: pitch and roll |
-| **Start** | toggle the policy — nothing moves until it is on |
+| **Start** | first press: torque on and a 2 s ramp to the home pose, then hold. Second press: the policy drives. After that it toggles the policy |
 | **Y** / triangle | head mode: sticks pose the head (body holds still) |
 | **B** / circle | body-pose mode: sticks lean and crouch the standing robot |
 | **A** / cross | ground pick |

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -308,7 +308,7 @@ fn main() -> std::process::ExitCode {
         socket = %args.socket.display(),
         hz = args.hz,
         roller,
-        "driving — Start toggles the policy, Y head mode, B body pose, A ground pick, \
+        "driving — Start once stands up, Start again toggles the policy, Y head mode, B body pose, A ground pick, \
          LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Up (3s) walk/roller, \
          Select (2s) shutdown"
     );
@@ -335,6 +335,10 @@ fn main() -> std::process::ExitCode {
     // starts the wheee ride. The prototype's threshold.
     let mut prev_rt = 0.0f64;
     let mut prev_lt = 0.0f64;
+    // Does this pad think the robot is up (torque on, at the home pose)? When not, Start sends
+    // `robot.init` (stand up and hold) instead of enabling the policy; the next Start enables it.
+    // Starts false: padd starts with the robot, and a robotd restart restarts padd too.
+    let mut up = false;
     // The continuous intents, and the buffer this tick's are built in. Both live across
     // ticks so a steady state neither allocates nor re-sends — see [`Continuous`].
     let mut continuous = Continuous::default();
@@ -444,7 +448,16 @@ fn main() -> std::process::ExitCode {
             }
         }
 
-        if toggle_enable {
+        if toggle_enable && !up {
+            tracing::warn!("Start — robot.init: standing up. Press Start again to drive");
+            match request(&mut stream, &mut next_id, &proto::Call::RobotInit) {
+                Err(e) => {
+                    tracing::error!(error = %e, "init failed");
+                    return std::process::ExitCode::FAILURE;
+                }
+                Ok(_) => up = true,
+            }
+        } else if toggle_enable {
             // The robot owns the toggle. A local on/off belief here drifts from the
             // robot's the moment anything else moves it — robot.relax, the shutdown
             // sequence, either side restarting — and a stale belief turns Start into a
@@ -523,6 +536,7 @@ fn main() -> std::process::ExitCode {
             let held = select_held_since.get_or_insert(tick);
             if tick.duration_since(*held) >= SHUTDOWN_HOLD && !shutdown_sent {
                 shutdown_sent = true;
+                up = false;
                 tracing::warn!("Select held — asking the robot to sit and power off");
                 if let Err(e) = request(&mut stream, &mut next_id, &proto::Call::RobotShutdown) {
                     tracing::error!(error = %e, "shutdown request failed");


### PR DESCRIPTION
On a freshly booted duck held in the air, the first Start started the gait straight out of the home ramp and the legs went everywhere.

Now:
- **Start, first press**: `robot.init` — torque on, 2 s ramp to the home pose, hold.
- **Start, second press**: the policy drives. After that Start toggles the policy as before.

padd keeps an `up` flag: false when it starts (a robotd restart restarts padd too) and after a shutdown, true after its own init. If the flag is ever wrong you get one extra home ramp, never a gait out of nowhere.

## How to test
Boot the duck, hold it in the air, press Start: it should just stand up and hold. Press Start again: the gait starts.
