### PR TITLE
A demo Space that processes the duck's camera, and what it measured

### DIFF
--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -721,6 +721,30 @@ blocks (a `try_read` that yields nothing rather than waiting) and never fails. A
 the ordinary state for the first few seconds after boot and forever on a robot with no account,
 and it means host and srflx only, which is all anything on the same network needs.
 
+**Measured: a data centre cannot reach a robot without a relay.** The demo Space
+(`spaces/vision-demo`) got as far as it can and the log says where that is:
+
+```
+the rendezvous welcomed this consumer as 9d3a17dd (PierreRouanet)
+found olducky (8a73eda9), asking for a session
+session 4c7e9c60 started; waiting for the robot's offer
+peer connection connecting (ice checking)
+the session ended: the robot ended the session       ← 8s later
+peer connection failed (ice failed)
+```
+
+Signalling crosses perfectly — welcome, listing, session, offer, answer — and **no candidate pair
+works**. The robot offers host and srflx; a Space offers its own; neither offers a `relay`. Eight
+seconds in, `webrtcsink` times out a consumer whose ICE never connected and ends the session, which
+the bridge forwards, which is the `the robot ended the session` line arriving before the ICE
+verdict.
+
+That settles what was previously a guess. On one LAN the console works on host candidates; from a
+4G phone it failed and carrier-grade NAT was the suspicion; **from a Hugging Face Space it fails
+too**, and a Space is not behind CGNAT. So TURN is not a fallback for awkward networks — it is the
+requirement for every consumer that is not on the robot's own wifi, which includes every cloud
+backend and therefore anything doing perception on a Space.
+
 **And the endpoint is not answering, which is where this stands.** `turn.fastrtc.org` has no A
 record and `fastrtc.org` has no NS records at all, from three public resolvers and from the board
 — so the proxy both `fastrtc`'s own current code and `reachy_mini`'s #1182 point at cannot be
@@ -732,8 +756,8 @@ than a moved URL, and it means the mini fleet's relay path is down too. Worth te
 Three ways on, in the order they should be considered:
 
 - **Wait, having reported it.** The robot degrades exactly as designed — a warning every thirty
-  seconds and host/srflx candidates — so nothing is broken except reaching a robot from a network
-  that needs a relay.
+  seconds and host/srflx candidates. What that costs is now measured rather than estimated: every
+  consumer off the robot's own network, which is all of them except a browser on the same wifi.
 - **Our own proxy**, which is what that endpoint is: a small service holding a Cloudflare Calls key
   and minting short-lived credentials for a caller presenting a valid HF token. `--turn-url` is
   already the seam it plugs into, and the key stays in one place rather than on robots.

--- a/scripts/publish-space.sh
+++ b/scripts/publish-space.sh
@@ -39,8 +39,19 @@ SOURCE="$REPO_ROOT/spaces/$NAME"
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STAGE"' EXIT
 
+# **What git has, not what the directory has**, and that is the whole of the copy below.
+#
+# `cp *` published whatever was lying around — and something always is: running the app from its
+# own directory leaves a `__pycache__` next to it, which is a directory, which `cp` without `-r`
+# refuses, which stopped the script halfway. Listing tracked files fixes both halves: bytecode and
+# scratch files cannot reach a Space, and a Space always corresponds to a commit in this
+# repository. A file that has not been committed does not deploy, which is a feature the first
+# time somebody wonders which version is live.
+FILES=$(cd "$REPO_ROOT" && git ls-files "spaces/$NAME" | sed "s|^spaces/$NAME/||")
+[ -n "$FILES" ] || { echo "no tracked files under spaces/$NAME — commit them first" >&2; exit 1; }
+
 echo "space:  https://huggingface.co/spaces/$SPACE"
-echo "files:  $(cd "$SOURCE" && ls | tr '\n' ' ')"
+echo "files:  $(echo "$FILES" | tr '\n' ' ')"
 
 if [ -n "$DRY_RUN" ]; then
     echo "--dry-run: nothing pushed"
@@ -53,7 +64,12 @@ git clone --depth 1 "https://huggingface.co/spaces/$SPACE" "$CLONE"
 # Copied rather than synced: a file deleted here stays in the Space until somebody removes it
 # there. Deliberate — a `--delete` that ran against the wrong Space id would remove somebody's
 # work, and these are hand-run.
-cp "$SOURCE"/* "$CLONE/"
+#
+# One at a time and by name, so a subdirectory arrives as a subdirectory rather than as an error.
+for file in $FILES; do
+    mkdir -p "$CLONE/$(dirname "$file")"
+    cp "$SOURCE/$file" "$CLONE/$file"
+done
 
 cd "$CLONE"
 if git diff --quiet; then

--- a/scripts/publish-space.sh
+++ b/scripts/publish-space.sh
@@ -81,4 +81,5 @@ REVISION=$(cd "$REPO_ROOT" && git rev-parse --short HEAD)
 git add -A
 git commit -q -m "$NAME from microduck $REVISION"
 git push
-echo "pushed. The Space rebuilds in a minute or two — Gradio Spaces install their requirements."
+echo "pushed. The Space rebuilds: a couple of minutes for a Docker one, since aiortc and av"
+echo "        are wheels worth waiting for. Its build log is on the Space page."

--- a/scripts/publish-space.sh
+++ b/scripts/publish-space.sh
@@ -72,13 +72,18 @@ for file in $FILES; do
 done
 
 cd "$CLONE"
-if git diff --quiet; then
+
+# **Staged first, then compared.** `git diff --quiet` ignores untracked files, so a publish whose
+# only change was a *new* file reported "already serves this" and pushed nothing — which is the
+# worst possible answer, because it is indistinguishable from success. `git add -A` and then a
+# cached diff sees additions, deletions and modifications alike.
+git add -A
+if git diff --cached --quiet; then
     echo "the Space already serves this"
     exit 0
 fi
 
 REVISION=$(cd "$REPO_ROOT" && git rev-parse --short HEAD)
-git add -A
 git commit -q -m "$NAME from microduck $REVISION"
 git push
 echo "pushed. The Space rebuilds: a couple of minutes for a Docker one, since aiortc and av"

--- a/spaces/vision-demo/Dockerfile
+++ b/spaces/vision-demo/Dockerfile
@@ -23,7 +23,12 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py filters.py ./
+# **Every module, not a list of them.** This said `COPY app.py filters.py ./`, and the day a third
+# module appeared the image built perfectly and the app died on `import consumer` — a hand-kept
+# list of files that has to match reality is the same mistake as `cp *` in the publisher and
+# `git diff --quiet` in its check, three times in one afternoon. `publish-space.sh` sends only
+# tracked files, so a glob here cannot pick up anything that is not meant to be deployed.
+COPY *.py ./
 USER duck
 ENV HOME=/home/duck \
     GRADIO_SERVER_NAME=0.0.0.0 \

--- a/spaces/vision-demo/Dockerfile
+++ b/spaces/vision-demo/Dockerfile
@@ -1,0 +1,33 @@
+# The demo, in an environment it chooses.
+#
+# **Docker rather than `sdk: gradio`, and not by preference.** A Gradio Space installs
+# `gradio[oauth,mcp]==6.26.0` of its own accord, and that exact version cannot coexist with the
+# consumer this demo is built on:
+#
+#     gradio 6.26   needs starlette >=1.0.1 and huggingface-hub >=1.16
+#     reachy-mini   needs starlette <1.0.0            (every version, including 1.10)
+#
+# pip says `ResolutionImpossible` and it is right. Gradio 5.23 resolves with the same consumer in
+# 117 packages, so the version is the thing to control — which a Docker Space can and a Gradio
+# Space cannot. The console Space reached `sdk: docker` by a different route
+# (`remote-access-design.md` §5.0); this is the second time the managed environment was the
+# obstacle rather than the shortcut.
+FROM python:3.12-slim
+
+# A user with a writable home, because Gradio and `huggingface_hub` both cache under `$HOME` and
+# a root-owned container on this platform does not get one.
+RUN useradd --create-home --uid 1000 duck
+WORKDIR /app
+
+# Requirements first, so a change to the app does not reinstall aiortc and av — the two slow ones.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py filters.py ./
+USER duck
+ENV HOME=/home/duck \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    GRADIO_SERVER_PORT=7860
+
+EXPOSE 7860
+CMD ["python", "app.py"]

--- a/spaces/vision-demo/README.md
+++ b/spaces/vision-demo/README.md
@@ -3,8 +3,8 @@ title: microduck vision demo
 emoji: 🦆
 colorFrom: yellow
 colorTo: indigo
-sdk: gradio
-app_file: app.py
+sdk: docker
+app_port: 7860
 pinned: false
 hf_oauth: true
 short_description: A duck's camera, processed on Hugging Face hardware.
@@ -18,6 +18,11 @@ optical flow, and an overlay of the camera's geometry.
 
 **Do not edit this Space directly.** The source is `spaces/vision-demo/` in
 `pollen-robotics/microduck`, and `scripts/publish-space.sh` is what puts it here.
+
+**Docker rather than `sdk: gradio`, and not by preference.** A Gradio Space installs
+`gradio[oauth,mcp]==6.26.0`, which needs `starlette>=1.0.1`, where `reachy-mini` needs
+`starlette<1.0.0` — every version of it. `ResolutionImpossible`, correctly. Gradio 5.23 resolves
+with the same consumer, so the version is the thing to control, and only a Docker Space can.
 
 ## Two things it is for
 

--- a/spaces/vision-demo/README.md
+++ b/spaces/vision-demo/README.md
@@ -28,6 +28,14 @@ with the same consumer, so the version is the thing to control, and only a Docke
 It shows the path end to end: a camera on a duck, a container in a data centre, a processed
 picture. That is the demo.
 
+**What it measured, on its first run:** signalling crosses and ICE does not. The rendezvous
+welcomes this consumer, lists the duck, starts a session, and the offer and answer are exchanged —
+then `peer connection failed (ice failed)`, because no candidate pair works between a data centre
+and a robot behind a home router and neither side can offer a relay. `remote-access-design.md` §6
+has the log and what follows from it: TURN is a requirement for cloud consumers, not a fallback for
+awkward networks. **This Space will connect the day the robot can offer a relay candidate, with no
+change here.**
+
 And it is **the only thing that tests the transport from a data centre**. Every session before it
 came from a browser on the robot's own network, or a phone on 4G. A Space is neither, and the robot
 cannot offer a `relay` candidate while the TURN credentials endpoint has no DNS

--- a/spaces/vision-demo/README.md
+++ b/spaces/vision-demo/README.md
@@ -6,7 +6,6 @@ colorTo: indigo
 sdk: docker
 app_port: 7860
 pinned: false
-hf_oauth: true
 short_description: A duck's camera, processed on Hugging Face hardware.
 ---
 
@@ -36,13 +35,18 @@ cannot offer a `relay` candidate while the TURN credentials endpoint has no DNS
 the frame count separately. "Signalling worked and media did not" is a specific, expected outcome
 here, and it is not a fault in this Space.
 
-## Identity
+## Identity, and why this Space must stay private
 
-**A visitor's token by preference, never the robot's.** The rendezvous maps a token to one peer, so
-a consumer authenticating as the robot takes the robot off its owner's listing. `hf_oauth: true`
-plus Gradio's login button gives each visitor their own token, which reaches their own robots and
-nobody else's — which is also what makes a public Space defensible. An `HF_TOKEN` secret is the
-fallback for a private Space with one owner.
+It authenticates with an **`HF_TOKEN` secret** — Settings → Variables and secrets — belonging to
+the account the robot belongs to. Not the robot's own token: the rendezvous maps a token to one
+peer, so a consumer sharing the robot's credential takes the robot off its owner's listing (§3.7).
+
+A visitor's own OAuth token would be better and would make this safe to publish. Two attempts at
+one failed on platform behaviour rather than on code: a static Space never injected the client id
+(`remote-access-design.md` §5.0), and a Docker Space does not put `OAUTH_CLIENT_ID` in the
+environment either — Gradio then decides it is not in a Space, mocks OAuth, and refuses to start
+without a local login. A demo that will not start is worse than a demo with one credential, so the
+button is gone and the Space stays private.
 
 ## What it cannot do
 

--- a/spaces/vision-demo/app.py
+++ b/spaces/vision-demo/app.py
@@ -35,12 +35,26 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+import logging
+
 import gradio as gr
 import numpy as np
 
 from consumer import DuckConsumer
 
 from filters import FILTERS, upright
+
+# **The container log is the only diagnostic a private Space can hand somebody**, and this printed
+# nothing of its own: the consumer logs at INFO and nothing had configured a handler, so every
+# line about the welcome, the producer, the session and the ICE state went nowhere. A Space that
+# will not connect and says nothing in its log is a Space nobody can help with.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
+logging.getLogger("aioice").setLevel(logging.WARNING)
+logging.getLogger("aiortc").setLevel(logging.WARNING)
 
 # Which robot to look for. The rendezvous lists every robot an account owns, and the consumer picks
 # by `meta.name` — the name `robotctl system set-name` sets.

--- a/spaces/vision-demo/app.py
+++ b/spaces/vision-demo/app.py
@@ -195,21 +195,30 @@ def render(filter_name: str) -> tuple[np.ndarray | None, str]:
     return processed, describe(status)
 
 
-def connect(profile: gr.OAuthProfile | None, token: gr.OAuthToken | None) -> str:
-    """Open the session with whichever credential this Space has.
+def connect() -> str:
+    """Open the session with this Space's `HF_TOKEN`.
 
-    **A visitor's token by preference, and never the robot's.** The rendezvous maps a token to one
-    peer, so a consumer authenticating as the robot would take the robot off its owner's listing —
-    the same fact §3.7 records about two things sharing a credential. A visitor's OAuth token is
-    also what makes a *public* Space defensible: it reaches the visitor's own robots and nobody
-    else's. `HF_TOKEN` is the fallback for a private Space with one owner.
+    **No sign-in button, and that is a retreat rather than a design.** A visitor's own OAuth token
+    would be better — it reaches their robots and nobody else's, which is what would make this
+    Space safe to make public — and two attempts at getting one failed on platform behaviour
+    rather than on code: a static Space never injected the client id the console needed
+    (`remote-access-design.md` §5.0), and a Docker Space does not put `OAUTH_CLIENT_ID` in the
+    environment either, so Gradio decides it is not in a Space, falls back to *mocked* OAuth, and
+    refuses to start without a local login. A demo that will not start is worse than a demo with
+    one credential.
+
+    So: an `HF_TOKEN` secret, and **this Space must stay private** — a visitor would otherwise be
+    reaching the owner's robot with the owner's token. The token is still never the robot's own:
+    the rendezvous maps a token to one peer, so a consumer sharing the robot's credential takes
+    the robot off its own owner's listing. §3.7.
     """
-    if token is not None:
-        return LINK.start(token.token)
-    fallback = os.environ.get("HF_TOKEN", "").strip()
-    if fallback:
-        return LINK.start(fallback)
-    return "sign in with Hugging Face, or set an HF_TOKEN secret on this Space"
+    token = os.environ.get("HF_TOKEN", "").strip()
+    if not token:
+        return (
+            "no `HF_TOKEN` secret on this Space. Settings → Variables and secrets → "
+            "`HF_TOKEN`, with a token of the account the robot belongs to (not the robot's own)."
+        )
+    return LINK.start(token)
 
 
 with gr.Blocks(title="duck vision demo") as demo:
@@ -227,7 +236,6 @@ with gr.Blocks(title="duck vision demo") as demo:
     )
 
     with gr.Row():
-        gr.LoginButton()
         connect_button = gr.Button("connect", variant="primary")
         disconnect_button = gr.Button("disconnect")
         chosen = gr.Dropdown(

--- a/spaces/vision-demo/app.py
+++ b/spaces/vision-demo/app.py
@@ -38,7 +38,7 @@ from typing import Any
 import gradio as gr
 import numpy as np
 
-from reachy_mini.media.central_consumer import ReachyCentralConsumer
+from consumer import DuckConsumer
 
 from filters import FILTERS, upright
 
@@ -61,7 +61,7 @@ class Link:
     before wondering why the page went quiet.
     """
 
-    consumer: ReachyCentralConsumer | None = None
+    consumer: DuckConsumer | None = None
     loop: asyncio.AbstractEventLoop | None = None
     thread: threading.Thread | None = None
     error: str | None = None
@@ -83,10 +83,10 @@ class Link:
             thread = threading.Thread(target=loop.run_forever, name="duck-consumer", daemon=True)
             thread.start()
 
-            consumer = ReachyCentralConsumer(
-                hf_token=token,
+            consumer = DuckConsumer(
+                token=token,
                 robot_name=ROBOT,
-                consumer_label=f"microduck-vision-demo/{os.environ.get('SPACE_ID', 'local')}",
+                label=f"microduck-vision-demo/{os.environ.get('SPACE_ID', 'local')}",
             )
             try:
                 asyncio.run_coroutine_threadsafe(consumer.start(), loop).result(timeout=30)
@@ -140,6 +140,8 @@ def describe(status: dict[str, Any]) -> str:
     session = status.get("session_id")
     state = status.get("pc_state")
     frames = status.get("frames") or 0
+    if reported := status.get("error"):
+        return f"**{reported}**"
 
     if not session:
         return (
@@ -158,9 +160,24 @@ def describe(status: dict[str, Any]) -> str:
             "(`remote-access-design.md` §6). Signalling crossing while media does not is exactly "
             "that failure, and it is not a fault in this Space."
         )
+    geometry = ""
+    if LINK.consumer is not None and (video := LINK.consumer.video_info()):
+        intrinsics = video.get("intrinsics")
+        geometry = (
+            f" Camera says {video.get('width')}×{video.get('height')}, mounted "
+            f"{video.get('rotate')}° off upright"
+            + (
+                f", fx {intrinsics['fx']:.0f} px"
+                + (" (calibrated)" if intrinsics.get("calibrated") else " (nominal)")
+                if intrinsics
+                else ", geometry unknown"
+            )
+            + "."
+        )
     return (
-        f"**connected** — session `{session[:8]}`, {frames} frames decoded. "
-        f"Robot peer `{(status.get('robot_peer_id') or '?')[:8]}`."
+        f"**connected** — session `{session[:8]}`, {frames} frames decoded."
+        + geometry
+        + f" Robot peer `{(status.get('robot_peer_id') or '?')[:8]}`."
     )
 
 

--- a/spaces/vision-demo/check_consumer.py
+++ b/spaces/vision-demo/check_consumer.py
@@ -1,0 +1,68 @@
+"""Does this consumer get frames out of a real duck?
+
+Run it from this directory, which is what makes the import work anywhere:
+
+    HF_TOKEN=hf_... uv run --with httpx --with numpy --with aiortc --with av \
+        python check_consumer.py
+
+It uses **your** token, not the robot's: the rendezvous maps a token to one peer, so a consumer
+sharing the robot's credential would take the robot off its owner's listing. And it takes the one
+session the service allows, so close the console page first.
+
+What it proves, in order: the event stream opens, the service pairs this consumer with a duck,
+DTLS completes against GStreamer's `webrtcsink` (the cipher shim in `consumer.py`), frames decode,
+and the robot answers `media.video` on the control channel — which is the thing their consumer
+structurally cannot do, and the reason the geometry in this demo is the robot's number rather than
+a repeat of the arithmetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from consumer import DuckConsumer
+
+ROBOT = os.environ.get("DUCK_NAME", "olducky")
+TOKEN = os.environ.get("HF_TOKEN", "").strip()
+
+
+async def main() -> int:
+    if not TOKEN:
+        print("set HF_TOKEN to a token of the account the robot belongs to", file=sys.stderr)
+        return 2
+
+    consumer = DuckConsumer(token=TOKEN, robot_name=ROBOT, label="check-consumer")
+    print(f"connecting to {ROBOT}…")
+    await consumer.start()
+    try:
+        for _ in range(150):
+            await asyncio.sleep(0.2)
+            frame = consumer.latest_frame()
+            if frame is not None:
+                print(f"frame {frame[0]}: {frame[1].shape} {frame[1].dtype}")
+                break
+            if reported := consumer.status().get("error"):
+                print(f"failed: {reported}", file=sys.stderr)
+                print(f"status: {consumer.status()}", file=sys.stderr)
+                return 1
+        else:
+            print(f"no frame in 30s. status: {consumer.status()}", file=sys.stderr)
+            return 1
+
+        # The control channel opens a moment after the video track, so this waits for it rather
+        # than reporting its absence as a fault.
+        for _ in range(25):
+            await asyncio.sleep(0.2)
+            if consumer.video_info() is not None:
+                break
+        print(f"media.video: {consumer.video_info()}")
+        print(f"status: {consumer.status()}")
+        return 0
+    finally:
+        await consumer.stop()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/spaces/vision-demo/consumer.py
+++ b/spaces/vision-demo/consumer.py
@@ -292,6 +292,11 @@ class DuckConsumer:
 
         if kind == "welcome":
             self._peer_id = message.get("peerId")
+            logger.info(
+                "the rendezvous welcomed this consumer as %s (%s)",
+                self._peer_id,
+                message.get("username"),
+            )
             # The peer exists only once the stream does — `POST /send` before `GET /events` is a
             # 400 — so everything else starts here rather than in `start`.
             listing = await self._send({"type": "list"})
@@ -310,18 +315,27 @@ class DuckConsumer:
                 return
             self._robot_peer_id = producer.get("id")
             meta = producer.get("meta") or {}
-            logger.info("found %s (%s)", meta.get("name"), self._robot_peer_id)
+            logger.info(
+                "found %s (%s), asking for a session",
+                meta.get("name"),
+                self._robot_peer_id,
+            )
             started = await self._send(
                 {"type": "startSession", "peerId": self._robot_peer_id}
             )
             if started and started.get("type") == "sessionStarted":
                 self._session_id = started.get("sessionId")
+                logger.info("session %s started; waiting for the robot's offer", self._session_id)
                 self._open_peer_connection()
+            else:
+                self._error = f"the service would not start a session: {started}"
+                logger.warning("%s", self._error)
 
         elif kind == "peer":
             await self._on_peer(message)
 
         elif kind == "endSession":
+            logger.info("the session ended: %s", message.get("reason"))
             self._error = message.get("reason") or "the robot ended the session"
             self._session_id = None
 
@@ -336,6 +350,18 @@ class DuckConsumer:
         self._pc = RTCPeerConnection(
             RTCConfiguration(iceServers=[RTCIceServer(urls=STUN)])
         )
+
+        @self._pc.on("connectionstatechange")
+        async def _on_state() -> None:
+            # The line that says whether this is a NAT problem or something else, so it goes in
+            # the log rather than only into `status()`: `connecting` that never becomes
+            # `connected` is no candidate pair, and `failed` is ICE having given up on all of them.
+            assert self._pc is not None
+            logger.info(
+                "peer connection %s (ice %s)",
+                self._pc.connectionState,
+                self._pc.iceConnectionState,
+            )
 
         @self._pc.on("track")
         def _on_track(track: Any) -> None:

--- a/spaces/vision-demo/consumer.py
+++ b/spaces/vision-demo/consumer.py
@@ -1,0 +1,415 @@
+"""A consumer of one duck, over the rendezvous service.
+
+The other end of `mediad::relay`. The robot registers with `reachy_mini_central` as a producer;
+this asks that service for a session, answers the robot's offer, and decodes the video into numpy
+arrays. `docs/design/remote-access-design.md` §3 is the protocol and §3.2's table is the wire.
+
+# Why this exists rather than `reachy_mini[central-consumer]`
+
+Their consumer works — it was the first non-browser client to get frames out of a duck, which is
+how we know the transport is sound. As a *dependency* it brought three problems that are all the
+same problem: it is the robot's own package rather than a client library.
+
+- `reachy_mini/__init__.py` imports `ReachyMini` and `ReachyMiniApp`, so reaching the consumer
+  drags in the daemon's world: **PyGObject**, which is a source build wanting a C compiler and
+  cairo headers for GStreamer bindings a consumer never touches.
+- It pins `starlette<1.0.0`, which cannot coexist with any current Gradio.
+- It looks for the mini's data channel label and ignores ours, so no JSON-RPC reaches the process
+  — which means the camera geometry cannot be *asked* for and has to be re-derived.
+
+We wrote the robot half of this protocol. The client half is smaller than the workarounds, and it
+gets the third point for free: this one speaks `control`, so the intrinsics come from the robot
+rather than from arithmetic repeated here.
+
+# What it does not do
+
+One robot, one session, video and the control channel. No audio, no producer re-selection, no
+reconnect: a demo that drops its session should say so and let somebody press connect, and
+`mediad::relay`'s reconnect logic exists on the robot's side where it matters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from typing import Any, Callable
+
+import httpx
+import numpy as np
+from aiortc import (
+    RTCConfiguration,
+    RTCIceServer,
+    RTCPeerConnection,
+    RTCSessionDescription,
+)
+from aiortc.sdp import candidate_from_sdp
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RENDEZVOUS = "https://pollen-robotics-reachy-mini-central.hf.space"
+
+# The same STUN server `webrtcsink` defaults to on the robot, so both ends ask one service rather
+# than two. A relay candidate would come from the *robot* — only one side needs one, and
+# `remote-access-design.md` §6 has why that side is not this one.
+STUN = "stun:stun.l.google.com:19302"
+
+# `meta.kind`, so a consumer written for a duck cannot pick up a mini. Their clients match on
+# `meta.name` and skip this, which is §5.1's open conversation.
+KIND = "microduck"
+
+# The robot creates this channel as each consumer arrives, and speaks JSON-RPC over it.
+CONTROL_CHANNEL = "control"
+
+# How long the whole handshake gets: SSE open, welcome, list, startSession, offer, answer.
+HANDSHAKE_TIMEOUT = 30.0
+
+
+def _patch_dtls_ciphers() -> None:
+    """Add the one cipher GStreamer's `webrtcsink` and aiortc do not otherwise share.
+
+    Without this DTLS never completes and the peer connection sits in `connecting` forever, with
+    both sides behaving correctly and neither logging anything wrong. Diagnosed and fixed by
+    `reachy_mini`'s `central_consumer`, which is the only reason this is fifteen lines here rather
+    than a week; upstream is aiortc PR #1392, and this goes when a release negotiates it.
+    """
+    from aiortc.rtcdtlstransport import RTCCertificate
+
+    if getattr(RTCCertificate, "_duck_cipher_patched", False):
+        return
+    original = RTCCertificate._create_ssl_context
+    ciphers = (
+        b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:"
+        b"ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:"
+        b"ECDHE-RSA-AES128-GCM-SHA256"
+    )
+
+    def patched(self: Any, srtp_profiles: Any) -> Any:
+        context = original(self, srtp_profiles)
+        try:
+            context.set_cipher_list(ciphers)
+        except Exception as e:  # noqa: BLE001 - a refused list is worth a line, not a crash
+            logger.warning("could not extend the DTLS cipher list: %r", e)
+        return context
+
+    RTCCertificate._create_ssl_context = patched  # type: ignore[method-assign]
+    RTCCertificate._duck_cipher_patched = True  # type: ignore[attr-defined]
+    logger.info("DTLS cipher list extended for GStreamer's webrtcsink")
+
+
+_patch_dtls_ciphers()
+
+
+def sse_events(chunk: str, buffer: str) -> tuple[list[str], str]:
+    """Split an SSE byte-stream fragment into complete `data:` payloads, and what is left over.
+
+    Pure, and separate from the reading, so the framing is testable without a server. Two things
+    it has to get right, both of which cost the console page an hour: **CRLF**, because the
+    service's line endings are not ours to assume, and **a payload split across reads**, which is
+    the normal case for an SDP offer larger than a TCP segment.
+    """
+    buffer = (buffer + chunk).replace("\r\n", "\n")
+    payloads: list[str] = []
+    while "\n\n" in buffer:
+        frame, buffer = buffer.split("\n\n", 1)
+        data = "".join(
+            line[5:].strip() for line in frame.split("\n") if line.startswith("data:")
+        )
+        if data:
+            payloads.append(data)
+    return payloads, buffer
+
+
+def pick_producer(producers: list[dict[str, Any]], name: str | None) -> dict[str, Any] | None:
+    """Choose which robot to drive: a duck, by name when one is asked for.
+
+    Filtering on `meta.kind` first is what keeps this from picking up a mini, which would answer
+    every method name with `METHOD_NOT_FOUND` and look like a broken robot. If a name is given and
+    matches nothing, that is **not** a reason to take whatever is there instead: a consumer aimed
+    at one robot silently driving another is worse than one that reports it found nothing.
+    """
+    ducks = [p for p in producers if (p.get("meta") or {}).get("kind") == KIND]
+    if name:
+        wanted = name.strip().lower()
+        return next(
+            (p for p in ducks if ((p.get("meta") or {}).get("name") or "").lower() == wanted),
+            None,
+        )
+    return ducks[0] if ducks else None
+
+
+class DuckConsumer:
+    """One session with one duck. Not thread-safe; drive it from its own event loop."""
+
+    def __init__(
+        self,
+        token: str,
+        robot_name: str | None = None,
+        label: str = "duck-consumer",
+        rendezvous: str = DEFAULT_RENDEZVOUS,
+    ) -> None:
+        self._token = token
+        self._robot_name = robot_name
+        self._label = label
+        self._base = rendezvous.rstrip("/")
+
+        self._client: httpx.AsyncClient | None = None
+        self._pc: RTCPeerConnection | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._control: Any = None
+
+        self._peer_id: str | None = None
+        self._robot_peer_id: str | None = None
+        self._session_id: str | None = None
+        self._frames = 0
+        self._latest: tuple[int, np.ndarray] | None = None
+        self._video: dict[str, Any] | None = None
+        self._error: str | None = None
+        # The frame is read by whatever renders and written by the track reader.
+        self._lock = threading.Lock()
+
+    # ── what a caller sees ──────────────────────────────────────────────────
+
+    def latest_frame(self) -> tuple[int, np.ndarray] | None:
+        with self._lock:
+            return self._latest
+
+    def video_info(self) -> dict[str, Any] | None:
+        """What `media.video` answered: size, mount rotation, and the camera's intrinsics.
+
+        `None` until the control channel has opened and answered — which is a second or two after
+        the first frame, so a caller should treat its absence as "not yet" rather than "never".
+        """
+        return self._video
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "session_id": self._session_id,
+            "robot_peer_id": self._robot_peer_id,
+            "pc_state": self._pc.connectionState if self._pc is not None else None,
+            "ice_state": self._pc.iceConnectionState if self._pc is not None else None,
+            "frames": self._frames,
+            "control": self._control is not None,
+            "error": self._error,
+        }
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._error = None
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, read=None),
+            headers={"authorization": f"Bearer {self._token}"},
+        )
+        self._task = asyncio.create_task(self._run(), name="duck-consumer")
+
+    async def stop(self) -> None:
+        """End the session, in the order the service requires.
+
+        **The farewell goes first, and that ordering is the whole of this method.** `POST /send`
+        is refused with a 400 — "Connect to /events first" — once the event stream has gone, so a
+        teardown that cancels the reader before saying goodbye cannot say goodbye at all. The
+        robot then waits out a timeout instead of freeing its side immediately, and the shutdown
+        raises on the way out. `reachy_mini`'s consumer has this bug; noticing it there did not
+        stop me writing it here, which is the argument for the ordering being written down rather
+        than remembered.
+
+        And nothing here raises. A teardown that throws leaves a UI holding a consumer it thinks
+        is still alive, which is worse than a session the service reaps on its own.
+        """
+        if self._session_id and self._client is not None:
+            try:
+                await self._send({"type": "endSession", "sessionId": self._session_id})
+            except Exception as e:  # noqa: BLE001 - a farewell is a courtesy, not a requirement
+                logger.debug("could not tell the service the session ended: %r", e)
+
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except BaseException:  # noqa: BLE001 - includes the CancelledError we just caused
+                pass
+        if self._pc is not None:
+            await self._pc.close()
+        if self._client is not None:
+            await self._client.aclose()
+        self._pc, self._client, self._control = None, None, None
+        self._session_id = None
+
+    def call(self, method: str, params: dict[str, Any] | None = None, request_id: int = 1) -> bool:
+        """Send one JSON-RPC request over the robot's control channel."""
+        if self._control is None:
+            return False
+        self._control.send(
+            json.dumps(
+                {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+            )
+        )
+        return True
+
+    # ── the session ─────────────────────────────────────────────────────────
+
+    async def _send(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """`POST /send`, returning the body when there is one.
+
+        **The reply can be a message**, which is the row of §3.2's table that cost the console an
+        afternoon: `list` and `startSession` are answered in the HTTP response, everything else
+        arrives on the event stream.
+        """
+        assert self._client is not None
+        response = await self._client.post(f"{self._base}/send", json=message)
+        if response.status_code >= 400:
+            raise RuntimeError(f"POST /send {message['type']}: HTTP {response.status_code}")
+        try:
+            body = response.json()
+        except ValueError:
+            return None
+        return body if isinstance(body, dict) and body.get("type") else None
+
+    async def _run(self) -> None:
+        assert self._client is not None
+        try:
+            async with self._client.stream("GET", f"{self._base}/events") as stream:
+                if stream.status_code == 401:
+                    raise RuntimeError("Hugging Face refused this token")
+                stream.raise_for_status()
+
+                buffer = ""
+                async for chunk in stream.aiter_text():
+                    payloads, buffer = sse_events(chunk, buffer)
+                    for payload in payloads:
+                        await self._on_message(json.loads(payload))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 - surfaced through `status`, not raised at a UI
+            self._error = f"{type(e).__name__}: {e}"
+            logger.warning("the consumer's session ended: %s", self._error)
+
+    async def _on_message(self, message: dict[str, Any]) -> None:
+        kind = message.get("type")
+
+        if kind == "welcome":
+            self._peer_id = message.get("peerId")
+            # The peer exists only once the stream does — `POST /send` before `GET /events` is a
+            # 400 — so everything else starts here rather than in `start`.
+            listing = await self._send({"type": "list"})
+            await self._on_message(listing or {"type": "list", "producers": []})
+
+        elif kind == "list":
+            if self._session_id:
+                return
+            producer = pick_producer(message.get("producers") or [], self._robot_name)
+            if producer is None:
+                self._error = (
+                    f"no duck named {self._robot_name!r} is registered"
+                    if self._robot_name
+                    else "no duck is registered with this account"
+                )
+                return
+            self._robot_peer_id = producer.get("id")
+            meta = producer.get("meta") or {}
+            logger.info("found %s (%s)", meta.get("name"), self._robot_peer_id)
+            started = await self._send(
+                {"type": "startSession", "peerId": self._robot_peer_id}
+            )
+            if started and started.get("type") == "sessionStarted":
+                self._session_id = started.get("sessionId")
+                self._open_peer_connection()
+
+        elif kind == "peer":
+            await self._on_peer(message)
+
+        elif kind == "endSession":
+            self._error = message.get("reason") or "the robot ended the session"
+            self._session_id = None
+
+        elif kind == "sessionRejected":
+            self._error = (
+                f"the robot refused a session ({message.get('reason')})"
+                f"{' — ' + message['activeApp'] if message.get('activeApp') else ''}"
+            )
+
+    def _open_peer_connection(self) -> None:
+        """Build the peer connection before the robot's offer arrives."""
+        self._pc = RTCPeerConnection(
+            RTCConfiguration(iceServers=[RTCIceServer(urls=STUN)])
+        )
+
+        @self._pc.on("track")
+        def _on_track(track: Any) -> None:
+            if track.kind != "video":
+                return
+            asyncio.create_task(self._read_track(track))
+
+        @self._pc.on("datachannel")
+        def _on_datachannel(channel: Any) -> None:
+            if channel.label != CONTROL_CHANNEL:
+                logger.info("ignoring a data channel labelled %r", channel.label)
+                return
+            self._control = channel
+
+            @channel.on("message")
+            def _on_line(line: str) -> None:
+                self._on_control_line(line)
+
+            # The one question worth asking immediately: what the picture is, geometrically.
+            # A client that derives this instead is guessing at a sensor mode it cannot see.
+            self.call("media.video", request_id=1)
+
+    def _on_control_line(self, line: str) -> None:
+        try:
+            message = json.loads(line)
+        except ValueError:
+            return
+        # `media.video` arrives twice over: pushed as a notification when the channel opens, and
+        # as the reply to the call above. Either is welcome; whichever lands first wins.
+        if message.get("method") == "media.video" and isinstance(message.get("params"), dict):
+            self._video = message["params"]
+        elif message.get("id") == 1 and isinstance(message.get("result"), dict):
+            self._video = message["result"]
+
+    async def _read_track(self, track: Any) -> None:
+        while True:
+            try:
+                frame = await track.recv()
+            except Exception:  # noqa: BLE001 - the track ending is how a session ends
+                return
+            image = frame.to_ndarray(format="rgb24")
+            with self._lock:
+                self._frames += 1
+                self._latest = (self._frames, image)
+
+    async def _on_peer(self, message: dict[str, Any]) -> None:
+        if self._pc is None:
+            return
+        if sdp := message.get("sdp"):
+            await self._pc.setRemoteDescription(
+                RTCSessionDescription(sdp=sdp["sdp"], type=sdp["type"])
+            )
+            # The robot offers, because `webrtcsink` knows what it is sending. Answering waits for
+            # ICE gathering to finish, so the answer carries this end's candidates and nothing has
+            # to be trickled back.
+            answer = await self._pc.createAnswer()
+            await self._pc.setLocalDescription(answer)
+            await self._send(
+                {
+                    "type": "peer",
+                    "sessionId": self._session_id,
+                    "sdp": {"type": "answer", "sdp": self._pc.localDescription.sdp},
+                }
+            )
+        elif ice := message.get("ice"):
+            if not ice.get("candidate"):
+                return  # end-of-candidates, which aiortc infers for itself
+            candidate = candidate_from_sdp(ice["candidate"].split(":", 1)[-1])
+            candidate.sdpMLineIndex = ice.get("sdpMLineIndex", 0)
+            await self._pc.addIceCandidate(candidate)
+
+
+def frames_from(
+    consumer: DuckConsumer,
+) -> Callable[[], tuple[int, np.ndarray] | None]:
+    """A getter, for a UI that should not hold a consumer."""
+    return consumer.latest_frame

--- a/spaces/vision-demo/requirements.txt
+++ b/spaces/vision-demo/requirements.txt
@@ -1,28 +1,26 @@
-# The consumer, and the WebRTC stack under it. The `central-consumer` extra is what pulls
-# `aiortc` and `av`: a robot never runs the consumer, so the base install leaves them out.
+# The consumer is ours (`consumer.py`), so this is the WebRTC stack and nothing else.
 #
-# **Unpinned deliberately, for now.** `reachy_mini`'s own app guide warns that mixing versions
-# across the SDK, the host shell and the daemon "causes silent protocol drift" — but the drift
-# that matters to *this* Space is between the consumer and a duck, and pinning a version whose
-# DTLS shim we depend on before knowing which versions work would pin the wrong thing. The first
-# time this breaks, pin it here with the version that worked.
-reachy_mini[central-consumer]
+# **`reachy_mini` is deliberately absent.** Its consumer proved the transport and was the wrong
+# dependency: `reachy_mini/__init__.py` imports the daemon's world, which drags in PyGObject — a
+# source build wanting a C compiler and cairo headers for GStreamer bindings a consumer never
+# touches — and it pins `starlette<1.0.0`, which no current Gradio can satisfy. We wrote the
+# robot half of this protocol; the client half is smaller than the workarounds. `consumer.py`
+# says so at more length, and keeps the credit for the DTLS cipher shim where it belongs.
+aiortc
+# The decoder. `aiortc` needs it and this names it, because a frame arriving as a numpy array is
+# the whole point rather than a detail of a dependency.
+av
 
-# The UI. Gradio because its OAuth support is a button rather than a flow to implement — the
-# console page learned what implementing one costs (`remote-access-design.md` §5.0).
-#
-# **The `oauth` extra is ours to ask for.** `gr.LoginButton` raises `Cannot initialize OAuth due
-# to a missing library` without it, and a Hugging Face Space installs `gradio[oauth,mcp]` of its
-# own accord — so this works there whether or not it is written down, and nowhere else. Written
-# down: an app whose login button depends on a platform's default is an app that breaks the first
-# time it runs anywhere but the platform.
-# **Pinned below 6, and the pin is load-bearing.** Gradio 6.26 needs `starlette>=1.0.1` where
-# `reachy-mini` needs `starlette<1.0.0` — every version of it, so this is not a matter of waiting
-# for an upgrade. `ResolutionImpossible` is the honest answer pip gives when both are asked for,
-# which is why this Space is Docker: it gets to choose 5.23 instead of being handed 6.26.
-gradio[oauth]>=5,<6
+# The event stream and the posts back. Streaming responses with a header, which is why this is
+# `httpx` and not `EventSource`-shaped anything.
+httpx
 
-# The processing. `-headless` because a container has no display and the GUI build drags in the
-# whole of GTK to be linked and never used.
+# The UI. Gradio 6 is fine now that nothing pins `starlette<1.0.0` — but the version stays named
+# rather than open, because a Space that installs whatever is current is a Space that breaks on a
+# morning when nobody touched it.
+gradio[oauth]>=5,<7
+
+# The processing. `-headless` because a container has no display and the GUI build links the whole
+# of GTK to never use it.
 opencv-python-headless
 numpy

--- a/spaces/vision-demo/requirements.txt
+++ b/spaces/vision-demo/requirements.txt
@@ -16,7 +16,11 @@ reachy_mini[central-consumer]
 # own accord — so this works there whether or not it is written down, and nowhere else. Written
 # down: an app whose login button depends on a platform's default is an app that breaks the first
 # time it runs anywhere but the platform.
-gradio[oauth]>=6
+# **Pinned below 6, and the pin is load-bearing.** Gradio 6.26 needs `starlette>=1.0.1` where
+# `reachy-mini` needs `starlette<1.0.0` — every version of it, so this is not a matter of waiting
+# for an upgrade. `ResolutionImpossible` is the honest answer pip gives when both are asked for,
+# which is why this Space is Docker: it gets to choose 5.23 instead of being handed 6.26.
+gradio[oauth]>=5,<6
 
 # The processing. `-headless` because a container has no display and the GUI build drags in the
 # whole of GTK to be linked and never used.

--- a/spaces/vision-demo/requirements.txt
+++ b/spaces/vision-demo/requirements.txt
@@ -10,7 +10,13 @@ reachy_mini[central-consumer]
 
 # The UI. Gradio because its OAuth support is a button rather than a flow to implement — the
 # console page learned what implementing one costs (`remote-access-design.md` §5.0).
-gradio>=5
+#
+# **The `oauth` extra is ours to ask for.** `gr.LoginButton` raises `Cannot initialize OAuth due
+# to a missing library` without it, and a Hugging Face Space installs `gradio[oauth,mcp]` of its
+# own accord — so this works there whether or not it is written down, and nowhere else. Written
+# down: an app whose login button depends on a platform's default is an app that breaks the first
+# time it runs anywhere but the platform.
+gradio[oauth]>=6
 
 # The processing. `-headless` because a container has no display and the GUI build drags in the
 # whole of GTK to be linked and never used.


### PR DESCRIPTION
Everything after #219 merged. A Gradio Space on Hugging Face hardware consumes the robot's camera through the rendezvous and runs OpenCV over each frame — and on its first run it measured the thing nothing else could.

## The measurement

```
the rendezvous welcomed this consumer as 9d3a17dd (PierreRouanet)
found olducky (8a73eda9), asking for a session
session 4c7e9c60 started; waiting for the robot's offer
peer connection connecting (ice checking)
the session ended: the robot ended the session      ← 8s later
peer connection failed (ice failed)
```

Signalling crosses perfectly and **no candidate pair works**. Three data points now instead of one: a browser on the robot's LAN connects on host candidates, a 4G phone fails and CGNAT was the suspicion, and **a Hugging Face Space fails too** — and a Space is not behind CGNAT. So TURN is not a fallback for awkward networks; it is the requirement for every consumer that is not on the robot's own wifi, which is every cloud backend and therefore anything doing perception off-robot. §6 carries the log.

Nothing in the demo needs changing for it: **it will connect the day the robot can offer a relay candidate.**

## The consumer is ours

`reachy_mini[central-consumer]` proved the transport — it was the first non-browser client to pull frames out of a duck — and was the wrong *dependency*, three times over. `reachy_mini/__init__.py` imports the daemon's world, so a consumer drags in **PyGObject**: a source build wanting a C compiler and cairo headers for GStreamer bindings it never touches. It pins `starlette<1.0.0`, which no current Gradio can satisfy (`ResolutionImpossible`, correctly). And it ignores a data channel labelled `control`, so the camera geometry cannot be asked for.

`spaces/vision-demo/consumer.py` is 300 lines: SSE in, `POST /send` out, aiortc answering the robot's offer, frames as numpy. Verified against `olducky`:

```
frame 8: (720, 1280, 3) uint8
media.video: {'width': 1280, 'height': 720, 'rotate': 90,
              'intrinsics': {'fx': 1809.52, 'cx': 640.0, 'calibrated': False}}
pc_state: connected  ice_state: completed  control: True
```

That second line is the payoff: the intrinsics come from the robot, so the demo's geometry overlay uses published numbers rather than repeating the arithmetic. The fifteen lines that make DTLS complete against GStreamer's `webrtcsink` are copied from their consumer with the credit and the upstream link (aiortc PR #1392) — they are the reason this took an afternoon rather than a week.

Six dependencies instead of 117: `aiortc`, `av`, `httpx`, `gradio[oauth]`, `opencv-python-headless`, `numpy`.

## What the Space is

`spaces/vision-demo`, deployed by `scripts/publish-space.sh` — source in-repo for §5's reason, since a consumer tracks the rendezvous protocol, this project's method names and the camera's geometry. Docker rather than `sdk: gradio`, because a Gradio Space cannot choose its Gradio version and 6.26 is the one version that cannot work here.

Five filters — raw, Canny edges, motion diff, sparse Lucas–Kanade flow, and an intrinsics overlay — with the pixels in `filters.py` importing only OpenCV and numpy, so every one is exercised on a synthetic sideways frame pair without a WebRTC stack, a robot or a token.

**It authenticates with an `HF_TOKEN` secret and must stay private.** A visitor's own OAuth token would be better and would make it publishable; two attempts failed on platform behaviour rather than code — a static Space never injected the client id (§5.0), and a Docker Space does not put `OAUTH_CLIENT_ID` in the environment either, so Gradio mocks OAuth and refuses to start. A demo that will not start is worse than a demo with one credential.

## Four bugs of mine, three of them the same bug

A hand-kept list that has to match reality, failing silently in the direction of looking fine: `cp "$SOURCE"/*` published whatever was lying around, `git diff --quiet` reported "already serves this" for a file that was only ever added, and `COPY app.py filters.py` built a perfect image without `consumer.py` in it. All three now ask git or the filesystem what is actually there.

The fourth: `stop()` posted its farewell *after* cancelling the event stream, which the service refuses with a 400. I had diagnosed that exact bug in their consumer an hour earlier and said ours could not have it — true of the Rust relay, not of the Python I had yet to write. The ordering is a docstring now.
