### PR TITLE
configd: reading the pairing pin takes the authority that sets it

### DIFF
--- a/btd/src/session.rs
+++ b/btd/src/session.rs
@@ -174,7 +174,7 @@ async fn dispatch(
             proto::code::PERMISSION_DENIED,
             format!(
                 "{} needs authentication first: send system.authenticate with the robot's PIN \
-                 (`robotctl system pin` on the robot)",
+                 (`sudo robotctl system pin` on the robot)",
                 call.method()
             ),
         );

--- a/configd/src/main.rs
+++ b/configd/src/main.rs
@@ -113,6 +113,20 @@ impl PeerPolicy {
     }
 }
 
+/// Whether a call takes the authority to change this robot.
+///
+/// Every mutating call does, and one read does with them: `system.pairingPin`. The PIN is not a
+/// status, it is a capability. Whoever holds it authenticates over BLE as the phone, and from there
+/// every mutating call is reachable, so a peer allowed to read it is a peer allowed to change the
+/// robot by another route. Reads are otherwise ungated on purpose, for [`PeerPolicy`]'s reasons,
+/// and the socket's group is every daemon that talks to one, the gamepad daemon included. A secret
+/// on that footing was readable by processes the design describes as having no privileged access.
+/// `btd` reads it to answer the pairing exchange and is in `--allow-user` for exactly that. A
+/// person reads it the way they set it, with `sudo robotctl system pin`.
+fn needs_authority(call: &proto::Call) -> bool {
+    call.is_mutating() || matches!(call, proto::Call::SystemPairingPin)
+}
+
 /// A user name to a uid.
 ///
 /// `SO_PEERCRED` reports a numeric uid, so a name has to become a number somewhere. Doing it
@@ -398,7 +412,7 @@ async fn dispatch(
 ) -> proto::Response {
     // Authorise before doing anything, and log the caller alongside the method: "who told this
     // robot to reboot" is the first thing support asks.
-    if call.is_mutating() {
+    if needs_authority(call) {
         if let Err(reason) = service.policy.may_mutate(peer) {
             tracing::warn!(method = call.method(), %reason, "refused");
             return proto::Response::err(
@@ -581,5 +595,22 @@ async fn shutdown() {
     tokio::select! {
         _ = term.recv() => {}
         _ = tokio::signal::ctrl_c() => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one read that is a capability. Pinned beside the rule that reads are ungated, so the
+    /// next read added to this daemon is asked the question rather than inheriting the answer.
+    #[test]
+    fn reading_the_pin_takes_the_authority_that_sets_it() {
+        assert!(needs_authority(&proto::Call::SystemPairingPin));
+        assert!(needs_authority(&proto::Call::SystemReboot));
+        assert!(!needs_authority(&proto::Call::SystemInfo));
+        assert!(!needs_authority(&proto::Call::NetStatus));
+        assert!(!needs_authority(&proto::Call::PadStatus));
+        assert!(!needs_authority(&proto::Call::SystemServices));
     }
 }

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -808,7 +808,7 @@ robotctl system info
 ```
 
 ```
-robotctl system pin
+sudo robotctl system pin
 ```
 
 ```

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -541,7 +541,7 @@ minutes with nothing arriving at all — which is why they are the way to run an
 - `--name <robot-name>` — which robot. Without it, `DUCK_ROBOT`; without that, the first one found
   wins. Worth giving always: it skips a slow fallback tier that tries every already-connected
   peripheral on the Mac, earbuds included.
-- `--pin <six-digits>` — defaults to `DUCK_PIN`, then to `000000`. `robotctl system pin` on the
+- `--pin <six-digits>` — defaults to `DUCK_PIN`, then to `000000`. `sudo robotctl system pin` on the
   robot shows the real one.
 - `--verbose` — print every line sent and received, and have `scan` list every device rather than
   only the robots. The first thing to add when something hangs.


### PR DESCRIPTION
fixes #233

configd gates every mutating call on the caller's uid and leaves reads open on purpose. system.pairingPin counts as a read, but the pin is what a phone authenticates with over ble — whoever holds it can reach every mutating call that way.

and the socket group is every daemon, so padd and tofd can read it too.

so it now takes the same authority as setting it. btd keeps it, it's already in --allow-user for the pairing exchange, and a person reads it with sudo the same way they set it. every other read stays open.

if you'd rather a person read it without sudo, the other option is allowing any uid over 1000. went with the simpler rule since it matches what set-pin already needs.
