### PR TITLE
docs: the default TURN endpoint is dead, and its delegation is dangling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ Dated records rather than reference. They describe a moment, and go stale on pur
 | [`media-bringup.md`](project/media-bringup.md) | What a Radxa Zero 3W does about video: the VPU, what MPP needs, and the two plugins that have to be built. |
 | [`pad-minimal-pairing.md`](project/pad-minimal-pairing.md) | The smallest board configuration a gamepad will bond under, found by taking one away at a time. |
 | [`idle-cpu.md`](project/idle-cpu.md) | What the daemons do when nobody is asking them to: four things that stopped, two that were measured and left alone, and what still wants a board. |
+| [`turn-endpoint-is-dead.md`](project/turn-endpoint-is-dead.md) | Why no robot offers a relay candidate: the default TURN proxy's DNS delegation is dangling, and a signed-in robot offers its account token to whoever takes it. |
 
 ## `ideas/` — not designed yet
 

--- a/docs/design/remote-access-design.md
+++ b/docs/design/remote-access-design.md
@@ -721,25 +721,38 @@ blocks (a `try_read` that yields nothing rather than waiting) and never fails. A
 the ordinary state for the first few seconds after boot and forever on a robot with no account,
 and it means host and srflx only, which is all anything on the same network needs.
 
-**And the endpoint is not answering, which is where this stands.** `turn.fastrtc.org` has no A
-record and `fastrtc.org` has no NS records at all, from three public resolvers and from the board
-— so the proxy both `fastrtc`'s own current code and `reachy_mini`'s #1182 point at cannot be
-reached by anybody. Their documentation describes it as a live Hugging Face–Cloudflare arrangement
-(10 GB a month free with an account), so this reads as a lapsed registration or an outage rather
-than a moved URL, and it means the mini fleet's relay path is down too. Worth telling whoever owns
-`fastrtc`.
+**And the endpoint is not answering, which is where this stands.** `turn.fastrtc.org` does not
+resolve, from three public resolvers and from the board — so the proxy both `fastrtc`'s own current
+code and `reachy_mini`'s #1182 point at cannot be reached by anybody, and the mini fleet's relay
+path is down with ours.
 
-Three ways on, in the order they should be considered:
+**It is a deleted hosted zone, and that is worse than an outage.** The `.org` registry delegates
+`fastrtc.org` to four Route53 nameservers, all four of which answer `REFUSED` for it, which is
+what a Route53 server says when the zone behind it is gone; a resolver therefore returns
+`SERVFAIL`. The registration is live and locked until 2027-02-17, so the owner could restore the
+zone in minutes and has not in three months. A dangling delegation is a takeover route: whoever
+lands one of those four nameservers serves records for the name, passes DNS validation for a
+certificate on it, and receives the account token every signed-in robot sends with the credentials
+request every thirty seconds. `docs/project/turn-endpoint-is-dead.md` has the checks, the dates
+and where `reachy_mini` stands on it.
 
-- **Wait, having reported it.** The robot degrades exactly as designed — a warning every thirty
-  seconds and host/srflx candidates — so nothing is broken except reaching a robot from a network
-  that needs a relay.
+That changes the order these were first written in, because waiting now costs a token rather than
+only a relay:
+
+- **Drop the default, so a relay is opt-in.** `--turn-url` with no value means `maintain` does not
+  spawn, which removes the exfiltration route and the thirty-second warning and costs no coverage
+  — there is none to cost. `reachy_mini`'s `no-default-turn-url` is the same change on that side.
 - **Our own proxy**, which is what that endpoint is: a small service holding a Cloudflare Calls key
   and minting short-lived credentials for a caller presenting a valid HF token. `--turn-url` is
-  already the seam it plugs into, and the key stays in one place rather than on robots.
+  already the seam it plugs into, and the key stays in one place rather than on robots. This is
+  what restores relay coverage, and it is its own piece of work.
 - **A Cloudflare key on the robot**, using `TURN_KEY_ID` and `TURN_KEY_API_TOKEN` directly. Fastest
   and worst: a long-lived API token on every board, which is the shape of mistake §2.4 exists to
   stop making.
+
+Whichever lands, a **relay-only connectivity check** goes with it. Every check there is passes
+today, because every check there is runs between peers that pair on host candidates and never
+reach for a relay — which is how a default endpoint that answers nothing merged in the first place.
 
 Nothing about a relay is fatal. `add-turn-server` is checked for existence before it is emitted —
 a panic in a C closure aborts the process rather than unwinding, which `pipeline.rs` learned once
@@ -808,6 +821,7 @@ Five slices, and the first two are independently useful and need no client:
 | §2.4 the scope breadth | one public device-code client in the `pollen-robotics` HF org with `openid profile read-repos`, created by somebody with org admin. Not blocking — a scope change is a re-login — and it should not ship without it |
 | a calibration for the camera | `media.video` publishes the module's design figures with `calibrated: false`, which is enough to map a room and not enough for metrology. Measuring one robot and writing `[media.intrinsics]` closes it for that robot; a per-unit calibration in provisioning closes it for the family. §11 of `remote-webrtc.md` |
 | everything on the wire should be timestamped at source | `remote-webrtc.md` §11: `abs-capture-time` on the media, checked against what `webrtcsink`, a browser and `aiortc` actually surface; and a monotonic-plus-epoch field on every control-channel notification that describes a moment. Wanted for any consumer that has to relate what the robot saw to what it felt — visual-inertial SLAM is the case that makes it concrete — and it wants its own version bump rather than riding along with a transport |
+| §6 the default TURN endpoint is dead, and dangling | dropping the default so a relay is opt-in, which is a small change and the urgent half — while `turn.fastrtc.org` is the default, every signed-in robot offers its account token to whoever takes that name. Relay coverage then needs a proxy of our own, which is its own piece of work. `docs/project/turn-endpoint-is-dead.md` |
 | §2.6 `logout` revokes nothing | whether Hugging Face accepts a revocation for the first-party device-code client, checked rather than assumed. Not blocking — signing out stops the robot being reachable, and a stolen board is answered on hf.co — but it is the difference between "forgotten" and "revoked" |
 
 Closed since this page was written: the OAuth client (§2.3 — Hugging Face ships one), whether the

--- a/docs/project/turn-endpoint-is-dead.md
+++ b/docs/project/turn-endpoint-is-dead.md
@@ -1,0 +1,131 @@
+# The TURN endpoint is dead, and the delegation behind it is dangling
+
+Recorded 2026-09-07, from
+[`reachy_mini` #1356](https://github.com/pollen-robotics/reachy_mini/issues/1356). Every claim
+below was re-checked from this machine on that date.
+
+`mediad` fetches relay credentials from `https://turn.fastrtc.org/credentials`
+(`mediad/src/turn.rs`, `DEFAULT_TURN_ENDPOINT`), and `mediad/systemd/mediad.service` passes no
+`--turn-url` — so that default is what every microduck robot in the fleet uses. It has not
+resolved since at least 2026-06-04, which is when
+[gradio-app/fastrtc#429](https://github.com/gradio-app/fastrtc/issues/429) was filed. It is still
+open, with two "me too" comments and no answer; `fastrtc`'s last push was 2026-01-12, and
+`backend/fastrtc/credentials.py` still points at the same host.
+
+## It is a deleted hosted zone, not a lapsed registration
+
+```bash
+dig turn.fastrtc.org @1.1.1.1
+```
+
+`SERVFAIL`. The `.org` registry does delegate the zone — four Route53 nameservers:
+
+```bash
+dig NS fastrtc.org @a0.org.afilias-nst.info +norecurse
+```
+
+```
+fastrtc.org.  3600  IN  NS  ns-79.awsdns-09.com.
+fastrtc.org.  3600  IN  NS  ns-974.awsdns-57.net.
+fastrtc.org.  3600  IN  NS  ns-1297.awsdns-34.org.
+fastrtc.org.  3600  IN  NS  ns-1797.awsdns-32.co.uk.
+```
+
+All four answer `REFUSED` for the zone they are named as authoritative for, which is what a
+Route53 nameserver says when the hosted zone behind it no longer exists:
+
+```bash
+dig SOA fastrtc.org @ns-79.awsdns-09.com +norecurse
+```
+
+The registration itself is healthy — created 2025-02-17, expiring 2027-02-17, last updated
+2026-08-12, and carrying all four `client*Prohibited` locks:
+
+```bash
+whois fastrtc.org
+```
+
+So somebody at `fastrtc` still holds the domain and could restore the zone in minutes. Nobody has
+in three months.
+
+This corrects `remote-access-design.md` §6, which recorded "`fastrtc.org` has no NS records at
+all" and read the outage as "a lapsed registration or an outage rather than a moved URL". The
+delegation is present and the registration is live; what is missing is the zone the delegation
+points at. The difference is not pedantic — it is the difference between waiting for an outage to
+end and sitting downstream of a dangling delegation.
+
+## What it costs this fleet
+
+**A signed-in robot offers its account token to whoever answers for that name.** A dangling
+Route53 delegation is a known takeover route: create hosted zones for `fastrtc.org` until AWS
+assigns one of the four delegated nameservers, and *one* is enough, because a resolver needs only
+one authoritative server to answer. Whoever lands it serves records for the name, passes DNS
+validation for a certificate on it, and then `turn.rs`'s `fetch` — `bearer_auth(token)` on a
+`GET`, every thirty seconds, from every signed-in robot — hands over the Hugging Face access
+token `updaterd` wrote. That token is the robot's whole account credential: §2.4 of
+`remote-access-design.md` is about how broad its scopes are.
+
+The redirect half of the same problem does not apply here. `reachy_mini` #1364 found bearer-
+carrying requests following redirects; `reqwest` 0.13.4 strips `Authorization` when a redirect
+crosses scheme, host or port (`src/redirect.rs`, `remove_sensitive_headers`), so `mediad` cannot
+be walked to a third-party origin that way. The exposure is same-origin, and same-origin needs no
+redirect.
+
+**No relay candidate is ever offered.** Host and srflx only, on both ends. A consumer behind
+symmetric NAT, CGNAT, or a firewall that drops UDP cannot reach a robot at all, and there is no
+fallback because the fallback is the thing that is down. Demos pass regardless: two peers on one
+network pair on host candidates and never look at a relay, which is exactly why this went
+unnoticed through #1182 and since.
+
+**A warning every thirty seconds, for the life of the daemon.** `turn.rs` treats every failed
+fetch as transient and retries after `RETRY_AFTER_FAILURE` — 30 s — logging `could not fetch relay
+credentials` each time. With `Environment=RUST_LOG=info` on the unit and journald persistent at
+three months' retention, that is about 2,880 lines a day of one message that will never come true,
+crowding out the history somebody reads while diagnosing something else. §6 of
+`remote-access-design.md` names this cost precisely — "a warning every thirty seconds for the life
+of the daemon is how a log stops being read" — and then spends it, because the case it guards
+against is the robot with no token. Nothing in the module distinguishes a proxy that hiccuped from
+a name that will not resolve today and will not resolve tomorrow.
+
+## Where `reachy_mini` stands on it
+
+- **#1182** introduced the default. The endpoint was already dead when it merged.
+- Branch **`no-default-turn-url`** (one commit, `20553846`) drops it: `REACHY_TURN_URL` defaults
+  to `""`, the refresher's `start()` becomes a no-op that says so once, and the docs stop
+  advertising the host. No PR is open for it, and it is 20 commits behind `main`.
+- **#1364 / PR #1365** (both open) require every endpoint that receives the daemon token to be
+  `https`, free of credentials, query and fragment, and refuse redirects on those requests — TURN
+  included. That closes the untrusted-destination gap and leaves `turn.fastrtc.org` as the
+  default, so the outcome is a validated dead endpoint.
+
+Neither is merged, so nothing has shipped on either side.
+
+## What to do here
+
+**Drop the default, so a relay is opt-in.** `--turn-url` stays as the seam; with no value,
+`maintain` does not spawn and says once that a relay is off. This removes the token exfiltration
+route, removes the log spam, and costs no relay coverage, because the coverage is already zero —
+the endpoint that would provide it does not answer. It is worth being clear that this is not a
+workaround for a broken dependency: the dependency is not coming back on its own, and the default
+is actively harmful while it stands.
+
+**Our own credentials proxy, as its own piece of work.** This is what that endpoint *is*: a small
+service holding a Cloudflare Calls key and minting short-lived credentials for a caller presenting
+a valid Hugging Face token. It restores relay coverage, it keeps the key in one place instead of
+on every board, and `--turn-url` is already where it plugs in. §6 of `remote-access-design.md`
+already reached this conclusion; what has changed is that "wait, having reported it" is no longer
+the cheap first option, because waiting now means leaving the token exposed.
+
+**A Cloudflare key on each robot** — `TURN_KEY_ID` and `TURN_KEY_API_TOKEN` straight on the board
+— remains the wrong answer for the reason §2.4 gives: a long-lived API token on every unit.
+
+**And a relay-only connectivity check**, so a default endpoint that answers nothing cannot merge
+silently a second time. Every existing check passes today, because every existing check runs
+between two peers that pair on host candidates.
+
+## Also worth doing, outside this repo
+
+Tell whoever owns `fastrtc`. #429 has been open since June with no maintainer reply, and the fix
+on their side is recreating one hosted zone. Until then anybody following their documentation ships
+the same dead default, and the `.org` delegation stays takeover-shaped for the rest of the fleet
+that trusts it.


### PR DESCRIPTION
Investigation of [`reachy_mini` #1356](https://github.com/pollen-robotics/reachy_mini/issues/1356), as it applies here.

`mediad` defaults to `https://turn.fastrtc.org/credentials` and `mediad.service` passes no `--turn-url`, so every robot in the fleet uses it. Three consequences, and the first is the one that wants a decision:

- **A signed-in robot offers its account token to whoever takes that name.** The `.org` registry delegates `fastrtc.org` to four Route53 nameservers and all four answer `REFUSED`, so the hosted zone behind a live, locked registration has been deleted. A dangling delegation is a takeover route — land one of the four, pass DNS validation for a certificate, and `turn.rs`'s `bearer_auth(token)` delivers the token every thirty seconds. The redirect half of `reachy_mini` #1364 does not apply: `reqwest` 0.13.4 strips `Authorization` across a cross-origin redirect, and same-origin needs no redirect.
- **No relay candidate is ever offered**, so there is no fallback behind symmetric NAT, CGNAT or a firewall that drops UDP. Demos pass because two peers on one network pair on host candidates.
- **A warning every thirty seconds for the life of the daemon** — every failed fetch is treated as transient, and nothing distinguishes a hiccup from a name that will not resolve.

`docs/project/turn-endpoint-is-dead.md` has the checks, the dates, and where `reachy_mini` stands (branch `no-default-turn-url` with no PR; #1364/#1365 validate the endpoint but keep the dead default). §6 of `remote-access-design.md` had this as "a lapsed registration or an outage" with "wait, having reported it" as the first option — corrected, with the open item added to §9.

## What this asks for

Docs only. The recommendation is **dropping the default so a relay is opt-in** — it removes the token route and the log spam and costs no coverage, because there is none today — with **a credentials proxy of our own** as its own piece of work, and a relay-only connectivity check alongside whichever lands. Say the word and the code change follows.

## Tested

`dig`/`whois` output in the report re-checked 2026-09-07 from this machine, against all four delegated nameservers. `reqwest`'s redirect behaviour read from the vendored 0.13.4 source rather than assumed.
