### PR TITLE
A head-IMU sample is two I²C reads, not three

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,8 +481,8 @@ dependencies = [
 
 [[package]]
 name = "bmi088"
-version = "0.1.0"
-source = "git+https://github.com/pollen-robotics/bmi088-rs?rev=6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c#6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c"
+version = "0.1.2"
+source = "git+https://github.com/pollen-robotics/bmi088-rs?tag=v0.1.2#bd113f317b14923f50f9a12a06678fe162b7fe06"
 dependencies = [
  "ahrs",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "bmi088"
 version = "0.1.0"
-source = "git+https://github.com/pollen-robotics/bmi088-rs?tag=v0.1.1#efddf2029f276495a99dd51435c61b643fa009b5"
+source = "git+https://github.com/pollen-robotics/bmi088-rs?rev=6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c#6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c"
 dependencies = [
  "ahrs",
  "embedded-hal",

--- a/tof/Cargo.toml
+++ b/tof/Cargo.toml
@@ -37,12 +37,9 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 # The BMI088 driver and its Madgwick fusion, ours because the crates.io ones stop at the raw
 # registers. Pinned to a tag: it is a second repository and a moving `main` is not a dependency.
-#
-# TEMPORARY: a rev, not a tag, for `Bmi088Ahrs::update_all` — bmi088-rs#1, which is what takes
-# a head-IMU sample from three I²C transactions to two. A rev is at least as reproducible as a
-# tag; what it is not is released. **Flip this back to `tag = "v0.1.2"` once that is tagged**,
-# and do not merge this line as it stands.
-bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", rev = "6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c" }
+# v0.1.2 is the one that has `Bmi088Ahrs::update_all`, which is what takes a head-IMU sample
+# from three I²C transactions to two.
+bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", tag = "v0.1.2" }
 # `I2cdev`, the `embedded-hal` bus the driver is generic over. Linux-only by construction —
 # `i2cdev`'s `linux` module is the whole crate.
 linux-embedded-hal = "0.4"

--- a/tof/Cargo.toml
+++ b/tof/Cargo.toml
@@ -37,7 +37,12 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 # The BMI088 driver and its Madgwick fusion, ours because the crates.io ones stop at the raw
 # registers. Pinned to a tag: it is a second repository and a moving `main` is not a dependency.
-bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", tag = "v0.1.1" }
+#
+# TEMPORARY: a rev, not a tag, for `Bmi088Ahrs::update_all` — bmi088-rs#1, which is what takes
+# a head-IMU sample from three I²C transactions to two. A rev is at least as reproducible as a
+# tag; what it is not is released. **Flip this back to `tag = "v0.1.2"` once that is tagged**,
+# and do not merge this line as it stands.
+bmi088 = { git = "https://github.com/pollen-robotics/bmi088-rs", rev = "6db3c2cd7428b0da43385cb68e8f90a17cb1cb1c" }
 # `I2cdev`, the `embedded-hal` bus the driver is generic over. Linux-only by construction —
 # `i2cdev`'s `linux` module is the whole crate.
 linux-embedded-hal = "0.4"

--- a/tof/src/imu.rs
+++ b/tof/src/imu.rs
@@ -145,19 +145,19 @@ pub fn imu_loop(
             let tick = Instant::now();
             let dt = (tick - last).as_secs_f32().clamp(1e-4, 0.2);
             last = tick;
-            match ahrs.update(dt) {
-                Ok((gyro, quat)) => {
-                    // A failed accelerometer read must not become `(0, 0, 0)`: zero acceleration
-                    // is indistinguishable from free-fall to a consumer, and nothing recovers from
-                    // it. Reopen the chip instead, exactly as a gyro failure does below.
-                    let accel = match ahrs.imu().read_accelerometer_ms2() {
-                        Ok(accel) => accel,
-                        Err(e) => {
-                            status.lost(format!("accelerometer read failed: {e:?}"));
-                            tracing::warn!("head IMU accelerometer read failed; reopening");
-                            break;
-                        }
-                    };
+            // `update_all` rather than `update`: both read the accelerometer and the gyroscope,
+            // and only this one hands the accelerometer sample back. Asking for it afterwards —
+            // which is what this loop used to do — read the same six registers a second time.
+            //
+            // **Not for the CPU.** A transaction is worth about 9 µs of the ~440 µs a sample
+            // costs on this board (`bench_imu` at 100 Hz: 4.53% for three reads against 4.46%
+            // for two), so this buys nothing measurable and the idle cost of this thread is
+            // somewhere else entirely. What it buys is that the published `accel` is the sample
+            // the quaternion was computed from, rather than one read ~200 µs later, and that a
+            // read can fail in one place instead of two — either chip failing reopens rather
+            // than publishing a zero acceleration, which a consumer cannot tell from free-fall.
+            match ahrs.update_all(dt) {
+                Ok((accel, gyro, quat)) => {
                     if seq.is_multiple_of(TEMP_EVERY)
                         && let Ok(t) = ahrs.imu().read_temperature()
                     {
@@ -169,7 +169,7 @@ pub fn imu_loop(
                         at_us: started.elapsed().as_micros() as u64,
                         t_ns: proto::clock::monotonic_ns(),
                         gyro,
-                        accel: [accel.0, accel.1, accel.2],
+                        accel,
                         quat,
                         temp_c,
                     });


### PR DESCRIPTION
`Bmi088Ahrs::update` reads the accelerometer to feed Madgwick and hands back only the gyro and the quaternion, so `imu_loop` asked for the accelerometer *again* to publish it — the same six registers, one transaction later, for a value the driver already had. `update_all` returns it from the two reads it already does, and this takes it. It arrived in [bmi088-rs#1](https://github.com/pollen-robotics/bmi088-rs/pull/1); `tof/Cargo.toml` pins the tag that carries it, `v0.1.2`.

## It is not the CPU saving I opened it for

I expected a third of the thread. `bench_imu` on olducky at 100 Hz, `tofd` stopped:

```text
  sleep only  (0 reads)   cpu  0.69 %
  filter only (0 reads)   cpu  1.00 %
  update      (2 reads)   cpu  3.35 %
  update_all  (2 reads)   cpu  3.86 %
  three-reads (3 reads)   cpu  4.20 %
```

The third read is worth 0.3–0.9 points, and `update`/`update_all` do identical work yet differ by 0.51 — so it is inside the noise. The reads dominate the loop (~2.4–2.9 of it), which is why nothing in that loop can be optimised and why the head IMU gets a switch instead (#250).

## What it is worth keeping for

- The published `accel` becomes the sample the quaternion was computed from, rather than one read ~200 µs later. For a consumer doing IMU pre-integration, that inconsistency is the kind that is very hard to find later.
- A read can fail in one place instead of two. Either chip failing still reopens rather than publishing a zero acceleration, which a consumer cannot distinguish from free-fall.
- ~200 µs a sample of bus stops being spent on a bus the ToF and the audio codec share.

`cargo test -p tof` passes, clippy clean for `aarch64`, `cargo board -p tof` builds. Independent of #249/#250 — this and the switch touch different lines and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
