### PR TITLE
a Mac builds the workspace and runs the twin

### DIFF
--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -162,6 +162,9 @@ struct Args {
     updater_socket: Option<std::path::PathBuf>,
 }
 
+// Gated with the `main` that calls it: off Linux there is no pipeline, so there is nothing to
+// point at a socket and `-D warnings` would call this dead.
+#[cfg(target_os = "linux")]
 impl Args {
     fn sockets(&self) -> mediad::upstream::Sockets {
         let mut s = mediad::upstream::Sockets::default();

--- a/scripts/duck-sim
+++ b/scripts/duck-sim
@@ -462,10 +462,19 @@ start_body() {
         */*)  scene_arg="--scene $SCENE" ;;
         *)    scene_arg="--scene $RL/src/mjlab_microduck/robot/microduck/scene_$SCENE.xml" ;;
     esac
+    # **The camera flags go with the cameras.** Rendering is newer than the body server, and a
+    # build without it has no `--cameras`/`--frame-port` — argparse then refuses the whole
+    # invocation over two arguments nobody asked to use, and the duck never starts. Passed only
+    # when a camera was actually requested, so asking for one against such a build still fails,
+    # loudly and about the thing that is missing.
+    cam_args=""
+    if [ -n "$CAMERAS" ]; then
+        cam_args="--cameras $CAMERAS --frame-port $FRAME_PORT"
+    fi
     # shellcheck disable=SC2086
     $SETSID nohup "$RL/.venv/bin/python" -m mjlab_microduck.sim.body_server \
         --port "$PORT" --ducks "$DUCKS" --keyframe "${DUCK_SIM_KEYFRAME:-SIT}" $HEADLESS $scene_arg \
-        --cameras "$CAMERAS" --frame-port "$FRAME_PORT" \
+        $cam_args \
         > "$STATE/body.log" 2>&1 &
     echo $! > "$STATE/body.pid"
     wait_for_port || die "the simulator did not come up. $STATE/body.log has why."

--- a/scripts/duck-sim
+++ b/scripts/duck-sim
@@ -453,6 +453,15 @@ start_body() {
     # `DUCK_SIM_VIEWER=0` for a window-less run: watching costs frames, and the daemon's loop is
     # wall-clock, so a simulator that cannot keep up is a robot that cannot balance.
     [ "${DUCK_SIM_VIEWER:-1}" = 0 ] && HEADLESS=--headless || HEADLESS=
+    # **The viewer needs `mjpython` on macOS.** MuJoCo's passive viewer has to own the main thread
+    # and the Cocoa event loop, so `launch_passive` refuses under a plain interpreter — the body
+    # server catches that and runs headless, which is a window that never opens and no error to
+    # explain it. `mjpython` is the launcher the wheel ships for exactly this. Linux has no such
+    # rule, and asking for headless has nothing to launch either way.
+    PY_BIN="$RL/.venv/bin/python"
+    if [ -z "$HEADLESS" ] && [ "$(uname -s)" = Darwin ] && [ -x "$RL/.venv/bin/mjpython" ]; then
+        PY_BIN="$RL/.venv/bin/mjpython"
+    fi
     # **Backgrounded directly, and in its own session.** `( cd X && nohup cmd & echo $! )` records
     # the *subshell's* pid, because `A && B & C` parses as `(A && B) & C` — so `down` killed a
     # wrapper and left MuJoCo running as an orphan. `setsid` puts the simulator in its own process
@@ -472,7 +481,7 @@ start_body() {
         cam_args="--cameras $CAMERAS --frame-port $FRAME_PORT"
     fi
     # shellcheck disable=SC2086
-    $SETSID nohup "$RL/.venv/bin/python" -m mjlab_microduck.sim.body_server \
+    $SETSID nohup "$PY_BIN" -m mjlab_microduck.sim.body_server \
         --port "$PORT" --ducks "$DUCKS" --keyframe "${DUCK_SIM_KEYFRAME:-SIT}" $HEADLESS $scene_arg \
         $cam_args \
         > "$STATE/body.log" 2>&1 &
@@ -551,6 +560,9 @@ Try DUCK_SIM_VIEWER=0, or fewer ducks." ;;
 # Every duck this script could have started, stopped and unmounted. By name from the same list that
 # starts them, so a duck left behind by an interrupted boot is still cleaned up.
 down_containers() {
+    # Called by every `down`, including the plain one. A machine with no systemd has no containers
+    # to stop, and sixteen `sudo systemctl` that cannot resolve would ask for a password first.
+    command -v systemctl >/dev/null 2>&1 || return 0
     i=0
     while [ "$i" -lt 16 ]; do
         name="$(duck_name "$i")"
@@ -581,6 +593,7 @@ duck_port() { echo $((PORT + $1)); }
 PACKAGES=systemd-sysv,dbus,libssl3,ca-certificates,alsa-utils,libasound2-plugins
 
 rootfs() {
+    containers_or_die
     # The list is recorded, so changing it rebuilds rather than silently not taking effect — which is
     # otherwise a round trip spent wondering why a pull changed nothing.
     if [ -d "$ROOTFS" ] && [ "$(cat "$STATE/rootfs.packages" 2>/dev/null)" = "$PACKAGES" ]; then
@@ -701,7 +714,16 @@ stage() {
     ' _ "$ROOTFS" "$REPO" "$ORT" "$PORT"
 }
 
+# `boot`, `shell` and `rootfs` are systemd, and a machine without it cannot run any of them. Said
+# here, before anything reaches for `sudo` — a password prompt followed by `machinectl: command not
+# found` is a worse way to learn it.
+containers_or_die() {
+    command -v systemd-nspawn >/dev/null 2>&1 && return 0
+    die "this needs systemd-nspawn, which is Linux only. \`scripts/duck-sim\` with no argument runs the same body and the same daemons as plain processes."
+}
+
 boot() {
+    containers_or_die
     # Always, not only when the directory is missing: deciding whether the rootfs is still the right
     # one is `rootfs`'s job, and guarding the call on the directory existing is what stopped a
     # changed package list from ever being noticed. It returns in a moment when nothing has changed.
@@ -849,16 +871,14 @@ NEXT
 }
 
 shell() {
+    containers_or_die
     sudo machinectl shell "${1:-$(duck_name 0)}"
 }
 
 case "${1:-up}" in
     up|"")   up ;;
     rootfs)  rootfs ;;
-    boot)    shift; DUCKS="${1:-$DUCKS}"
-             command -v systemd-nspawn >/dev/null 2>&1 ||
-                 die "boot needs systemd-nspawn, which is Linux only. \`scripts/duck-sim\` with no argument runs the same body and the same daemons as plain processes."
-             boot ;;
+    boot)    shift; DUCKS="${1:-$DUCKS}"; boot ;;
     shell)   shift; shell "$@" ;;
     down)    down_containers; down ;;
     drive)   shift; drive "$@" ;;

--- a/scripts/duck-sim
+++ b/scripts/duck-sim
@@ -32,6 +32,12 @@ set -eu
 STATE="${DUCK_SIM_STATE:-$HOME/.cache/duck-sim}"
 RL="${DUCK_SIM_RL:-$HOME/Pollen/microduck_rl}"
 PORT="${DUCK_SIM_PORT:-7801}"
+
+# `setsid` is util-linux: Linux has it, a Mac does not. What it buys is a daemon in its own session,
+# so closing this terminal does not take the duck with it — and on a machine without it `nohup`
+# alone covers the hangup, which is the part that matters. Nothing here kills by process group any
+# more (see `stop_one`), so a session was the only thing ever wanted from it.
+SETSID="$(command -v setsid 2>/dev/null || true)"
 DUCKS="${DUCK_SIM_DUCKS:-1}"
 
 # Which world. A bare name is one of the simulator's own scenes; anything with a slash is a path.
@@ -84,6 +90,20 @@ ctl() {
 #
 # No group kill at all any more. Every process this starts is a single process that exits on TERM,
 # and the group form bought nothing but the reach to do damage.
+# How a pid says what it is. /proc is Linux and a Mac has none, so `ps` answers there — and the
+# question is the same either way, which is the point: nothing above may signal a pid without it.
+#
+# A dead pid must not fall through to the other branch and get a second opinion. On Linux an
+# unreadable `cmdline` *is* the answer (the process is gone), so this returns empty rather than
+# asking `ps`; only a machine with no /proc at all reaches it.
+cmdline_of() {
+    if [ -d /proc ]; then
+        tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null
+    else
+        ps -p "$1" -o command= 2>/dev/null
+    fi
+}
+
 stop_one() {
     file="$STATE/$1.pid"
     expect="$2"
@@ -94,16 +114,21 @@ stop_one() {
 
     [ -n "$pid" ] || return 0
     [ "$pid" -gt 1 ] 2>/dev/null || return 0
-    [ -r "/proc/$pid/cmdline" ] || return 0
-    tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -q -- "$expect" || {
+    cmdline_of "$pid" | grep -q -- "$expect" || {
         say "not stopping pid $pid: it is no longer $1"
         return 0
     }
 
     kill -TERM "$pid" 2>/dev/null || sudo -n kill -TERM "$pid" 2>/dev/null || true
-    i=0
-    while [ $i -lt 25 ] && [ -d "/proc/$pid" ]; do i=$((i + 1)); sleep 0.2; done
-    [ -d "/proc/$pid" ] || return 0
+    # `waited`, not `i`: there are no locals in POSIX sh, and `down` walks its ducks with `i`.
+    # This loop used to leave it wherever the wait ended, so stopping a `robotd` that took a moment
+    # to go moved the caller's counter forward and the `tofd` beside it was never signalled at all.
+    waited=0
+    while [ $waited -lt 25 ] && kill -0 "$pid" 2>/dev/null; do
+        waited=$((waited + 1))
+        sleep 0.2
+    done
+    kill -0 "$pid" 2>/dev/null || return 0
     kill -KILL "$pid" 2>/dev/null || sudo -n kill -KILL "$pid" 2>/dev/null || true
 }
 
@@ -143,29 +168,55 @@ build_daemons() {
     (cd "$REPO" && cargo build --quiet -p robotd -p robotctl -p tof -p sounds)
 }
 
+# **A checkout has no policies.** They live on the Hub and reach a robot through
+# `scripts/seed-policies.sh` at install time, deliberately outside the release — so a fresh clone
+# has nothing to name here, and a duck started against seven missing files comes up *degraded* and
+# never stands. Same script, same set, a root under the state directory.
+#
+# A `policies/` beside the repo wins if it has one: that is somebody's own set, and fetching over
+# it would silently swap the gait they are working on.
+policies() {
+    if [ -f "$REPO/policies/alpha_stand.onnx" ]; then
+        POLICIES="$REPO/policies"
+        return 0
+    fi
+    POLICIES="$STATE/policies/current"
+    [ -f "$POLICIES/alpha_stand.onnx" ] || {
+        say "no policy set here — fetching the official one"
+        sh "$REPO/scripts/seed-policies.sh" "$STATE/policies" || true
+    }
+    [ -f "$POLICIES/alpha_stand.onnx" ] ||
+        die "no policy set in $STATE/policies. It needs the network once, or your own .onnx files in $REPO/policies."
+}
+
 up() {
     [ -d "$RL" ] || die "no simulator at $RL. It is the microduck_rl repo — set DUCK_SIM_RL."
     [ -x "$RL/.venv/bin/python" ] || die "$RL has no .venv. Run \`uv sync\` there first."
-    ORT="$(ls "$RL"/.venv/lib/python*/site-packages/onnxruntime/capi/libonnxruntime.so.* 2>/dev/null | head -1)"
+    # `.so.<version>` on Linux, `.<version>.dylib` on macOS — the wheel names it after the platform
+    # and `ort` dlopens whatever this points at, so both spellings are looked for rather than one.
+    ORT="$(ls "$RL"/.venv/lib/python*/site-packages/onnxruntime/capi/libonnxruntime.so.* \
+            "$RL"/.venv/lib/python*/site-packages/onnxruntime/capi/libonnxruntime*.dylib \
+            2>/dev/null | head -1)"
     [ -n "$ORT" ] || die "no onnxruntime in $RL/.venv — the policies cannot load without it."
 
     down
     mkdir -p "$STATE"
 
     build_daemons
+    policies
 
     # Every policy named explicitly: `RELEASE_DIR` is /opt/robot/daemon/current, which exists on a
     # robot and not here, and `PolicyParams::resolved` uses a named path verbatim when it has one.
     cat > "$STATE/robotd.toml" <<TOML
 [policy]
 enabled = true
-walk = "$REPO/policies/alpha_walking.onnx"
-stand = "$REPO/policies/alpha_stand.onnx"
-sitstand = "$REPO/policies/alpha_sitstand.onnx"
-ground_pick = "$REPO/policies/alpha_ground_pick.onnx"
-kick_left = "$REPO/policies/ball_kick_left.onnx"
-kick_right = "$REPO/policies/ball_kick_right.onnx"
-roulade = "$REPO/policies/roulade.onnx"
+walk = "$POLICIES/alpha_walking.onnx"
+stand = "$POLICIES/alpha_stand.onnx"
+sitstand = "$POLICIES/alpha_sitstand.onnx"
+ground_pick = "$POLICIES/alpha_ground_pick.onnx"
+kick_left = "$POLICIES/ball_kick_left.onnx"
+kick_right = "$POLICIES/ball_kick_right.onnx"
+roulade = "$POLICIES/roulade.onnx"
 
 # Singing is opt-in, and a room full of ducks that will not sing together is a poor demonstration
 # of a room full of ducks. On a real robot this is a decision someone makes; here it is the point.
@@ -216,7 +267,7 @@ TOML
     i=0
     while [ "$i" -lt "$DUCKS" ]; do
         name="$(duck_name "$i")"
-        DUCK_RUNTIME_DIR="$STATE" setsid nohup "$REPO/target/debug/tofd" \
+        DUCK_RUNTIME_DIR="$STATE" $SETSID nohup "$REPO/target/debug/tofd" \
             --sim "127.0.0.1:$(duck_port "$i")" --socket "$STATE/$name-tof.sock" \
             > "$STATE/$name-tof.log" 2>&1 &
         echo $! > "$STATE/$name-tof.pid"
@@ -232,7 +283,7 @@ TOML
         # other's beacons and never hear anybody. A container gets this from its own machine-id.
         DUCK_IDENTITY="$name" \
         DUCK_RUNTIME_DIR="$STATE" ORT_DYLIB_PATH="$ORT" RUST_LOG="${RUST_LOG:-info}" \
-            setsid nohup "$REPO/target/debug/robotd" --sim "127.0.0.1:$(duck_port "$i")" \
+            $SETSID nohup "$REPO/target/debug/robotd" --sim "127.0.0.1:$(duck_port "$i")" \
             --params "$STATE/robotd-$name.toml" --socket "$STATE/$name.sock" \
             > "$STATE/$name.log" 2>&1 &
         echo $! > "$STATE/$name.pid"
@@ -254,7 +305,7 @@ TOML
             [ -x "$REPO/target/debug/mediad" ] || (cd "$REPO" && cargo build --quiet -p mediad)
             printf '[media]\nquality = "360p30"\n' > "$STATE/mediad-$name.toml"
             DUCK_RUNTIME_DIR="$STATE" RUST_LOG="${RUST_LOG:-info}" \
-                setsid nohup "$REPO/target/debug/mediad" \
+                $SETSID nohup "$REPO/target/debug/mediad" \
                 --sim-camera "127.0.0.1:$((FRAME_PORT + i))" \
                 --config "$STATE/mediad-$name.toml" \
                 --robot-socket "$STATE/$name.sock" --tof-socket "$STATE/$name-tof.sock" \
@@ -277,7 +328,7 @@ TOML
             i=$((i + 1))
         done
         # shellcheck disable=SC2086
-        setsid nohup "$REPO/target/debug/duck-ether" $args > "$STATE/ether.log" 2>&1 &
+        $SETSID nohup "$REPO/target/debug/duck-ether" $args > "$STATE/ether.log" 2>&1 &
         echo $! > "$STATE/ether.pid"
         say "the ether is open — $DUCKS ducks can hear each other"
     fi
@@ -412,7 +463,7 @@ start_body() {
         *)    scene_arg="--scene $RL/src/mjlab_microduck/robot/microduck/scene_$SCENE.xml" ;;
     esac
     # shellcheck disable=SC2086
-    setsid nohup "$RL/.venv/bin/python" -m mjlab_microduck.sim.body_server \
+    $SETSID nohup "$RL/.venv/bin/python" -m mjlab_microduck.sim.body_server \
         --port "$PORT" --ducks "$DUCKS" --keyframe "${DUCK_SIM_KEYFRAME:-SIT}" $HEADLESS $scene_arg \
         --cameras "$CAMERAS" --frame-port "$FRAME_PORT" \
         > "$STATE/body.log" 2>&1 &
@@ -795,7 +846,10 @@ shell() {
 case "${1:-up}" in
     up|"")   up ;;
     rootfs)  rootfs ;;
-    boot)    shift; DUCKS="${1:-$DUCKS}"; boot ;;
+    boot)    shift; DUCKS="${1:-$DUCKS}"
+             command -v systemd-nspawn >/dev/null 2>&1 ||
+                 die "boot needs systemd-nspawn, which is Linux only. \`scripts/duck-sim\` with no argument runs the same body and the same daemons as plain processes."
+             boot ;;
     shell)   shift; shell "$@" ;;
     down)    down_containers; down ;;
     drive)   shift; drive "$@" ;;

--- a/tof/Cargo.toml
+++ b/tof/Cargo.toml
@@ -23,14 +23,24 @@ path = "src/main.rs"
 anyhow = "1"
 clap = { workspace = true, features = ["derive"] }
 duck-ipc-proto = { path = "../duck-ipc-proto" }
-bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", tag = "v0.1.1" }
-linux-embedded-hal = "0.4"
 libc = "0.2"
 serde = { workspace = true }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt", "signal", "sync", "time", "io-util"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+# The head IMU (`src/imu.rs`) reaches the BMI088 through `/dev/i2c-*`, which exists on no other
+# platform — the same rule `build.rs` already applies to the vendored ULDs, and for the same reason:
+# `cargo test --workspace` has to run on a developer's Mac. Off Linux `tofd` still builds, still
+# serves depth from `--fake` or `--sim`, and answers `head_imu.stream` with why it has no sensor.
+[target.'cfg(target_os = "linux")'.dependencies]
+# The BMI088 driver and its Madgwick fusion, ours because the crates.io ones stop at the raw
+# registers. Pinned to a tag: it is a second repository and a moving `main` is not a dependency.
+bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", tag = "v0.1.1" }
+# `I2cdev`, the `embedded-hal` bus the driver is generic over. Linux-only by construction —
+# `i2cdev`'s `linux` module is the whole crate.
+linux-embedded-hal = "0.4"
 
 [build-dependencies]
 cc = "1"

--- a/tof/src/imu.rs
+++ b/tof/src/imu.rs
@@ -10,34 +10,53 @@
 //! behind that. Same shape as the ToF loop otherwise — open, read at `hz`, broadcast frames,
 //! retry with backoff on error — so a BMI088 fitted later needs no reconnect.
 //!
+//! **Linux only, and quietly so**, like the vendored ULDs `build.rs` skips off a board: the bus is
+//! `/dev/i2c-*` and the driver is `linux-embedded-hal`, so on a developer's Mac there is no sensor
+//! to open and `imu_loop` says as much instead of being compiled. `tofd` still builds and still
+//! serves depth from `--fake` or `--sim` there, which is what a laptop runs it for.
+//!
 //! Orientation is a Madgwick fusion (the `bmi088` crate's `Bmi088Ahrs`); `gyro`/`accel` are the
 //! raw sensor axes. Placing the sample in the head frame (the IMU is rigid to the camera) is a
 //! `kinematics` job for the consumer, not this daemon's.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+
+use duck_ipc_proto as proto;
+
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::sync::atomic::Ordering;
+#[cfg(target_os = "linux")]
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "linux")]
 use bmi088::{Bmi088, Bmi088Ahrs, Config};
-use duck_ipc_proto as proto;
+#[cfg(target_os = "linux")]
 use linux_embedded_hal::I2cdev;
 
+#[cfg(target_os = "linux")]
 use crate::BUS_CANDIDATES;
 
 /// Madgwick convergence rate. 0.1 is the crate's recommended starting point: fast enough to track
 /// a walking head, slow enough not to chase gyro noise.
+#[cfg(target_os = "linux")]
 const BETA: f64 = 0.1;
 
 /// Reopen backoff after an I²C error, same reasoning as the ToF loop: a bus glitch and a missing
 /// chip look alike from here, and one backoff serves both without hammering a shared bus.
+#[cfg(target_os = "linux")]
 const RETRY_MIN: Duration = Duration::from_millis(500);
+#[cfg(target_os = "linux")]
 const RETRY_MAX: Duration = Duration::from_secs(30);
 
 /// How far an IMU subscriber may fall behind before it loses samples. At 100 Hz this is ~2.5 s.
 pub const FRAME_BUFFER: usize = 256;
 
 /// Read `temp_c` this often (every Nth sample); it barely moves and costs a bus read.
+#[cfg(target_os = "linux")]
 const TEMP_EVERY: u64 = 100;
 
 /// What the `imu.stream` answer reports — whether a BMI088 was found and at what rate.
@@ -64,6 +83,7 @@ impl ImuStatus {
         }
     }
 
+    #[cfg(target_os = "linux")]
     fn found(&self, sensor: &str) {
         let mut inner = self.inner.lock().unwrap();
         inner.sensor = Some(sensor.to_owned());
@@ -88,6 +108,7 @@ impl ImuStatus {
 }
 
 /// Read the BMI088 forever, broadcasting [`proto::HeadImuFrame`]. Returns only at shutdown.
+#[cfg(target_os = "linux")]
 pub fn imu_loop(
     bus: Option<&Path>,
     hz: u8,
@@ -160,9 +181,24 @@ pub fn imu_loop(
     }
 }
 
+/// Off Linux there is no `/dev/i2c-*` to open, so this returns at once and the status says why —
+/// the same answer `head_imu.stream` gives on a board whose HAT has no BMI088 fitted, which is the
+/// shape every consumer already handles.
+#[cfg(not(target_os = "linux"))]
+pub fn imu_loop(
+    _bus: Option<&Path>,
+    _hz: u8,
+    status: &ImuStatus,
+    _frames: &tokio::sync::broadcast::Sender<proto::HeadImuFrame>,
+    _shutdown: &Arc<AtomicBool>,
+) {
+    status.lost("the head IMU is on an I2C bus, which exists only on Linux".to_owned());
+}
+
 /// Open the BMI088 on the first bus that answers. The `bmi088` crate hardwires accel `0x19` /
 /// gyro `0x68` (the HAT's addresses), so there is nothing to sweep — a failure to read the
 /// chip-id in `Bmi088::new` is the "not fitted / bus glitch" signal.
+#[cfg(target_os = "linux")]
 fn open_imu(bus: Option<&Path>) -> anyhow::Result<Bmi088Ahrs<I2cdev>> {
     let buses: Vec<PathBuf> = match bus {
         Some(bus) => vec![bus.to_path_buf()],
@@ -192,6 +228,7 @@ fn open_imu(bus: Option<&Path>) -> anyhow::Result<Bmi088Ahrs<I2cdev>> {
     Err(last.unwrap_or_else(|| anyhow::anyhow!("no bus to look on")))
 }
 
+#[cfg(target_os = "linux")]
 fn sleep_unless_shutdown(dur: Duration, shutdown: &Arc<AtomicBool>) {
     // Slice the sleep so shutdown is prompt even during a long backoff.
     let slice = Duration::from_millis(50);


### PR DESCRIPTION
Targets #232, not `main`.

## What broke

`cargo check --workspace` does not build on macOS on the `vslam` branch, in two places.

**`tof` takes `linux-embedded-hal` as an unconditional dependency.** It pulls `i2cdev`, whose
`linux` module is the whole crate — `#[cfg(any(target_os = "linux", target_os = "android"))]` — so
off Linux it fails with thirteen errors before any of `tof`'s own code is reached.

`build.rs` already states the rule for the vendored ULDs, in as many words: *"on a developer's Mac
there is nothing here to compile … Skipping rather than failing is what lets `cargo test
--workspace` run off a board at all"*. The BMI088 is the same kind of thing and now gets the same
treatment: the dependency moves under `[target.'cfg(target_os = "linux")'.dependencies]`, the way
`evdev` does in `padd` and `bluer` in `btd`, and `imu.rs` gates the driver that uses it.

`ImuStatus` stays portable, so `serve` and the `head_imu.stream` answer need no `cfg` at all. Off
Linux `imu_loop` returns at once having said why, and a subscriber is told there is no sensor —
the same answer a board whose HAT has no BMI088 fitted already gives, which every consumer
handles.

**`mediad`'s new `Args::sockets` is dead code off Linux**, because the `main` that calls it is
`#[cfg(target_os = "linux")]` and `-D warnings` makes that an error. Gated with its caller.

## On a robot

Nothing changes. On Linux every item touched here compiles exactly as it did — the gates are all
`cfg(target_os = "linux")` around code that only ever ran there.

## Verified

On macOS (aarch64-apple-darwin, rustc 1.97.1): `cargo check --workspace --all-targets` and
`cargo clippy -p tof --all-targets` clean under `-D warnings`. `tofd` builds and runs — it did not
build at all before — and answers `tof.stream` and `head_imu.stream` with `accepted: true` and a
reason for each missing sensor:

```
{"result":{"accepted":true,"cols":8,"hz":15,"rows":8,"unavailable":"/dev/i2c-3 does not exist"}}
{"result":{"accepted":true,"hz":100,"unavailable":"the head IMU is on an I2C bus, which exists only on Linux"}}
```

`cargo test --workspace` passes apart from `robotd::single_instance::non_socket_paths_are_not_removed`,
which fails the same way on `main` — a macOS-only gap in that test, not this branch's and not #232's.

`cargo clippy --workspace` on rustc 1.97 also trips `manual_option_zip` in `robotd/src/chorale.rs:545`.
That file is byte-identical to `main` here, and CI's clippy runs on 1.98.1, where the lint does not
fire — so it is a toolchain gap on the developer's side, not a finding. Linux is CI's word either
way, and #235's `check` job is green.


## And the script that runs it

`scripts/duck-sim` did not run on macOS either, for four reasons — and testing it turned up a
fifth that is a bug everywhere.

`stop_one` confirmed a pid's identity through `/proc`, which a Mac has none of, so the check failed
open and `down` signalled nothing at all: every daemon survived it. `cmdline_of` now asks `/proc`
where there is one and `ps -p` where there is not, and the wait loop asks `kill -0` instead of
looking for a directory. The rule the comment above it states is unchanged — nothing signals a pid
without first confirming it is still what the pidfile says.

`setsid` is util-linux; `nohup` alone covers the hangup where it is missing, and nothing here kills
by process group any more. The venv's ONNX Runtime is `libonnxruntime.so.<version>` on Linux and
`libonnxruntime.<version>.dylib` on macOS, so both are looked for. A checkout has no `policies/` —
they reach a robot from the Hub through `seed-policies.sh`, outside the release — so `up` seeds a
set under the state directory rather than naming seven paths that do not exist and coming up
degraded; a `policies/` beside the repo still wins. And `boot` says it needs `systemd-nspawn`
rather than failing four steps in.

**The bug:** `stop_one` ran its wait loop on `i`, which is also what `down` walks its ducks with,
and POSIX sh has no locals. Stopping a `robotd` that took a moment to go left `i` wherever the wait
ended, so the `tofd` beside it was never signalled — `down` reported success with a daemon still
holding the socket. It is only reliable on Linux because a process that exits at once leaves `i` at
0. Renamed to `waited`.

## The twin, on a Mac

`duck-sim up` brings up `tofd` and `robotd` against a body on 7801 — `robotd` healthy, 50.0 of
50.0 Hz, bus ok — and this branch's subject answers:

```
robot.model  asset=alpha trunk_height=0.1200 joints=15 beams=64 fov=45.0 links=15
robot.state  t=27.09 t_ns=97775844084000 skeleton=15 imu.quat=[1.0, 0.0, 0.0, 0.0]
  frames.camera.pos [0.0683, -0.0535, 0.0082] head_imu: present
```

`down` then leaves nothing behind. The body here was a stub speaking the documented protocol rather
than MuJoCo — the physics half is unmerged in `microduck_rl` — so this exercises the daemon side of
the seam, not the simulator behind it.


## A correction, and a thing this is not

Commit `b04339b`'s message says `drive` walked the duck forward. That was read off the script's own
"walking forward for 8 s", not off odometry — measured, `drive`'s default of 0.15 m/s does not move
the duck at all. The daemon side is doing everything right: the intent lands, the deadman clears,
the mode switches to `walk`, and `move.applied` holds 0.15 for the full eight seconds. The walk
policy simply produces almost nothing at that command — joint targets span 0.02–0.07 rad, a twitch
in place — and odometry advances 7 mm.

At `drive 0.45` the same policy swings its joints 0.2–1.4 rad and the duck covers 1.26 m in seven
seconds. So `${1:-0.15}` sits below the policy's useful range, and the headline "walk it forward"
command looks broken to anyone trying the simulator for the first time.

Not changed here: what that default should be is a question about the policy's trained range, not
about portability, and it belongs to whoever tuned it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


