### PR TITLE
padd: Select press = robot.relax (torque off)

### DIFF
--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -476,7 +476,8 @@ mapping is the prototype's, so muscle memory carries over:
 | **DPad-Down** | sit ↔ stand |
 | **RT / LT** | mouth (either trigger) — RT also quacks; LT rides the "wheee" while held |
 | **DPad-Up**, held 3 s | switch drive mode, walk ⇄ roller |
-| **Select**, held 2 s | sit down, then power off |
+| **Select** | torque off (`robot.relax`): the emergency release. The robot drops, so hold it |
+| **Select**, held 2 s | power off (the press has already cut torque) |
 
 There is no stop button: release the sticks and the robot stands, and `robotd`'s deadman stops it
 if `padd` dies. On a roller robot (`mode = "roller"` in `robotd.toml`) the sticks take the roller

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -310,7 +310,7 @@ fn main() -> std::process::ExitCode {
         roller,
         "driving — Start toggles the policy, Y head mode, B body pose, A ground pick, \
          LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Up (3s) walk/roller, \
-         Select (2s) shutdown"
+         Select torque off, Select (2s) shutdown"
     );
 
     let period = Duration::from_secs_f64(1.0 / args.hz as f64);
@@ -364,6 +364,7 @@ fn main() -> std::process::ExitCode {
         // Which bindable buttons went down this tick, by their config name. A list rather than
         // a flag apiece, because what each one runs is config now and this loop no longer knows.
         let mut pressed: Vec<&'static str> = Vec::new();
+        let mut relax = false;
         while let Some(event) = gilrs.next_event() {
             if let gilrs::EventType::ButtonPressed(button, _) = event.event {
                 match button {
@@ -381,6 +382,8 @@ fn main() -> std::process::ExitCode {
                     Button::LeftTrigger => pressed.push("lb"),
                     Button::RightTrigger => pressed.push("rb"),
                     Button::DPadDown => pressed.push("dpad_down"),
+                    // Emergency release: torque off. Held on, it is still the shutdown below.
+                    Button::Select => relax = true,
                     _ => {}
                 }
             }
@@ -515,6 +518,14 @@ fn main() -> std::process::ExitCode {
         {
             tracing::error!(error = %e, "send failed");
             return std::process::ExitCode::FAILURE;
+        }
+
+        if relax {
+            tracing::warn!("Select — robot.relax: torque off");
+            if let Err(e) = request(&mut stream, &mut next_id, &proto::Call::RobotRelax) {
+                tracing::error!(error = %e, "relax request failed");
+                return std::process::ExitCode::FAILURE;
+            }
         }
 
         // Select held two seconds: sit down, then power off. Sent once per hold — the


### PR DESCRIPTION
An emergency release on the pad: press **Select** and the motors let go (`robot.relax`). Holding Select 2 s still powers off, and since the press already cut torque, the duck can no longer be shut down with its motors on.

## How to test
Hold the robot with the policy on, press Select: torque goes off at once. Press Start to stand up again. Hold Select 2 s: powers off as before.
