### PR TITLE
robot.soften: let go softly, on the pad's Select

### DIFF
--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -354,7 +354,7 @@ fn permits(call: &proto::Call) -> bool {
         // offer, and `robot.init` is its counterpart: standing a robot up moves every joint at once,
         // which wants the person doing it to be looking at the robot rather than at a screen. Both
         // are `robotctl` on the robot, deliberately.
-        RobotInit | RobotRelax => false,
+        RobotInit | RobotRelax | RobotSoften => false,
 
         // `robot.stop` deserves its own line, because refusing it looks wrong. An emergency stop
         // in the app is exactly what someone reaches for, and §6 does say local should preempt

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -411,6 +411,7 @@ sudo robotctl robot init
 
 ```
 sudo robotctl robot relax --yes
+sudo robotctl robot soften          # the gentle version: 1 s gain ramp to zero, then torque off
 ```
 
 `init` powers the joints and ramps to the home pose over about two seconds — **it moves every joint**,
@@ -476,7 +477,8 @@ mapping is the prototype's, so muscle memory carries over:
 | **DPad-Down** | sit ↔ stand |
 | **RT / LT** | mouth (either trigger) — RT also quacks; LT rides the "wheee" while held |
 | **DPad-Up**, held 3 s | switch drive mode, walk ⇄ roller |
-| **Select**, held 2 s | sit down, then power off |
+| **Select** | soft release: gain down to zero over 1 s, then torque off. The robot folds to the floor |
+| **Select**, held 2 s | power off (the press above has already let go of the motors) |
 
 There is no stop button: release the sticks and the robot stands, and `robotd`'s deadman stops it
 if `padd` dies. On a roller robot (`mode = "roller"` in `robotd.toml`) the sticks take the roller

--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -176,6 +176,8 @@ pub struct FakeIo {
     pub writes: usize,
     /// Last gain commanded, so a test can tell "went limp" from "stopped commanding".
     pub last_gain: Option<u16>,
+    /// Lowest gain ever commanded, so a test can tell a ramp reached the bottom.
+    pub min_gain: Option<u16>,
     /// Whether the orientation filter reports converged. False models the first seconds after
     /// startup, when projected gravity is not yet a measurement.
     pub imu_ready: bool,
@@ -209,6 +211,7 @@ impl FakeIo {
             reads: 0,
             writes: 0,
             last_gain: None,
+            min_gain: None,
             imu_ready: true,
             slow: Some(SlowSensors {
                 volts: 7.4,
@@ -275,6 +278,7 @@ impl RobotIo for FakeIo {
 
     fn set_gain(&mut self, kp: u16) -> Result<()> {
         self.last_gain = Some(kp);
+        self.min_gain = Some(self.min_gain.map_or(kp, |m| m.min(kp)));
         Ok(())
     }
 

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -469,6 +469,10 @@ pub mod method {
     /// yield a fallen robot is commanded at, which keeps torque on. This is the register.
     pub const ROBOT_RELAX: &str = "robot.relax";
 
+    /// Let go softly: gain to `gain_limp` at once, then down to zero over one second, then
+    /// torque off. Same end state as `relax`, without the snap. The gamepad's Select press.
+    pub const ROBOT_SOFTEN: &str = "robot.soften";
+
     // ── skills ───────────────────────────────────────────────────────────────
     //
     // One-shot scripted moves, ported from `microduck_runtime`. Each swaps a dedicated
@@ -809,6 +813,8 @@ pub enum Call {
     RobotInit,
     /// Cut power to the joints. The robot collapses if nothing holds it.
     RobotRelax,
+    /// Let go softly over a second, then cut power. See [`method::ROBOT_SOFTEN`].
+    RobotSoften,
     /// Run a one-shot skill, or toggle sit↔stand.
     RobotDo(DoParams),
     /// Standing body pose. Continuous. Send as a notification.
@@ -978,6 +984,7 @@ impl Call {
             Call::RobotEnable(_) => method::ROBOT_ENABLE,
             Call::RobotInit => method::ROBOT_INIT,
             Call::RobotRelax => method::ROBOT_RELAX,
+            Call::RobotSoften => method::ROBOT_SOFTEN,
             Call::RobotDo(_) => method::ROBOT_DO,
             Call::RobotPose(_) => method::ROBOT_POSE,
             Call::RobotMouth(_) => method::ROBOT_MOUTH,
@@ -1148,6 +1155,7 @@ impl Call {
             | Call::RobotEnable(_)
             | Call::RobotInit
             | Call::RobotRelax
+            | Call::RobotSoften
             | Call::RobotDo(_)
             | Call::RobotPose(_)
             | Call::RobotMouth(_)
@@ -1288,6 +1296,7 @@ impl Call {
             | Call::RobotStop
             | Call::RobotInit
             | Call::RobotRelax
+            | Call::RobotSoften
             | Call::RobotShutdown
             | Call::RobotPolicies
             | Call::RobotReloadPolicies
@@ -1345,6 +1354,7 @@ impl Call {
             method::ROBOT_ENABLE => Call::RobotEnable(decode(params)?),
             method::ROBOT_INIT => Call::RobotInit,
             method::ROBOT_RELAX => Call::RobotRelax,
+            method::ROBOT_SOFTEN => Call::RobotSoften,
             method::ROBOT_DO => Call::RobotDo(decode(params)?),
             method::ROBOT_POSE => Call::RobotPose(decode(params)?),
             method::ROBOT_MOUTH => Call::RobotMouth(decode(params)?),
@@ -1492,6 +1502,7 @@ pub mod test_support {
             }),
             Call::RobotInit,
             Call::RobotRelax,
+            Call::RobotSoften,
             Call::RobotDo(DoParams {
                 skill: "ground_pick".into(),
             }),
@@ -4636,7 +4647,7 @@ mod tests {
     fn every_call_covers_every_variant() {
         assert_eq!(
             every_call().len(),
-            61,
+            62,
             "a Call variant was added or removed — update every_call() and this count"
         );
     }

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -82,7 +82,7 @@ fn permits(call: &proto::Call) -> bool {
         // camera: it is looking at the robot, which is precisely what a phone in the room over
         // Bluetooth was not. Permitted for that reason, and it would be worth revisiting if a
         // control-only session without video ever becomes a normal thing.
-        RobotEnable(_) | RobotInit | RobotRelax => true,
+        RobotEnable(_) | RobotInit | RobotRelax | RobotSoften => true,
 
         // `robot.stop` is permitted here and refused over BLE, and the difference is honesty
         // rather than authority. BLE's objection was that a stop button over "an unbonded,

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -310,7 +310,7 @@ fn main() -> std::process::ExitCode {
         roller,
         "driving — Start toggles the policy, Y head mode, B body pose, A ground pick, \
          LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Up (3s) walk/roller, \
-         Select (2s) shutdown"
+         Select soft release, Select (2s) shutdown"
     );
 
     let period = Duration::from_secs_f64(1.0 / args.hz as f64);
@@ -364,6 +364,7 @@ fn main() -> std::process::ExitCode {
         // Which bindable buttons went down this tick, by their config name. A list rather than
         // a flag apiece, because what each one runs is config now and this loop no longer knows.
         let mut pressed: Vec<&'static str> = Vec::new();
+        let mut soften = false;
         while let Some(event) = gilrs.next_event() {
             if let gilrs::EventType::ButtonPressed(button, _) = event.event {
                 match button {
@@ -381,6 +382,8 @@ fn main() -> std::process::ExitCode {
                     Button::LeftTrigger => pressed.push("lb"),
                     Button::RightTrigger => pressed.push("rb"),
                     Button::DPadDown => pressed.push("dpad_down"),
+                    // Soft emergency release. Held on, it is still the shutdown below.
+                    Button::Select => soften = true,
                     _ => {}
                 }
             }
@@ -515,6 +518,14 @@ fn main() -> std::process::ExitCode {
         {
             tracing::error!(error = %e, "send failed");
             return std::process::ExitCode::FAILURE;
+        }
+
+        if soften {
+            tracing::warn!("Select — asking the robot to let go softly (robot.soften)");
+            if let Err(e) = request(&mut stream, &mut next_id, &proto::Call::RobotSoften) {
+                tracing::error!(error = %e, "soften request failed");
+                return std::process::ExitCode::FAILURE;
+            }
         }
 
         // Select held two seconds: sit down, then power off. Sent once per hold — the

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -436,6 +436,13 @@ enum RobotCommand {
         json: bool,
     },
 
+    /// Let go softly: gain to the limp value at once, down to zero over a second, then torque
+    /// off. The robot still ends up on the floor, just without the snap. Then `init` or Start.
+    Soften {
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Run a one-shot skill by name — `roulade`, `kick_left`, `ground_pick`, `sit_toggle`, or
     /// whatever else this robot has.
     ///
@@ -2601,6 +2608,7 @@ fn run_robot(socket: &Path, command: RobotCommand) -> Result<(), Failure> {
     let (call, json) = match &command {
         RobotCommand::Init { json } => (proto::Call::RobotInit, *json),
         RobotCommand::Relax { json, .. } => (proto::Call::RobotRelax, *json),
+        RobotCommand::Soften { json } => (proto::Call::RobotSoften, *json),
         RobotCommand::Do { skill, json } => (
             proto::Call::RobotDo(proto::DoParams {
                 skill: skill.clone(),
@@ -2668,6 +2676,7 @@ fn run_robot(socket: &Path, command: RobotCommand) -> Result<(), Failure> {
     match command {
         RobotCommand::Init { .. } => println!("standing up — about two seconds to the home pose"),
         RobotCommand::Relax { .. } => println!("torque off"),
+        RobotCommand::Soften { .. } => println!("letting go softly — torque off in a second"),
         RobotCommand::Do { skill, .. } => println!("{skill:?} queued"),
         RobotCommand::Mode { .. } | RobotCommand::Look { .. } => unreachable!("answered above"),
     }

--- a/robotd/src/intents.rs
+++ b/robotd/src/intents.rs
@@ -34,6 +34,7 @@ const THEREMIN_UP: u8 = 1;
 const THEREMIN_DOWN: u8 = 2;
 const POWER_INIT: u8 = 1;
 const POWER_RELAX: u8 = 2;
+const POWER_SOFTEN: u8 = 3;
 use std::time::{Duration, Instant};
 
 use arc_swap::{ArcSwap, ArcSwapOption};
@@ -230,6 +231,8 @@ pub enum PowerRequest {
     Init,
     /// Torque off. The robot collapses if nothing holds it.
     Relax,
+    /// Gain to `gain_limp` now, to zero over a second, then torque off. The soft `Relax`.
+    Soften,
 }
 
 /// What the loop reads at the top of a tick.
@@ -471,6 +474,12 @@ impl Intents {
         self.power.store(POWER_RELAX, Ordering::Relaxed);
     }
 
+    /// Ask the loop to let go softly, then cut power. Clears `enabled` like `request_relax`.
+    pub fn request_soften(&self) {
+        self.enabled.store(false, Ordering::Relaxed);
+        self.power.store(POWER_SOFTEN, Ordering::Relaxed);
+    }
+
     /// Take the pending request, leaving none.
     ///
     /// Called once per tick by the loop. A later request replaces an unread earlier one, which is
@@ -540,6 +549,7 @@ impl Intents {
         match self.power.swap(POWER_NONE, Ordering::Relaxed) {
             POWER_INIT => Some(PowerRequest::Init),
             POWER_RELAX => Some(PowerRequest::Relax),
+            POWER_SOFTEN => Some(PowerRequest::Soften),
             _ => None,
         }
     }

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -91,6 +91,30 @@ const RATE_WINDOW: Duration = Duration::from_secs(1);
 /// snap. Not a parameter yet — one number with no evidence that anyone wants a different one.
 const HOME_RAMP: Duration = Duration::from_secs(2);
 
+/// `robot.soften`: how long the gain takes to go from `gain_limp` to zero before torque is cut.
+const SOFTEN_RAMP: Duration = Duration::from_secs(1);
+
+/// A `robot.soften` in progress: joints commanded where they were when it started, gain going
+/// down from `gain_limp` to zero over [`SOFTEN_RAMP`], then torque off.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Softening {
+    since: Instant,
+    from: [f64; NUM_JOINTS],
+}
+
+impl Softening {
+    /// The gain for this tick, or `None` once the ramp is over and torque should be cut.
+    /// In steps of five: a gain is a register write to every servo, so not a new value every tick.
+    fn gain_at(&self, now: Instant, gain_limp: u16) -> Option<u16> {
+        let t = now.duration_since(self.since).as_secs_f64() / SOFTEN_RAMP.as_secs_f64();
+        if t >= 1.0 {
+            return None;
+        }
+        let raw = f64::from(gain_limp) * (1.0 - t);
+        Some(((raw / 5.0).round() * 5.0) as u16)
+    }
+}
+
 /// Smoothing on the reported battery voltage. At one sample per [`RATE_WINDOW`] this is a
 /// ~10 s time constant, which is what makes the number readable: the raw voltage sags
 /// several tenths of a volt on every step and recovers between them, so an unsmoothed
@@ -1697,6 +1721,7 @@ async fn control_loop<T: RobotIo>(
     let limp_fall_max = Duration::from_millis(params.safety.limp_fall_max_ms);
     let limp_fall_pose = Duration::from_millis(params.safety.limp_fall_pose_ms);
     let mut limp_fall = LimpFall::Idle;
+    let mut softening: Option<Softening> = None;
 
     // The voice, and the ear. Both optional equipment: a robot without a codec or a bank
     // walks identically — the player degrades to a debug line, and the mic worker is only
@@ -1886,12 +1911,45 @@ async fn control_loop<T: RobotIo>(
                     // ends up rather than assuming it is still at the home pose.
                     bringup = Bringup::Limp;
                     was_driving = false;
+                    softening = None;
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "cannot cut torque; the robot is still powered")
                 }
             },
+            // Soften: remember where the joints are; the gain ramp happens in the target
+            // selection below and the end of the ramp (next block) cuts torque.
+            Some(intents::PowerRequest::Soften) => {
+                if bringup == Bringup::Limp {
+                    tracing::info!("robot.soften: already limp");
+                } else if softening.is_none() {
+                    let from = coast.known_positions(hold);
+                    tracing::warn!(gain = params.safety.gain_limp, "robot.soften: letting go");
+                    softening = Some(Softening {
+                        since: tick_start,
+                        from,
+                    });
+                    limp_fall = LimpFall::Idle;
+                    falling.reset();
+                    hold = from;
+                }
+            }
             None => {}
+        }
+
+        // End of a soften: gain reached zero, cut torque, back to limp — what `relax` does.
+        if let Some(s) = softening
+            && s.gain_at(tick_start, params.safety.gain_limp).is_none()
+        {
+            match safety.set_torque(false) {
+                Ok(()) => {
+                    tracing::warn!("robot.soften: torque off");
+                    bringup = Bringup::Limp;
+                    was_driving = false;
+                    softening = None;
+                }
+                Err(e) => tracing::warn!(error = %e, "robot.soften: cannot cut torque; retrying"),
+            }
         }
 
         // One-shot skill requests, taken once per tick like the power request. They need a
@@ -2538,6 +2596,8 @@ async fn control_loop<T: RobotIo>(
             // The limp-fall sequence owns the robot for its duration: the whole point is
             // that the policy is *not* driving while the robot falls, lands and is posed.
             && !in_limp_fall
+            // So does a soften.
+            && softening.is_none()
             && sensors.is_some()
             && imu_warm
             && !powered_off;
@@ -2588,6 +2648,16 @@ async fn control_loop<T: RobotIo>(
         };
 
         let (mut targets, gain, moving, policy_label) = match (driving, sensors.as_ref()) {
+            // A soften: joints where they were, gain ramping down.
+            _ if softening.is_some() => {
+                let s = softening.expect("checked above");
+                (
+                    s.from,
+                    s.gain_at(tick_start, params.safety.gain_limp).unwrap_or(0),
+                    true,
+                    "soften".into(),
+                )
+            }
             // The limp-fall sequence, before anything else — `driving` is false throughout,
             // so without this it would fall through to the hold branch and the robot would
             // be commanded its pre-fall pose at walking gain, which is precisely the thing
@@ -4203,6 +4273,12 @@ fn dispatch(
         // need to know, which is why `robotctl` asks for `--yes` and BLE cannot reach this at all.
         proto::Call::RobotRelax => {
             intents.request_relax();
+            proto::Response::ok(Some(id), &proto::IntentResult::accepted())
+        }
+
+        // Never refused either: the soft way to the same place.
+        proto::Call::RobotSoften => {
+            intents.request_soften();
             proto::Response::ok(Some(id), &proto::IntentResult::accepted())
         }
 
@@ -7485,6 +7561,69 @@ mod tests {
             !s.homed.load(Ordering::Relaxed),
             "still reporting homed after relax"
         );
+    }
+
+    /// `robot.soften`: the gain goes down to zero, then torque is cut once, like `relax`.
+    #[tokio::test]
+    async fn robot_soften_ramps_the_gain_down_then_cuts_power() {
+        let io = FakeIo::at(DEFAULT_POSITION).frozen();
+        let mut params = Params::default();
+        params.policy.enabled = false;
+        let s = Arc::new(RobotState::new(
+            &params,
+            std::path::Path::new("/test/robotd.toml"),
+            false,
+            false,
+        ));
+        let intents = Arc::new(Intents::new());
+        intents.request_init();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let loop_state = Arc::clone(&s);
+        let loop_intents = Arc::clone(&intents);
+        let handle = tokio::spawn(async move {
+            let mut io = io;
+            control_loop_probe_with(&mut io, loop_state, loop_intents, Duration::from_millis(2))
+                .await;
+            tx.send((io.torque, io.torque_writes, io.min_gain)).unwrap();
+        });
+        while s.ticks.load(Ordering::Relaxed) < 3 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        let at = s.ticks.load(Ordering::Relaxed);
+        intents.request_soften();
+        while s.ticks.load(Ordering::Relaxed) < at + 3 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(
+            s.moving.load(Ordering::Relaxed),
+            "a softening robot reports moving"
+        );
+        tokio::time::sleep(SOFTEN_RAMP + Duration::from_millis(100)).await;
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle.await.unwrap();
+
+        let (torque, writes, min_gain) = rx.recv().unwrap();
+        assert_eq!(torque, Some(false), "soften left the joints powered");
+        assert_eq!(writes, 2, "expected one on and one off, got {writes}");
+        assert_eq!(min_gain, Some(0), "the gain never reached zero");
+        assert!(
+            !s.homed.load(Ordering::Relaxed),
+            "still reporting homed after soften"
+        );
+    }
+
+    /// The ramp arithmetic: limp gain at the start, zero at the end, `None` after.
+    #[test]
+    fn the_soften_ramp_starts_at_limp_gain_and_ends_at_zero() {
+        let since = Instant::now();
+        let s = Softening {
+            since,
+            from: DEFAULT_POSITION,
+        };
+        assert_eq!(s.gain_at(since, 50), Some(50));
+        assert_eq!(s.gain_at(since + SOFTEN_RAMP / 2, 50), Some(25));
+        assert_eq!(s.gain_at(since + SOFTEN_RAMP, 50), None);
     }
 
     /// Relaxing clears `enabled` too. Otherwise the very next tick sees a robot that was asked to

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -745,6 +745,7 @@ impl Server {
             | Call::RobotEnable(_)
             | Call::RobotInit
             | Call::RobotRelax
+            | Call::RobotSoften
             | Call::RobotDo(_)
             | Call::RobotSound(_)
             | Call::RobotPose(_)


### PR DESCRIPTION
`robot.relax` cuts torque at once and the robot drops. This adds the gentle version, for a robot forcing against something: you want it to let go *now*, but not to fall like a stone.

## What

- `robot.soften`: gain to `gain_limp` (50) at once, then down to zero over 1 s (in steps of 5, so it is not a register write on every tick) while the joints are commanded where they are, then torque off. Same end state as `relax`: the robot is limp, `init` or Start brings it up. Refused over Bluetooth like `relax`, allowed on the console like `relax`.
- **Pad: Select** = soften. Select held 2 s still powers off (the motors are already let go by then).
- `sudo robotctl robot soften` for the bench.

## How to test
Hold the robot with the policy on, press Select: it goes soft within a second and the joints are free. Press Start to stand up again. Select held 2 s: powers off as before.
