### PR TITLE
Classic pad pairing

### DIFF
--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -156,6 +156,12 @@
 //! Discovery stays on `auto`, so BlueZ sweeps both transports and a Pro Controller and an Xbox pad
 //! are both found by the same search.
 //!
+//! Once bonded, a classic pad's reports are the kernel's business and not bluetoothd's:
+//! `scripts/setup-board.sh` sets `UserspaceHID=false` in `input.conf`, because the default relays
+//! this pad's ~200 packets/s of IMU through bluetoothd and uhid at 16% of a core. Nothing in this
+//! file depends on which path is in use; it is noted here because it is the other half of what
+//! "supporting a classic pad" turned out to mean.
+//!
 //! ## Where this has and has not run
 //!
 //! **Run against a real BlueZ on a Radxa Zero 3W with an Xbox Wireless Controller**, which is where

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -168,10 +168,10 @@
 //! that re-initiates: the adapter scans as a central for a bonded peripheral while `btd` advertises
 //! as a peripheral itself. Both roles at once hold on this board's radio.
 //!
-//! The BR/EDR path was written from the Pro Controller clone's journal and from the `bluetoothctl`
-//! sequence that works on it by hand; `bond` follows that sequence call for call. The classic pad
-//! that the clone is bonded through today was bonded by hand, so the pair-first path in this file
-//! still owes its first `robotctl pad pair` on hardware.
+//! **And against the Pro Controller clone**, 2026-09-09, on the board above: `pad pair` with the pad
+//! in pairing mode found the classic face, bonded it and connected it in eight seconds — `bonded
+//! (classic)`, `connected`, `gamepad paired and trusted` — and `padd` drove from it. An Xbox pad
+//! paired a minute later through the unchanged LE path.
 //!
 //! What has **not** been exercised on hardware: a DualSense, two pads in pairing mode at once, and
 //! pairing by explicit address.

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -144,11 +144,14 @@
 //! **The clone is also two devices at once.** In pairing mode it advertises an LE face,
 //! `BLE Controller_280609` at `98:B6:ED:28:06:09` — no class, no appearance, matched by the name
 //! heuristic alone — and the BR/EDR face, `Pro Controller` at `98:B6:E9:28:06:09`. The LE face is
-//! reported first. The first `robotctl pad pair` on this branch (2026-09-09) stopped on it, took the
+//! reported first — and, after the adapter power cycle `pad pair` performs on this board, several
+//! seconds first. The first `robotctl pad pair` on this branch (2026-09-09) stopped on it, took the
 //! LE order, hung [`BOND_TIMEOUT`] in `Connect()`, and by the time `Pair()` was tried the temporary
-//! object was gone: `UnknownObject: Method "Pair" ... doesn't exist`. So `find` now sweeps
-//! [`SIBLING_GRACE`] past the first unbonded match, and `one_face_per_pad` folds candidates that
-//! share their unit octets into the classic one before the ambiguity rule sees them.
+//! object was gone: `UnknownObject: Method "Pair" ... doesn't exist`. A two-second grace after the
+//! first match did not help; the BR/EDR face was still not in the tree. So `find` now ends the
+//! search early only on a match the radio classified — the LE face's name-only match is kept as a
+//! fallback but never stops the sweep — and `one_face_per_pad` folds candidates that share their
+//! unit octets into the classic one before the ambiguity rule sees them.
 //!
 //! Discovery stays on `auto`, so BlueZ sweeps both transports and a Pro Controller and an Xbox pad
 //! are both found by the same search.
@@ -185,7 +188,7 @@ use duck_ipc_proto as proto;
 use zbus::names::OwnedInterfaceName;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue};
 
-use crate::pad::{PadResult, Pads, looks_like_a_gamepad, same_pad};
+use crate::pad::{Evidence, PadResult, Pads, gamepad_evidence, same_pad};
 
 /// Where our pairing agent lives on the bus. Any path we own will do; this one says whose it is.
 const AGENT_PATH: &str = "/com/pollenrobotics/configd/pad_agent";
@@ -213,13 +216,16 @@ const BOND_SETTLE: Duration = Duration::from_secs(5);
 /// How often to re-read `Paired` while waiting for a bond.
 const BOND_POLL: Duration = Duration::from_millis(200);
 
-/// How long to keep sweeping after the first unbonded pad turns up, for the rest of it.
+/// How long to keep sweeping after the first classified, unbonded pad turns up, for the rest of it.
 ///
-/// A pad can be two devices — the Pro Controller clones advertise an LE face and a BR/EDR face, and
-/// the LE one is reported first. Stopping on the first match picked that one, whose `Connect()`
-/// hangs for [`BOND_TIMEOUT`] and whose object is gone by the time `Pair()` is tried. Two seconds is
-/// several inquiry results on this adapter, and the cost is two seconds on every pairing.
-const SIBLING_GRACE: Duration = Duration::from_secs(2);
+/// A pad can be two devices — the Pro Controller clones advertise an LE face and a BR/EDR face.
+/// The classified one is the one worth having, and this is a short courtesy for the case where the
+/// two arrive close together and the other happens to be classified too. It is **not** what
+/// protects against the LE face: that face has nothing but a name, and a name-only match never
+/// ends the search early at all — see `find`. Measured: after the adapter power cycle `pad pair`
+/// performs on this board, the LE face was in BlueZ's tree within two seconds and the BR/EDR face
+/// was not, so no grace short enough to be free would have caught it.
+const SIBLING_GRACE: Duration = Duration::from_secs(1);
 
 /// How often to re-read the object tree while looking for a pad.
 ///
@@ -436,13 +442,23 @@ impl Snapshot {
         self.class.is_some()
     }
 
-    fn is_gamepad(&self) -> bool {
-        looks_like_a_gamepad(
+    fn evidence(&self) -> Option<Evidence> {
+        gamepad_evidence(
             &self.name,
             self.icon.as_deref(),
             self.class,
             self.appearance,
         )
+    }
+
+    fn is_gamepad(&self) -> bool {
+        self.evidence().is_some()
+    }
+
+    /// Unbonded, and a pad on the radio's word rather than its name's — the only kind of match the
+    /// search ends early on.
+    fn is_fresh_and_classified(&self) -> bool {
+        !self.paired && self.evidence() == Some(Evidence::Classified)
     }
 
     fn as_pad(&self) -> proto::Pad {
@@ -551,9 +567,13 @@ impl BlueZ {
     /// first, which is the wrong shape: a robot may have several pads bonded, and `padd` drives
     /// whichever connects.
     ///
-    /// So with no address given, the sweep only ends early on a candidate that is **not yet paired**;
-    /// otherwise it runs to the deadline and reports what it has, which may be the pad already
-    /// bonded. The cost is that re-running `pad pair` with nothing new in pairing mode takes the whole
+    /// So with no address given, the sweep only ends early on a candidate that is **not yet paired
+    /// and classified by the radio** — icon, class or appearance, not its name alone. A name-only
+    /// match is kept and used if nothing better arrives by the deadline, but it does not stop the
+    /// search: the Pro Controller clone's LE face is exactly such a match, it is reported seconds
+    /// before the BR/EDR face that actually pairs, and stopping on it cost every attempt a
+    /// thirty-second hang and a dead object. Otherwise the sweep runs to the deadline and reports
+    /// what it has, which may be the pad already bonded. The cost is that re-running `pad pair` with nothing new in pairing mode takes the whole
     /// window before saying "already paired" — `--timeout` shortens it.
     ///
     /// An explicit address ends the sweep as soon as it appears, paired or not: the caller has named
@@ -566,8 +586,8 @@ impl BlueZ {
     /// no way to learn the address that `--mac` needs. So the refusal carries the list.
     async fn find(&self, mac: Option<&str>, timeout: Duration) -> PadResult<Found> {
         let deadline = tokio::time::Instant::now() + timeout;
-        // When the first unbonded candidate was seen, so the sweep can run [`SIBLING_GRACE`] past
-        // it and catch a pad's other face before deciding.
+        // When the first classified, unbonded candidate was seen, so the sweep can run
+        // [`SIBLING_GRACE`] past it before deciding.
         let mut first_fresh: Option<tokio::time::Instant> = None;
         loop {
             let seen = self.devices().await?;
@@ -586,7 +606,7 @@ impl BlueZ {
             let worth_stopping_for = match mac {
                 Some(_) => !matches.is_empty(),
                 None => {
-                    if matches.iter().any(|device| !device.paired) {
+                    if matches.iter().any(Snapshot::is_fresh_and_classified) {
                         let since = *first_fresh.get_or_insert(now);
                         now - since >= SIBLING_GRACE
                     } else {

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -141,6 +141,15 @@
 //! what `bond` does when `Class` is present. A pad already in the broken state is recovered with
 //! `pad forget` and a fresh `pad pair`.
 //!
+//! **The clone is also two devices at once.** In pairing mode it advertises an LE face,
+//! `BLE Controller_280609` at `98:B6:ED:28:06:09` — no class, no appearance, matched by the name
+//! heuristic alone — and the BR/EDR face, `Pro Controller` at `98:B6:E9:28:06:09`. The LE face is
+//! reported first. The first `robotctl pad pair` on this branch (2026-09-09) stopped on it, took the
+//! LE order, hung [`BOND_TIMEOUT`] in `Connect()`, and by the time `Pair()` was tried the temporary
+//! object was gone: `UnknownObject: Method "Pair" ... doesn't exist`. So `find` now sweeps
+//! [`SIBLING_GRACE`] past the first unbonded match, and `one_face_per_pad` folds candidates that
+//! share their unit octets into the classic one before the ambiguity rule sees them.
+//!
 //! Discovery stays on `auto`, so BlueZ sweeps both transports and a Pro Controller and an Xbox pad
 //! are both found by the same search.
 //!
@@ -176,7 +185,7 @@ use duck_ipc_proto as proto;
 use zbus::names::OwnedInterfaceName;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue};
 
-use crate::pad::{PadResult, Pads, looks_like_a_gamepad};
+use crate::pad::{PadResult, Pads, looks_like_a_gamepad, same_pad};
 
 /// Where our pairing agent lives on the bus. Any path we own will do; this one says whose it is.
 const AGENT_PATH: &str = "/com/pollenrobotics/configd/pad_agent";
@@ -203,6 +212,14 @@ const BOND_SETTLE: Duration = Duration::from_secs(5);
 
 /// How often to re-read `Paired` while waiting for a bond.
 const BOND_POLL: Duration = Duration::from_millis(200);
+
+/// How long to keep sweeping after the first unbonded pad turns up, for the rest of it.
+///
+/// A pad can be two devices — the Pro Controller clones advertise an LE face and a BR/EDR face, and
+/// the LE one is reported first. Stopping on the first match picked that one, whose `Connect()`
+/// hangs for [`BOND_TIMEOUT`] and whose object is gone by the time `Pair()` is tried. Two seconds is
+/// several inquiry results on this adapter, and the cost is two seconds on every pairing.
+const SIBLING_GRACE: Duration = Duration::from_secs(2);
 
 /// How often to re-read the object tree while looking for a pad.
 ///
@@ -549,6 +566,9 @@ impl BlueZ {
     /// no way to learn the address that `--mac` needs. So the refusal carries the list.
     async fn find(&self, mac: Option<&str>, timeout: Duration) -> PadResult<Found> {
         let deadline = tokio::time::Instant::now() + timeout;
+        // When the first unbonded candidate was seen, so the sweep can run [`SIBLING_GRACE`] past
+        // it and catch a pad's other face before deciding.
+        let mut first_fresh: Option<tokio::time::Instant> = None;
         loop {
             let seen = self.devices().await?;
             let matches: Vec<Snapshot> = seen
@@ -562,11 +582,19 @@ impl BlueZ {
                 .cloned()
                 .collect();
 
+            let now = tokio::time::Instant::now();
             let worth_stopping_for = match mac {
                 Some(_) => !matches.is_empty(),
-                None => matches.iter().any(|device| !device.paired),
+                None => {
+                    if matches.iter().any(|device| !device.paired) {
+                        let since = *first_fresh.get_or_insert(now);
+                        now - since >= SIBLING_GRACE
+                    } else {
+                        false
+                    }
+                }
             };
-            if worth_stopping_for || tokio::time::Instant::now() >= deadline {
+            if worth_stopping_for || now >= deadline {
                 return Ok(Found { matches, seen });
             }
             tokio::time::sleep(DISCOVERY_POLL.min(deadline - tokio::time::Instant::now())).await;
@@ -741,6 +769,38 @@ impl BlueZ {
     }
 }
 
+/// Collapse a pad that presents as two devices into the one worth bonding.
+///
+/// Candidates that share their unit octets — [`same_pad`] — are one pad seen over two transports,
+/// and the classic face is the one to keep: it is the one that carries HID to the kernel and the one
+/// `bond` knows the order for. Among faces of the same kind the lowest address wins, for the same
+/// determinism the caller applies to bonded pads. Candidates that share nothing pass through, so a
+/// genuine second pad in pairing mode is still refused as ambiguous.
+fn one_face_per_pad(fresh: Vec<&Snapshot>) -> Vec<&Snapshot> {
+    let mut kept: Vec<&Snapshot> = Vec::new();
+    for candidate in fresh {
+        match kept.iter_mut().find(|k| same_pad(&k.mac, &candidate.mac)) {
+            Some(face) => {
+                let better = match (candidate.is_classic(), face.is_classic()) {
+                    (true, false) => true,
+                    (false, true) => false,
+                    _ => candidate.mac < face.mac,
+                };
+                if better {
+                    tracing::info!(
+                        kept = %candidate.mac,
+                        dropped = %face.mac,
+                        "one pad, two faces: keeping the classic one"
+                    );
+                    *face = candidate;
+                }
+            }
+            None => kept.push(candidate),
+        }
+    }
+    kept
+}
+
 /// Did BlueZ refuse this because the bond already exists?
 fn is_already_paired(error: &zbus::Error) -> bool {
     matches!(error, zbus::Error::MethodError(name, _, _)
@@ -850,6 +910,7 @@ impl Pads for BlueZ {
                 // Without this, adding a second pad in a room where the first is in range would be
                 // refused as ambiguous forever.
                 let fresh: Vec<&Snapshot> = several.iter().filter(|d| !d.paired).collect();
+                let fresh = one_face_per_pad(fresh);
                 match fresh.as_slice() {
                     [only] => (*only).clone(),
                     // Nothing new: report the bonded one, and let `bond` re-assert `Trusted`. This is
@@ -986,5 +1047,50 @@ impl Pads for BlueZ {
             .map_err(|e| format!("bluetoothd would not remove {mac}: {e}"))?;
         tracing::info!(mac, "pad forgotten");
         Ok(proto::PadForgetResult { removed: true })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn face(mac: &str, name: &str, class: Option<u32>) -> Snapshot {
+        Snapshot {
+            path: OwnedObjectPath::try_from(format!(
+                "/org/bluez/hci0/dev_{}",
+                mac.replace(':', "_")
+            ))
+            .unwrap(),
+            mac: mac.to_owned(),
+            name: name.to_owned(),
+            icon: None,
+            class,
+            appearance: None,
+            paired: false,
+            trusted: false,
+            connected: false,
+        }
+    }
+
+    /// The Pro Controller clone as the radio reports it: an LE face first, the classic one after.
+    /// One pad comes out, and it is the classic one whichever order they arrived in.
+    #[test]
+    fn a_pad_with_two_faces_is_one_candidate_and_the_classic_face_wins() {
+        let le = face("98:B6:ED:28:06:09", "BLE Controller_280609", None);
+        let classic = face("98:B6:E9:28:06:09", "Pro Controller", Some(0x2508));
+
+        for order in [vec![&le, &classic], vec![&classic, &le]] {
+            let kept = one_face_per_pad(order);
+            assert_eq!(kept.len(), 1);
+            assert_eq!(kept[0].mac, classic.mac);
+        }
+    }
+
+    /// Two different pads stay two candidates — the ambiguity refusal downstream depends on it.
+    #[test]
+    fn two_pads_stay_two_candidates() {
+        let a = face("98:B6:E9:28:06:09", "Pro Controller", Some(0x2508));
+        let b = face("78:86:2E:BB:13:28", "Xbox Wireless Controller", None);
+        assert_eq!(one_face_per_pad(vec![&a, &b]).len(), 2);
     }
 }

--- a/configd/src/bluez.rs
+++ b/configd/src/bluez.rs
@@ -6,12 +6,21 @@
 //!
 //! ## The order, and why the state decides rather than the return values
 //!
-//! `connect` **before** `pair`, and `trust` after both. Leading with `Pair()` on an Xbox controller
-//! returns `AuthenticationCanceled`; that ordering comes from `microduck_runtime`'s notes and is the
-//! one that works on this board. It used to live in a provisioning script's comments and in whoever
-//! had done it before; now it is here, once, with the reason attached.
+//! **Which order depends on the transport**, and the two are opposite:
 //!
-//! But the order is **tried, not enforced**, because BlueZ's replies do not describe what happened:
+//!  - an **LE** pad (Xbox): `connect` **before** `pair`, and `trust` after both. Leading with
+//!    `Pair()` on an Xbox controller returns `AuthenticationCanceled`; that ordering comes from
+//!    `microduck_runtime`'s notes and is the one that works on this board.
+//!  - a **BR/EDR** pad (a "Pro Controller" Switch clone, and by the specification a DualShock or a
+//!    DualSense): `pair` **before** `connect`, then `trust`. See [the transport section](#which-transport-and-what-that-leaves-untested)
+//!    for what the other order does to it.
+//!
+//! `Snapshot::is_classic` decides, on whether BlueZ reports a `Class`. The rule used to live in a
+//! provisioning script's comments and in whoever had done it before; now it is here, once, with the
+//! reason attached.
+//!
+//! On the LE path the order is **tried, not enforced**, because BlueZ's replies do not describe what
+//! happened:
 //!
 //!  - `Connect()` on a device BlueZ has never bonded with can answer
 //!    `br-connection-profile-unavailable` — there is no profile to connect to *yet*. Refusing there
@@ -103,8 +112,8 @@
 //! BR/EDR and LE together, and every property `Snapshot` reads is optional partly because the two
 //! transports present different ones.
 //!
-//! But the pad all of this has been run against is **LE-only**. Its bond stores long-term keys and no
-//! `[LinkKey]`, and BlueZ reports no `Class` for it at all:
+//! The Xbox pad is **LE-only**. Its bond stores long-term keys and no `[LinkKey]`, and BlueZ reports
+//! no `Class` for it at all:
 //!
 //! ```text
 //! # /var/lib/bluetooth/<adapter>/<pad>/info
@@ -113,14 +122,27 @@
 //! [PeripheralLongTermKey]
 //! ```
 //!
-//! So the BR/EDR half of this file comes from the specification rather than from a radio. That
-//! includes the class-of-device branch in [`looks_like_a_gamepad`], which cannot have fired — an LE
-//! pad has no class to match — and the `br-connection-profile-unavailable` soft-fail above.
+//! The first **BR/EDR** pad arrived on 2026-09-09: a no-name "Pro Controller", a clone of Nintendo's
+//! Switch Pro Controller down to the modalias (`usb:v057Ep2009`), which is what makes the kernel's
+//! `hid-nintendo` bind it and expose it as "Nintendo Switch Pro Controller" on evdev. BlueZ reports
+//! it with `Class: 0x2508` — peripheral, gamepad — and derives `Icon: input-gaming` from that, so
+//! [`looks_like_a_gamepad`] recognises it on two signals, and the class-of-device branch has now
+//! fired on hardware. Only the HID and PnP UUIDs, no LE at all.
 //!
-//! Discovery stays on `auto` regardless, because the pads the heuristic names that are *not* LE — a
-//! DualShock, a DualSense — are BR/EDR HID, and filtering to LE would make hardware this claims to
-//! recognise unreachable. The thing to know is which way the risk runs: dropping BR/EDR would cost
-//! nothing yet observed, and the first classic pad to arrive exercises that path for the first time.
+//! What the LE order does to it, from `configd`'s own journal (2026-09-07, an earlier unit of the
+//! same pad): `Connect()` on the unbonded pad spends ten seconds and answers
+//! `br-connection-create-socket`; the `Pair()` fallback then answers
+//! `ConnectionAttemptFailed: Page Timeout`. The pad has left pairing mode — a rejected classic
+//! connection is enough to make it stop page-scanning — and every retry repeats the pair. Reproduced
+//! by hand, the same order (`bluetoothctl connect`, which bonds as a side effect, then `trust`) goes
+//! one step further and ends in the state that is hardest to read: `Paired: yes`, `Connected: yes`,
+//! a solid light on the pad, `pad status` saying connected — and **no input device**, so `padd` waits
+//! for a pad that BlueZ insists is there. `pair` → `connect` → `trust` works every time, so that is
+//! what `bond` does when `Class` is present. A pad already in the broken state is recovered with
+//! `pad forget` and a fresh `pad pair`.
+//!
+//! Discovery stays on `auto`, so BlueZ sweeps both transports and a Pro Controller and an Xbox pad
+//! are both found by the same search.
 //!
 //! ## Where this has and has not run
 //!
@@ -134,8 +156,13 @@
 //! that re-initiates: the adapter scans as a central for a bonded peripheral while `btd` advertises
 //! as a peripheral itself. Both roles at once hold on this board's radio.
 //!
-//! What has **not** been exercised on hardware: a pad that bonds over BR/EDR at all, a DualSense, two
-//! pads in pairing mode at once, and pairing by explicit address.
+//! The BR/EDR path was written from the Pro Controller clone's journal and from the `bluetoothctl`
+//! sequence that works on it by hand; `bond` follows that sequence call for call. The classic pad
+//! that the clone is bonded through today was bonded by hand, so the pair-first path in this file
+//! still owes its first `robotctl pad pair` on hardware.
+//!
+//! What has **not** been exercised on hardware: a DualSense, two pads in pairing mode at once, and
+//! pairing by explicit address.
 //!
 //! And one case that cannot be fixed from here: `pad forget` removes only the robot's half of the
 //! bond. A pad that still holds its half will not pair again until it is put back into pairing mode
@@ -382,6 +409,16 @@ impl Snapshot {
         })
     }
 
+    /// Does this pad bond over BR/EDR rather than LE?
+    ///
+    /// `Class` is the tell: it is the classic class-of-device, which an LE-only device has no way
+    /// to present, and BlueZ reports it from the inquiry response before anything else is known
+    /// about the device. `AddressType` does not separate the two — an Xbox pad's is `public` too.
+    /// The order `bond` tries depends on this, and the module docs say why.
+    fn is_classic(&self) -> bool {
+        self.class.is_some()
+    }
+
     fn is_gamepad(&self) -> bool {
         looks_like_a_gamepad(
             &self.name,
@@ -576,9 +613,52 @@ impl BlueZ {
             .await
             .map_err(|e| (proto::PadPairFailure::Other, e.to_string()))?;
 
-        if !device.paired {
-            // `Connect()` first, which is the order that works on this board — leading with `Pair()`
-            // on an Xbox controller returns `AuthenticationCanceled`.
+        if !device.paired && device.is_classic() {
+            // A BR/EDR pad: `Pair()` first, then `Connect()`. The other order — the one below, which
+            // an LE pad needs — does not work on classic HID and leaves things worse than it found
+            // them. Seen against a "Pro Controller" (a Switch Pro clone, class 0x2508):
+            // `Connect()` on the unbonded pad spends ten seconds and answers
+            // `br-connection-create-socket`, and the `Pair()` after it answers
+            // `ConnectionAttemptFailed: Page Timeout` — the pad has stopped page-scanning by then,
+            // and the person has to put it back into pairing mode. Done by hand in the same order,
+            // `bluetoothctl connect` then `trust`, the pad ends up *Paired and Connected* with no
+            // input device behind it: the light on the pad goes solid, `pad status` says connected,
+            // and `padd` has nothing to open. `pair` → `connect` → `trust` is the sequence that
+            // works, so it is the one this takes.
+            //
+            // `Pair()` on BR/EDR is synchronous and answers when the bond is done — but it is still
+            // raced against `Paired`, as below, because that property is the ground truth and the
+            // reply is only one way to learn it.
+            let paired = tokio::select! {
+                outcome = tokio::time::timeout(BOND_TIMEOUT, proxy.pair()) => match outcome {
+                    Ok(Ok(())) => { tracing::info!("bonded (classic)"); true }
+                    Ok(Err(e)) if is_already_paired(&e) => { tracing::info!("already bonded"); true }
+                    Ok(Err(e)) => return Err((proto::PadPairFailure::Rejected, e.to_string())),
+                    Err(_) => false,
+                },
+                bonded = self.wait_until_paired(&device.mac, BOND_TIMEOUT) => bonded,
+            };
+            if !paired {
+                return Err((
+                    proto::PadPairFailure::Timeout,
+                    "the pad did not finish pairing".to_owned(),
+                ));
+            }
+
+            // Now connect, which is what brings up the HID channel and hands the pad to the kernel
+            // driver — `hid-nintendo`, for the clone above — so an input device appears. Soft: a
+            // bonded and trusted pad reconnects by itself, so a refusal here is not worth failing a
+            // pairing that succeeded. Logged at warn rather than info, though, because a classic
+            // pad that bonded and will not connect is the "connected light, no input" state from
+            // the other order, and worth a line in the journal.
+            match tokio::time::timeout(BOND_TIMEOUT, proxy.connect()).await {
+                Ok(Ok(())) => tracing::info!("connected"),
+                Ok(Err(e)) => tracing::warn!(error = %e, "bonded but not connected yet"),
+                Err(_) => tracing::warn!("bonded; connect did not answer in time"),
+            }
+        } else if !device.paired {
+            // An LE pad. `Connect()` first, which is the order that works on this board — leading
+            // with `Pair()` on an Xbox controller returns `AuthenticationCanceled`.
             //
             // But **soft-failed**, deliberately. A device BlueZ has never bonded with has no known
             // profile to connect to, so `Connect()` can answer

--- a/configd/src/pad.rs
+++ b/configd/src/pad.rs
@@ -85,8 +85,9 @@ pub fn pair_timeout(requested: Option<u32>) -> Duration {
 ///  - **`class`** is the BR/EDR class-of-device: bits 8-12 are the major device class, and `0x05`
 ///    is Peripheral. Bits 6-7 of the minor field distinguish keyboard from pointing device from
 ///    gamepad — `0x01` in bits 2-5 with the keyboard/pointer bits clear is a joystick or gamepad.
-///    Present for a classic pad, absent for a BLE-only one — and every pad tried so far has been
-///    LE-only, so this arm is from the specification and has never fired on hardware.
+///    Present for a classic pad, absent for a BLE-only one. A no-name "Pro Controller" (a Switch
+///    Pro clone) presents `0x2508` — peripheral, gamepad — and this is the arm that names it when
+///    BlueZ has not yet derived the icon from it.
 ///  - **`appearance`** is the BLE equivalent: category 15 (`0x03C0..=0x03C4`) is HID, and `0x03C4`
 ///    is specifically Gamepad. Many pads never set it, which is why it cannot stand alone. Only the
 ///    gamepad value counts, so an LE pad advertising generic HID falls through to its name.
@@ -287,14 +288,16 @@ mod tests {
     }
 
     /// A classic pad, identified by class-of-device with no icon and no name — which is what
-    /// discovery reports before a device is queried. Synthetic in a way the others are not: no pad
-    /// bonded to this robot has ever presented a class, so this arm is only ever exercised here.
+    /// discovery reports before a device is queried.
     #[test]
     fn a_peripheral_joystick_class_is_a_gamepad() {
         // Major 0x05 (peripheral), minor 0x01 (joystick): 0x000504.
         assert!(looks_like_a_gamepad("", None, Some(0x000504), None));
         // Minor 0x02, gamepad: 0x000508.
         assert!(looks_like_a_gamepad("", None, Some(0x000508), None));
+        // The class a "Pro Controller" Switch clone actually presents on the board (2026-09-09):
+        // the same gamepad minor with the limited-discoverable service bit set.
+        assert!(looks_like_a_gamepad("", None, Some(0x002508), None));
     }
 
     /// The direction that matters more. A keyboard and a mouse are peripherals too, and pairing

--- a/configd/src/pad.rs
+++ b/configd/src/pad.rs
@@ -103,8 +103,29 @@ pub fn looks_like_a_gamepad(
     class: Option<u32>,
     appearance: Option<u16>,
 ) -> bool {
+    gamepad_evidence(name, icon, class, appearance).is_some()
+}
+
+/// How a device came to look like a gamepad — and how much that is worth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Evidence {
+    /// The radio said so: BlueZ's icon, the class-of-device or the gamepad appearance. Settled.
+    Classified,
+    /// Only the name said so. Enough to pair when nothing better turns up, and not enough to stop
+    /// looking: the Pro Controller clone's LE face is `BLE Controller_280609` with nothing else
+    /// set, and stopping on it is what cost every pairing thirty seconds and a dead object.
+    NameOnly,
+}
+
+/// [`looks_like_a_gamepad`], with the strength of the answer. Same four signals, same order.
+pub fn gamepad_evidence(
+    name: &str,
+    icon: Option<&str>,
+    class: Option<u32>,
+    appearance: Option<u16>,
+) -> Option<Evidence> {
     if icon == Some("input-gaming") {
-        return true;
+        return Some(Evidence::Classified);
     }
 
     if let Some(class) = class {
@@ -114,7 +135,7 @@ pub fn looks_like_a_gamepad(
         // 0x03 remote control — the keyboard (0x10) and pointing-device (0x20) bits are the ones
         // this must not match, and they live above these values rather than overlapping them.
         if major == 0x05 && matches!(minor & 0x0f, 0x01 | 0x02) {
-            return true;
+            return Some(Evidence::Classified);
         }
     }
 
@@ -122,7 +143,7 @@ pub fn looks_like_a_gamepad(
         // 0x03C4 is Gamepad; the rest of category 15 is other HID. Only the gamepad value counts,
         // because a Bluetooth keyboard is category 15 too and must not be paired as a pad.
         if appearance == 0x03C4 {
-            return true;
+            return Some(Evidence::Classified);
         }
     }
 
@@ -138,6 +159,7 @@ pub fn looks_like_a_gamepad(
     ]
     .iter()
     .any(|needle| lower.contains(needle))
+    .then_some(Evidence::NameOnly)
 }
 
 /// Are these two Bluetooth addresses two faces of one pad?
@@ -369,6 +391,21 @@ mod tests {
             assert!(looks_like_a_gamepad(name, None, None, None), "{name}");
         }
         assert!(!looks_like_a_gamepad("Pierre's iPhone", None, None, None));
+    }
+
+    /// A name is enough to pair on and not enough to stop looking on; anything the radio classified
+    /// is both. The clone's two faces, as BlueZ reports them, land on opposite sides.
+    #[test]
+    fn a_name_alone_is_weak_evidence() {
+        assert_eq!(
+            gamepad_evidence("BLE Controller_280609", None, None, None),
+            Some(Evidence::NameOnly)
+        );
+        assert_eq!(
+            gamepad_evidence("Pro Controller", Some("input-gaming"), Some(0x2508), None),
+            Some(Evidence::Classified)
+        );
+        assert_eq!(gamepad_evidence("Pierre's iPhone", None, None, None), None);
     }
 
     /// The whole arc, over the fake: pair the pad that is in pairing mode, see it bonded and

--- a/configd/src/pad.rs
+++ b/configd/src/pad.rs
@@ -140,6 +140,37 @@ pub fn looks_like_a_gamepad(
     .any(|needle| lower.contains(needle))
 }
 
+/// Are these two Bluetooth addresses two faces of one pad?
+///
+/// Some pads are two devices at once. The no-name "Pro Controller" Switch clones advertise an LE
+/// personality (`BLE Controller_280609`, for phones) *and* the BR/EDR one that drives a robot, from
+/// two addresses that differ only in the vendor half: `98:B6:ED:28:06:09` and `98:B6:E9:28:06:09`.
+/// The lower three octets — the part a vendor assigns per unit — are identical, and the LE name
+/// even spells them out.
+///
+/// So two candidates that agree on those octets are one pad presenting twice, not two pads in
+/// pairing mode, and the choice between them is not ambiguous: the classic one is the one that
+/// carries HID to the kernel. Refusing would leave that pad unpairable without an address, and
+/// picking whichever appeared first is how the LE face got connected to for thirty seconds while
+/// the pad waited for a bond that never came.
+///
+/// Three octets, not two or four: two is too few to separate unrelated devices from one vendor,
+/// and four already reaches into the OUI, which is exactly the half that differs.
+pub fn same_pad(a: &str, b: &str) -> bool {
+    let tail = |mac: &str| -> Option<[u8; 3]> {
+        let mut parts = mac.rsplit(':');
+        let mut tail = [0u8; 3];
+        for slot in tail.iter_mut().rev() {
+            *slot = u8::from_str_radix(parts.next()?, 16).ok()?;
+        }
+        Some(tail)
+    };
+    match (tail(a), tail(b)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
 /// A set of pads that exists only in memory.
 ///
 /// Used by the tests and by `--fake-pads`, which is what makes the whole `pad.*` surface — and the
@@ -442,6 +473,16 @@ mod tests {
             panic!("{result:?}");
         };
         assert_eq!(pad.mac, "A4:AE:11:00:22:33");
+    }
+
+    /// The Pro Controller clone's two faces share their unit octets and nothing else about the
+    /// address; an unrelated device from the same vendor shares the OUI and nothing else.
+    #[test]
+    fn two_faces_of_one_pad_share_their_unit_octets() {
+        assert!(same_pad("98:B6:ED:28:06:09", "98:B6:E9:28:06:09"));
+        assert!(same_pad("98:b6:ed:28:06:09", "98:B6:E9:28:06:09"));
+        assert!(!same_pad("98:B6:E9:28:06:09", "98:B6:E9:46:9F:EA"));
+        assert!(!same_pad("98:B6:E9:28:06:09", "not an address"));
     }
 
     /// A caller cannot hold the adapter in discovery for as long as it likes, and zero means "look

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -14,6 +14,12 @@ On an **Xbox** controller this is two presses, and the second is the one that go
 
 On a **DualSense**: hold Create and PS together until the light bar flashes.
 
+On a **Pro Controller** — the no-name Switch-style pads, which bluetoothctl lists as
+`Pro Controller` — hold the small **Sync** button on the top edge, next to the USB-C port, until the
+player lights sweep back and forth. It is a classic Bluetooth (BR/EDR) pad, the Xbox one is LE, and
+the robot pairs the two in opposite orders; `pad pair` picks the right one by itself, and
+[pairing one by hand](#pairing-a-pro-controller-by-hand) says what the order is if you have to.
+
 ## Pair it
 
 ```bash
@@ -128,6 +134,29 @@ to check and how to drop it.
 
 Both are workarounds for the aic8800 radio, not properties of the design. They go when the radio
 does.
+
+## Pairing a Pro Controller by hand
+
+Only if `pad pair` is not available. The order matters and is the **reverse** of the Xbox one:
+
+```bash
+bluetoothctl pair 98:B6:E9:28:06:09
+```
+
+```bash
+bluetoothctl connect 98:B6:E9:28:06:09
+```
+
+```bash
+bluetoothctl trust 98:B6:E9:28:06:09
+```
+
+`connect` first — which bonds as a side effect — ends in the state that is hardest to read: the pad's
+light goes solid, `pad status` says `connected`, `bluetoothctl info` says `Paired: yes` and
+`Connected: yes`, and **no input device exists**, so `padd` sits at "waiting for padd to open a pad"
+and nothing drives. Recover with `sudo robotctl pad forget <address>`, put the pad back into pairing
+mode and pair again. Running `pad pair` never produces this state: it knows the pad is classic from
+the class BlueZ reports and pairs before it connects.
 
 ## When pairing fails every time
 

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -135,6 +135,21 @@ to check and how to drop it.
 Both are workarounds for the aic8800 radio, not properties of the design. They go when the radio
 does.
 
+### A classic pad and bluetoothd's CPU
+
+A Pro Controller streams IMU samples in every packet, about 200 packets a second, whether or not
+anyone touches it. With BlueZ's default `UserspaceHID=true` each one is relayed by bluetoothd through
+uhid, and that cost 16% of a core on graphite with the pad idle. `scripts/setup-board.sh` sets
+`UserspaceHID=false` in `/etc/bluetooth/input.conf` on every board, which hands the channel to the
+kernel's `hidp` and takes bluetoothd out of the data path — measured 0.0% afterwards, same driver,
+same input nodes, same bond. It applies at the next boot. An LE pad such as the Xbox is untouched by
+the setting: HID over GATT never went through `input.conf`. A board provisioned before this exists
+gets it by re-running the script:
+
+```bash
+sudo sh scripts/setup-board.sh && sudo reboot
+```
+
 ## Pairing a Pro Controller by hand
 
 Only if `pad pair` is not available. The order matters and is the **reverse** of the Xbox one:

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -823,7 +823,8 @@ enum PadCommand {
     /// the Xbox button, then press the small **Sync** button on the top edge, next to the USB-C
     /// port, until the Xbox light flashes quickly. Do NOT hold the Xbox button itself — that
     /// switches the controller off. On a DualSense: hold Create and PS together until the light bar
-    /// flashes.
+    /// flashes. On a Pro Controller (the Switch-style pads): hold the small Sync button on the top
+    /// edge until the player lights sweep.
     ///
     /// Then run this. No MAC address needed: the robot looks for a gamepad in pairing mode and
     /// takes the one it finds.
@@ -4013,7 +4014,8 @@ fn run_pad(socket: &Path, command: PadCommand) -> Result<(), Failure> {
         // someone who ran this needs to know *now* that they should be holding the button.
         eprintln!(
             "looking for a gamepad in pairing mode — on an Xbox pad, press the small Sync \
-             button on the top edge (not the Xbox button, which switches it off)"
+             button on the top edge (not the Xbox button, which switches it off); on a Pro \
+             Controller, hold its Sync button until the player lights sweep"
         );
     }
 

--- a/scripts/setup-board.sh
+++ b/scripts/setup-board.sh
@@ -48,6 +48,10 @@ CMDLINE="${CMDLINE:-/proc/cmdline}"
 
 BT_CONF=/etc/bluetooth/main.conf
 
+# BlueZ's input profile settings. One line in it decides who carries a classic (BR/EDR) gamepad's
+# reports — see `configure_classic_hid`. Every board gets that change; no flag.
+BT_INPUT_CONF=/etc/bluetooth/input.conf
+
 # Does this board need `Privacy = device`? `--weird-ble` on provision-board.sh.
 #
 # Off by default: some Zero 3W units bond a pad under BlueZ's own default and want nothing from
@@ -812,6 +816,49 @@ configure_bluetooth() {
     write_pause_marker
 }
 
+# A classic (BR/EDR) gamepad's reports go through the kernel, not through bluetoothd.
+#
+# BlueZ 5.82 defaults `UserspaceHID=true`: bluetoothd reads every HID report from the L2CAP socket
+# and re-injects it into the kernel through uhid. For an LE pad (Xbox) this setting is irrelevant —
+# HID over GATT is bluetoothd's own profile either way, and the Xbox sends nothing while idle. For a
+# classic pad it is the whole data path, and the no-name "Pro Controller" Switch clones stream IMU
+# samples in every packet at ~200 packets/s whether or not anyone touches them. Measured on graphite,
+# 2026-09-09, pad connected and untouched:
+#
+#   UserspaceHID=true   bluetoothd 15.8 % CPU, ~594 IMU reports/s on /dev/input/event5, nodes under
+#                       /sys/devices/virtual/misc/uhid/
+#   UserspaceHID=false  bluetoothd  0.0 %, same reports, nodes under .../hci0/hci0:128/ — the
+#                       kernel's hidp owns the channel and hid-nintendo binds exactly as before
+#
+# The bond, the reconnect after a reboot and `padd` driving from the pad were all unchanged by the
+# switch; the pad reconnected by itself on the first boot with the new value. No flag, because there
+# is no board on which the userspace path is the better one: it costs a core's worth of context
+# switches and buys nothing this robot uses.
+#
+# Applies at the next bluetoothd start, which on this board means a reboot — see the note on
+# `needs_reboot` above `configure_bluetooth`.
+configure_classic_hid() {
+    if [ ! -f "$BT_INPUT_CONF" ]; then
+        say "no ${BT_INPUT_CONF}; writing one with UserspaceHID=false"
+        printf '[General]\nUserspaceHID=false\n' > "$BT_INPUT_CONF"
+        needs_reboot=1
+        return 0
+    fi
+    if grep -Eq '^[[:space:]]*UserspaceHID[[:space:]]*=[[:space:]]*false' "$BT_INPUT_CONF"; then
+        say "bluetooth UserspaceHID already false (classic pads go through the kernel)"
+        return 0
+    fi
+    say "setting UserspaceHID=false in ${BT_INPUT_CONF} (classic pads through the kernel, not bluetoothd)"
+    if grep -Eq '^[[:space:]]*#?[[:space:]]*UserspaceHID[[:space:]]*=' "$BT_INPUT_CONF"; then
+        sed -i -E 's|^[[:space:]]*#?[[:space:]]*UserspaceHID[[:space:]]*=.*|UserspaceHID=false|' "$BT_INPUT_CONF"
+    elif grep -q '^\[General\]' "$BT_INPUT_CONF"; then
+        sed -i '/^\[General\]/a UserspaceHID=false' "$BT_INPUT_CONF"
+    else
+        printf '\n[General]\nUserspaceHID=false\n' >> "$BT_INPUT_CONF"
+    fi
+    needs_reboot=1
+}
+
 # The marker `robotctl` reads to decide whether to pause `btd` for a pairing.
 #
 # Its own function because both flags write it and only one of them touches `Privacy` — which is the
@@ -1059,6 +1106,7 @@ main() {
     check_network
     free_motor_port
     configure_bluetooth
+    configure_classic_hid
     configure_audio
     configure_tof
     # After configure_audio, which is what installs the vendor kernel: the camera's MIPI-CSI


### PR DESCRIPTION
robotctl pad pair works with the Xbox pad and failed with the new "Pro Controller"
pads. Three causes, each fixed in its own commit:

1. The pad is classic (BR/EDR). bond() now pairs before connecting when BlueZ reports a
   Class; the LE (Xbox) path is unchanged. Connect-first on this pad fails with
   br-connection-create-socket then Page Timeout, and done by hand it leaves the pad
   Paired+Connected with no input device.
2. In pairing mode the pad is two devices: an LE face "BLE Controller_280609" (name-only
   match, reported first) and the BR/EDR face "Pro Controller" (Class 0x2508). Candidates
   sharing the lower three address octets are folded into one pad, classic face wins.
3. After the weird-ble adapter power cycle the classic face arrives seconds after the LE
   one. A name-only match is now weak evidence: kept as fallback, never ends the search.

Validated on graphite 2026-09-09: Pro Controller bonded classic in 8 s and padd drove;
Xbox paired through the LE path a minute later. Docs: module docs in configd/src/bluez.rs,
docs/robot/pair-a-gamepad.md (Pro Controller pairing mode, by-hand order and its trap),
robotctl pad pair hint. 47 configd tests, clippy clean, cargo board builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)