### PR TITLE
`duckctl logs`: a daemon's last words, over the radio

### DIFF
--- a/btd/src/bluez.rs
+++ b/btd/src/bluez.rs
@@ -20,8 +20,13 @@
 //! So: one session for the service's lifetime, one notify pump, and a write callback that pushes
 //! bytes into it.
 //!
-//! **Untested against hardware.** It type-checks for aarch64 and has never met a real central.
-//! Treat what follows as intent until someone connects a phone.
+//! **What the callback model costs is flow control**, and that bill came due the first time a
+//! reply was more than a few kilobytes. `notify` hands a D-Bus signal to the connection and
+//! returns; nothing here can ask BlueZ whether the radio has caught up, and nothing reports the
+//! notification MTU either. Both gaps are worked around rather than solved: the payload is taken
+//! from what BlueZ reports on inbound writes (one ATT MTU serves both directions), and the pump
+//! pauses every [`NOTIFY_BURST`] chunks. The IO model has the readiness signal this wants and
+//! still cannot be used, for the reason above — it serves only the `Acquire*` paths.
 
 use std::net::Ipv4Addr;
 use std::sync::Arc;
@@ -34,11 +39,13 @@ use bluer::agent::Agent;
 // which is how it first presented.
 use bluer::gatt::local::ReqError as GattError;
 use bluer::gatt::local::{
-    Application, Characteristic, CharacteristicNotify, CharacteristicNotifyMethod,
-    CharacteristicRead, CharacteristicWrite, CharacteristicWriteMethod, Service,
+    Application, Characteristic, CharacteristicNotifier, CharacteristicNotify,
+    CharacteristicNotifyMethod, CharacteristicRead, CharacteristicWrite, CharacteristicWriteMethod,
+    Service,
 };
 use futures::FutureExt;
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokio::sync::mpsc;
 
@@ -47,12 +54,45 @@ use crate::link::Link;
 use crate::session;
 use crate::upstream::{NameChoice, Sockets};
 
-/// Notification payload assumed for outbound chunks.
+/// Notification payload a session starts with, before any write has reported the negotiated one.
 ///
-/// The write side learns the negotiated MTU (BlueZ reports it per request); the notify side has no
-/// way to ask. So chunks are sized for 20 bytes — the payload every BLE link is required to
-/// support — which is slower than necessary on a good link and correct on every link.
+/// 20 bytes is what every BLE link is required to support, so it is the only safe *first* guess.
+/// It used to be the guess for the whole session — the notify side has no way to ask BlueZ, which
+/// remains true — and that was wrong in two ways. Tenfold more notifications than the link needed
+/// was the visible half; the other half is that a reply above roughly 5 KiB tore the session down
+/// (see [`NOTIFY_BURST`]). The write side does learn the real MTU, BlueZ reports it on every
+/// inbound write, and both directions share one ATT MTU — so the floor now lasts until the
+/// client's first write, which is always `system.authenticate`.
 const FLOOR_MTU: usize = 20;
+
+/// How many notifications to queue before pausing to let the radio drain.
+///
+/// **This is the only backpressure the callback model offers, and it has to exist.**
+/// `CharacteristicNotifier::notify` emits a D-Bus `PropertiesChanged` signal and returns as soon
+/// as the signal is queued on the connection — it does not wait for BlueZ, let alone for the
+/// controller — so an unpaced pump queues a whole reply in microseconds. Measured on the board:
+/// a ~5 KiB reply at the 20-byte floor (≈265 notifications) got through in 1.8 s, and a ~7 KiB one
+/// (≈350) killed the notification session 150 ms in, leaving the client waiting out its idle
+/// timeout against a robot that had already torn down the session. `bluer`'s IO model has a real
+/// readiness signal for this and cannot be used here — it serves only the `Acquire*` fd paths,
+/// which a CoreBluetooth central never drives (see this module's header).
+///
+/// Sixteen chunks is what a connection interval can plausibly carry, so a small reply — an
+/// authentication answer is four chunks — never pauses at all.
+const NOTIFY_BURST: usize = 16;
+
+/// How long to pause between bursts. Roughly one connection interval.
+const NOTIFY_PAUSE: Duration = Duration::from_millis(20);
+
+/// How many times to re-send a chunk the D-Bus connection would not take, and how long to wait
+/// between attempts.
+///
+/// A `notify` that fails while the session is *not* stopped is a queue that is momentarily full,
+/// which is recoverable and was being treated as the central having left — the session was torn
+/// down mid-reply and the client learned nothing at all. Only an exhausted budget, or a genuinely
+/// stopped session, ends the session now.
+const NOTIFY_RETRIES: u32 = 5;
+const NOTIFY_RETRY_BACKOFF: Duration = Duration::from_millis(20);
 
 /// How often to advertise, and this is the difference between a robot that is found and one that is
 /// not.
@@ -313,6 +353,13 @@ async fn serve_on_an_adapter(
     let for_write = current.clone();
     let for_notify = current.clone();
 
+    // The negotiated payload, written by the write callback and read by the session when it sizes
+    // a reply. An atomic rather than a channel or the mutex above, because the write callback may
+    // not await and may not block: a yield point there lets two chunks swap places. See
+    // [`crate::link::Link::mtu`].
+    let mtu = Arc::new(AtomicUsize::new(FLOOR_MTU));
+    let write_mtu = mtu.clone();
+
     // The notify callback below takes ownership of `sockets` for the sessions it spawns, and the
     // reconcile loop at the end outlives it.
     let for_reconcile = sockets.clone();
@@ -364,6 +411,15 @@ async fn serve_on_an_adapter(
                             String::from_utf8_lossy(&value[..value.len().min(8)]).to_string();
                         let sender = for_write.lock().expect("write slot poisoned").clone();
 
+                        // What BlueZ says this link negotiated, minus the three bytes of ATT
+                        // header a notification cannot use. Stored on every write because it is
+                        // free to do so and a central may renegotiate; logged only when it moves,
+                        // because the value that matters is the one a reply gets chunked for and
+                        // that number had never appeared in the journal at all.
+                        let payload = usize::from(req.mtu).saturating_sub(3).max(FLOOR_MTU);
+                        let previous = write_mtu.swap(payload, Ordering::Relaxed);
+                        let learned = (previous != payload).then_some(payload);
+
                         let result = match sender {
                             None => {
                                 // Nowhere to send an answer, so accepting the request would be a
@@ -394,6 +450,12 @@ async fn serve_on_an_adapter(
                         };
 
                         async move {
+                            if let Some(payload) = learned {
+                                tracing::info!(
+                                    payload,
+                                    "negotiated notification payload; replies are sized for this"
+                                );
+                            }
                             // Eight bytes of the chunk, so a reordering is visible in the journal
                             // rather than inferred from a parse error three layers up. Truncated
                             // because a request may carry a wifi passphrase.
@@ -416,12 +478,17 @@ async fn serve_on_an_adapter(
                     method: CharacteristicNotifyMethod::Fun(Box::new(move |mut notifier| {
                         let slot = for_notify.clone();
                         let sockets = sockets.clone();
+                        let mtu = mtu.clone();
                         async move {
                             tokio::spawn(async move {
                                 // A fresh session, so nothing from a previous central can leak
                                 // into this one.
+                                // Back to the floor for a new central: the previous one's MTU is
+                                // not this one's, and the first write will report the real value
+                                // before any reply is chunked.
+                                mtu.store(FLOOR_MTU, Ordering::Relaxed);
                                 let (link, inbound, mut outbound) =
-                                    Link::pair(FLOOR_MTU, "central");
+                                    Link::pair_sharing_mtu(mtu.clone(), "central");
                                 let mine = inbound.clone();
                                 {
                                     let mut slot = slot.lock().expect("write slot poisoned");
@@ -438,6 +505,11 @@ async fn serve_on_an_adapter(
                                 let session = tokio::spawn(session::run(link, sockets));
                                 tracing::info!("central subscribed");
 
+                                // Notifications queued since the last pause. See `NOTIFY_BURST`
+                                // for why a pump with no readiness signal has to pace itself.
+                                let mut queued = 0usize;
+                                let mut gone = false;
+
                                 loop {
                                     tokio::select! {
                                         // Biased so a central that has gone away is noticed before
@@ -448,15 +520,21 @@ async fn serve_on_an_adapter(
                                         // when a notify fails — which needs a reply to send, so a
                                         // client that disconnects while idle would hold the slot
                                         // until the next request arrives for nobody.
-                                        () = notifier.stopped() => break,
+                                        () = notifier.stopped() => {
+                                            gone = true;
+                                            break;
+                                        }
                                         chunk = outbound.recv() => match chunk {
                                             None => break,
                                             Some(chunk) => {
-                                                if let Err(e) = notifier.notify(chunk).await {
-                                                    tracing::debug!(
-                                                        error = %e, "notify failed; central gone"
-                                                    );
+                                                if !notify_chunk(&mut notifier, chunk).await {
+                                                    gone = true;
                                                     break;
+                                                }
+                                                queued += 1;
+                                                if queued >= NOTIFY_BURST {
+                                                    queued = 0;
+                                                    tokio::time::sleep(NOTIFY_PAUSE).await;
                                                 }
                                             }
                                         },
@@ -474,7 +552,20 @@ async fn serve_on_an_adapter(
                                         // its reassembly buffer and its upstream connections.
                                         slot.take();
                                         session.abort();
-                                        tracing::info!("central unsubscribed; session discarded");
+                                        // Which of the two it was, because they need different
+                                        // next moves and the old line said "unsubscribed" for
+                                        // both — including for a reply this pump could not
+                                        // deliver, which is a robot problem wearing a client's
+                                        // clothes.
+                                        if gone {
+                                            tracing::info!(
+                                                "the central is gone; session discarded"
+                                            );
+                                        } else {
+                                            tracing::info!(
+                                                "the outbound queue closed; session discarded"
+                                            );
+                                        }
                                     } else {
                                         tracing::debug!(
                                             "a newer session holds the slot; leaving it alone"
@@ -529,6 +620,46 @@ async fn serve_on_an_adapter(
         ) => {}
     }
     Ok(())
+}
+
+/// Send one chunk, retrying a queue that is momentarily full. `false` means give up on the session.
+///
+/// **The distinction this function exists to draw**: `notify` returns the same error for "the
+/// central unsubscribed" and "the D-Bus connection would not take this signal", and the pump used
+/// to read both as the central having left. So a reply too big for one burst tore down the session
+/// mid-line, and the client — still connected, as far as CoreBluetooth was concerned — waited out
+/// its idle timeout with no error to report and half an answer in its reassembler. That was
+/// diagnosed from a board, not from the journal, because the only line it left was a `debug` one
+/// blaming the central.
+///
+/// `is_stopped` tells them apart: it is closed only when the notification session really has
+/// ended. Anything else is retried, and the chunk is cloned because `notify` consumes it and a
+/// dropped chunk corrupts the line rather than failing it.
+async fn notify_chunk(notifier: &mut CharacteristicNotifier, chunk: Vec<u8>) -> bool {
+    for attempt in 1..=NOTIFY_RETRIES {
+        match notifier.notify(chunk.clone()).await {
+            Ok(()) => return true,
+            Err(_) if notifier.is_stopped() => {
+                tracing::debug!("the notification session ended mid-reply");
+                return false;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    attempt,
+                    error = %e,
+                    "the notification queue would not take a chunk; retrying"
+                );
+                tokio::time::sleep(NOTIFY_RETRY_BACKOFF).await;
+            }
+        }
+    }
+    // A warning rather than a silence, which is the whole point: this ends a session, and
+    // whoever is holding the client deserves to find out why from the robot's own journal.
+    tracing::warn!(
+        retries = NOTIFY_RETRIES,
+        "gave up on a notification chunk; ending the session rather than sending a corrupt line"
+    );
+    false
 }
 
 /// What the advertisement says about the robot: what it is called, and where it is on the network.

--- a/btd/src/framing.rs
+++ b/btd/src/framing.rs
@@ -21,20 +21,50 @@
 /// and it is reachable by anyone in radio range. Generous next to any real request — the
 /// largest is an `update.apply` with a long ref — and far below `updaterd`'s own 1 MiB line
 /// limit, because nothing that big has any business arriving over BLE.
+///
+/// **This bounds what a peer may send, not what the robot may answer.** The two are not the
+/// same size and were one constant until a reply outgrew it: see [`MAX_REPLY_LINE`].
 pub const MAX_LINE: usize = 8 * 1024;
 
+/// Longest line a *client* will reassemble from the robot.
+///
+/// The other direction, and it needs its own number. [`MAX_LINE`] is a security bound — the
+/// peer it limits is anyone in radio range, so it is deliberately tight — whereas this limits
+/// the robot a client chose to connect to and already trusts. Reusing the tight one here made
+/// every reply over 8 KiB unreadable, which quietly took `update.show` (kilobytes for an
+/// ordinary run) and `system.logs` (a screenful of journal) out of reach of `duckctl` while
+/// `btd` served both correctly.
+///
+/// 64 KiB, and the real limit on a reply is smaller still and lives elsewhere: `proto`'s
+/// `MAX_LOG_BYTES` keeps the journal tail well inside this, because at a typical ATT MTU
+/// 64 KiB is a minute on the air and no answer should take that long.
+pub const MAX_REPLY_LINE: usize = 64 * 1024;
+
 /// Reassembles inbound chunks into whole lines.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Reassembler {
     buf: Vec<u8>,
+    /// What "too long" means for this direction. See [`MAX_LINE`] and [`MAX_REPLY_LINE`].
+    limit: usize,
+}
+
+/// The robot's side: [`MAX_LINE`], the tight bound, because the default must be the safe one.
+impl Default for Reassembler {
+    fn default() -> Self {
+        Self {
+            buf: Vec::new(),
+            limit: MAX_LINE,
+        }
+    }
 }
 
 /// Why a peer's bytes were rejected. Both cases mean "drop the connection", but they are
 /// logged differently: one is a client that cannot frame, the other may be an attack.
 #[derive(Debug, PartialEq, Eq)]
 pub enum FramingError {
-    /// No newline within [`MAX_LINE`].
-    LineTooLong,
+    /// No newline within this reassembler's limit, which the variant carries because the two
+    /// directions have different ones and the message must say which was hit.
+    LineTooLong { limit: usize },
     /// Not valid UTF-8, so it cannot be JSON either.
     NotUtf8,
 }
@@ -42,7 +72,7 @@ pub enum FramingError {
 impl std::fmt::Display for FramingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::LineTooLong => write!(f, "no newline within {MAX_LINE} bytes"),
+            Self::LineTooLong { limit } => write!(f, "no newline within {limit} bytes"),
             Self::NotUtf8 => write!(f, "not valid UTF-8"),
         }
     }
@@ -57,17 +87,28 @@ impl Reassembler {
         Self::default()
     }
 
+    /// A reassembler for the answers coming *back*, bounded by [`MAX_REPLY_LINE`].
+    ///
+    /// Named for the direction rather than taking a number, so that a client reading replies
+    /// cannot pick the wrong bound and `btd` cannot accidentally be given the loose one.
+    pub fn for_replies() -> Self {
+        Self {
+            buf: Vec::new(),
+            limit: MAX_REPLY_LINE,
+        }
+    }
+
     /// Feed one chunk; get back every complete line it completed.
     ///
     /// Returns a `Vec` because one write can legitimately carry several short lines — a
     /// client that batches `hello` and `update.status` into one 40-byte write is being
     /// efficient, not wrong.
     pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<String>, FramingError> {
-        if self.buf.len() + chunk.len() > MAX_LINE {
+        if self.buf.len() + chunk.len() > self.limit {
             // Clear rather than keep the partial line: whatever follows is unparseable
             // anyway, and holding it would let a peer pin the memory.
             self.buf.clear();
-            return Err(FramingError::LineTooLong);
+            return Err(FramingError::LineTooLong { limit: self.limit });
         }
         self.buf.extend_from_slice(chunk);
 
@@ -165,9 +206,33 @@ mod tests {
     fn a_line_without_a_newline_is_refused_at_the_cap() {
         let mut r = Reassembler::new();
         let big = vec![b'x'; MAX_LINE + 1];
-        assert_eq!(r.push(&big), Err(FramingError::LineTooLong));
+        assert_eq!(
+            r.push(&big),
+            Err(FramingError::LineTooLong { limit: MAX_LINE })
+        );
         // And the buffer was released, so the peer cannot pin memory by retrying.
         assert_eq!(r.pending(), 0);
+    }
+
+    /// A reply larger than the request cap must reassemble on the client side.
+    ///
+    /// The regression this pins is one constant serving both directions: with a single 8 KiB
+    /// cap, a `system.logs` answer arrived intact from the robot and died in `duckctl` as
+    /// "no newline within 8192 bytes", which reads like a broken robot and is not one.
+    #[test]
+    fn a_reply_bigger_than_the_request_cap_is_accepted_by_a_client() {
+        let reply = format!("{{\"result\":\"{}\"}}\n", "x".repeat(32 * 1024));
+
+        let mut robot_side = Reassembler::new();
+        assert!(matches!(
+            robot_side.push(reply.as_bytes()),
+            Err(FramingError::LineTooLong { limit: MAX_LINE })
+        ));
+
+        let mut client_side = Reassembler::for_replies();
+        let lines = client_side.push(reply.as_bytes()).expect("under the cap");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].len(), reply.len() - 1);
     }
 
     #[test]

--- a/btd/src/link.rs
+++ b/btd/src/link.rs
@@ -11,6 +11,9 @@
 //! goes away. What happens between those two channels is [`crate::session`], and it never
 //! learns whether a radio is involved.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use tokio::sync::mpsc;
 
 /// How many chunks may queue in either direction.
@@ -38,18 +41,36 @@ pub struct Link {
     pub outbound: mpsc::Sender<Vec<u8>>,
     /// Usable notification payload — `ATT_MTU - 3` — as negotiated for this connection.
     ///
-    /// Read once per session rather than per message: a central may renegotiate, but not
-    /// mid-line, and re-reading it would let a line be chunked two different ways.
-    pub mtu: usize,
+    /// **A shared cell rather than a number, because the two halves of the link learn it at
+    /// different times.** BlueZ reports the negotiated MTU on every inbound write and offers the
+    /// notify side no way to ask, so a session begins knowing only the 20-byte floor and learns
+    /// the real value from the first write a client makes — which is always `system.authenticate`,
+    /// before any reply worth chunking exists. Sizing replies for the floor for the whole session
+    /// was a tenfold cost in notifications, and above about 5 KiB it stopped being merely slow:
+    /// see the pacing in `bluez`.
+    ///
+    /// Read once per *line*, never per chunk, which is the invariant that matters — a line chunked
+    /// two different ways cannot be reassembled.
+    mtu: Arc<AtomicUsize>,
     /// The central's address, for the log line. Never used for authorization — a BLE address
     /// is trivially spoofed, and pairing is what authorizes (`architecture.md` §4.2).
     pub peer: String,
 }
 
 impl Link {
-    /// A link wired to channels the caller drives. Used by tests and by `--fake`.
+    /// A link wired to channels the caller drives, with a payload size that never changes.
+    /// Used by tests and by `--fake`.
     pub fn pair(
         mtu: usize,
+        peer: impl Into<String>,
+    ) -> (Self, mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
+        Self::pair_sharing_mtu(Arc::new(AtomicUsize::new(mtu)), peer)
+    }
+
+    /// A link whose payload size is written by somebody else — the radio backend, from what
+    /// BlueZ reports on each inbound write. See [`Link::mtu`].
+    pub fn pair_sharing_mtu(
+        mtu: Arc<AtomicUsize>,
         peer: impl Into<String>,
     ) -> (Self, mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
         let (to_robot, inbound) = mpsc::channel(QUEUE);
@@ -64,6 +85,11 @@ impl Link {
             to_robot,
             from_robot,
         )
+    }
+
+    /// The payload to size the next outbound line for.
+    pub fn mtu(&self) -> usize {
+        self.mtu.load(Ordering::Relaxed)
     }
 }
 

--- a/btd/src/route.rs
+++ b/btd/src/route.rs
@@ -152,6 +152,25 @@ fn permits(call: &proto::Call) -> bool {
         // cannot report on this way is `btd` itself, which answering at all proves is running.
         SystemServices => true,
 
+        // The tail of one daemon's journal, and the next question after the line above: a unit
+        // reported as `failed` is a diagnosis nobody can act on without the reason it failed.
+        //
+        // Permitted because BLE is where the question is asked. A robot with no network cannot be
+        // reached by ssh, and that robot — one whose wifi never came up, whose `robotd` died on
+        // boot — is exactly the one whose journal somebody needs. Refusing here would mean the
+        // logs are readable over every transport except the one available when things are broken.
+        //
+        // Read-only, and bounded on the other side rather than trusted: `configd` picks the unit
+        // from a fixed list and refuses anything else, so this grants "the tail of a daemon this
+        // project ships", not `journalctl`. What a phone in the room learns is what that phone
+        // could already learn by watching the robot fail, in words it can put in a support ticket.
+        //
+        // The one thing worth naming as a cost: a journal line can carry more than a status. Ours
+        // are reviewed for that where it matters — `net.connect`'s passphrase is redacted by a
+        // hand-written `Debug` with a test pinning it (`proto::NetConnectParams`) — and this
+        // routing is the second reason that redaction is load-bearing rather than tidy.
+        SystemLogs(_) => true,
+
         // Rebooting is drastic but recoverable, and it is what an app offers when a robot is
         // confused — the alternative being "unplug it", which for a walking robot is worse.
         // Unlike `resetToGolden` it discards nothing.

--- a/btd/src/session.rs
+++ b/btd/src/session.rs
@@ -31,7 +31,8 @@ const PIN_ATTEMPTS: u32 = 3;
 /// Serve one central until it disconnects or breaks framing.
 pub async fn run(mut link: Link, sockets: Sockets) {
     let peer = link.peer.clone();
-    tracing::info!(peer = %peer, mtu = link.mtu, "session opened");
+    tracing::info!(peer = %peer, mtu = link.mtu(), "session opened; mtu is the floor \
+     until the first write reports the negotiated one");
 
     let (replies_tx, mut replies) = mpsc::channel::<String>(QUEUE);
     let config_socket = sockets.config.clone();
@@ -305,7 +306,9 @@ async fn authenticate(
 
 /// Chunk one line out to the central.
 async fn send_line(link: &Link, line: &str) -> Result<(), ()> {
-    for chunk in framing::chunks(line, link.mtu) {
+    // Read once here, so one line is chunked one way even if a write reports a new MTU
+    // meanwhile. See `Link::mtu`.
+    for chunk in framing::chunks(line, link.mtu()) {
         if link.outbound.send(chunk).await.is_err() {
             // The backend dropped its half: the central is gone.
             return Err(());
@@ -388,6 +391,22 @@ mod tests {
                 .expect("link closed");
             if let Some(line) = r.push(&chunk).expect("framing").into_iter().next() {
                 return line;
+            }
+        }
+    }
+
+    /// Like [`read_reply`], and also says how the line was cut up on the way out.
+    async fn read_reply_in_chunks(from_robot: &mut Receiver<Vec<u8>>) -> (String, Vec<usize>) {
+        let mut r = Reassembler::new();
+        let mut sizes = Vec::new();
+        loop {
+            let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), from_robot.recv())
+                .await
+                .expect("client saw no reply")
+                .expect("link closed");
+            sizes.push(chunk.len());
+            if let Some(line) = r.push(&chunk).expect("framing").into_iter().next() {
+                return (line, sizes);
             }
         }
     }
@@ -530,6 +549,71 @@ mod tests {
         assert!(
             updater_seen.try_recv().is_err(),
             "robotd's call went to updaterd"
+        );
+    }
+
+    /// **A reply is sized for the MTU the link has learned, and a session starts knowing only
+    /// the floor.**
+    ///
+    /// This is the mechanism behind `bluez`'s shared MTU cell, tested here because that file needs
+    /// a radio and this one does not. What it pins is the ordering that makes the trick sound: a
+    /// central subscribes before it writes, so a session opens at the 20-byte floor and learns the
+    /// real payload from the first write — which is always `system.authenticate`, before any reply
+    /// worth chunking exists.
+    ///
+    /// Sizing every reply for the floor was not merely slow. Ten times the notifications is ten
+    /// times the queue depth in BlueZ, and past roughly 5 KiB the notification session was torn
+    /// down mid-reply — a `system.logs` tail was the first reply big enough to find it.
+    #[tokio::test]
+    async fn a_reply_is_chunked_for_the_mtu_the_link_has_learned() {
+        let dir = tempdir();
+        let (_, _) = FakeDaemon::spawn(dir.path(), "configd.sock", vec![pin_reply("424242")]);
+        let (_, _) = FakeDaemon::spawn(dir.path(), "updaterd.sock", vec![]);
+        let (_, _) = FakeDaemon::spawn(
+            dir.path(),
+            "robotd.sock",
+            vec![r#"{"jsonrpc":"2.0","id":2,"result":{"healthy":true}}"#.into()],
+        );
+
+        let mtu = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(20));
+        let (link, to_robot, mut from_robot) = Link::pair_sharing_mtu(mtu.clone(), "AA:BB");
+        tokio::spawn(run(
+            link,
+            sockets(dir.path(), "updaterd.sock", "robotd.sock"),
+        ));
+
+        // At the floor, so the authentication answer goes out in 20-byte pieces.
+        to_robot
+            .send(
+                b"{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"system.authenticate\",\"params\":{\"pin\":\"424242\"}}\n"
+                    .to_vec(),
+            )
+            .await
+            .unwrap();
+        let (reply, sizes) = read_reply_in_chunks(&mut from_robot).await;
+        assert!(reply.contains(r#""authenticated":true"#), "{reply}");
+        assert!(
+            sizes.len() > 1,
+            "a floor-sized reply arrived whole: {sizes:?}"
+        );
+        assert!(
+            sizes.iter().all(|&n| n <= 20),
+            "a chunk exceeded the floor: {sizes:?}"
+        );
+
+        // What the write callback does on a real link, once BlueZ has reported the MTU.
+        mtu.store(182, std::sync::atomic::Ordering::Relaxed);
+
+        to_robot
+            .send(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"robot.health\"}\n".to_vec())
+            .await
+            .unwrap();
+        let (reply, sizes) = read_reply_in_chunks(&mut from_robot).await;
+        assert!(reply.contains(r#""healthy":true"#), "{reply}");
+        assert_eq!(
+            sizes.len(),
+            1,
+            "the reply was still cut up for the floor: {sizes:?}"
         );
     }
 

--- a/configd/Cargo.toml
+++ b/configd/Cargo.toml
@@ -15,7 +15,9 @@ description = "Wifi and robot identity — the config service"
 duck-ipc-proto = { path = "../duck-ipc-proto" }
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal"] }
+# `process` is for reading the journal: `logs` spawns `journalctl` rather than linking libsystemd
+# for one read-only query. See that module for why.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal", "process"] }
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/configd/src/lib.rs
+++ b/configd/src/lib.rs
@@ -27,6 +27,7 @@
 #[cfg(target_os = "linux")]
 pub mod bluez;
 pub mod identity;
+pub mod logs;
 pub mod net;
 #[cfg(target_os = "linux")]
 pub mod nm;

--- a/configd/src/logs.rs
+++ b/configd/src/logs.rs
@@ -145,6 +145,23 @@ pub async fn read(
     ))
 }
 
+/// The pid a line was written by, if the line is the daemon's own.
+///
+/// `short-iso` puts the writer in the second field, as `robotd[3227]:` — or as `systemd[1]:` for
+/// the lines systemd writes *about* the unit, which `journalctl -u` returns alongside it. Those
+/// are the reason this checks the identifier: `Stopping`, `Stopped` and `Started` all come from
+/// pid 1, so a bare "the pid changed" would announce a new process three times per restart and
+/// name the wrong one.
+#[cfg(any(target_os = "linux", test))]
+fn pid_of(line: &str, service: &str) -> Option<u32> {
+    let field = line.split_whitespace().nth(1)?.strip_suffix(':')?;
+    let (identifier, pid) = field.strip_suffix(']')?.split_once('[')?;
+    if identifier != service {
+        return None;
+    }
+    pid.parse().ok()
+}
+
 /// Turn `journalctl`'s output into a reply that fits the wire.
 ///
 /// Split out from [`read`] so the trimming is testable without a journal, which is the half with
@@ -153,12 +170,27 @@ pub async fn read(
 /// escaping is what makes an estimate wrong.
 #[cfg(any(target_os = "linux", test))]
 fn assemble(unit: &'static str, stdout: &str) -> proto::LogsResult {
-    let mut lines: Vec<String> = stdout
-        .lines()
-        .map(str::trim_end)
-        .filter(|line| !line.is_empty())
-        .map(truncate_line)
-        .collect();
+    let service = crate::units::service_of(unit);
+    let mut lines: Vec<String> = Vec::new();
+    let mut writer: Option<u32> = None;
+
+    for line in stdout.lines().map(str::trim_end).filter(|l| !l.is_empty()) {
+        if let Some(pid) = pid_of(line, service) {
+            // The tail a person reads spans restarts without saying so: a release is installed,
+            // every daemon restarts, and forty lines carry two different builds with nothing
+            // between them. systemd's own `Started …` line is in there, but it is one line among
+            // forty identical warnings and it reads as just another one.
+            //
+            // `-- … --` is `journalctl`'s own shape for a line it inserted rather than recorded
+            // (`-- Reboot --`, `-- No entries --`), so it is the form a reader already knows not
+            // to attribute to the daemon.
+            if writer.is_some_and(|previous| previous != pid) {
+                lines.push(format!("-- new {service} process, pid {pid} --"));
+            }
+            writer = Some(pid);
+        }
+        lines.push(truncate_line(line));
+    }
 
     let mut truncated = false;
     while serde_json::to_string(&lines).map_or(0, |json| json.len()) > proto::MAX_LOG_BYTES
@@ -243,6 +275,90 @@ mod tests {
         let result = assemble("robotd.service", "one\ntwo\n\nthree\n");
         assert_eq!(result.lines, ["one", "two", "three"]);
         assert!(!result.truncated);
+    }
+
+    /// A tail that spans a restart says so, once, naming the process that took over.
+    #[test]
+    fn a_restart_is_marked_where_it_happened() {
+        let stdout = "\
+2026-09-09T12:27:19+00:00 robotd[965]: old build, still running
+2026-09-09T12:27:20+00:00 systemd[1]: Stopping robotd.service - Robot control daemon...
+2026-09-09T12:27:20+00:00 systemd[1]: Stopped robotd.service - Robot control daemon.
+2026-09-09T12:27:20+00:00 systemd[1]: Starting robotd.service - Robot control daemon...
+2026-09-09T12:27:21+00:00 robotd[3227]: control loop running
+2026-09-09T12:27:24+00:00 robotd[3227]: bus read failed
+";
+        let lines = assemble("robotd.service", stdout).lines;
+
+        // systemd's three lines come from pid 1 and must not each announce a new process.
+        assert_eq!(
+            lines.iter().filter(|l| l.starts_with("-- ")).count(),
+            1,
+            "{lines:#?}"
+        );
+        // Immediately before the first line of the new process, not where systemd spoke.
+        let at = lines
+            .iter()
+            .position(|l| l.starts_with("-- "))
+            .expect("a marker");
+        assert_eq!(lines[at], "-- new robotd process, pid 3227 --");
+        assert!(lines[at + 1].contains("control loop running"), "{lines:#?}");
+        assert!(
+            lines[at - 1].contains("Starting robotd.service"),
+            "{lines:#?}"
+        );
+    }
+
+    /// One process for the whole tail is the ordinary case, and it gets no marker at all —
+    /// including for the very first line, whose pid this has nothing to compare against.
+    #[test]
+    fn one_process_is_not_marked() {
+        let stdout = "\
+2026-09-09T12:27:21+00:00 robotd[3227]: control loop running
+2026-09-09T12:27:24+00:00 robotd[3227]: bus read failed
+";
+        let lines = assemble("robotd.service", stdout).lines;
+        assert_eq!(lines.len(), 2, "{lines:#?}");
+        assert!(!lines.iter().any(|l| l.starts_with("-- ")), "{lines:#?}");
+    }
+
+    /// A daemon that has restarted twice in one tail is marked twice.
+    #[test]
+    fn every_restart_in_the_tail_is_marked() {
+        let stdout = "\
+2026-09-09T12:00:00+00:00 btd[1]: first
+2026-09-09T12:00:01+00:00 btd[2]: second
+2026-09-09T12:00:02+00:00 btd[3]: third
+";
+        let lines = assemble("btd.service", stdout).lines;
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|l| l.starts_with("-- new btd process"))
+                .count(),
+            2,
+            "{lines:#?}"
+        );
+    }
+
+    /// The unit's *own* lines are what carry the pid. A line from anything else — systemd, or a
+    /// child process logging under its own name — cannot start a marker or the tail would be full
+    /// of them.
+    #[test]
+    fn only_the_daemons_own_lines_carry_a_pid() {
+        assert_eq!(
+            pid_of("2026-09-09T12:27:21+00:00 robotd[3227]: hello", "robotd"),
+            Some(3227)
+        );
+        for line in [
+            "2026-09-09T12:27:20+00:00 systemd[1]: Started robotd.service.",
+            "2026-09-09T12:27:20+00:00 setsid[4010]: a child of the daemon",
+            "2026-09-09T12:27:20+00:00 robotd: an identifier with no pid",
+            "not a journal line at all",
+            "",
+        ] {
+            assert_eq!(pid_of(line, "robotd"), None, "{line}");
+        }
     }
 
     /// Over budget, the *newest* lines survive — the ones somebody asked for.

--- a/configd/src/logs.rs
+++ b/configd/src/logs.rs
@@ -1,0 +1,291 @@
+//! The tail of one daemon's journal, for a client that has no shell on the robot.
+//!
+//! [`units`](crate::units) answers "is `robotd` running"; this answers the question that follows a
+//! `failed` — *why*. Until it existed the only answer was `journalctl` over ssh, which needs a
+//! network the robot may not have and an address a phone cannot reach. The robot whose journal
+//! somebody actually needs is the one whose wifi never came up.
+//!
+//! **`configd` reads it because reading the journal needs privilege**, the same reason
+//! [`units`](crate::units) is here: it runs as root (see `systemd/configd.service`), and
+//! `robotctl` does not. On the robot itself nobody should use this — `journalctl` is right there,
+//! with `-g`, `--since` and a pager. This is for the transports that have none of that.
+//!
+//! ## Why it shells out to `journalctl`
+//!
+//! Reading the journal in-process means linking `libsystemd`, which means vendored C in a
+//! cross-compiled build for one read-only query. `journalctl` is on every board this ships to,
+//! it is already how the updater talks to systemd (`updater::engine` spawns `systemctl`), and
+//! the sandbox in this service's unit permits it: `ProtectSystem=strict` leaves `/usr/bin`
+//! readable, and root can read the journal without any capability.
+//!
+//! ## Why it takes a unit name and not arguments
+//!
+//! This call is reachable from a phone in radio range (`btd::route`). `journalctl` arguments are
+//! not a language to hand such a peer — `-D` reads another journal directory, `_PID=` matches
+//! anything on the box — so the unit is chosen from a fixed list and everything else is refused
+//! by name. What that costs is the searching a person with a shell would do. What it buys is that
+//! the worst any client can ask for is the tail of a daemon this project ships.
+
+use duck_ipc_proto as proto;
+
+/// Units that are not part of a daemon release but whose journals answer *our* failures.
+///
+/// Both earn their place by being the thing that is broken when the robot cannot be reached at
+/// all: BlueZ, when no phone can see the robot, and NetworkManager, when wifi never came up.
+/// Neither is ours, which is exactly why their logs are otherwise unreachable — nothing in
+/// `system.services` reports on them either.
+pub const ALSO_LOGGABLE: [&str; 2] = ["bluetooth.service", "NetworkManager.service"];
+
+/// Every unit whose journal this service will read, in the order a reader wants them.
+///
+/// Derived from [`crate::units::MANAGED`] rather than repeated, so a unit added to a release
+/// becomes readable here without anyone remembering this file — the mistake that list's own doc
+/// records having made once.
+pub fn loggable() -> impl Iterator<Item = &'static str> {
+    crate::units::MANAGED.into_iter().chain(ALSO_LOGGABLE)
+}
+
+/// Longest single line kept, in bytes.
+//
+// Off Linux there is no `read` to call these, and only the tests do — the same shape
+// `units::describe` takes, where the Linux half is the real one and the other half exists so a
+// laptop can still build and test the crate.
+#[cfg(any(target_os = "linux", test))]
+///
+/// journald accepts a stdout line up to its own `LineMax` (48 KiB by default), so one daemon
+/// logging a serialised blob could otherwise fill a whole reply with one entry and push out the
+/// hundred lines around it — which is the opposite of what a tail is for. Truncated with an
+/// ellipsis, so a reader can see that the line went on.
+const MAX_LINE_BYTES: usize = 2 * 1024;
+
+/// Resolve a caller's unit name against [`loggable`].
+///
+/// `robotd` and `robotd.service` both work: a caller typing the daemon's name should not have to
+/// know that systemd spells it with a suffix. The answer is the canonical name, so the reply says
+/// what was actually read.
+pub fn resolve(name: &str) -> Option<&'static str> {
+    let wanted = name.trim();
+    let wanted = wanted.strip_suffix(".service").unwrap_or(wanted);
+    // Case-insensitive for `NetworkManager` alone, really: nobody types that capitalisation from
+    // memory, and refusing `networkmanager` would be a puzzle rather than a guard.
+    loggable().find(|unit| {
+        unit.strip_suffix(".service")
+            .unwrap_or(unit)
+            .eq_ignore_ascii_case(wanted)
+    })
+}
+
+/// What to tell a caller that named something else. Names the real list, the way `pad.bind`
+/// refuses an unknown skill: a typo should come back as the answer, not as a shrug.
+pub fn refusal(name: &str) -> proto::Error {
+    proto::Error::new(
+        proto::code::INVALID_PARAMS,
+        format!(
+            "no journal here for {name:?}; readable units are {}",
+            loggable().collect::<Vec<_>>().join(", ")
+        ),
+    )
+}
+
+/// Read the tail of a unit's journal.
+///
+/// `unit` must have come from [`resolve`] — that is what keeps a caller's string out of
+/// `journalctl`'s argument list.
+#[cfg(target_os = "linux")]
+pub async fn read(
+    unit: &'static str,
+    lines: usize,
+    boot: i32,
+) -> Result<proto::LogsResult, String> {
+    let lines = lines.clamp(1, proto::MAX_LOG_LINES);
+
+    let output = tokio::process::Command::new("journalctl")
+        .arg("--unit")
+        .arg(unit)
+        // `--boot=-1` as one argument rather than `-b -1`: an offset that starts with a dash is
+        // otherwise ambiguous with an option, and which of the two `journalctl` decides it is has
+        // changed between versions.
+        .arg(format!("--boot={boot}"))
+        .arg("--lines")
+        .arg(lines.to_string())
+        .arg("--no-pager")
+        // The timestamp is the point — a log line with no time answers nothing — and the
+        // `robotd[1234]:` prefix carries the PID, which is how a restart shows up in a tail.
+        // The hostname is the one field that is the same on every line and known already.
+        .arg("--output=short-iso")
+        .arg("--no-hostname")
+        .output()
+        .await
+        .map_err(|e| format!("could not run journalctl: {e}"))?;
+
+    if !output.status.success() {
+        // journalctl's own words, which for the case a caller will actually hit — a boot that is
+        // not in the journal — are already the right answer ("Data from the specified boot (-1) is
+        // not available"). Ours would be a worse paraphrase.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.lines().next().unwrap_or("no output").trim();
+        return Err(format!("journalctl refused: {detail}"));
+    }
+
+    Ok(assemble(unit, &String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Off the board there is no journal to read, and inventing one would make a laptop look like a
+/// robot. An error rather than an empty answer, for the same reason [`crate::units::describe`]
+/// reports `Unknown` off Linux: "there is nothing here to read" and "this daemon said nothing"
+/// are different answers.
+#[cfg(not(target_os = "linux"))]
+pub async fn read(
+    unit: &'static str,
+    _lines: usize,
+    _boot: i32,
+) -> Result<proto::LogsResult, String> {
+    Err(format!(
+        "no systemd journal on this host, so nothing to read for {unit}"
+    ))
+}
+
+/// Turn `journalctl`'s output into a reply that fits the wire.
+///
+/// Split out from [`read`] so the trimming is testable without a journal, which is the half with
+/// the decisions in it: **oldest lines go first**, because the newest are the ones somebody asked
+/// for, and the budget is measured on the serialised form rather than estimated, since JSON
+/// escaping is what makes an estimate wrong.
+#[cfg(any(target_os = "linux", test))]
+fn assemble(unit: &'static str, stdout: &str) -> proto::LogsResult {
+    let mut lines: Vec<String> = stdout
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(truncate_line)
+        .collect();
+
+    let mut truncated = false;
+    while serde_json::to_string(&lines).map_or(0, |json| json.len()) > proto::MAX_LOG_BYTES
+        && !lines.is_empty()
+    {
+        lines.remove(0);
+        truncated = true;
+    }
+
+    proto::LogsResult {
+        unit: unit.to_owned(),
+        lines,
+        truncated,
+    }
+}
+
+/// One line, bounded. Cuts on a character boundary, since the reply has to be valid UTF-8.
+#[cfg(any(target_os = "linux", test))]
+fn truncate_line(line: &str) -> String {
+    if line.len() <= MAX_LINE_BYTES {
+        return line.to_owned();
+    }
+    let mut end = MAX_LINE_BYTES;
+    while end > 0 && !line.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &line[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_daemon_is_named_with_or_without_the_suffix() {
+        assert_eq!(resolve("robotd"), Some("robotd.service"));
+        assert_eq!(resolve("robotd.service"), Some("robotd.service"));
+        assert_eq!(resolve(" btd "), Some("btd.service"));
+    }
+
+    /// Nobody types that capitalisation from memory.
+    #[test]
+    fn networkmanager_is_matched_whatever_the_case() {
+        assert_eq!(resolve("networkmanager"), Some("NetworkManager.service"));
+        assert_eq!(resolve("NetworkManager"), Some("NetworkManager.service"));
+    }
+
+    /// The guard the BLE route depends on: anything not on the list is refused, including the
+    /// shapes somebody would try if they were treating this as a `journalctl` command line.
+    #[test]
+    fn anything_else_is_refused() {
+        for name in [
+            "sshd",
+            "",
+            "robotd.service extra",
+            "--directory=/run/log/journal",
+            "_PID=1",
+            "*",
+        ] {
+            assert_eq!(resolve(name), None, "{name} resolved");
+        }
+    }
+
+    /// A unit added to a release becomes readable without touching this file.
+    #[test]
+    fn every_managed_unit_is_loggable() {
+        for unit in crate::units::MANAGED {
+            assert_eq!(resolve(unit), Some(unit), "{unit} is not loggable");
+        }
+    }
+
+    #[test]
+    fn the_refusal_names_the_units_it_would_accept() {
+        let message = refusal("sshd").message;
+        assert!(message.contains("sshd"), "{message}");
+        assert!(message.contains("robotd.service"), "{message}");
+        assert!(message.contains("NetworkManager.service"), "{message}");
+    }
+
+    #[test]
+    fn a_tail_comes_back_oldest_first_with_blank_lines_dropped() {
+        let result = assemble("robotd.service", "one\ntwo\n\nthree\n");
+        assert_eq!(result.lines, ["one", "two", "three"]);
+        assert!(!result.truncated);
+    }
+
+    /// Over budget, the *newest* lines survive — the ones somebody asked for.
+    #[test]
+    fn an_oversized_tail_keeps_the_end_and_says_it_was_cut() {
+        let stdout: String = (0..4000)
+            .map(|i| format!("2026-09-09T12:00:00+0200 robotd[1]: line {i}\n"))
+            .collect();
+
+        let result = assemble("robotd.service", &stdout);
+
+        assert!(result.truncated);
+        assert!(
+            serde_json::to_string(&result.lines).unwrap().len() <= proto::MAX_LOG_BYTES,
+            "reply is over the budget the transport can carry"
+        );
+        assert!(
+            result.lines.last().unwrap().ends_with("line 3999"),
+            "dropped from the wrong end: {:?}",
+            result.lines.last()
+        );
+    }
+
+    /// One daemon logging a serialised blob must not push out the lines around it.
+    #[test]
+    fn a_single_enormous_line_is_cut_rather_than_taking_the_whole_reply() {
+        let stdout = format!("prefix {}\nafter\n", "x".repeat(60 * 1024));
+        let result = assemble("robotd.service", &stdout);
+
+        assert_eq!(result.lines.len(), 2);
+        assert!(result.lines[0].len() <= MAX_LINE_BYTES + '…'.len_utf8());
+        assert!(result.lines[0].ends_with('…'));
+        assert_eq!(result.lines[1], "after");
+        assert!(!result.truncated);
+    }
+
+    /// Cutting a multi-byte character in half would make the reply invalid UTF-8, and the line
+    /// that will hit this is a log message with an arrow or an accent in it — which ours have.
+    #[test]
+    fn a_line_is_cut_on_a_character_boundary() {
+        let line = "é".repeat(MAX_LINE_BYTES);
+        let cut = truncate_line(&line);
+        assert!(cut.ends_with('…'));
+        assert!(cut.len() <= MAX_LINE_BYTES + '…'.len_utf8());
+    }
+}

--- a/configd/src/main.rs
+++ b/configd/src/main.rs
@@ -11,7 +11,7 @@ use configd::net::{FakeNet, Net};
 use configd::pad::{FakePads, Pads};
 use configd::power;
 use configd::store::Store;
-use configd::{pad, units};
+use configd::{logs, pad, units};
 use duck_ipc_proto as proto;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -444,6 +444,27 @@ async fn dispatch(
         // question support asks first, and needing privilege to ask it would put it out of reach of
         // exactly the person diagnosing a robot.
         proto::Call::SystemServices => proto::Response::ok(Some(id), &units::all().await),
+
+        // Read-only, and not gated behind `may_mutate` for the same reason as the line above: the
+        // person who needs a daemon's last words is the person diagnosing a robot, and needing
+        // privilege to read them would put them out of that person's reach.
+        //
+        // The unit is resolved against a fixed list *before* it reaches `journalctl`, which is
+        // what makes this safe to route over BLE — see `logs` for the boundary and `btd::route`
+        // for the decision to route it.
+        proto::Call::SystemLogs(params) => match logs::resolve(&params.unit) {
+            None => proto::Response::err(Some(id), logs::refusal(&params.unit)),
+            Some(unit) => match logs::read(unit, params.lines, params.boot).await {
+                Ok(result) => proto::Response::ok(Some(id), &result),
+                // INTERNAL rather than INVALID_PARAMS: the request was well-formed and something
+                // on the board could not answer it. The one exception a caller will actually meet
+                // — a boot that is not in the journal — carries journalctl's own wording.
+                Err(e) => proto::Response::err(
+                    Some(id),
+                    proto::Error::new(proto::code::INTERNAL_ERROR, e),
+                ),
+            },
+        },
 
         proto::Call::SystemInfo => proto::Response::ok(
             Some(id),

--- a/configd/src/units.rs
+++ b/configd/src/units.rs
@@ -93,8 +93,9 @@ pub async fn describe(unit: &str) -> proto::ServiceUnit {
     }
 }
 
-/// `btd.service` names the service `btd`, which is what it publishes under.
-fn service_of(unit: &str) -> &str {
+/// `btd.service` names the service `btd`, which is what it publishes under — and, with a pid
+/// after it, what it logs under. [`crate::logs`] reads it for the second reason.
+pub fn service_of(unit: &str) -> &str {
     unit.strip_suffix(".service").unwrap_or(unit)
 }
 

--- a/configd/systemd/configd.service
+++ b/configd/systemd/configd.service
@@ -71,6 +71,12 @@ RestartSec=2s
 #   - CAP_SYS_BOOT is NOT granted, because logind performs the reboot; configd only asks. A
 #     capability here would let it call reboot(2) directly, which is precisely the unclean
 #     shutdown this service exists to avoid.
+#
+# `system.logs` spawns `journalctl` (see `configd::logs`) and needs nothing added here, which is
+# worth stating so nobody loosens this file for it: /usr stays executable under
+# ProtectSystem=strict, and the journal files are 0640 root:systemd-journal — so uid 0 reads them
+# as their owner, with the capability bounding set still empty. If a future kernel or journald
+# changes that, the fix is a SupplementaryGroups=systemd-journal, not a capability.
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes

--- a/docs/design/app-path-design.md
+++ b/docs/design/app-path-design.md
@@ -386,6 +386,40 @@ the tidier model and needs `btd` to know when a call ended, which needs it to pa
 never does (§3), and that property is what keeps the routed subset a transport rather than a second
 implementation of the API.
 
+### 3.6 A reply bigger than one burst, and the MTU the notify side cannot ask  · **measured**
+
+`bluer`'s callback model — the one that works here, for the reason in `btd/src/bluez.rs`'s header —
+gives the notify side neither of the two things a sender needs. It cannot ask what the link
+negotiated, and `notify` returns as soon as a D-Bus signal is queued, so nothing tells the pump when
+the radio has caught up. Both gaps were papered over by sizing every reply for the 20-byte floor and
+firing chunks as fast as the loop would spin.
+
+Measured against the board from a Mac, asking `system.logs` for a journal tail:
+
+| reply | notifications at the floor | what happened |
+|---|---|---|
+| ~5 KiB (24 lines) | ≈265 | delivered, in 1.83 s |
+| ~7 KiB (32 lines) | ≈350 | the notification session was torn down 150 ms in |
+
+The second row is the one that cost a board session to find. `btd` logged one INFO line saying the
+central had unsubscribed — it had not; CoreBluetooth still had the link up — and the client sat
+waiting out a 60-second idle budget with half an answer in its reassembler and no error to report.
+The pump was reading `notify`'s single error as "the central left", when a full queue and a departed
+central are the same `Err` from `bluer` and only `is_stopped()` tells them apart.
+
+Three changes, none of them a real solution, because the model has no readiness signal to offer:
+
+- **The payload comes from the write side.** BlueZ reports the negotiated MTU on every inbound
+  write, one ATT MTU serves both directions, and a central always writes before there is a reply to
+  send — `system.authenticate` is the first write of every session. So a session opens at the floor
+  and is sized properly from its first answer onward, roughly a tenfold cut in notifications.
+- **The pump pauses every 16 chunks**, about a connection interval. A small reply never pauses.
+- **A refused chunk is retried** rather than read as a disconnect, and giving up now logs a warning
+  saying so.
+
+What would solve it properly is the IO model's `sendable()`, and that stays out of reach: it serves
+only the `Acquire*` fd paths, which a CoreBluetooth central does not drive.
+
 ## 5. Pairing: just-works, and a PIN the transport checks
 
 A six-digit PIN, stored by `configd`, checked by `btd` before it serves anything. **Not** by the

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -271,6 +271,17 @@ refused with that list.
 Lines go to stdout and everything else to stderr, so `logs robotd -n 200 | grep -i panic` works.
 A long tail is trimmed to what the radio can carry, oldest lines first, with a note saying so.
 
+A tail that spans a restart says where:
+
+```
+2026-09-09T12:27:20+00:00 systemd[1]: Starting robotd.service - Robot control daemon...
+-- new robotd process, pid 3227 --
+2026-09-09T12:27:21+00:00 robotd[3227]: control loop running joints=15 hz=50.0 driving=true
+```
+
+Which matters after an update, when forty lines carry two different builds' output. Anything in
+`-- … --` comes from the robot rather than the journal.
+
 There is no `-f`, no `--since` and no search. For those, ssh in:
 
 ```bash

--- a/docs/robot/duckctl.md
+++ b/docs/robot/duckctl.md
@@ -248,6 +248,39 @@ duckctl --name <robot-name> version
 The API version, the release, and the git revision it was built from. A `revision` of `null` means
 the release was built on somebody's laptop rather than by CI.
 
+## Logs
+
+```bash
+duckctl --name <robot-name> logs robotd
+```
+
+The last 40 lines of that daemon's journal, this boot. For more, and for the boot before this one:
+
+```bash
+duckctl --name <robot-name> logs robotd -n 200
+```
+
+```bash
+duckctl --name <robot-name> logs btd --boot -1
+```
+
+Readable units: `updaterd`, `robotd`, `configd`, `btd`, `padd`, `mediad`, `tofd`, plus
+`bluetooth` and `NetworkManager`. The `.service` suffix is optional, and anything else comes back
+refused with that list.
+
+Lines go to stdout and everything else to stderr, so `logs robotd -n 200 | grep -i panic` works.
+A long tail is trimmed to what the radio can carry, oldest lines first, with a note saying so.
+
+There is no `-f`, no `--since` and no search. For those, ssh in:
+
+```bash
+ssh radxa@$(duckctl --name <robot-name> ip)
+```
+
+```bash
+journalctl -u robotd -f
+```
+
 ## Updates
 
 Same words as `robotctl update`, so a command learned on the robot works here. Every one of them
@@ -549,7 +582,8 @@ minutes with nothing arriving at all — which is why they are the way to run an
 ## What it prints
 
 Replies go to stdout as pretty JSON, and everything else — progress, diagnosis, what the radio
-saw — to stderr. So `duckctl ... info > reply.json` keeps the two apart, and a JSON-RPC error
+saw — to stderr. `logs` is the exception and prints its lines as lines, since a journal tail in
+escaped JSON is unreadable; a refusal from it still prints as JSON. So `duckctl ... info > reply.json` keeps the two apart, and a JSON-RPC error
 from the robot still exits non-zero. Progress lines start with `·` and are one line each, so
 `update apply > outcome.json` leaves them on screen and keeps the outcome in the file.
 

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -3849,6 +3849,12 @@ pub struct LogsResult {
     /// The unit as systemd names it, so a caller that typed `robotd` sees what it actually read.
     pub unit: String,
     /// Oldest first, the way a journal reads. No trailing newlines.
+    ///
+    /// **A line in `-- … --` is the robot's, not the journal's.** `journalctl` uses that shape
+    /// for what it inserts rather than recorded (`-- Reboot --`, `-- No entries --`) and this
+    /// borrows it for the one thing a tail cannot otherwise show: `-- new robotd process, pid
+    /// 3227 --`, where the daemon restarted. A tail spanning an update carries two different
+    /// builds' output, and nothing in the lines themselves says where one ends.
     pub lines: Vec<String>,
     /// Lines were dropped from the front to fit [`MAX_LOG_BYTES`]. Not an error — it is what
     /// asking for more than the radio can carry looks like, and a caller can say so.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -301,7 +301,21 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// [`RobotState::frames`] (camera, ToF, head IMU) is a few leaves — without carrying a copy of the
 /// kinematics, the same reason `frames` and `tof_beams` come from the robot. Both from the same FK
 /// `robot.look` uses. Additive: the `Vec`s are empty from a daemon predating it.
-pub const API_VERSION: u32 = 25;
+///
+/// # v26 — `system.logs`
+///
+/// The tail of one daemon's journal, over the wire. Until now the answer to "what did it say
+/// before it stopped" was `journalctl` over ssh, which needs a network the robot may not have and
+/// an address a phone has no way to reach — so the one question support asks first was the one
+/// question the wire could not answer.
+///
+/// Additive as a method, and narrow on purpose: a unit from a fixed list, a line count, and which
+/// boot. Not a `journalctl` command line — see [`LogsParams`] for why that boundary is where it is.
+///
+/// An older `configd` answers [`code::METHOD_NOT_FOUND`] naming the method, which is the designed
+/// skew and not a handshake refusal: a new `duckctl` against a robot on an older release reports
+/// that the robot is too old rather than failing obscurely.
+pub const API_VERSION: u32 = 26;
 
 /// The observation width every policy this robot family runs is built against.
 ///
@@ -668,6 +682,8 @@ pub mod method {
     pub const SYSTEM_INFO: &str = "system.info";
     /// What systemd says about each daemon, and which release each is running from.
     pub const SYSTEM_SERVICES: &str = "system.services";
+    /// The tail of one unit's journal, for a client with no shell on the robot.
+    pub const SYSTEM_LOGS: &str = "system.logs";
     /// Rename the robot. This is the name a phone sees.
     pub const SYSTEM_SET_NAME: &str = "system.setName";
     /// Reboot, cleanly, through systemd.
@@ -918,6 +934,8 @@ pub enum Call {
     // ── system.* ─────────────────────────────────────────────────────────────
     SystemInfo,
     SystemServices,
+    /// The tail of one unit's journal; see [`method::SYSTEM_LOGS`].
+    SystemLogs(LogsParams),
     SystemSetName(SetNameParams),
     SystemReboot,
     /// Read the pairing PIN.
@@ -1060,6 +1078,7 @@ impl Call {
             Call::NetForget(_) => method::NET_FORGET,
             Call::SystemInfo => method::SYSTEM_INFO,
             Call::SystemServices => method::SYSTEM_SERVICES,
+            Call::SystemLogs(_) => method::SYSTEM_LOGS,
             Call::SystemSetName(_) => method::SYSTEM_SET_NAME,
             Call::SystemReboot => method::SYSTEM_REBOOT,
             Call::SystemPairingPin => method::SYSTEM_PAIRING_PIN,
@@ -1224,6 +1243,7 @@ impl Call {
             | Call::NetForget(_)
             | Call::SystemInfo
             | Call::SystemServices
+            | Call::SystemLogs(_)
             | Call::SystemSetName(_)
             | Call::SystemReboot
             | Call::SystemPairingPin
@@ -1329,6 +1349,7 @@ impl Call {
             Call::RobotSubscribe(p) => encode(p),
             Call::NetConnect(p) => encode(p),
             Call::NetForget(p) => encode(p),
+            Call::SystemLogs(p) => encode(p),
             Call::SystemSetName(p) => encode(p),
             Call::SystemSetPairingPin(p) => encode(p),
             Call::SystemAuthenticate(p) => encode(p),
@@ -1436,6 +1457,7 @@ impl Call {
             method::NET_FORGET => Call::NetForget(decode(params)?),
             method::SYSTEM_INFO => Call::SystemInfo,
             method::SYSTEM_SERVICES => Call::SystemServices,
+            method::SYSTEM_LOGS => Call::SystemLogs(decode(params)?),
             method::SYSTEM_SET_NAME => Call::SystemSetName(decode(params)?),
             method::SYSTEM_REBOOT => Call::SystemReboot,
             method::SYSTEM_PAIRING_PIN => Call::SystemPairingPin,
@@ -1606,6 +1628,11 @@ pub mod test_support {
             }),
             Call::SystemInfo,
             Call::SystemServices,
+            Call::SystemLogs(LogsParams {
+                unit: "robotd".into(),
+                lines: 40,
+                boot: -1,
+            }),
             Call::SystemSetName(SetNameParams {
                 name: "duck-01".into(),
             }),
@@ -3777,6 +3804,57 @@ pub struct ServiceUnit {
     pub identity: Option<Identity>,
 }
 
+/// Which unit's journal to read, and how much of it. Parameters of [`Call::SystemLogs`].
+///
+/// **A unit name, not a filter expression.** The service picks from a fixed list and refuses
+/// anything else, because this call is reachable from a phone in radio range and `journalctl`
+/// arguments are not a language to hand such a peer. What that costs is `-g`, `--since` and
+/// several other things a person with a shell would reach for; what it buys is that the worst a
+/// client can ask for is the tail of a daemon this project ships.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LogsParams {
+    /// `robotd` or `robotd.service` — the service resolves either. See `configd::logs` for the
+    /// units it will read.
+    pub unit: String,
+    /// How many lines from the end. Clamped to [`MAX_LOG_LINES`], and the byte budget below
+    /// usually binds first.
+    pub lines: usize,
+    /// Which boot: `0` is the current one, `-1` the one before it, and so on backwards.
+    ///
+    /// Negative rather than an index because that is the question — "what did it say before it
+    /// restarted" — and because it is `journalctl -b`'s own convention, so the answer to "which
+    /// boot did I just read" is the same number in both places.
+    pub boot: i32,
+}
+
+/// Ceiling on [`LogsParams::lines`], applied by the service rather than trusted from the caller.
+pub const MAX_LOG_LINES: usize = 500;
+
+/// Ceiling on the serialised `lines` array, in bytes.
+///
+/// **This exists because of the transport, and it is the binding limit in practice.** BLE
+/// reassembles a reply into one line, and the client's buffer for that is bounded — a peer that
+/// never sends a newline must not be able to grow it without limit. 48 KiB leaves the rest of a
+/// JSON-RPC envelope room inside a 64 KiB client buffer, and at a typical ATT MTU it is already
+/// several seconds on the air, which is the other reason not to raise it.
+///
+/// The service drops the *oldest* lines to fit and says it did, because the newest are the ones
+/// somebody asked for.
+pub const MAX_LOG_BYTES: usize = 48 * 1024;
+
+/// Answer to [`Call::SystemLogs`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogsResult {
+    /// The unit as systemd names it, so a caller that typed `robotd` sees what it actually read.
+    pub unit: String,
+    /// Oldest first, the way a journal reads. No trailing newlines.
+    pub lines: Vec<String>,
+    /// Lines were dropped from the front to fit [`MAX_LOG_BYTES`]. Not an error — it is what
+    /// asking for more than the radio can carry looks like, and a caller can say so.
+    pub truncated: bool,
+}
+
 /// Answer to [`Call::PadStatus`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PadStatusResult {
@@ -4914,7 +4992,7 @@ mod tests {
     fn every_call_covers_every_variant() {
         assert_eq!(
             every_call().len(),
-            64,
+            65,
             "a Call variant was added or removed — update every_call() and this count"
         );
     }

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -20,6 +20,11 @@
 //! module the robot uses, so if the framing were asymmetric this would not work — which makes
 //! it a real test of the protocol rather than a reimplementation that could agree with itself.
 //!
+//! The one thing that *is* asymmetric is how long a line may be, and it has to be: the robot's cap
+//! bounds what an unpaired peer in radio range can make it buffer, and this end has no such peer.
+//! Sharing the tight one made every reply over 8 KiB unreadable here while `btd` served it
+//! correctly — see `framing::MAX_REPLY_LINE`.
+//!
 //! ```text
 //! cargo run -p duckctl -- scan          # robots in range, and their addresses
 //! cargo run -p duckctl -- status
@@ -27,6 +32,7 @@
 //! cargo run -p duckctl -- wifi connect "Pollen" --psk secret
 //! cargo run -p duckctl -- name "Ducky"
 //! cargo run -p duckctl -- call robot.health
+//! cargo run -p duckctl -- logs robotd -n 100
 //! ```
 //!
 //! `DUCK_ROBOT` and `DUCK_PIN` in the environment are the defaults for `--name` and `--pin`, for
@@ -811,6 +817,38 @@ enum Command {
         #[arg(long, default_value_t = 8080)]
         port: u16,
     },
+    /// The tail of one daemon's journal.
+    ///
+    /// `duckctl logs robotd` after a robot has misbehaved, which is the question `journalctl`
+    /// answers on the robot and nothing answered from here. Reachable with no network at all, so
+    /// it works on the robot whose wifi never came up — the one whose logs are hardest to get.
+    ///
+    /// `duckctl call system.services` names the units, and an unknown name is refused with the
+    /// real list. `bluetooth` and `NetworkManager` are readable too: they are what is broken when
+    /// the robot cannot be reached at all.
+    ///
+    /// Not a `journalctl` command line, and it never will be: this is served over a radio anyone
+    /// in range can talk to, so the robot picks the unit from a fixed list. For searching, take
+    /// the `ip` and use ssh.
+    Logs {
+        /// `robotd`, `btd`, `configd`, `updaterd`, `padd`, `mediad`, `tofd`, `bluetooth` or
+        /// `NetworkManager`. The `.service` suffix is optional.
+        #[arg(value_name = "SERVICE")]
+        service: String,
+        /// How many lines from the end.
+        ///
+        /// The default is what a BLE link carries in a couple of seconds. More is allowed and
+        /// costs proportionally — the robot trims the oldest lines to fit what the radio can
+        /// carry, and says so when it did.
+        #[arg(long, short = 'n', default_value_t = 40)]
+        lines: usize,
+        /// Which boot: `0` is this one, `-1` the one before it.
+        ///
+        /// `--boot -1` is "what did it say before it restarted", which is the reason the journal
+        /// is configured to survive a reboot at all (`deploy/journald.conf.d`).
+        #[arg(long, short = 'b', default_value_t = 0, allow_hyphen_values = true)]
+        boot: i32,
+    },
     /// Version handshake plus update status.
     Status,
     /// What the robot is running: the API version, the release, and the revision it was built from.
@@ -1471,7 +1509,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
     }
 
-    let mut reassembler = Reassembler::new();
+    // `for_replies`, not `new`: this is the client end, and the robot's answers are bounded by
+    // `MAX_REPLY_LINE` rather than by the tighter cap that limits what a radio peer may send. A
+    // `logs` tail is the reply that outgrew the other one.
+    let mut reassembler = Reassembler::for_replies();
     // The deadline is **idle**, not total: it is pushed back by every notification that arrives,
     // because a robot sending progress is a robot that is working. See `REPLY_TIMEOUT`.
     let mut deadline = tokio::time::Instant::now() + timeout;
@@ -1522,6 +1563,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 };
             }
 
+            // `logs` asked for text, so it prints text. A journal tail rendered as a JSON array
+            // of escaped strings is the one reply nobody can read, and reading it is the whole
+            // point of the command. A refusal still prints as JSON below, because the refusal
+            // names the units it would have accepted and that is worth seeing whole.
+            if let Command::Logs { service, boot, .. } = &cli.command
+                && value.get("error").is_none()
+            {
+                let _ = peripheral.disconnect().await;
+                return print_journal(&value["result"], service, *boot);
+            }
+
             println!("{}", serde_json::to_string_pretty(&value)?);
             let _ = peripheral.disconnect().await;
             // A JSON-RPC error is the robot answering, not this tool failing — so it is
@@ -1544,6 +1596,49 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             };
         }
     }
+}
+
+/// Print a journal tail: the lines on stdout, everything about them on stderr.
+///
+/// The split is what makes `duckctl logs robotd | grep panic` work — a truncation note or an
+/// empty-tail explanation in that pipe would be a line the robot never logged.
+fn print_journal(
+    result: &serde_json::Value,
+    service: &str,
+    boot: i32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let unit = result["unit"].as_str().unwrap_or(service);
+    let Some(lines) = result["lines"].as_array() else {
+        // A well-formed answer in a shape this build does not know. Printed rather than
+        // paraphrased, because the reply itself is the only evidence of what happened.
+        return Err(format!(
+            "the robot answered system.logs with no `lines`, which this version of duckctl              cannot read:\n{}",
+            serde_json::to_string_pretty(result)?
+        )
+        .into());
+    };
+
+    for line in lines {
+        match line.as_str() {
+            Some(text) => println!("{text}"),
+            None => println!("{line}"),
+        }
+    }
+
+    if lines.is_empty() {
+        // Not an error: a daemon that has not run this boot is a real answer, and it is a
+        // different one from a daemon that is running and silent. `system.services` tells them
+        // apart, so that is where this points.
+        eprintln!(
+            "no lines for {unit} in boot {boot} — it may not have run then. `duckctl call              system.services` says whether it is running now."
+        );
+    }
+    if result["truncated"] == serde_json::Value::Bool(true) {
+        eprintln!(
+            "note: older lines were dropped to fit what BLE can carry. Ask for fewer with              `-n`, or read the whole journal over ssh — `duckctl ip` has the address."
+        );
+    }
+    Ok(())
 }
 
 /// How a wait for the next notification ended.
@@ -1665,7 +1760,7 @@ async fn read_line(
     notifications: &mut (impl futures::Stream<Item = btleplug::api::ValueNotification> + Unpin),
     timeout: Duration,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let mut reassembler = Reassembler::new();
+    let mut reassembler = Reassembler::for_replies();
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
@@ -1782,6 +1877,18 @@ fn request_line(command: &Command) -> Result<(String, Duration), Box<dyn std::er
         ),
         Command::Update(update) => return update_request_line(update),
         Command::Info => ("system.info", serde_json::json!({}), REPLY_TIMEOUT),
+        // A journal read is a `journalctl` spawn on the robot plus a reply several times larger
+        // than any other, chunked at 20 bytes a notification — seconds rather than milliseconds,
+        // so it gets the slow budget for the same reason `wifi scan` does.
+        Command::Logs {
+            service,
+            lines,
+            boot,
+        } => (
+            proto::method::SYSTEM_LOGS,
+            serde_json::json!({ "unit": service, "lines": lines, "boot": boot }),
+            SLOW_REPLY_TIMEOUT,
+        ),
         Command::Health => ("robot.health", serde_json::json!({}), REPLY_TIMEOUT),
         Command::Name { name } => (
             "system.setName",
@@ -2722,6 +2829,48 @@ mod tests {
         assert!(answers_to("duck [1]", "duck [1]"));
         assert!(!answers_to("[duck-c51b]", "duck-c51b"));
         assert!(!answers_to("duck-c51b [", "duck-c51b"));
+    }
+
+    /// A negative boot offset is an argument, not a mistyped flag.
+    ///
+    /// `--boot -1` is the whole reason this command is worth having — "what did it say before it
+    /// restarted" — and clap rejects a value starting with `-` unless the argument says
+    /// otherwise. Pinned because the failure is at parse time, on the one invocation nobody
+    /// reaches for until something is already wrong.
+    #[test]
+    fn the_boot_before_this_one_can_be_asked_for() {
+        let wire = |args: &[&str]| {
+            let cli = Cli::try_parse_from([&["duckctl"], args].concat()).expect("parses");
+            request_line(&cli.command).expect("a request").0
+        };
+
+        let previous = wire(&["logs", "btd", "--boot", "-1"]);
+        assert!(
+            previous.contains(duck_ipc_proto::method::SYSTEM_LOGS),
+            "{previous}"
+        );
+        assert!(previous.contains(r#""boot":-1"#), "{previous}");
+
+        let default = wire(&["logs", "btd"]);
+        assert!(default.contains(r#""boot":0"#), "{default}");
+        assert!(default.contains(r#""lines":40"#), "{default}");
+        // The unit goes over verbatim, suffix and all: the robot resolves it against its own
+        // list, so this tool has no list to keep in step.
+        assert!(
+            wire(&["logs", "NetworkManager.service"])
+                .contains(r#""unit":"NetworkManager.service""#)
+        );
+    }
+
+    /// A journal read spawns `journalctl` and carries a reply several times larger than any
+    /// other, chunked at 20 bytes a notification. The reply budget has to match.
+    #[test]
+    fn reading_a_journal_gets_the_slow_budget() {
+        let cli = Cli::try_parse_from(["duckctl", "logs", "robotd", "-n", "500"]).expect("parses");
+        assert_eq!(
+            request_line(&cli.command).expect("a request").1,
+            SLOW_REPLY_TIMEOUT
+        );
     }
 
     /// **The Hub commands take the budget their work needs**, because the failure otherwise

--- a/mediad/src/route.rs
+++ b/mediad/src/route.rs
@@ -219,6 +219,11 @@ fn permits(call: &proto::Call) -> bool {
 
         // ── identity and status ─────────────────────────────────────────────
         SystemInfo | SystemServices | SystemSetName(_) => true,
+        // A daemon's journal tail. Read-only, and the question that follows a unit reported as
+        // `failed` — which `SystemServices` above can now say and could not explain. Permitted
+        // here for the reason `Show` is: a datachannel has room for a reply BLE has to trim,
+        // so the console is the transport where a whole screenful is cheap.
+        SystemLogs(_) => true,
         // Drops this session, and unlike an update leaves nothing mid-transition: the robot comes
         // back and the client reconnects. It is what you offer a confused robot.
         SystemReboot => true,

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -67,6 +67,22 @@ const MAX_LINE: usize = 64 * 1024;
 /// journal size cap it is what *evicts* the logs support needs.
 const LOOP_SUMMARY_INTERVAL: Duration = Duration::from_secs(300);
 
+/// How often an *isolated* dropped bus transaction is worth a line.
+///
+/// One drop is ordinary on a serial bus and a run of them is a fault, so the loop logs the first
+/// of a run and every tenth after it. That rule reads `consecutive_errors`, which resets on the
+/// next good read — so it never fired on the case a board actually produces: one drop, one good
+/// read, one drop, at about a hertz, forever `consecutive=1`. Every one of them was logged.
+///
+/// Which is the failure [`LOOP_SUMMARY_INTERVAL`] exists to prevent, arriving by another door: a
+/// journal under a size cap, filled with the most ordinary event the robot has, evicting the
+/// history somebody will need — and, since `duckctl logs` reads that journal over a radio, forty
+/// lines of it saying nothing else.
+///
+/// So an isolated drop gets one line a minute, carrying how many it stands for. A *run* is not
+/// rate-limited: that is the spasm, and it stays as loud as it was.
+const BUS_DROP_QUIET: Duration = Duration::from_secs(60);
+
 /// How fast the beak follows the vowel being sung, as a time constant.
 ///
 /// A vowel is a step — `ah` opens the mouth to 0.90 and `mm` to 0.02 — and a servo asked to jump
@@ -1694,6 +1710,11 @@ async fn control_loop<T: RobotIo>(
     let mut window_start = Instant::now();
     let mut window_ticks = 0u64;
     let mut last_summary = Instant::now();
+    // Dropped bus reads: when one was last reported, how many have gone unreported since, and how
+    // many happened in this summary window. See [`BUS_DROP_QUIET`].
+    let mut last_bus_drop: Option<Instant> = None;
+    let mut bus_drops_quiet = 0u32;
+    let mut bus_drops_window = 0u32;
     let mut was_driving = false;
     let mut bringup = Bringup::Limp;
     // A mode switch in flight: the mode to end up in, once the robot is home. `None` the rest of
@@ -1852,11 +1873,28 @@ async fn control_loop<T: RobotIo>(
             }
             Err(e) => {
                 let n = state.consecutive_errors.fetch_add(1, Ordering::Relaxed) + 1;
-                // One dropped transaction is ordinary on a serial bus; a run of them is not.
-                // Log the first and then every tenth, so a persistent fault is visible
-                // without a wall of identical lines.
-                if n == 1 || n.is_multiple_of(10) {
-                    tracing::warn!(error = %e, consecutive = n, "bus read failed");
+                bus_drops_window += 1;
+
+                // A run of them is a fault, and stays as loud as it was: every tenth, at once.
+                // An isolated drop is ordinary, and `consecutive` resets on the next good read —
+                // so `n == 1` was true of every drop on a bus that recovers each time, and
+                // logging on it filled the journal. One line per [`BUS_DROP_QUIET`], saying how
+                // many it stands for.
+                let a_run = n.is_multiple_of(10);
+                let due = last_bus_drop.is_none_or(|at| at.elapsed() >= BUS_DROP_QUIET);
+                if a_run || due {
+                    tracing::warn!(
+                        error = %e,
+                        consecutive = n,
+                        // Zero on a run, and on the first drop after a quiet spell. Non-zero is
+                        // the rate: that many more happened and were not worth their own lines.
+                        also = bus_drops_quiet,
+                        "bus read failed"
+                    );
+                    last_bus_drop = Some(Instant::now());
+                    bus_drops_quiet = 0;
+                } else {
+                    bus_drops_quiet += 1;
                 }
                 None
             }
@@ -2994,6 +3032,9 @@ async fn control_loop<T: RobotIo>(
                     total = ticks,
                     hz = format!("{hz:.1}"),
                     missed = state.missed.load(Ordering::Relaxed),
+                    // Every dropped bus read in this window, reported or suppressed. The warnings
+                    // above are rate-limited, so this is where the true rate lives.
+                    bus_drops = bus_drops_window,
                     driving,
                     fallen = safety.fallen(),
                     battery_v = format!(
@@ -3011,6 +3052,7 @@ async fn control_loop<T: RobotIo>(
                     "control loop"
                 );
                 last_summary = Instant::now();
+                bus_drops_window = 0;
             }
         }
     }

--- a/updater/src/ipc.rs
+++ b/updater/src/ipc.rs
@@ -779,6 +779,7 @@ impl Server {
             | Call::NetForget(_)
             | Call::SystemInfo
             | Call::SystemServices
+            | Call::SystemLogs(_)
             | Call::SystemSetName(_)
             | Call::SystemReboot
             | Call::SystemPairingPin


### PR DESCRIPTION
"Is `robotd` running" has had an answer over the wire since `system.services`. The question that
follows a `failed` — why — has not. The only answer was `journalctl` over ssh, which needs a network
the robot may not have and an address a phone cannot reach, and the robot whose journal somebody
actually needs is the one whose wifi never came up.

```bash
duckctl logs robotd
```

```bash
duckctl logs btd --boot -1
```

Lines go to stdout and everything about them to stderr, so `duckctl logs robotd -n 200 | grep -i
panic` works and a truncation note is never a line the robot logged. No `-f`, no `--since`, no
search — for those, take the `ip` and use ssh.

A tail that spans a restart says where, because one that spans an update carries two builds' output
and nothing in the lines themselves says which is which:

```
2026-09-09T12:27:20+00:00 systemd[1]: Starting robotd.service - Robot control daemon...
-- new robotd process, pid 3227 --
2026-09-09T12:27:21+00:00 robotd[3227]: control loop running joints=15 hz=50.0
```

Keyed on the pid of the daemon's *own* lines — `journalctl -u` returns systemd's messages about the
unit alongside them, and those all come from pid 1, so a bare "the pid changed" would announce a new
process three times per restart and name the wrong one. In `configd`, so the console and the phone
app get it too, and in `journalctl`'s own `-- … --` shape for a line it inserted rather than
recorded.

## Where it is served

`configd`, for the same reason it answers `system.services`: reading the journal needs privilege
`robotctl` does not have. It spawns `journalctl` rather than linking libsystemd — vendored C in a
cross-compiled build for one read-only query — which is already how the updater talks to systemd.
The sandbox in `configd.service` permits it unchanged, and the unit now says so, so nobody loosens
that file for this: `/usr` stays executable under `ProtectSystem=strict`, and the journal files are
`0640 root:systemd-journal`, so uid 0 reads them as their owner with the capability bounding set
still empty. Verified on the board — called on its socket directly, `system.logs` answers in 0.04 s.

## A unit from a fixed list, not a `journalctl` command line

This is routed over BLE, so the caller may be a phone in radio range, and `journalctl` arguments are
not a language to hand such a peer: `-D` reads another journal directory, `_PID=` matches anything on
the box. The readable list is `units::MANAGED` plus `bluetooth` and `NetworkManager` — the two that
are broken when the robot cannot be reached at all, and the two nothing else on the wire reports on.
It is derived from `MANAGED` rather than repeated, so a unit added to a release becomes readable
without anyone remembering that file. Anything else is refused, naming the list.

The reply is trimmed to what the transport can carry, oldest lines first, because the newest are the
ones somebody asked for. Measured on the serialised form rather than estimated, since JSON escaping
is what makes an estimate wrong, and one enormous line is cut rather than allowed to push out the
hundred around it.

## The transport could not carry it, and that was not a logs bug

The first `duckctl logs robotd` against a board hung with no error at all. It found two faults in
`btd`'s notify pump that any reply this size hits — which is also why `update.show` was never usable
from a laptop.

Measured from a Mac against olducky:

| reply | notifications at the 20-byte floor | what happened |
|---|---|---|
| ~5 KiB (24 lines) | ≈265 | delivered, in 1.83 s |
| ~7 KiB (32 lines) | ≈350 | notification session torn down 150 ms in |

**A full queue is not a departed central.** `bluer`'s `notify` returns the same
`NotificationSessionStopped` for "the central unsubscribed" and "the D-Bus connection would not take
this signal", and the pump read both as the central leaving. So a reply too big for one burst ended
the session mid-line, while the client — link still up as far as CoreBluetooth was concerned — waited
out its idle timeout with half an answer and nothing to blame. `is_stopped()` is what distinguishes
them. A chunk is now retried, and only a stopped session or an exhausted budget ends anything; giving
up logs a warning, where the old line was `debug` and the visible one blamed the client.

**The payload now comes from the write side.** The notify side still cannot ask BlueZ what the link
negotiated, and the IO model — which has both an MTU and a real `sendable()` — still serves only the
`Acquire*` paths a CoreBluetooth central never drives (bf0d5f9, on hardware). But BlueZ reports the
MTU on every inbound *write*, one ATT MTU serves both directions, and a central always writes before
there is a reply to send: `system.authenticate` is the first write of every session. So `Link`
carries a shared cell, a session opens at the floor, and every reply after that first write is sized
for the real link — roughly a tenfold cut in notifications. Read once per line, never per chunk.

**And the pump paces itself** — sixteen chunks, then about a connection interval. That is a
workaround for a missing readiness signal rather than flow control, and it says so.

`app-path-design.md` §3.6 carries the measurements; a session test pins the ordering the MTU trick
depends on.

## The framing cap had to split in two

`btd::framing::MAX_LINE` bounds what an *unpaired peer in radio range* can make the robot buffer, so
it is deliberately tight at 8 KiB — and `duckctl` was reusing it for the reply direction, where there
is no such peer. Every answer over 8 KiB therefore died in the client as "no newline within 8192
bytes", which reads like a broken robot and is not one.

`MAX_REPLY_LINE` is the client's bound, `Reassembler::for_replies` is how a client asks for it, and
`LineTooLong` now carries the limit it hit so the message says which of the two it was.

Permitted over WebRTC as well, for the reason `update.show` is: a datachannel has room for a reply
BLE has to trim.

## API v26

Additive. An older `configd` answers `METHOD_NOT_FOUND` naming the method, so a new `duckctl` against
an un-updated robot says the robot is too old rather than failing obscurely. Both halves come out of
one release.

## The journal was also drowning in one ordinary event

The first tail this feature returned was forty lines of nothing but
`bus read failed … consecutive=1`, about one a second. `robotd`'s dedup — log the first of a run and
every tenth — reads `consecutive_errors`, which resets on the next good read, so on a bus that drops
one transaction and recovers, *every* drop is the first of its run and gets logged. The rule only
ever suppressed a continuous run, which is the one case a board does not produce.

That is the failure `LOOP_SUMMARY_INTERVAL` exists to prevent arriving by another door: a journal
under a 200 MB cap, filled with the most ordinary event the robot has, evicting what support will
ask for. An isolated drop now gets one line a minute carrying `also=N`, the five-minute summary
gains `bus_drops` so the true rate survives the rate-limiting, and a *run* is untouched — every
tenth, immediately, because that is the spasm these lines exist for.

## What has run on hardware

On olducky, before the transport fix: `system.logs` direct on configd's socket (0.04 s, correct
output, `--output=short-iso --no-hostname` accepted on that systemd), and `duckctl logs robotd` over
BLE up to `-n 24`, with `-n 32` reproducing the tear-down above.

After it, dev-pushed and confirmed on the board: `duckctl logs robotd -n 200` returns, and the link
reports `negotiated notification payload=514` — a 517-byte ATT MTU, so the 32-line reply that used to
kill the session is ~16 notifications instead of ~350.

The `robotd` log change is on the board too, and this is it working — 62 seconds apart, the second
line standing for the 24 drops that did not get their own:

    12:27:24 WARN robotd: bus read failed error=… Operation timed out consecutive=1 also=0
    12:28:26 WARN robotd: bus read failed error=… Operation timed out consecutive=1 also=24

About 25 lines a minute before, one after.

Unrelated and pre-existing, noted so nobody blames this branch: `robotd`'s
`non_socket_paths_are_not_removed` integration test fails on macOS — the daemon does not refuse to
start over a regular file at the socket path there — identically with these commits stashed. CI runs
Linux, where it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



