### PR TITLE
robotd: prevent duplicate startup from replacing the live IPC socket

### DIFF
--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -43,24 +43,41 @@ the hardware does: the v2 board sits on the Dynamixel bus and serves an on-chip 
 quaternion out of the same register block the servos answer at. One board, one code path, no
 IMU abstraction. It is listed first in the id vector so it answers before the servo burst.
 
-**One owner at a time, and nothing hard-enforces it.** `serialport` sets `TIOCEXCL`, which
+**One owner at a time; tty exclusivity alone does not enforce it.** `serialport` sets `TIOCEXCL`, which
 turns a second *unprivileged* open into `EBUSY` — but `robotd.service` runs as root, because
-motor control needs the character devices, and root is not stopped by that flag. So the
-exclusion is arranged rather than enforced, and each other claimant is kept off the port
-deliberately:
+motor control needs the character devices, and root is not stopped by that flag. The daemon
+and standalone `init` therefore share an advisory lock, and other claimants are kept off the
+port separately:
 
 - **The control loop** owns it for as long as the daemon runs.
-- **`robotd init`** opens the port itself, and as root it will succeed *while the daemon is
-  running* — two writers interleaving packets on one bus, which reads as a hardware fault. So
-  it wants the daemon stopped, and that is exactly why `robot.init` and `robot.relax` exist as
-  IPC methods (§3.3): the daemon serves both from inside the loop, so nothing else has to open
-  the bus at all. `init` is the escape hatch for a robot whose daemon is not running.
+- **`robotd init`** opens the port itself, but must first take the daemon's endpoint lock.
+  It holds that lock through the entire ramp: a running daemon refuses `init`, and an `init`
+  already moving the robot refuses a daemon startup or another `init`. `robot.init` and
+  `robot.relax` remain the IPC methods (§3.3) for a running daemon; standalone `init` is the
+  escape hatch for a robot whose daemon is not running.
 - **`serial-getty@ttyS2`** — Armbian runs a login console on UART2 by default, and an `agetty`
   holding the port makes every servo invisible to everything else. `scripts/setup-board.sh`
   masks the unit; `fuser -v /dev/ttyS2` naming `agetty` is how that was found, and it is still
   the command that answers "who has the bus".
 - **The runtime**, at a coarser grain: it drives the same bus, so a board runs the runtime or
   `robotd` and never both, and the units say so with `Conflicts=` (§5.2).
+
+**Socket ownership.** Both entry points acquire `<socket>.lock` (normally
+`/run/robotd.sock.lock`) before publishing `/run/robotd/identity.json` or opening the bus.
+The daemon also binds its listener before starting the control thread, and keeps the lock
+through control-thread shutdown and socket cleanup. A refused duplicate must not overwrite
+the owner's PID and build: `robotctl health` and updater startup checks read that identity.
+For a listener left by an older daemon without a lock, the daemon's bind path removes only
+an actual socket that refuses a bounded connection probe; live listeners and ambiguous paths
+are preserved. Standalone `init` only locks and never binds or cleans up the socket.
+
+**Never unlink the lock file, even at shutdown.** The kernel releases the advisory lock when
+its file is closed or the process exits, including `SIGKILL`; the file itself stays in place.
+Deleting and recreating it could leave contenders locking two different inodes under the same
+name. File existence does not mean the lock is held. The lock is per `--socket`, so callers
+using the same physical bus must use the same socket setting; separate endpoints remain useful
+for independent fake daemons. Older binaries and other tools do not participate in this lock
+and must still be stopped before standalone `init` takes over the bus.
 
 ### 1.2 Who talks to `robotd`
 

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -898,6 +898,15 @@ async fn main() -> ExitCode {
     }
 
     if let Some(Command::Init { duration }) = args.command {
+        // init opens the motor bus itself. Keep ownership until the whole ramp returns,
+        // so neither a daemon nor another init can join it partway through.
+        let _instance_lock = match claim_lock(&args.socket) {
+            Ok(lock) => lock,
+            Err(e) => {
+                tracing::error!(path = %args.socket.display(), error = %e, "cannot claim robot IPC socket");
+                return ExitCode::FAILURE;
+            }
+        };
         duck_ipc_proto::log_startup_identity!("robotd");
         return run_init(&params, duration);
     }
@@ -3080,11 +3089,10 @@ fn publish_slow_sensors<T: RobotIo>(io: &mut Safety<T>, state: &RobotState) {
     }
 }
 
-/// Claim one daemon endpoint, including the window before there is a listener to probe.
-async fn claim_socket(socket_path: &Path) -> std::io::Result<(std::fs::File, UnixListener)> {
+/// Own an endpoint even when no listener exists, as during startup or standalone init.
+fn claim_lock(socket_path: &Path) -> std::io::Result<std::fs::File> {
     use std::fs::{OpenOptions, TryLockError};
     use std::io::{Error, ErrorKind};
-    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
     if let Some(parent) = socket_path.parent().filter(|p| !p.as_os_str().is_empty()) {
         std::fs::create_dir_all(parent)?;
@@ -3111,7 +3119,15 @@ async fn claim_socket(socket_path: &Path) -> std::io::Result<(std::fs::File, Uni
         }
         Err(TryLockError::Error(e)) => return Err(e),
     }
+    Ok(lock)
+}
 
+/// Claim one daemon endpoint, including the window before there is a listener to probe.
+async fn claim_socket(socket_path: &Path) -> std::io::Result<(std::fs::File, UnixListener)> {
+    use std::io::ErrorKind;
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+    let lock = claim_lock(socket_path)?;
     let listener = match UnixListener::bind(socket_path) {
         Ok(listener) => listener,
         Err(e) if e.kind() == ErrorKind::AddrInUse => {

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -26,7 +26,7 @@ mod soc;
 mod sound;
 mod theremin;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
@@ -878,8 +878,6 @@ async fn main() -> ExitCode {
         .with_writer(std::io::stderr)
         .init();
 
-    duck_ipc_proto::log_startup_identity!("robotd");
-
     let explicit = args.params.is_some();
     let params_path = args
         .params
@@ -900,8 +898,20 @@ async fn main() -> ExitCode {
     }
 
     if let Some(Command::Init { duration }) = args.command {
+        duck_ipc_proto::log_startup_identity!("robotd");
         return run_init(&params, duration);
     }
+
+    // Own the endpoint before publishing an identity or starting a thread that can touch
+    // the motors. Keep the lock through control-thread shutdown and socket cleanup.
+    let (_instance_lock, listener) = match claim_socket(&args.socket).await {
+        Ok(owned) => owned,
+        Err(e) => {
+            tracing::error!(path = %args.socket.display(), error = %e, "cannot claim robot IPC socket");
+            return ExitCode::FAILURE;
+        }
+    };
+    duck_ipc_proto::log_startup_identity!("robotd");
 
     let state = Arc::new(RobotState::new(
         &params,
@@ -947,6 +957,7 @@ async fn main() -> ExitCode {
     let serving = serve(
         Arc::clone(&state),
         Arc::clone(&intents),
+        listener,
         args.socket.clone(),
     );
     let mut code = ExitCode::SUCCESS;
@@ -3069,25 +3080,74 @@ fn publish_slow_sensors<T: RobotIo>(io: &mut Safety<T>, state: &RobotState) {
     }
 }
 
+/// Claim one daemon endpoint, including the window before there is a listener to probe.
+async fn claim_socket(socket_path: &Path) -> std::io::Result<(std::fs::File, UnixListener)> {
+    use std::fs::{OpenOptions, TryLockError};
+    use std::io::{Error, ErrorKind};
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+    if let Some(parent) = socket_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Append, rather than replace the extension: distinct --socket paths need distinct
+    // locks. Never unlink this file, even at shutdown — a waiter could already have the
+    // old inode open. The kernel releases the lock on exit, including SIGKILL.
+    let mut lock_path = socket_path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)?;
+    match lock.try_lock() {
+        Ok(()) => (),
+        Err(TryLockError::WouldBlock) => {
+            return Err(Error::new(
+                ErrorKind::AddrInUse,
+                "another robotd owns this socket",
+            ));
+        }
+        Err(TryLockError::Error(e)) => return Err(e),
+    }
+
+    let listener = match UnixListener::bind(socket_path) {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == ErrorKind::AddrInUse => {
+            // An older daemon may own the socket without holding our new lock. Only a
+            // real socket that refuses connections is stale; a timeout, permission error,
+            // regular file or symlink is not permission to remove somebody else's path.
+            if !std::fs::symlink_metadata(socket_path)?
+                .file_type()
+                .is_socket()
+            {
+                return Err(e);
+            }
+            match tokio::time::timeout(Duration::from_secs(1), UnixStream::connect(socket_path))
+                .await
+            {
+                Ok(Err(probe)) if probe.kind() == ErrorKind::ConnectionRefused => {
+                    tracing::warn!(path = %socket_path.display(), "removing stale socket");
+                    std::fs::remove_file(socket_path)?;
+                    UnixListener::bind(socket_path)?
+                }
+                Ok(Err(probe)) => return Err(probe),
+                _ => return Err(e),
+            }
+        }
+        Err(e) => return Err(e),
+    };
+    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(SOCKET_MODE))?;
+    Ok((lock, listener))
+}
+
 async fn serve(
     state: Arc<RobotState>,
     intents: Arc<Intents>,
+    listener: UnixListener,
     socket_path: PathBuf,
 ) -> std::io::Result<()> {
-    // A leftover socket from a killed process must not stop us coming up.
-    if socket_path.exists() {
-        tracing::warn!(path = %socket_path.display(), "removing stale socket");
-        let _ = std::fs::remove_file(&socket_path);
-    }
-    if let Some(parent) = socket_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    let listener = UnixListener::bind(&socket_path)?;
-
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(SOCKET_MODE))?;
-
     tracing::info!(
         path = %socket_path.display(),
         mode = format!("{SOCKET_MODE:o}"),

--- a/robotd/tests/single_instance.rs
+++ b/robotd/tests/single_instance.rs
@@ -1,0 +1,196 @@
+//! Startup ownership against the actual binary, with fake I/O and private sockets.
+use std::io::Read;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use updater::robot::{Health, RobotClient, SocketRobotClient};
+
+struct Robotd(Child);
+
+impl Robotd {
+    fn spawn(socket: &Path, extra: &[&str]) -> Self {
+        // An explicit empty config keeps host /etc/robot settings out of the test.
+        let params = socket.parent().unwrap().join("params.toml");
+        std::fs::write(&params, "").unwrap();
+        Self(
+            Command::new(env!("CARGO_BIN_EXE_robotd"))
+                .arg("--socket")
+                .arg(socket)
+                .arg("--params")
+                .arg(params)
+                .args(["--fake", "--no-policy"])
+                .args(extra)
+                .env("RUST_LOG", "warn")
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("spawn robotd"),
+        )
+    }
+
+    async fn wait_for_exit(&mut self) -> (ExitStatus, String) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(status) = self.0.try_wait().unwrap() {
+                let mut log = String::new();
+                self.0
+                    .stderr
+                    .take()
+                    .unwrap()
+                    .read_to_string(&mut log)
+                    .unwrap();
+                return (status, log);
+            }
+            assert!(Instant::now() < deadline, "robotd did not exit");
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    async fn assert_refused(&mut self) {
+        let (status, log) = self.wait_for_exit().await;
+        assert_eq!(status.code(), Some(1), "{status}: {log}");
+        assert!(log.contains("cannot claim robot IPC socket"), "{log}");
+        assert!(
+            !log.contains("--fake: no bus, no robot"),
+            "a refused startup must not start the control loop: {log}"
+        );
+    }
+
+    fn kill(&mut self) {
+        self.0.kill().unwrap();
+        self.0.wait().unwrap();
+    }
+}
+
+impl Drop for Robotd {
+    fn drop(&mut self) {
+        // A failed assertion must not leave a daemon behind, either.
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+async fn wait_until_healthy(socket: &Path) {
+    let client = SocketRobotClient::new(socket.to_owned());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let health = client.health(Duration::from_millis(500)).await;
+        if matches!(health, Health::Healthy) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "robotd never became healthy: {health:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// The second process used to unlink the first one's listener and take all new clients,
+/// while both control loops kept running. Its forced unhealthy response identifies a takeover.
+#[tokio::test]
+async fn a_second_daemon_cannot_replace_the_running_service() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let mut first = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    let inode = std::fs::metadata(&socket).unwrap().ino();
+
+    let mut second = Robotd::spawn(&socket, &["--unhealthy"]);
+    second.assert_refused().await;
+
+    assert!(first.0.try_wait().unwrap().is_none());
+    assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
+    wait_until_healthy(&socket).await;
+}
+
+/// A PID file or an unconditionally exclusive create would survive SIGKILL and prevent
+/// recovery. The kernel lock must release, and the abandoned socket must be replaceable.
+#[tokio::test]
+async fn a_killed_daemon_can_restart_using_the_same_lock_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let lock_path = dir.path().join("robotd.sock.lock");
+    let mut first = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    let lock_inode = std::fs::metadata(&lock_path).unwrap().ino();
+    first.kill();
+    assert!(socket.exists(), "SIGKILL leaves a stale socket");
+
+    let _restarted = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    assert_eq!(std::fs::metadata(lock_path).unwrap().ino(), lock_inode);
+    let mut duplicate = Robotd::spawn(&socket, &["--unhealthy"]);
+    duplicate.assert_refused().await;
+    wait_until_healthy(&socket).await;
+}
+
+/// Graceful shutdown must remove the socket but keep the lock inode reusable, so a
+/// normal service restart cannot split contenders across two different lock files.
+#[tokio::test]
+async fn a_clean_shutdown_can_restart_using_the_same_lock_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let lock_path = dir.path().join("robotd.sock.lock");
+    let mut first = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    let inode = std::fs::metadata(&lock_path).unwrap().ino();
+    assert_eq!(unsafe { libc::kill(first.0.id() as i32, libc::SIGTERM) }, 0);
+    let (status, log) = first.wait_for_exit().await;
+    assert!(status.success(), "{status}: {log}");
+    assert!(!socket.exists());
+
+    let _restarted = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    assert_eq!(std::fs::metadata(lock_path).unwrap().ino(), inode);
+}
+
+/// An older robotd does not hold our new lock. A listening socket is still owned and
+/// must not be mistaken for the file a killed process left behind.
+#[tokio::test]
+async fn a_live_listener_without_a_lock_is_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let _listener = UnixListener::bind(&socket).unwrap();
+    let inode = std::fs::metadata(&socket).unwrap().ino();
+
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    daemon.assert_refused().await;
+    assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
+    UnixStream::connect(&socket).expect("original listener remains reachable");
+}
+
+/// The lock must exclude a second launch even before the first has bound its socket.
+/// Checking only whether a listener answers leaves that startup window unprotected.
+#[tokio::test]
+async fn a_held_lock_refuses_startup_before_a_socket_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let lock = std::fs::File::create(dir.path().join("robotd.sock.lock")).unwrap();
+    lock.try_lock().unwrap();
+
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    daemon.assert_refused().await;
+    assert!(!socket.exists());
+}
+
+/// A path typo is not permission to delete a regular file or a dangling symlink.
+#[tokio::test]
+async fn non_socket_paths_are_not_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    std::fs::write(&socket, "keep this file").unwrap();
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    daemon.assert_refused().await;
+    assert_eq!(std::fs::read_to_string(&socket).unwrap(), "keep this file");
+
+    std::fs::remove_file(&socket).unwrap();
+    let target = dir.path().join("missing");
+    std::os::unix::fs::symlink(&target, &socket).unwrap();
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    daemon.assert_refused().await;
+    assert_eq!(std::fs::read_link(&socket).unwrap(), target);
+}

--- a/robotd/tests/single_instance.rs
+++ b/robotd/tests/single_instance.rs
@@ -54,8 +54,16 @@ impl Robotd {
         assert_eq!(status.code(), Some(1), "{status}: {log}");
         assert!(log.contains("cannot claim robot IPC socket"), "{log}");
         assert!(
+            !log.contains("starting service="),
+            "a refused startup must not publish the loser's identity: {log}"
+        );
+        assert!(
             !log.contains("--fake: no bus, no robot"),
             "a refused startup must not start the control loop: {log}"
+        );
+        assert!(
+            !log.contains("cannot open the bus"),
+            "a refused init must not try to open the bus: {log}"
         );
     }
 
@@ -105,6 +113,48 @@ async fn a_second_daemon_cannot_replace_the_running_service() {
     assert!(first.0.try_wait().unwrap().is_none());
     assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
     wait_until_healthy(&socket).await;
+}
+
+/// `init` used to bypass the daemon's lock and open the motor bus itself. A missing,
+/// private port makes reaching run_init observable without ever opening real hardware.
+#[tokio::test]
+async fn init_cannot_open_the_bus_while_a_daemon_is_running() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let port = dir.path().join("missing-bus");
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    let inode = std::fs::metadata(&socket).unwrap().ino();
+
+    let mut init = Robotd::spawn(&socket, &["--port", port.to_str().unwrap(), "init"]);
+    init.assert_refused().await;
+
+    assert!(daemon.0.try_wait().unwrap().is_none());
+    assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
+    wait_until_healthy(&socket).await;
+}
+
+/// A failed init must release ownership just like a successful ramp: the operator may
+/// need to start the daemon to diagnose the bus. It must not create an IPC listener.
+#[tokio::test]
+async fn a_failed_init_releases_the_lock_without_creating_a_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let port = dir.path().join("missing-bus");
+    let lock_path = dir.path().join("robotd.sock.lock");
+    let mut init = Robotd::spawn(&socket, &["--port", port.to_str().unwrap(), "init"]);
+    let (status, log) = init.wait_for_exit().await;
+    assert_eq!(status.code(), Some(1), "{status}: {log}");
+    #[cfg(target_os = "linux")]
+    assert!(log.contains("cannot open the bus"), "{log}");
+    #[cfg(not(target_os = "linux"))]
+    assert!(log.contains("init needs a real bus"), "{log}");
+    assert!(!socket.exists(), "init must not bind a listener");
+    let inode = std::fs::metadata(&lock_path).unwrap().ino();
+
+    let _daemon = Robotd::spawn(&socket, &[]);
+    wait_until_healthy(&socket).await;
+    assert_eq!(std::fs::metadata(&lock_path).unwrap().ino(), inode);
 }
 
 /// Both launches start together, before either has answered a client. Repeating the race
@@ -259,8 +309,12 @@ async fn a_held_lock_refuses_startup_before_a_socket_exists() {
     let lock = std::fs::File::create(dir.path().join("robotd.sock.lock")).unwrap();
     lock.try_lock().unwrap();
 
-    let mut daemon = Robotd::spawn(&socket, &[]);
-    daemon.assert_refused().await;
+    let port = dir.path().join("missing-bus");
+    // `init` has no listener at all, so both entry points must respect the lock alone.
+    for command in [vec![], vec!["--port", port.to_str().unwrap(), "init"]] {
+        let mut process = Robotd::spawn(&socket, &command);
+        process.assert_refused().await;
+    }
     assert!(!socket.exists());
 }
 

--- a/robotd/tests/single_instance.rs
+++ b/robotd/tests/single_instance.rs
@@ -107,6 +107,46 @@ async fn a_second_daemon_cannot_replace_the_running_service() {
     wait_until_healthy(&socket).await;
 }
 
+/// Both launches start together, before either has answered a client. Repeating the race
+/// exercises both possible winners; waiting for the first daemon to be ready would miss it.
+#[tokio::test]
+async fn simultaneous_starts_leave_exactly_one_daemon_running() {
+    for _ in 0..10 {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("robotd.sock");
+        let gate = std::sync::Barrier::new(2);
+        let (mut first, mut second) = std::thread::scope(|scope| {
+            let start = || {
+                gate.wait();
+                Robotd::spawn(&socket, &[])
+            };
+            let first = scope.spawn(start);
+            let second = scope.spawn(start);
+            (first.join().unwrap(), second.join().unwrap())
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let winner = loop {
+            match (first.0.try_wait().unwrap(), second.0.try_wait().unwrap()) {
+                (Some(_), None) => {
+                    first.assert_refused().await;
+                    break &mut second;
+                }
+                (None, Some(_)) => {
+                    second.assert_refused().await;
+                    break &mut first;
+                }
+                (Some(a), Some(b)) => panic!("both daemons exited: {a}, {b}"),
+                (None, None) => (),
+            }
+            assert!(Instant::now() < deadline, "both daemons kept running");
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        };
+        wait_until_healthy(&socket).await;
+        assert!(winner.0.try_wait().unwrap().is_none());
+    }
+}
+
 /// A PID file or an unconditionally exclusive create would survive SIGKILL and prevent
 /// recovery. The kernel lock must release, and the abandoned socket must be replaceable.
 #[tokio::test]
@@ -161,6 +201,53 @@ async fn a_live_listener_without_a_lock_is_preserved() {
     daemon.assert_refused().await;
     assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
     UnixStream::connect(&socket).expect("original listener remains reachable");
+}
+
+/// Linux AF_UNIX can refuse a connection with EAGAIN when the accept queue is full.
+/// A busy listener must be preserved just like one that answers the liveness probe.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn a_live_listener_with_a_full_accept_queue_is_preserved() {
+    use std::io::ErrorKind;
+    use std::os::fd::AsRawFd;
+
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("robotd.sock");
+    let listener = UnixListener::bind(&socket).unwrap();
+    // Shrink the queue on this live listener so the test needs only a few connections.
+    assert_eq!(unsafe { libc::listen(listener.as_raw_fd(), 1) }, 0);
+    let inode = std::fs::metadata(&socket).unwrap().ino();
+    let mut queued = Vec::new();
+    let mut full = false;
+    for _ in 0..8 {
+        match tokio::time::timeout(
+            Duration::from_secs(1),
+            tokio::net::UnixStream::connect(&socket),
+        )
+        .await
+        {
+            Ok(Ok(stream)) => queued.push(stream),
+            Ok(Err(e)) if e.kind() == ErrorKind::WouldBlock => {
+                full = true;
+                break;
+            }
+            Err(_) => {
+                full = true;
+                break;
+            }
+            Ok(Err(e)) => panic!("cannot fill the accept queue: {e}"),
+        }
+    }
+    assert!(full && !queued.is_empty(), "accept queue was not saturated");
+
+    let mut daemon = Robotd::spawn(&socket, &[]);
+    daemon.assert_refused().await;
+    assert_eq!(std::fs::metadata(&socket).unwrap().ino(), inode);
+    listener.set_nonblocking(true).unwrap();
+    while let Ok((stream, _)) = listener.accept() {
+        drop(stream);
+    }
+    UnixStream::connect(&socket).expect("original listener still accepts new connections");
 }
 
 /// The lock must exclude a second launch even before the first has bound its socket.


### PR DESCRIPTION
Starting a second `robotd` with the same `--socket` currently unlinks the first daemon's listener after starting another control thread. Both processes stay alive while new clients reach the second process. The duplicate also overwrites the running daemon's PID and build in `/run/robotd/identity.json`, which `robotctl health` and updater startup checks trust. Standalone `robotd init` is another unguarded bus writer: its requirement to stop the daemon first was only documented.

Acquire an advisory lock on `<socket>.lock` before publishing identity or opening the motor bus. The daemon binds its IPC listener before starting the control thread and holds the lock through shutdown and socket cleanup. `robotd init` uses the same lock-only claim and holds it through the entire initialization ramp, so a daemon and an init cannot join each other mid-operation. A refused contender exits with a clear error before publishing identity or touching the bus.

The lock file stays in place so all contenders use the same inode; file existence does not mean the lock is held. Closing the file or exiting releases ownership, including after `SIGKILL`. The design documentation now records this lifecycle and why cleanup must never unlink the lock file.

For an existing socket without a lock, the daemon's bind path uses a bounded connection probe. It removes only an actual socket returning `ConnectionRefused`, preserving live listeners, non-socket paths and ambiguous failures. Standalone `init` only locks: it neither binds nor removes the socket. The advisory lock is per `--socket`; callers using the same physical bus must use the same setting. Older binaries and other tools do not participate and must still be stopped before standalone init. Independent fake daemons can use different endpoints. No dependency or wire-protocol changes.

Validation on Linux x86_64 (Ubuntu 24.04 under WSL):

- The duplicate-daemon regression fails on the original `bc41fb5` base. The three init-related regression cases fail on the previous PR head `e72a489` and pass with the revision.
- `cargo test --locked -p robotd`: **159 passed** (142 unit tests, 10 process-level startup tests, 7 updater-gate tests).
- Startup coverage includes duplicate and simultaneous daemon startup (ten rounds), locks occupied before a socket exists, live legacy listeners including a saturated Linux accept queue, `SIGKILL` recovery, clean restart, non-socket preservation, init refusal against a running daemon, and lock release after init failure. Refusals also check that startup identity was not published.
- `cargo fmt --all --check` and `cargo clippy --locked -p robotd --all-targets -- -D warnings` pass.
- An additional local probe, separate from the Cargo suite, runs the actual `robotd init` against a private pseudo-terminal responding to Dynamixel v2 traffic. It completes a 1.5-second / 75-write ramp, observes the lock at every interpolation write, rejects both a concurrent daemon and another init, preserves the owner's identity, and starts a healthy fake daemon after init returns. A subsequent refused init sends no bus packets. The same probe fails on `e72a489`.

The PTY peer validates process exclusion and lock lifetime, not physical actuator behavior. No physical robot was used. Full-workspace and aarch64/userland checks run in repository CI; see Checks for the current head.
