### PR TITLE
The theremin ships off, like the chorale

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -292,8 +292,16 @@ mode = "walk"
 # The ToF theremin: a hand's distance in front of the beak becomes a note, and the mouth
 # opens with the pitch. Picked up with `robotctl theremin` (or `robot.theremin`) — this
 # switch is only whether it *can* be, so a duck with a known-bad ToF can refuse outright.
+#
+# **Off by default.** It is a party trick, and a duck nobody asked to play one has no
+# business holding a subscription to the depth stream; `robotctl theremin` on a duck that has
+# not opted in says so and names this key. Turning it on does not start anything by itself.
+#
+# Nothing else changes with it: `tofd` runs and polls the sensor either way, so
+# `robotctl monitor`'s ToF grid works the same whichever way this is set.
+#
 # Needs [audio] on: a theremin with no voice is a mouth opening for no reason.
-# enabled = true
+# enabled = false
 
 # tofd's depth stream.
 # socket = "/run/tofd/tof.sock"

--- a/docs/project/idle-cpu.md
+++ b/docs/project/idle-cpu.md
@@ -35,8 +35,11 @@ find one frame, six of them answered no. The loop now sits out the stretch in wh
 cannot yet have one and polls through the rest. Frame age is unchanged — still bounded by the
 10 ms poll, which is the granularity a frame is noticed at either way.
 
-This runs on every duck with a ToF fitted whether or not anyone uses the theremin, because
-`robotd`'s depth reader subscribes at startup rather than when the instrument is picked up.
+This runs on every duck with a ToF fitted whether or not anyone uses the theremin: `tofd`
+ranges continuously and sends to whoever happens to be subscribed, so no subscriber is the
+normal state and none of this poll is conditional on one. `[theremin] enabled` is off by
+default and does not change the figure — what it saves is `robotd`'s parked read, which was
+never the cost here.
 
 ### `padd` re-sent the same three zeros fifty times a second
 

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -666,6 +666,11 @@ closer is higher — and the mouth opens with the note, wide at the top of the r
 until Ctrl-C and puts the instrument down on the way out. `--off` puts down one a client left
 up.
 
+**Off by default** — `[theremin] enabled` in `robotd.toml`, per duck, like the chorale above.
+`robotctl configure` is the way to set it, and it offers the `robotd` restart that picks it up;
+until then `robotctl theremin` refuses and names the key. Nothing else turns off with it: `tofd`
+runs regardless, so the depth grid below works on a duck that has never played a note.
+
 An explicit mode with nothing clever inside it: while it is up, the nearest return inside the
 playable band is the hand. Point the duck at open space and it is silent; point it at a wall
 40 cm away and it plays a steady note. It plays sitting, standing or walking — the mouth is

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -524,9 +524,10 @@ pub struct ChoraleParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct ThereminParams {
-    /// Master switch. On by default: the instrument still has to be picked up with
-    /// `robot.theremin`, so what this turns off is the *ability* to, on a duck where the
-    /// feature is unwanted or the sensor is known bad.
+    /// Master switch. **Off by default**: the theremin is a party trick, and a duck that
+    /// nobody asked to play one should not be reaching for the depth stream at all. Turning
+    /// it on grants the *ability* to pick the instrument up — that still takes
+    /// `robot.theremin` — on a duck where somebody wants it and the ToF is known good.
     pub enabled: bool,
     /// `tofd`'s depth stream.
     pub socket: PathBuf,
@@ -548,7 +549,7 @@ impl Default for ThereminParams {
     fn default() -> Self {
         let hand = kinematics::hand::Config::default();
         Self {
-            enabled: true,
+            enabled: false,
             socket: PathBuf::from(duck_ipc_proto::socket::TOF),
             near_m: hand.near_m,
             far_m: hand.far_m,

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -332,7 +332,7 @@ pub const REGISTRY: &[Entry] = &[
     feature(
         "theremin.enabled",
         Kind::Bool,
-        "The ToF theremin may be picked up at all (robot.theremin still starts it)",
+        "The ToF theremin may be picked up at all — off by default (robot.theremin starts it)",
     ),
     entry("theremin.socket", Kind::Text, "tofd's depth stream"),
     entry(

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -627,6 +627,12 @@ struct RobotState {
     /// drops off the I²C bus — and an accepted theremin on a duck with no depth is a
     /// feature that silently does nothing.
     theremin_ready: AtomicBool,
+    /// Whether `[theremin] enabled` allows an instrument at all, and there is a voice to play
+    /// it in. Read once at startup, like the policies — and kept separate from
+    /// [`State::theremin_ready`] so that the refusal can name the switch. Off is the default,
+    /// so "the feature is not turned on" is the answer most of these refusals want, and
+    /// sending that person to look at `tofd` wastes their evening.
+    theremin_allowed: bool,
     /// Whether this robot's config allows it to sing with others. Read once at startup, like the
     /// policies: `[chorale] accept`, false by default.
     chorale_accepted: bool,
@@ -693,6 +699,7 @@ impl RobotState {
             config_path: config_path.to_owned(),
             has_voice: params.audio.enabled && has_any_wav(&params.audio.bank),
             theremin_ready: AtomicBool::new(false),
+            theremin_allowed: params.theremin.enabled && params.audio.enabled,
             chorale_accepted: params.chorale.accept,
             mode: AtomicU8::new(mode_code(params.policy.mode)),
             fallen: AtomicBool::new(false),
@@ -1877,12 +1884,16 @@ async fn control_loop<T: RobotIo>(
         None
     };
 
-    // The theremin. Its depth reader starts now and parks on `tofd`'s socket whether or not
-    // anyone ever asks for an instrument: one blocked read costs nothing, and connecting
-    // lazily would make the first arming window wait for a connection as well as for
-    // frames — a second of silence that reads as a broken feature. Off entirely when the
-    // params say so, or when audio is off, since a theremin with no voice is a mouth
-    // opening for no reason.
+    // The theremin. `[theremin] enabled` is off by default, so on most ducks this is `None`
+    // and nothing here subscribes to depth at all — `tofd` keeps its own counsel, and
+    // `robotctl monitor` is unaffected either way, since it subscribes to `tofd` itself.
+    //
+    // On a duck that has turned it on, the depth reader starts *now* and parks on `tofd`'s
+    // socket whether or not anyone ever asks for an instrument: one blocked read costs
+    // nothing, and connecting lazily would make the first arming window wait for a
+    // connection as well as for frames — a second of silence that reads as a broken feature.
+    // Also off when audio is off, since a theremin with no voice is a mouth opening for no
+    // reason.
     let mut theremin = (params.theremin.enabled && params.audio.enabled)
         .then(|| theremin::Theremin::spawn(params.theremin.socket.clone(), params.theremin.hand()));
     // How far the beak is open for the chorale, slewed across ticks — see where it is written.
@@ -4189,6 +4200,15 @@ fn dispatch(
                     accepted: false,
                     reason: Some("this robot has no voice to play a theremin in".to_owned()),
                 }
+            } else if p.active && !state.theremin_allowed {
+                proto::ThereminResult {
+                    accepted: false,
+                    reason: Some(
+                        "the theremin is off by default — turn `[theremin] enabled` on with \
+                         `robotctl configure`, which offers the robotd restart it needs"
+                            .to_owned(),
+                    ),
+                }
             } else if p.active && !state.theremin_ready.load(Ordering::Relaxed) {
                 proto::ThereminResult {
                     accepted: false,
@@ -5155,6 +5175,51 @@ mod tests {
             .result_as()
             .unwrap();
         assert!(init.accepted, "nor may init refuse for gravity");
+    }
+
+    /// The theremin ships **off**, and the refusal has to name the switch.
+    ///
+    /// The switch and a silent depth stream are different problems with the same symptom, and
+    /// they used to share one message. Now that off is the default, that message would send
+    /// every first-time player to inspect a `tofd` that is running perfectly.
+    #[test]
+    fn a_switched_off_theremin_names_the_switch_and_not_tofd() {
+        let ask = |params: &Params| -> proto::ThereminResult {
+            let mut s = RobotState::new(
+                params,
+                std::path::Path::new("/test/robotd.toml"),
+                false,
+                false,
+            );
+            // A voice, which `RobotState::new` decides by looking for wavs on disk: a test
+            // machine has no bank, and without this every answer here is "no voice to play in".
+            s.has_voice = true;
+            dispatch(
+                &s,
+                &Arc::new(Intents::new()),
+                proto::Id::Number(1),
+                &proto::Call::RobotTheremin(proto::ThereminParams { active: true }),
+            )
+            .result_as()
+            .expect("a theremin answer")
+        };
+
+        let params = Params::default();
+        assert!(!params.theremin.enabled, "the theremin ships off");
+        let refused = ask(&params);
+        assert!(!refused.accepted);
+        let reason = refused.reason.expect("a refusal says why");
+        assert!(reason.contains("[theremin] enabled"), "{reason}");
+        assert!(!reason.contains("tofd"), "not tofd's fault: {reason}");
+
+        // Switched on, and the honest complaint becomes the one about depth — `theremin_ready`
+        // is published by the loop, which is not running under a dispatch test.
+        let mut on = Params::default();
+        on.theremin.enabled = true;
+        let refused = ask(&on);
+        assert!(!refused.accepted);
+        let reason = refused.reason.expect("a refusal says why");
+        assert!(reason.contains("tofd"), "{reason}");
     }
 
     fn state() -> RobotState {


### PR DESCRIPTION
`[theremin] enabled` was on by default, so every duck with audio held a subscription to `tofd`'s depth stream from boot for a party trick nobody had asked for. It is opt-in now, per duck, the same way `[chorale] accept` is and for the same reason: it moves the beak.

`robotctl configure` sets it and offers the `robotd` restart that picks it up. The shipped `deploy/robotd.toml`, the cheat sheet's theremin section and the params editor's description all say off.

## The refusal had to be split

`robot.theremin` answered a switched-off duck with "no depth frames — the ToF sensor is not delivering (is tofd running?)". That is the right sentence for a wedged sensor, and with the switch off by default it becomes the answer a first-time player gets from a duck that is working perfectly.

So the params gate is read once at startup as `State::theremin_allowed`, beside `has_voice`, and refuses by naming `[theremin] enabled`. The depth complaint stays for when depth is genuinely the problem. A dispatch test pins both messages, in both directions.

## `tofd` is untouched, and so is `monitor`

Worth stating because it was the question this started from: nothing about the ToF daemon changes with this switch, and nothing needs to.

- `tofd.service` is `WantedBy=multi-user.target` with `Restart=always`, enabled by the postinstall. Its ranging loop polls the sensor and publishes frames whether or not anything is subscribed — no subscribers is its normal state.
- `robotctl monitor` only ever subscribes: `read_tof` connects and retries forever, and an absent socket renders "connecting to tofd…" rather than an error. The `t` grid works identically on a duck that has never played a note.
- Nothing in the tree starts or stops that unit. The only `systemctl` callers are `robotctl configure` (the daemons whose keys you edited) and `btctl` (`btd`, around a scan); there is no IPC method for it, `system.services` being read-only.

What the switch now saves on a default duck is `robotd`'s parked read of the depth stream — which was never the cost the idle-CPU work was about, and `docs/project/idle-cpu.md` now says which of the two is which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)