### PR TITLE
Prepare release 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "btd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bluer",
  "clap",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "configd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "duck-control"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "duck-ipc-proto",
  "libloading 0.8.9",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "duck-detect"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "duck-ipc-proto"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "semver",
  "serde",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "duckctl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "btd",
  "btleplug",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "kinematics"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "roxmltree",
  "serde",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "mediad"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "odometry"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "duck-ipc-proto",
  "kinematics",
@@ -2900,7 +2900,7 @@ checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "padd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "duck-ipc-proto",
@@ -3006,7 +3006,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pet-detect"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "robotctl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "robotd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "clap",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "robotd-params"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "duck-ipc-proto",
  "kinematics",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "sounds"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "minisign",
@@ -4308,7 +4308,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tof"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -4716,7 +4716,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5330,7 +5330,7 @@ checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xtask"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "minisign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ repo    = "pollen-robotics/microduck-gst-plugins"
 version = "v3"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 # 1.89 for `std::fs::File::try_lock`, which is how the single-flight update lock works
 # without a dependency (updater/src/journal.rs). Edition 2024 needs 1.85, so this covers


### PR DESCRIPTION
Bumps the workspace version to 0.11.0, which is what `xtask package` checks the tag against.

96 commits since `daemon-v0.10.0`. `API_VERSION` goes 16 → 23, so a client built against 0.10.0 will
see routes it does not know.

**Reaching a duck that is not on your LAN.** A robot registers with the rendezvous service and can
belong to a Hugging Face account; the console signs in and out, and a sign-out reaches the relay. The
relay plays the consumer for a remote peer, offers a relay candidate for a consumer behind a NAT, and
carries a session refusal from the board to the browser. A Python consumer gets frames with nothing
added on either side, and a Space processes a duck's camera on Hugging Face hardware.

**The policy set.** Manifest schema 2 gives a repo and the set one vocabulary; the set says how its
own ground pick and sit↔stand run. Gaits download from the Hub instead of riding along with every
daemon release, `policy update` fetches what the set actually declares, the library gets tidied, and
the skill table crosses the wire so a phone knows which button runs which skill.

**Idle CPU.** The pad, the ToF, the camera and the petting classifier all stopped doing work nobody
asked for.

**Standing up, and not standing up.** A reset, a shutdown and a policy update no longer stand the
robot up; a mode switch waits for what it needs. `robot.rebootMotors` reboots the servos in place.
On the pad, Start stands up then drives, Select relaxes.

**robotd startup.** The IPC socket is claimed before control starts, the endpoint lock is held
throughout standalone init, and a restarted daemon gets the next request rather than the one after.

Once CI is green here, `daemon-staging-v0.11.0` builds the candidate for a canary.
