### PR TITLE
Pad imu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "robotd-params",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -90,7 +90,11 @@ this is relative motion and it drifts; it answers "did it walk in a circle" and 
 angles between degrees and radians; `t` opens the [ToF matrix](#the-tof-sensor-tofd); `d` toggles
 the robot view and `[` / `]` orbit it; `p` opens the pad's raw input stream — every evdev report
 from the gamepad, with the gaps between them, which is the only place a stalled radio is visible
-([pair a gamepad](pair-a-gamepad.md#when-it-drops-while-you-are-driving)). Angles are degrees on screen — joints, head and the yaw rate.
+([pair a gamepad](pair-a-gamepad.md#when-it-drops-while-you-are-driving)). A pad with an inertial
+unit — the Pro Controller clones have one, the Xbox does not — grows that block by a panel: a
+wireframe pad that tilts and turns with the one in your hands, its pitch, roll and drifting yaw,
+the raw acceleration and rates, and whether the gyro's rest bias has been learned yet (hold it
+still half a second). The yellow bar is the pad's front edge. Angles are degrees on screen — joints, head and the yaw rate.
 Redirected or piped it prints one line per tick instead, so `> run.log` and `| grep FALLEN`
 behave, and those numbers stay radians whatever the screen is set to. The joint vectors are in
 `--json`, which carries the whole state, one object per line:

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -63,6 +63,14 @@ padd    active — driving whatever pad connects
 Two lines, because they fail separately: a connected pad with a dead driver looks exactly like a
 working robot ignoring you.
 
+A Pro Controller also carries a six-axis IMU, which the kernel exposes as a second input device
+beside the one that drives. `robotctl monitor`, with `p` for the pad block, shows it as a panel
+that appears only when the pad has one: a wireframe pad posed like the real one, pitch and roll
+from gravity, yaw from the gyro alone (it drifts — nothing on a pad observes heading), and the
+gyro's rest bias, which the clone needs learned before the picture stops turning on its own. Set
+the pad down for half a second and the panel says `settled`. The stream costs nothing while the
+monitor is not open: `padd` reads the IMU node only while somebody is subscribed to the tap.
+
 `paired but NOT trusted` is the state worth knowing. It works now and does not reconnect after a
 reboot, because approving a reconnection needs an agent and at boot there is none. Re-run `pad pair`
 to fix it.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -4186,9 +4186,10 @@ pub struct PadImuDevice {
 ///
 /// A batch rather than one sample per report, because of what a sample costs to send: at six
 /// hundred a second, one JSON line and one socket write each was measured at 6.6% of a core on the
-/// board (2026-09-09, `padd` with a subscriber). The kernel already groups them — the clone packs
-/// three samples into every HID packet — so the tap sends what one `read` returned, and the
-/// viewer takes them in order. Nothing is summarised: every sample is here.
+/// board (2026-09-09, `padd` with a subscriber, above its 1.6% idle). The kernel already groups
+/// them — the clone packs three samples into every HID packet — so the tap sends what one `read`
+/// returned, and the viewer takes them in order: measured at exactly three per batch, two hundred
+/// batches a second, and 4.4% of a core. Nothing is summarised: every sample is here.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PadImuBatch {
     /// In the order the kernel delivered them, oldest first. Never empty on the wire.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -315,7 +315,18 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// An older `configd` answers [`code::METHOD_NOT_FOUND`] naming the method, which is the designed
 /// skew and not a handshake refusal: a new `duckctl` against a robot on an older release reports
 /// that the robot is too old rather than failing obscurely.
-pub const API_VERSION: u32 = 26;
+///
+/// # v27 — the pad's IMU, on the pad tap
+///
+/// Three more [`PadReport`] variants: a pad's inertial unit as a second evdev node beside the one
+/// that drives, its samples, and its going away. The "Pro Controller" Switch clones ship a
+/// six-axis IMU and the kernel's `hid-nintendo` exposes it as a separate accelerometer device
+/// under the same HID parent; an Xbox pad has none and a subscriber never sees the variants.
+///
+/// A new variant on a tagged enum is what a robotctl built before it cannot decode, which is the
+/// one reason this is a bump rather than a note: the tap is still `padd`'s own socket, and every
+/// other client is untouched.
+pub const API_VERSION: u32 = 27;
 
 /// The observation width every policy this robot family runs is built against.
 ///
@@ -4134,6 +4145,66 @@ pub enum PadReport {
         /// usually an errno the operator wants verbatim.
         why: String,
     },
+    /// The pad has an inertial unit and its node is open. Sent on subscribing if one is already
+    /// being read, and again each time one appears — the same one code path as `Attached`.
+    ///
+    /// Independent of `Attached`: the IMU is a second evdev device with a life of its own, and a
+    /// pad without one simply never sends this. Everything in a [`PadImuSample`] is read against
+    /// the device here.
+    ImuAttached { device: Box<PadImuDevice> },
+    /// One inertial sample, as the kernel framed it.
+    Imu(PadImuSample),
+    /// The IMU node closed.
+    ImuDetached { why: String },
+}
+
+/// A pad's inertial unit, as the kernel describes it.
+///
+/// One device rather than six axes in [`PadInputDevice::axes`], because the kernel keeps them
+/// apart: an accelerometer node carries `INPUT_PROP_ACCELEROMETER` and its `ABS_X..Z` are metres
+/// per second squared, not a stick. Reading them as a stick is what gilrs would do, which is why
+/// `padd` drives from the other node and this one is only ever tapped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadImuDevice {
+    /// As the kernel names it: "Nintendo Switch Pro Controller IMU".
+    pub name: String,
+    /// The event node being read.
+    pub node: String,
+    /// Raw units per **g** on the accelerometer axes, from the driver's `resolution`. 4096 on
+    /// `hid-nintendo`. Zero when the driver did not say, in which case the raw numbers are all a
+    /// reader has.
+    pub accel_per_g: i32,
+    /// Raw units per **degree per second** on the gyro axes. 14247 on `hid-nintendo`.
+    pub gyro_per_dps: i32,
+    /// The accelerometer's full scale, raw units, so a reader can tell a clipped sample.
+    pub accel_max: i32,
+    /// The gyro's full scale, raw units.
+    pub gyro_max: i32,
+}
+
+/// One inertial sample: everything the IMU node delivered between two `SYN_REPORT`s.
+///
+/// Raw kernel units, deliberately — the tap hands out what the device said and the resolution to
+/// read it with, and the conversion happens once, in the viewer. Six integers rather than a
+/// `PadFrame`'s event list because this arrives at several hundred a second and every byte is
+/// paid for on the board's CPU.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadImuSample {
+    /// Samples since this IMU attached, counted by `padd`. A hole is [`Self::socket_dropped`].
+    pub seq: u64,
+    /// The kernel's timestamp, microseconds since the epoch — the same clock and the same
+    /// caveats as [`PadFrame::at_us`].
+    pub at_us: u64,
+    /// `ABS_X`, `ABS_Y`, `ABS_Z`: acceleration, including gravity. At rest on a table the axis
+    /// pointing up reads about `+accel_per_g`.
+    pub accel: [i32; 3],
+    /// `ABS_RX`, `ABS_RY`, `ABS_RZ`: angular rate about the same three axes.
+    pub gyro: [i32; 3],
+    /// Samples this subscriber missed because its own socket was behind, since the last one it
+    /// did receive. Counted apart from [`PadFrame::socket_dropped`]: a dropped IMU sample says
+    /// nothing about the stick reports.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub socket_dropped: u64,
 }
 
 /// One report from the pad: everything the kernel delivered between two `SYN_REPORT`s.

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -4152,8 +4152,8 @@ pub enum PadReport {
     /// pad without one simply never sends this. Everything in a [`PadImuSample`] is read against
     /// the device here.
     ImuAttached { device: Box<PadImuDevice> },
-    /// One inertial sample, as the kernel framed it.
-    Imu(PadImuSample),
+    /// Inertial samples, as many as the kernel handed over in one read — see [`PadImuBatch`].
+    Imu(PadImuBatch),
     /// The IMU node closed.
     ImuDetached { why: String },
 }
@@ -4182,6 +4182,24 @@ pub struct PadImuDevice {
     pub gyro_max: i32,
 }
 
+/// The inertial samples one read of the IMU node produced.
+///
+/// A batch rather than one sample per report, because of what a sample costs to send: at six
+/// hundred a second, one JSON line and one socket write each was measured at 6.6% of a core on the
+/// board (2026-09-09, `padd` with a subscriber). The kernel already groups them — the clone packs
+/// three samples into every HID packet — so the tap sends what one `read` returned, and the
+/// viewer takes them in order. Nothing is summarised: every sample is here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PadImuBatch {
+    /// In the order the kernel delivered them, oldest first. Never empty on the wire.
+    pub samples: Vec<PadImuSample>,
+    /// Batches this subscriber missed because its own socket was behind, since the last one it did
+    /// receive. Counted apart from [`PadFrame::socket_dropped`]: a dropped IMU batch says nothing
+    /// about the stick reports.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub socket_dropped: u64,
+}
+
 /// One inertial sample: everything the IMU node delivered between two `SYN_REPORT`s.
 ///
 /// Raw kernel units, deliberately — the tap hands out what the device said and the resolution to
@@ -4190,7 +4208,8 @@ pub struct PadImuDevice {
 /// paid for on the board's CPU.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PadImuSample {
-    /// Samples since this IMU attached, counted by `padd`. A hole is [`Self::socket_dropped`].
+    /// Samples since this IMU attached, counted by `padd`. A hole is a batch this subscriber
+    /// missed — [`PadImuBatch::socket_dropped`].
     pub seq: u64,
     /// The kernel's timestamp, microseconds since the epoch — the same clock and the same
     /// caveats as [`PadFrame::at_us`].
@@ -4200,11 +4219,6 @@ pub struct PadImuSample {
     pub accel: [i32; 3],
     /// `ABS_RX`, `ABS_RY`, `ABS_RZ`: angular rate about the same three axes.
     pub gyro: [i32; 3],
-    /// Samples this subscriber missed because its own socket was behind, since the last one it
-    /// did receive. Counted apart from [`PadFrame::socket_dropped`]: a dropped IMU sample says
-    /// nothing about the stick reports.
-    #[serde(default, skip_serializing_if = "is_zero")]
-    pub socket_dropped: u64,
 }
 
 /// One report from the pad: everything the kernel delivered between two `SYN_REPORT`s.

--- a/padd/Cargo.toml
+++ b/padd/Cargo.toml
@@ -40,3 +40,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 evdev = "0.13"
 # `getgrnam`/`chown`, to hand the tap's socket to the `robot` group. Bindings only, no C to build.
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -373,8 +373,12 @@ impl Shared {
         state.send(&Arc::new(proto::PadReport::ImuDetached { why }));
     }
 
-    fn sample(&self, sample: proto::PadImuSample) {
-        self.lock().send(&Arc::new(proto::PadReport::Imu(sample)));
+    fn samples(&self, samples: Vec<proto::PadImuSample>) {
+        self.lock()
+            .send(&Arc::new(proto::PadReport::Imu(proto::PadImuBatch {
+                samples,
+                socket_dropped: 0,
+            })));
     }
 
     fn attach(&self, device: proto::PadInputDevice) {
@@ -558,12 +562,12 @@ fn subscriber(stream: UnixStream, shared: &Arc<Shared>) {
                     })
                 })
             }
-            proto::PadReport::Imu(sample) => {
+            proto::PadReport::Imu(batch) => {
                 let missed = dropped.samples.swap(0, Ordering::Relaxed);
                 (missed > 0).then(|| {
-                    proto::PadReport::Imu(proto::PadImuSample {
+                    proto::PadReport::Imu(proto::PadImuBatch {
                         socket_dropped: missed,
-                        ..sample.clone()
+                        ..batch.clone()
                     })
                 })
             }
@@ -695,7 +699,8 @@ fn read_imu(shared: &Arc<Shared>) {
 ///
 /// A sample is the six `ABS_*` values as they stand at each `SYN_REPORT`. Axes a report did not
 /// mention keep their last value, which is the kernel's own contract for absolute axes — a driver
-/// that leaves an unchanged axis out of a report has not zeroed it.
+/// that leaves an unchanged axis out of a report has not zeroed it. The samples one read produced
+/// go out together, as one report: that is what keeps this affordable at six hundred a second.
 fn stream_imu(shared: &Arc<Shared>, node: &Path) -> String {
     let mut device = match RawDevice::open(node) {
         Ok(device) => device,
@@ -707,6 +712,7 @@ fn stream_imu(shared: &Arc<Shared>, node: &Path) -> String {
 
     let mut seq = 0u64;
     let mut resyncing = false;
+    let mut samples: Vec<proto::PadImuSample> = Vec::new();
     loop {
         let batch = match device.fetch_events() {
             Ok(batch) => batch,
@@ -727,12 +733,11 @@ fn stream_imu(shared: &Arc<Shared>, node: &Path) -> String {
                             continue;
                         }
                         seq += 1;
-                        shared.sample(proto::PadImuSample {
+                        samples.push(proto::PadImuSample {
                             seq,
                             at_us: micros(event.timestamp()),
                             accel: [current[0], current[1], current[2]],
                             gyro: [current[3], current[4], current[5]],
-                            socket_dropped: 0,
                         });
                     }
                     _ => {}
@@ -744,6 +749,9 @@ fn stream_imu(shared: &Arc<Shared>, node: &Path) -> String {
             {
                 current[slot] = event.value();
             }
+        }
+        if !samples.is_empty() {
+            shared.samples(std::mem::take(&mut samples));
         }
         if let Some(why) = shared.done_with_imu(node) {
             return why.to_owned();
@@ -1043,11 +1051,13 @@ mod tests {
     }
 
     fn a_sample(seq: u64) -> Arc<proto::PadReport> {
-        Arc::new(proto::PadReport::Imu(proto::PadImuSample {
-            seq,
-            at_us: 1_000_000 + seq * 1_667,
-            accel: [-391, -35, 4270],
-            gyro: [25_000, -9_000, 171_000],
+        Arc::new(proto::PadReport::Imu(proto::PadImuBatch {
+            samples: vec![proto::PadImuSample {
+                seq,
+                at_us: 1_000_000 + seq * 1_667,
+                accel: [-391, -35, 4270],
+                gyro: [25_000, -9_000, 171_000],
+            }],
             socket_dropped: 0,
         }))
     }

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -34,6 +34,21 @@
 //! first report following the last one leaving — the same bargain `robotd` strikes by only
 //! assembling a `robot.state` frame when someone is subscribed. A pad at rest is silent, so a
 //! parked reader is not a wakeup either.
+//!
+//! ## The pad's IMU, when it has one
+//!
+//! Some pads carry an inertial unit. The "Pro Controller" Switch clones do, and the kernel's
+//! `hid-nintendo` exposes it as a **second** evdev node under the same HID device, flagged
+//! `INPUT_PROP_ACCELEROMETER` and named "... IMU". gilrs never opens it — an accelerometer's `ABS_X`
+//! is not a stick — so `padd` drives from the other node and this tap reads the IMU beside it, on a
+//! reader of its own with the same lifecycle: open while somebody subscribes, closed when nobody
+//! does. It is found by walking sysfs from the node gilrs named to its HID parent and back down to a
+//! sibling with the accelerometer property; a pad without one has no such sibling and nothing here
+//! changes for it.
+//!
+//! Unlike a stick it is never silent: the clone streams several hundred samples a second whether
+//! or not anyone touches it. That is why a sample is six integers rather than an event list, why it
+//! has its own drop counter, and why the IMU is not opened at all unless someone is watching.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::fs::PermissionsExt;
@@ -98,12 +113,17 @@ struct Shared {
 struct State {
     /// The node to read, as gilrs named it. `None` when no pad is connected.
     wanted: Option<PathBuf>,
+    /// The pad's IMU node, when the pad has one — see [`imu_sibling`]. Resolved once per pad node
+    /// rather than per tick, because it is a walk through sysfs.
+    wanted_imu: Option<PathBuf>,
     subscribers: Vec<Subscriber>,
     /// The `Attached` report for the device currently open.
     ///
     /// Kept so a subscriber arriving mid-stream is told what it is looking at immediately, rather
     /// than having to wait for the pad to be unplugged and put back to find out.
     attached: Option<Arc<proto::PadReport>>,
+    /// The `ImuAttached` report for the IMU currently open, for the same reason.
+    imu_attached: Option<Arc<proto::PadReport>>,
 }
 
 struct Subscriber {
@@ -111,6 +131,9 @@ struct Subscriber {
     /// Frames dropped because this subscriber's queue was full. Its writer stamps them into the
     /// next frame it does send, so a slow client cannot read as a stalled radio.
     dropped: Arc<AtomicU64>,
+    /// IMU samples dropped for the same reason, counted apart: a lost sample says nothing about
+    /// the stick reports, and stamping it onto a `PadFrame` would say it did.
+    dropped_imu: Arc<AtomicU64>,
 }
 
 impl Tap {
@@ -146,8 +169,10 @@ impl Tap {
         let shared = Arc::new(Shared {
             state: Mutex::new(State {
                 wanted: None,
+                wanted_imu: None,
                 subscribers: Vec::new(),
                 attached: None,
+                imu_attached: None,
             }),
             wake: Condvar::new(),
         });
@@ -162,6 +187,11 @@ impl Tap {
             .name("pad-tap-read".to_owned())
             .spawn(move || read(&reading))?;
 
+        let reading_imu = Arc::clone(&shared);
+        thread::Builder::new()
+            .name("pad-tap-imu".to_owned())
+            .spawn(move || read_imu(&reading_imu))?;
+
         Ok(Self { shared })
     }
 
@@ -173,23 +203,92 @@ impl Tap {
     /// It takes the gamepad rather than a path so the node can only come from gilrs — the one place
     /// that knows which of a pad's several input devices is the one being driven from.
     pub fn watch(&self, pad: &gilrs::Gamepad<'_>) {
-        self.want(Some(pad.devpath().to_path_buf()));
+        let node = pad.devpath().to_path_buf();
+        // The sysfs walk for the IMU happens only when the pad's node changes, which is the
+        // comparison `want` makes anyway — so it is made here first, before the walk.
+        if self.shared.lock().wanted.as_deref() == Some(node.as_path()) {
+            return;
+        }
+        let imu = imu_sibling(Path::new("/sys"), Path::new("/dev"), &node);
+        if let Some(imu) = imu.as_deref() {
+            tracing::info!(node = %node.display(), imu = %imu.display(), "the pad has an IMU");
+        }
+        self.want(Some(node), imu);
     }
 
-    /// No pad. The reader closes the device and says so to whoever is watching.
+    /// No pad. The readers close their devices and say so to whoever is watching.
     pub fn idle(&self) {
-        self.want(None);
+        self.want(None, None);
     }
 
-    fn want(&self, node: Option<PathBuf>) {
+    fn want(&self, node: Option<PathBuf>, imu: Option<PathBuf>) {
         let mut state = self.shared.lock();
-        if state.wanted == node {
+        if state.wanted == node && state.wanted_imu == imu {
             return;
         }
         state.wanted = node;
+        state.wanted_imu = imu;
         drop(state);
         self.shared.wake.notify_all();
     }
+}
+
+/// The IMU node that belongs to the same pad as `node`, if the pad has one.
+///
+/// A pad's several input devices share one HID parent in sysfs, and only the inertial one carries
+/// `INPUT_PROP_ACCELEROMETER` (bit 6 of `properties`). So: from `/sys/class/input/eventN/device`
+/// up one to the HID device, then over every other `eventM` whose HID device is the same one and
+/// whose properties say accelerometer. The first such node is it — a pad has one IMU.
+///
+/// `sysfs` and `dev` are parameters so a test can lay the tree out in a temporary directory;
+/// production passes `/sys` and `/dev`.
+fn imu_sibling(sysfs: &Path, dev: &Path, node: &Path) -> Option<PathBuf> {
+    let event = node.file_name()?.to_owned();
+    let class = sysfs.join("class/input");
+    let hid_parent =
+        |event: &std::ffi::OsStr| std::fs::canonicalize(class.join(event).join("device/device")).ok();
+    let parent = hid_parent(&event)?;
+
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(&class)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("event"))
+        })
+        .collect();
+    // Sorted so "the first" is the same one on every call rather than directory order.
+    candidates.sort();
+
+    for candidate in candidates {
+        let name = candidate.file_name()?.to_owned();
+        if name == event {
+            continue;
+        }
+        if hid_parent(&name).as_deref() != Some(parent.as_path()) {
+            continue;
+        }
+        let properties = std::fs::read_to_string(candidate.join("device/properties")).ok()?;
+        if has_accelerometer_property(&properties) {
+            return Some(dev.join("input").join(name));
+        }
+    }
+    None
+}
+
+/// Does a sysfs `properties` bitmask carry `INPUT_PROP_ACCELEROMETER`?
+///
+/// The file is hex words, most significant first, space separated — `40` for a device with only
+/// that bit, `0` for a pad. Bit 6, from `linux/input.h`.
+fn has_accelerometer_property(properties: &str) -> bool {
+    // The property bits fit one word on every kernel, so the last word is the one that matters
+    // and any earlier ones are zero padding.
+    let Some(low) = properties.split_whitespace().last() else {
+        return false;
+    };
+    u64::from_str_radix(low, 16).is_ok_and(|bits| bits & (1 << 6) != 0)
 }
 
 impl Shared {
@@ -231,6 +330,53 @@ impl Shared {
         None
     }
 
+    /// The IMU reader's [`Self::wait_for_work`]: a pad with an IMU, and somebody to read it for.
+    fn wait_for_imu_work(&self) -> PathBuf {
+        let mut state = self.lock();
+        loop {
+            if let Some(node) = state.wanted_imu.clone()
+                && !state.subscribers.is_empty()
+            {
+                return node;
+            }
+            state = self
+                .wake
+                .wait(state)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+
+    /// The IMU reader's [`Self::done_with`].
+    fn done_with_imu(&self, node: &Path) -> Option<&'static str> {
+        let state = self.lock();
+        if state.subscribers.is_empty() {
+            return Some("nobody is watching any more");
+        }
+        if state.wanted_imu.as_deref() != Some(node) {
+            return Some("the pad changed");
+        }
+        None
+    }
+
+    fn attach_imu(&self, device: proto::PadImuDevice) {
+        let report = Arc::new(proto::PadReport::ImuAttached {
+            device: Box::new(device),
+        });
+        let mut state = self.lock();
+        state.imu_attached = Some(Arc::clone(&report));
+        state.send(&report);
+    }
+
+    fn detach_imu(&self, why: String) {
+        let mut state = self.lock();
+        state.imu_attached = None;
+        state.send(&Arc::new(proto::PadReport::ImuDetached { why }));
+    }
+
+    fn sample(&self, sample: proto::PadImuSample) {
+        self.lock().send(&Arc::new(proto::PadReport::Imu(sample)));
+    }
+
     fn attach(&self, device: proto::PadInputDevice) {
         let report = Arc::new(proto::PadReport::Attached {
             device: Box::new(device),
@@ -256,26 +402,40 @@ impl Shared {
         self.lock().send(report);
     }
 
-    /// Add a subscriber, seeded with the device it is about to see frames from.
+    /// Add a subscriber, seeded with the device — and the IMU, if any — it is about to see
+    /// reports from.
     ///
-    /// Hands back the counter of what gets dropped for it, which only its own writer may clear.
-    fn subscribe(&self) -> (Receiver<Arc<proto::PadReport>>, Arc<AtomicU64>) {
+    /// Hands back the counters of what gets dropped for it, which only its own writer may clear.
+    fn subscribe(&self) -> (Receiver<Arc<proto::PadReport>>, Dropped) {
         let (reports, rx) = sync_channel(QUEUE);
         let mut state = self.lock();
         if let Some(attached) = state.attached.clone() {
             // Cannot fail: the queue is empty and this is the first thing in it.
             let _ = reports.try_send(attached);
         }
-        let dropped = Arc::new(AtomicU64::new(0));
+        if let Some(attached) = state.imu_attached.clone() {
+            let _ = reports.try_send(attached);
+        }
+        let dropped = Dropped {
+            frames: Arc::new(AtomicU64::new(0)),
+            samples: Arc::new(AtomicU64::new(0)),
+        };
         state.subscribers.push(Subscriber {
             reports,
-            dropped: Arc::clone(&dropped),
+            dropped: Arc::clone(&dropped.frames),
+            dropped_imu: Arc::clone(&dropped.samples),
         });
         drop(state);
         // A subscriber is the reader's other precondition, so it may have work now.
         self.wake.notify_all();
         (rx, dropped)
     }
+}
+
+/// One subscriber's drop counters, as its writer holds them.
+struct Dropped {
+    frames: Arc<AtomicU64>,
+    samples: Arc<AtomicU64>,
 }
 
 impl State {
@@ -285,11 +445,17 @@ impl State {
     /// a subscriber that stalled it would corrupt the measurement it asked for — every frame after
     /// the stall would carry a gap the radio had nothing to do with.
     fn send(&mut self, report: &Arc<proto::PadReport>) {
+        let is_sample = matches!(**report, proto::PadReport::Imu(_));
         self.subscribers.retain(|subscriber| {
             match subscriber.reports.try_send(Arc::clone(report)) {
                 Ok(()) => true,
                 Err(TrySendError::Full(_)) => {
-                    subscriber.dropped.fetch_add(1, Ordering::Relaxed);
+                    let counter = if is_sample {
+                        &subscriber.dropped_imu
+                    } else {
+                        &subscriber.dropped
+                    };
+                    counter.fetch_add(1, Ordering::Relaxed);
                     true
                 }
                 // The writer is gone: the client disconnected.
@@ -382,13 +548,24 @@ fn subscriber(stream: UnixStream, shared: &Arc<Shared>) {
         // Whatever this subscriber missed goes on the next frame it does get, where it belongs:
         // beside the gap it explains. Left on the counter until then, so it cannot be lost to an
         // `Attached` or a `Detached` that carries nowhere to put it.
-        let stamped = match (&*report, dropped.load(Ordering::Relaxed)) {
-            (proto::PadReport::Frame(frame), missed) if missed > 0 => {
-                dropped.store(0, Ordering::Relaxed);
-                Some(proto::PadReport::Frame(proto::PadFrame {
-                    socket_dropped: missed,
-                    ..frame.clone()
-                }))
+        let stamped = match &*report {
+            proto::PadReport::Frame(frame) => {
+                let missed = dropped.frames.swap(0, Ordering::Relaxed);
+                (missed > 0).then(|| {
+                    proto::PadReport::Frame(proto::PadFrame {
+                        socket_dropped: missed,
+                        ..frame.clone()
+                    })
+                })
+            }
+            proto::PadReport::Imu(sample) => {
+                let missed = dropped.samples.swap(0, Ordering::Relaxed);
+                (missed > 0).then(|| {
+                    proto::PadReport::Imu(proto::PadImuSample {
+                        socket_dropped: missed,
+                        ..sample.clone()
+                    })
+                })
             }
             _ => None,
         };
@@ -498,6 +675,110 @@ fn stream(shared: &Arc<Shared>, node: &Path) -> String {
             return why.to_owned();
         }
     }
+}
+
+/// Open the wanted IMU node, stream it, and go back to waiting when it ends. Forever.
+///
+/// [`read`], for the second device. Its own thread because `fetch_events` blocks, and one reader
+/// cannot block on two nodes.
+fn read_imu(shared: &Arc<Shared>) {
+    loop {
+        let node = shared.wait_for_imu_work();
+        let why = stream_imu(shared, &node);
+        tracing::info!(node = %node.display(), why, "pad tap stopped reading the IMU");
+        shared.detach_imu(why);
+        thread::sleep(REOPEN_AFTER);
+    }
+}
+
+/// Read one IMU node until it ends, describing how it ended.
+///
+/// A sample is the six `ABS_*` values as they stand at each `SYN_REPORT`. Axes a report did not
+/// mention keep their last value, which is the kernel's own contract for absolute axes — a driver
+/// that leaves an unchanged axis out of a report has not zeroed it.
+fn stream_imu(shared: &Arc<Shared>, node: &Path) -> String {
+    let mut device = match RawDevice::open(node) {
+        Ok(device) => device,
+        Err(e) => return format!("cannot open {}: {e}", node.display()),
+    };
+    let (described, mut current) = describe_imu(&device, node);
+    shared.attach_imu(described);
+    tracing::info!(node = %node.display(), "pad tap reading the IMU");
+
+    let mut seq = 0u64;
+    let mut resyncing = false;
+    loop {
+        let batch = match device.fetch_events() {
+            Ok(batch) => batch,
+            Err(e) => return format!("{} ended: {e}", node.display()),
+        };
+        for event in batch {
+            let kind = EventType(event.event_type().0);
+            let code = event.code();
+            if kind == EventType::SYNCHRONIZATION {
+                match SynchronizationCode(code) {
+                    SynchronizationCode::SYN_DROPPED => resyncing = true,
+                    SynchronizationCode::SYN_REPORT => {
+                        if resyncing {
+                            // The half-sample after a drop is discarded, as for the pad; the
+                            // values themselves are still the newest the kernel has, so the next
+                            // complete report is right.
+                            resyncing = false;
+                            continue;
+                        }
+                        seq += 1;
+                        shared.sample(proto::PadImuSample {
+                            seq,
+                            at_us: micros(event.timestamp()),
+                            accel: [current[0], current[1], current[2]],
+                            gyro: [current[3], current[4], current[5]],
+                            socket_dropped: 0,
+                        });
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+            if kind == EventType::ABSOLUTE
+                && let Some(slot) = imu_slot(code)
+            {
+                current[slot] = event.value();
+            }
+        }
+        if let Some(why) = shared.done_with_imu(node) {
+            return why.to_owned();
+        }
+    }
+}
+
+/// Which of the six sample slots an `ABS_*` code fills: X, Y, Z, RX, RY, RZ.
+fn imu_slot(code: u16) -> Option<usize> {
+    (code <= AbsoluteAxisCode::ABS_RZ.0).then_some(usize::from(code))
+}
+
+/// The IMU as the kernel describes it, and where its axes stand right now.
+fn describe_imu(device: &RawDevice, node: &Path) -> (proto::PadImuDevice, [i32; 6]) {
+    let mut current = [0i32; 6];
+    let mut resolution = [0i32; 6];
+    let mut max = [0i32; 6];
+    if let Ok(axes) = device.get_absinfo() {
+        for (code, info) in axes {
+            if let Some(slot) = imu_slot(code.0) {
+                current[slot] = info.value();
+                resolution[slot] = info.resolution();
+                max[slot] = info.maximum();
+            }
+        }
+    }
+    let described = proto::PadImuDevice {
+        name: device.name().unwrap_or("unnamed IMU").to_owned(),
+        node: node.display().to_string(),
+        accel_per_g: resolution[0],
+        gyro_per_dps: resolution[3],
+        accel_max: max[0],
+        gyro_max: max[3],
+    };
+    (described, current)
 }
 
 /// Everything about the device that a number in a frame has to be read against.
@@ -646,8 +927,10 @@ mod tests {
         Arc::new(Shared {
             state: Mutex::new(State {
                 wanted: None,
+                wanted_imu: None,
                 subscribers: Vec::new(),
                 attached: None,
+                imu_attached: None,
             }),
             wake: Condvar::new(),
         })
@@ -681,9 +964,14 @@ mod tests {
         }
 
         assert_eq!(
-            dropped.load(Ordering::Relaxed),
+            dropped.frames.load(Ordering::Relaxed),
             10,
             "the overflow is counted"
+        );
+        assert_eq!(
+            dropped.samples.load(Ordering::Relaxed),
+            0,
+            "and not against the IMU, which sent nothing"
         );
         assert_eq!(
             shared.lock().subscribers.len(),
@@ -752,6 +1040,109 @@ mod tests {
         assert_eq!(event_name(0x15, 1), "21:1");
         let unnamed = event_name(EventType::ABSOLUTE.0, 0x3e);
         assert!(!unnamed.contains(' '), "no prose on the wire: {unnamed}");
+    }
+
+    fn a_sample(seq: u64) -> Arc<proto::PadReport> {
+        Arc::new(proto::PadReport::Imu(proto::PadImuSample {
+            seq,
+            at_us: 1_000_000 + seq * 1_667,
+            accel: [-391, -35, 4270],
+            gyro: [25_000, -9_000, 171_000],
+            socket_dropped: 0,
+        }))
+    }
+
+    /// IMU samples that overflow a slow subscriber are counted against the IMU, not the pad. The
+    /// clone sends six hundred a second and the sticks a handful; a shared counter would report a
+    /// pad link losing reports it never lost.
+    #[test]
+    fn dropped_samples_are_not_dropped_frames() {
+        let shared = a_shared();
+        let (reports, dropped) = shared.subscribe();
+
+        for seq in 0..(QUEUE as u64 + 25) {
+            shared.frame_report(&a_sample(seq));
+        }
+
+        assert_eq!(dropped.samples.load(Ordering::Relaxed), 25);
+        assert_eq!(dropped.frames.load(Ordering::Relaxed), 0);
+        drop(reports);
+    }
+
+    /// A subscriber arriving while an IMU is open is told about it, as it is told about the pad.
+    #[test]
+    fn a_subscriber_arriving_mid_stream_is_told_the_imu_too() {
+        let shared = a_shared();
+        shared.attach(a_device());
+        shared.attach_imu(proto::PadImuDevice {
+            name: "Nintendo Switch Pro Controller IMU".to_owned(),
+            node: "/dev/input/event5".to_owned(),
+            accel_per_g: 4096,
+            gyro_per_dps: 14247,
+            accel_max: 32767,
+            gyro_max: 32_767_000,
+        });
+
+        let (reports, _dropped) = shared.subscribe();
+        assert!(matches!(&*reports.try_recv().unwrap(), proto::PadReport::Attached { .. }));
+        assert!(matches!(
+            &*reports.try_recv().unwrap(),
+            proto::PadReport::ImuAttached { .. }
+        ));
+    }
+
+    /// The IMU is a sibling node under the pad's HID device with the accelerometer property, and
+    /// nothing else qualifies: not the pad itself, not a node of another device, not a sibling
+    /// without the property. Laid out as sysfs lays it out — `eventN/device` is the input device,
+    /// its `device` the HID one — so the walk here is the walk on a board.
+    #[test]
+    fn the_imu_is_the_accelerometer_sibling_under_the_same_hid_device() {
+        let root = tempfile::tempdir().unwrap();
+        let sysfs = root.path().join("sys");
+        let dev = root.path().join("dev");
+        let hid_pad = sysfs.join("devices/hci0/0005:057E:2009.0001");
+        let hid_other = sysfs.join("devices/hci0/0005:045E:0B13.0002");
+        let class = sysfs.join("class/input");
+        std::fs::create_dir_all(&class).unwrap();
+
+        // (event, hid device, properties)
+        let nodes = [
+            ("event3", &hid_other, "0"),
+            ("event4", &hid_pad, "0"),
+            ("event5", &hid_pad, "40"),
+            ("event6", &hid_other, "40"),
+        ];
+        for (index, (event, hid, props)) in nodes.iter().enumerate() {
+            // As on a board: `<hid>/input/inputN/eventN` is the node's directory, its `device`
+            // is the input device `inputN`, and *that* device's `device` is the HID one.
+            let input = hid.join(format!("input/input{index}"));
+            let node = input.join(event);
+            std::fs::create_dir_all(&node).unwrap();
+            std::fs::write(input.join("properties"), format!("{props}\n")).unwrap();
+            std::os::unix::fs::symlink(&node, class.join(event)).unwrap();
+            std::os::unix::fs::symlink(&input, node.join("device")).unwrap();
+            std::os::unix::fs::symlink(hid, input.join("device")).unwrap();
+        }
+
+        assert_eq!(
+            imu_sibling(&sysfs, &dev, Path::new("/dev/input/event4")),
+            Some(dev.join("input/event5")),
+            "the pad's own accelerometer sibling"
+        );
+        assert_eq!(
+            imu_sibling(&sysfs, &dev, Path::new("/dev/input/event3")),
+            Some(dev.join("input/event6")),
+            "another pad, its own sibling — never the first pad's"
+        );
+        assert_eq!(
+            imu_sibling(&sysfs, &dev, Path::new("/dev/input/event9")),
+            None,
+            "a node sysfs has never heard of"
+        );
+        assert!(has_accelerometer_property("40"));
+        assert!(has_accelerometer_property("0 40"));
+        assert!(!has_accelerometer_property("0"));
+        assert!(!has_accelerometer_property(""));
     }
 
     /// The tap's wire types are the protocol's, so a frame it builds is a frame `robotctl` parses.

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -43,6 +43,7 @@ use robotd_params::Slot;
 mod configure;
 mod duck;
 mod monitor;
+mod pad_imu;
 mod path_map;
 mod show;
 

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -31,7 +31,7 @@ use ratatui::widgets::{
     Block, Cell, Paragraph, RenderDirection, Row, Sparkline, Table, TableState,
 };
 
-use crate::{Client, Failure, duck, exit, path_map};
+use crate::{Client, Failure, duck, exit, pad_imu, path_map};
 
 /// Tracking error at the edge of a deviation bar, radians.
 ///
@@ -71,6 +71,21 @@ const SUBSCRIBE_ID: u64 = 1;
 /// Fixed, like the header and for the same reason — but *only while open*. Toggling it is a
 /// deliberate act, and everything below moving then is what the reader asked for.
 const PAD_HEIGHT: u16 = 8;
+
+/// Rows the pad block grows by while the pad has an IMU: two borders and ten rows of a
+/// wireframe pad tilting with the real one, beside the numbers. Ten because the picture is drawn
+/// two pixels a row and a pad needs about twenty to read as one.
+///
+/// Only while one is attached. An Xbox pad has none and its block is exactly what it was; the
+/// Pro Controller clones have one and the block opens up the moment `padd` finds it — which is the
+/// right moment for the reader to learn the pad can do that at all.
+const IMU_HEIGHT: u16 = 12;
+
+/// How often IMU samples alone may repaint the frame.
+///
+/// The clone sends six hundred a second, and a terminal redrawn at that rate is a terminal doing
+/// nothing else. Thirty a second is smooth to the eye and leaves the CPU for the filter.
+const IMU_REPAINT: Duration = Duration::from_millis(33);
 
 /// Rows the ToF block occupies while it is open: two borders and the eight rows
 /// of an 8×8 frame.
@@ -964,9 +979,26 @@ struct PadView {
     /// Times the robot's realtime clock stepped backwards between two reports. Expected exactly
     /// once on a board with no RTC, when its first NTP reply lands.
     clock_steps: u64,
+    /// The pad's inertial unit, while `padd` has one open. Its own lifecycle: a pad without one
+    /// never sets this, and a pad that drops takes it away through `ImuDetached`, not `Detached`.
+    imu: Option<pad_imu::Imu>,
+    /// When a sample last earned a repaint — see [`IMU_REPAINT`].
+    imu_painted: Option<Instant>,
 }
 
 impl PadView {
+    /// Has enough time passed since the last IMU-driven repaint for another one?
+    fn imu_repaint_due(&mut self) -> bool {
+        let now = Instant::now();
+        match self.imu_painted {
+            Some(at) if now.duration_since(at) < IMU_REPAINT => false,
+            _ => {
+                self.imu_painted = Some(now);
+                true
+            }
+        }
+    }
+
     /// Take one report.
     fn absorb(&mut self, report: proto::PadReport) {
         match report {
@@ -1002,6 +1034,15 @@ impl PadView {
                 self.trouble = Some(why);
             }
             proto::PadReport::Frame(frame) => self.frame(frame),
+            proto::PadReport::ImuAttached { device } => {
+                self.imu = Some(pad_imu::Imu::new(*device));
+            }
+            proto::PadReport::Imu(sample) => {
+                if let Some(imu) = self.imu.as_mut() {
+                    imu.absorb(&sample);
+                }
+            }
+            proto::PadReport::ImuDetached { .. } => self.imu = None,
         }
     }
 
@@ -1087,6 +1128,111 @@ impl PadView {
         };
         Some((age, verdict))
     }
+}
+
+/// The pad's inertial unit: a wireframe pad posed like the real one, and the numbers beside it.
+///
+/// Left, the picture; right, the words. The picture is what a person reads — a pad tilting on
+/// screen as it tilts in the hand is understood in the time it takes to see it — and the numbers
+/// are for when the picture is wrong: they say which axis, by how much, and whether the gyro bias
+/// the picture depends on has been learned yet.
+fn render_imu(imu: &pad_imu::Imu, frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+    let device = imu.device();
+    let mut title = vec![
+        Span::raw(" imu "),
+        Span::styled(
+            device.name.clone(),
+            Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+        ),
+    ];
+    match imu.rate_hz() {
+        Some(hz) => title.push(Span::raw(format!(" · {hz:.0} Hz ")).dim()),
+        None => title.push(Span::raw(" · waiting for samples ").dim()),
+    }
+    let block = Block::bordered()
+        .border_style(Style::new().fg(Color::Magenta))
+        .title(Line::from(title))
+        .title_bottom(
+            Line::from(format!(
+                " {} samples · {} · yellow bar = front edge ",
+                imu.samples(),
+                device.node
+            ))
+            .dim(),
+        );
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // The picture gets the left half of the width, capped where a wider one stops adding detail;
+    // the words take the rest. The picture is the one that earns its place, so it is sized first.
+    let picture_width = (inner.width / 2).clamp(12, 48);
+    let [picture, words] = Layout::horizontal([
+        Constraint::Length(picture_width),
+        Constraint::Min(0),
+    ])
+    .areas::<2>(inner);
+    imu.draw(picture, frame.buffer_mut());
+
+    let [pitch, roll, yaw] = imu.euler_deg();
+    let a = imu.accel_g();
+    let g = imu.gyro_dps();
+    let magnitude = (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt();
+    let signed = |v: f32| format!("{v:+7.2}");
+    let bias = match imu.bias_dps() {
+        Some(b) => Line::from(vec![
+            Span::raw(" bias  "),
+            Span::raw(format!(
+                "{} {} {} °/s ",
+                signed(b[0]),
+                signed(b[1]),
+                signed(b[2])
+            )),
+            Span::styled("settled", Style::new().fg(Color::Green)),
+            Span::raw(" — removed from the rates above").dim(),
+        ]),
+        None => Line::from(vec![
+            Span::raw(" bias  "),
+            Span::styled(
+                "learning — hold the pad still for half a second",
+                Style::new().fg(Color::Yellow),
+            ),
+        ]),
+    };
+    let mut lines = vec![
+        Line::from(vec![
+            Span::raw(" tilt  "),
+            Span::styled(
+                format!("pitch {pitch:+6.1}°  roll {roll:+6.1}°"),
+                Style::new().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!("  yaw {yaw:+6.1}°")),
+            Span::raw(" (gyro only, drifts)").dim(),
+        ]),
+        Line::from(format!(
+            " accel {} {} {} g   |a| {magnitude:.2} g",
+            signed(a[0]),
+            signed(a[1]),
+            signed(a[2])
+        )),
+        Line::from(format!(
+            " gyro  {} {} {} °/s",
+            signed(g[0]),
+            signed(g[1]),
+            signed(g[2])
+        )),
+        bias,
+        Line::from(" axes  +X front · +Y left · +Z up · at rest Z reads +1 g").dim(),
+    ];
+    if imu.socket_dropped() > 0 {
+        lines.push(Line::from(vec![Span::styled(
+            format!(
+                " {} samples dropped reaching this view",
+                imu.socket_dropped()
+            ),
+            Style::new().fg(Color::Magenta),
+        )]));
+    }
+    frame.render_widget(Paragraph::new(lines), words);
 }
 
 /// What the time since the last report means.
@@ -1250,10 +1396,15 @@ impl View {
                 Ok(true)
             }
             Update::Pad(report) => {
+                let sample = matches!(*report, proto::PadReport::Imu(_));
                 self.pad.absorb(*report);
                 // A repaint even while the block is closed would be a redraw per report, at up to
-                // 125 a second, for something nobody is looking at.
-                Ok(self.show_pad)
+                // 125 a second, for something nobody is looking at — and an IMU sample, at six
+                // hundred a second, earns one only every [`IMU_REPAINT`] even when it is.
+                if !self.show_pad {
+                    return Ok(false);
+                }
+                Ok(!sample || self.pad.imu_repaint_due())
             }
             Update::Tof(frame) => {
                 self.tof = Some(*frame);
@@ -1329,7 +1480,7 @@ impl View {
             // connect to. Either way the pad block is still drawn when it is open: it reads a
             // different daemon over a different socket, and a robot is not a precondition for
             // watching the sticks.
-            let pad_height = if self.show_pad { PAD_HEIGHT } else { 0 };
+            let pad_height = self.pad_height();
             let tof_height = if self.show_tof { TOF_HEIGHT } else { 0 };
             let [pad, tof, rest] = Layout::vertical([
                 Constraint::Length(pad_height),
@@ -1386,7 +1537,7 @@ impl View {
         // The pad block, when open, sits directly under the header rather than at the bottom: it is
         // the *source* of the command the header reports, and the frame then reads top to bottom in
         // the order the robot does — sticks, command, joints, loop rate.
-        let pad_height = if self.show_pad { PAD_HEIGHT } else { 0 };
+        let pad_height = self.pad_height();
         let tof_height = if self.show_tof { TOF_HEIGHT } else { 0 };
         let trace_height = area
             .height
@@ -1426,6 +1577,15 @@ impl View {
         if let Some(duck) = duck {
             self.render_duck(frame, duck);
         }
+    }
+
+    /// Rows the pad block takes: none while closed, [`PAD_HEIGHT`] open, and [`IMU_HEIGHT`] more
+    /// while the pad has an inertial unit to show.
+    fn pad_height(&self) -> u16 {
+        if !self.show_pad {
+            return 0;
+        }
+        PAD_HEIGHT + if self.pad.imu.is_some() { IMU_HEIGHT } else { 0 }
     }
 
     /// Carve the robot view's column off the right, when it is wanted and fits.
@@ -2319,14 +2479,19 @@ impl View {
         };
 
         // Fixed rows, in the order the questions arrive: is it arriving, has it been arriving, and
-        // what is it saying.
-        let [cadence, gaps, axes, held] = Layout::vertical([
+        // what it is saying — and, when the pad has one, where the pad is in space.
+        let imu_height = if self.pad.imu.is_some() { IMU_HEIGHT } else { 0 };
+        let [cadence, gaps, axes, held, imu] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(AXIS_ROWS as u16),
             Constraint::Length(1),
+            Constraint::Length(imu_height),
         ])
-        .areas::<4>(inner);
+        .areas::<5>(inner);
+        if let Some(unit) = self.pad.imu.as_ref() {
+            render_imu(unit, frame, imu);
+        }
 
         frame.render_widget(self.pad_cadence(), cadence);
         // A label beside the trace rather than a title above it: a bordered block for one row of
@@ -2363,6 +2528,13 @@ impl View {
             title.push(Span::styled(
                 "· on USB, so there is no radio here ",
                 Style::new().fg(Color::Yellow),
+            ));
+        }
+        if self.pad.imu.is_some() {
+            // Loud on purpose: a pad with an IMU is news, and the block below has just grown.
+            title.push(Span::styled(
+                "· IMU ",
+                Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD),
             ));
         }
         title
@@ -3642,6 +3814,96 @@ mod tests {
         );
         view.toggle_pad();
         view
+    }
+
+    fn an_imu() -> proto::PadImuDevice {
+        proto::PadImuDevice {
+            name: "Nintendo Switch Pro Controller IMU".to_owned(),
+            node: "/dev/input/event6".to_owned(),
+            accel_per_g: 4096,
+            gyro_per_dps: 14247,
+            accel_max: 32767,
+            gyro_max: 32_767_000,
+        }
+    }
+
+    /// The pad block is what it always was for a pad without an IMU, and grows — with the
+    /// picture, the numbers and a loud tag in the title — the moment `padd` opens one. An Xbox
+    /// pad's owner must see no change; a Pro Controller's must not be able to miss it.
+    #[test]
+    fn the_pad_block_grows_an_imu_panel_only_when_the_pad_has_one() {
+        let mut view = watching_a_pad();
+        let without = render_to(&mut view, 100, 40);
+        assert!(!without.contains("front edge"), "no IMU, no panel:\n{without}");
+        assert!(!without.contains("· IMU"), "{without}");
+
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::ImuAttached {
+                device: Box::new(an_imu()),
+            })),
+        );
+        // Two hundred samples of a pad lying flat, a second's worth: level, bias learned.
+        for i in 1..=200u64 {
+            feed(
+                &mut view,
+                Update::Pad(Box::new(proto::PadReport::Imu(proto::PadImuSample {
+                    seq: i,
+                    at_us: 1_000_000 + i * 5_000,
+                    accel: [-391, -35, 4270],
+                    gyro: [25_000, -9_000, 171_000],
+                    socket_dropped: 0,
+                }))),
+            );
+        }
+        let with = render_to(&mut view, 100, 40);
+        assert!(with.contains("· IMU"), "the title says so:\n{with}");
+        assert!(
+            with.contains("Nintendo Switch Pro Controller IMU"),
+            "the panel names the unit:\n{with}"
+        );
+        assert!(with.contains("pitch"), "and reads its attitude:\n{with}");
+        assert!(with.contains("settled"), "a second still learns the bias:\n{with}");
+        assert!(
+            with.contains('▀') || with.contains('▄'),
+            "and draws the pad:\n{with}"
+        );
+
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::ImuDetached {
+                why: "the pad changed".to_owned(),
+            })),
+        );
+        let gone = render_to(&mut view, 100, 40);
+        assert!(!gone.contains("· IMU"), "and it goes when the IMU does:\n{gone}");
+    }
+
+    /// Six hundred samples a second must not become six hundred repaints a second.
+    #[test]
+    fn imu_samples_repaint_at_most_thirty_times_a_second() {
+        let mut view = watching_a_pad();
+        feed(
+            &mut view,
+            Update::Pad(Box::new(proto::PadReport::ImuAttached {
+                device: Box::new(an_imu()),
+            })),
+        );
+        let repaints = (1..=100u64)
+            .filter(|i| {
+                view.absorb(Update::Pad(Box::new(proto::PadReport::Imu(
+                    proto::PadImuSample {
+                        seq: *i,
+                        at_us: 1_000_000 + i * 1_667,
+                        accel: [0, 0, 4096],
+                        gyro: [0, 0, 0],
+                        socket_dropped: 0,
+                    },
+                ))))
+                .unwrap_or_else(|_| panic!("an update is not a failure"))
+            })
+            .count();
+        assert!(repaints <= 2, "a burst of samples earned {repaints} repaints");
     }
 
     /// Stopping `tofd` must be an ordinary thing to do. The subscribe reports why

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -1037,9 +1037,9 @@ impl PadView {
             proto::PadReport::ImuAttached { device } => {
                 self.imu = Some(pad_imu::Imu::new(*device));
             }
-            proto::PadReport::Imu(sample) => {
+            proto::PadReport::Imu(batch) => {
                 if let Some(imu) = self.imu.as_mut() {
-                    imu.absorb(&sample);
+                    imu.absorb(&batch);
                 }
             }
             proto::PadReport::ImuDetached { .. } => self.imu = None,
@@ -3847,11 +3847,13 @@ mod tests {
         for i in 1..=200u64 {
             feed(
                 &mut view,
-                Update::Pad(Box::new(proto::PadReport::Imu(proto::PadImuSample {
-                    seq: i,
-                    at_us: 1_000_000 + i * 5_000,
-                    accel: [-391, -35, 4270],
-                    gyro: [25_000, -9_000, 171_000],
+                Update::Pad(Box::new(proto::PadReport::Imu(proto::PadImuBatch {
+                    samples: vec![proto::PadImuSample {
+                        seq: i,
+                        at_us: 1_000_000 + i * 5_000,
+                        accel: [-391, -35, 4270],
+                        gyro: [25_000, -9_000, 171_000],
+                    }],
                     socket_dropped: 0,
                 }))),
             );
@@ -3892,11 +3894,13 @@ mod tests {
         let repaints = (1..=100u64)
             .filter(|i| {
                 view.absorb(Update::Pad(Box::new(proto::PadReport::Imu(
-                    proto::PadImuSample {
-                        seq: *i,
-                        at_us: 1_000_000 + i * 1_667,
-                        accel: [0, 0, 4096],
-                        gyro: [0, 0, 0],
+                    proto::PadImuBatch {
+                        samples: vec![proto::PadImuSample {
+                            seq: *i,
+                            at_us: 1_000_000 + i * 1_667,
+                            accel: [0, 0, 4096],
+                            gyro: [0, 0, 0],
+                        }],
                         socket_dropped: 0,
                     },
                 ))))

--- a/robotctl/src/pad_imu.rs
+++ b/robotctl/src/pad_imu.rs
@@ -209,10 +209,16 @@ impl Imu {
         self.bias.value
     }
 
-    /// Take one sample.
-    pub fn absorb(&mut self, sample: &proto::PadImuSample) {
+    /// Take one batch, sample by sample and in order.
+    pub fn absorb(&mut self, batch: &proto::PadImuBatch) {
+        self.socket_dropped += batch.socket_dropped;
+        for sample in &batch.samples {
+            self.sample(sample);
+        }
+    }
+
+    fn sample(&mut self, sample: &proto::PadImuSample) {
         self.samples += 1;
-        self.socket_dropped += sample.socket_dropped;
 
         let accel_scale = scale(self.device.accel_per_g);
         let gyro_scale = scale(self.device.gyro_per_dps);
@@ -654,6 +660,12 @@ mod tests {
                 (gyro_dps[1] * 14247.0) as i32,
                 (gyro_dps[2] * 14247.0) as i32,
             ],
+        }
+    }
+
+    fn one(sample: proto::PadImuSample) -> proto::PadImuBatch {
+        proto::PadImuBatch {
+            samples: vec![sample],
             socket_dropped: 0,
         }
     }
@@ -663,7 +675,7 @@ mod tests {
         let n = (seconds * 200.0) as u64;
         let start = imu.last_us.unwrap_or(0);
         for i in 1..=n {
-            imu.absorb(&sample(i, start + i * 5_000, accel_g, gyro_dps));
+            imu.absorb(&one(sample(i, start + i * 5_000, accel_g, gyro_dps)));
         }
     }
 
@@ -734,7 +746,12 @@ mod tests {
         steady(&mut imu, 2.0, [0.0, 0.0, 1.0], [0.0; 3]);
         let before = imu.euler_deg();
         let last = imu.last_us.unwrap();
-        imu.absorb(&sample(9_999, last + 3_000_000, [0.0, 0.0, 1.0], [90.0, 0.0, 0.0]));
+        imu.absorb(&one(sample(
+            9_999,
+            last + 3_000_000,
+            [0.0, 0.0, 1.0],
+            [90.0, 0.0, 0.0],
+        )));
         let after = imu.euler_deg();
         assert!((after[1] - before[1]).abs() < 0.5, "{before:?} → {after:?}");
     }
@@ -788,15 +805,17 @@ mod probe {
                 gyro_max: 32_767_000,
             };
             let mut imu = Imu::new(device);
-            imu.absorb(&proto::PadImuSample {
-                seq: 1,
-                at_us: 1_000_000,
-                accel: [
-                    (accel[0] * 4096.0) as i32,
-                    (accel[1] * 4096.0) as i32,
-                    (accel[2] * 4096.0) as i32,
-                ],
-                gyro: [0; 3],
+            imu.absorb(&proto::PadImuBatch {
+                samples: vec![proto::PadImuSample {
+                    seq: 1,
+                    at_us: 1_000_000,
+                    accel: [
+                        (accel[0] * 4096.0) as i32,
+                        (accel[1] * 4096.0) as i32,
+                        (accel[2] * 4096.0) as i32,
+                    ],
+                    gyro: [0; 3],
+                }],
                 socket_dropped: 0,
             });
             let area = Rect::new(0, 0, 44, 10);

--- a/robotctl/src/pad_imu.rs
+++ b/robotctl/src/pad_imu.rs
@@ -314,7 +314,7 @@ impl Imu {
         let rotation = matrix(self.q);
 
         // World → screen: yaw the camera for a three-quarter view, then look down at it. The
-        // result is in body millimetres until it is fitted below.
+        // result is in body millimetres until it is scaled below.
         let (az_sin, az_cos) = CAMERA_AZIMUTH.sin_cos();
         let (el_sin, el_cos) = CAMERA_ELEVATION.sin_cos();
         let project = |p: [f32; 3]| -> (f32, f32) {
@@ -325,32 +325,27 @@ impl Imu {
             (x, -up)
         };
 
-        // Fit the whole pad, whatever its attitude, into the canvas with a pixel of margin. Fitted
-        // per frame rather than to a fixed extent: a pad on its edge is tall and thin, a pad flat
-        // is wide and short, and a fixed scale that framed both would draw each at half size.
-        // The pad's own centre stays put, so tilting reads as tilting and not as sliding.
-        let ends: Vec<((f32, f32), (f32, f32))> = PAD_WIREFRAME
+        // One zoom for every attitude: the pad's bounding sphere is what has to fit, so a pad on
+        // its edge and a pad lying flat are drawn at the same scale and tilting reads as tilting,
+        // not as the picture breathing. The body origin sits at the canvas centre. Framed at 80% of
+        // the sphere rather than all of it: only a grip tip pointing straight at the camera's edge
+        // ever reaches the last 20%, and framing for that moment shrinks every other one.
+        let radius = PAD_WIREFRAME
             .iter()
-            .map(|s| (project(s.from), project(s.to)))
-            .collect();
-        let (mut min_x, mut max_x, mut min_y, mut max_y) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
-        for (a, b) in &ends {
-            for p in [a, b] {
-                min_x = min_x.min(p.0);
-                max_x = max_x.max(p.0);
-                min_y = min_y.min(p.1);
-                max_y = max_y.max(p.1);
-            }
-        }
-        let extent_x = (max_x - min_x).max(1.0);
-        let extent_y = (max_y - min_y).max(1.0);
-        let scale = ((w as f32 - 2.0) / extent_x).min((h as f32 - 2.0) / extent_y);
+            .flat_map(|s| [s.from, s.to])
+            .map(norm)
+            .fold(1.0f32, f32::max)
+            * 0.8;
+        let scale = ((w as f32 - 2.0) / (2.0 * radius)).min((h as f32 - 2.0) / (2.0 * radius));
         let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
-        let (mid_x, mid_y) = ((min_x + max_x) / 2.0, (min_y + max_y) / 2.0);
-        let place = |p: (f32, f32)| ((p.0 - mid_x) * scale + cx, (p.1 - mid_y) * scale + cy);
+        let place = |p: (f32, f32)| (p.0 * scale + cx, p.1 * scale + cy);
 
-        for (segment, (a, b)) in PAD_WIREFRAME.iter().zip(ends) {
-            canvas.line(place(a), place(b), segment.colour());
+        for segment in PAD_WIREFRAME {
+            canvas.line(
+                place(project(segment.from)),
+                place(project(segment.to)),
+                segment.colour(),
+            );
         }
         canvas.blit(area, buf);
     }
@@ -761,7 +756,7 @@ mod tests {
         steady(&mut level, 0.1, [0.0, 0.0, 1.0], [0.0; 3]);
         let flat = picture(&level);
         let inked = flat.iter().flat_map(|r| r.chars()).filter(|c| *c != ' ').count();
-        assert!(inked > 60, "a wireframe is more than a few pixels: {inked}");
+        assert!(inked > 30, "a wireframe is more than a few pixels: {inked}");
 
         let mut rolled = Imu::new(a_device());
         steady(&mut rolled, 0.1, [0.0, 0.7, 0.7], [0.0; 3]);

--- a/robotctl/src/pad_imu.rs
+++ b/robotctl/src/pad_imu.rs
@@ -1,0 +1,817 @@
+//! The pad's inertial unit, as the monitor reads it and draws it.
+//!
+//! Some pads carry a six-axis IMU. The "Pro Controller" Switch clones do, and `padd`'s tap hands
+//! its samples out as [`proto::PadReport::Imu`] — raw kernel units at several hundred a second.
+//! This module turns that stream into something a person can read at a glance: the pad's attitude,
+//! drawn as a wireframe that tilts and turns with the pad in your hands, next to the numbers.
+//!
+//! ## What it computes
+//!
+//! **Orientation**, as a quaternion from the pad's body frame to the world, by integrating the
+//! gyro and pulling the result back toward the accelerometer's gravity — the smallest useful
+//! complementary filter. Gravity fixes pitch and roll; yaw comes from the gyro alone and drifts,
+//! which is honest: nothing on a pad can observe heading.
+//!
+//! **Gyro bias**, because the clone's gyro is not calibrated. At rest on a table its Z rate reads
+//! about 12 °/s, and integrated as-is the drawn pad would spin a full turn every thirty seconds
+//! while lying still. So the rate is watched for stillness — a short window in which the three
+//! rates barely move and the accelerometer reads one g — and the mean over such a window is taken
+//! as the bias. Until the first still window the raw rate is used and the view says the bias is
+//! still being learned.
+//!
+//! ## Axes
+//!
+//! `hid-nintendo` reports the accelerometer on `ABS_X/Y/Z` and the gyro on `ABS_RX/RY/RZ`, with
+//! `+Z` up when the pad lies flat: the clone reads about `+1 g` there at rest. The body frame drawn
+//! here takes **+X as the pad's front** — the edge with the triggers, away from the player — and
+//! **+Y as the pad's left**, which follows from a right-handed frame with Z up. The wireframe puts
+//! a marker on the front edge so a wrong guess about X is visible the first time the pad tilts.
+//!
+//! ## What it costs
+//!
+//! The filter is a few dozen multiplications per sample. The drawing is a dozen line segments
+//! rasterised into half-block pixels, redrawn at the monitor's own pace rather than the IMU's —
+//! six hundred samples a second is a rate for a filter, not for a terminal.
+
+use duck_ipc_proto as proto;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+/// How hard the accelerometer pulls the orientation back toward gravity, per second.
+///
+/// Two: a tilt error decays with a half-second time constant, which is slow enough that shaking
+/// the pad does not make the picture flinch and fast enough that it is level a second after being
+/// set down.
+const GRAVITY_GAIN: f32 = 2.0;
+
+/// Accelerometer magnitudes accepted as "this is gravity", in g.
+///
+/// Outside this the pad is being moved, and the accelerometer measures the hand as much as the
+/// earth. The orientation then runs on the gyro alone until the pad settles.
+const GRAVITY_BAND: std::ops::RangeInclusive<f32> = 0.85..=1.15;
+
+/// How long the rates have to hold still before a bias is taken from them, seconds.
+const STILL_WINDOW_S: f64 = 0.5;
+
+/// How far the rates may wander across a still window and still count as still, °/s.
+///
+/// Above the clone's noise (about one °/s peak to peak at rest) and well below the slowest turn a
+/// hand makes on purpose.
+const STILL_SPREAD_DPS: f32 = 3.0;
+
+/// Longest gap between two samples the integrator will bridge, seconds.
+///
+/// Beyond it the pad was silent — a dropped batch, a paused terminal — and integrating one stale
+/// rate over the whole gap would throw the picture. The sample is taken; the interval is not.
+const MAX_DT_S: f32 = 0.05;
+
+/// One pad IMU, as accumulated from the tap.
+pub struct Imu {
+    device: proto::PadImuDevice,
+    samples: u64,
+    socket_dropped: u64,
+    /// The last sample's kernel timestamp, for the interval.
+    last_us: Option<u64>,
+    /// Sample rate, hertz, as an average over the recent intervals.
+    rate_hz: Option<f32>,
+    /// The newest sample in physical units.
+    accel_g: [f32; 3],
+    gyro_dps: [f32; 3],
+    bias: Bias,
+    /// Body → world.
+    q: [f32; 4],
+    /// Has the orientation been seeded from gravity yet?
+    seeded: bool,
+}
+
+/// The gyro's rest offset, and the still window being watched for the next one.
+struct Bias {
+    /// The bias in use, °/s. `None` until the first still window completes.
+    value: Option<[f32; 3]>,
+    /// The window under way: when it opened, what it has seen.
+    since_us: Option<u64>,
+    min: [f32; 3],
+    max: [f32; 3],
+    sum: [f64; 3],
+    count: u32,
+}
+
+impl Bias {
+    fn new() -> Self {
+        Self {
+            value: None,
+            since_us: None,
+            min: [f32::INFINITY; 3],
+            max: [f32::NEG_INFINITY; 3],
+            sum: [0.0; 3],
+            count: 0,
+        }
+    }
+
+    /// Offer one raw rate. Only samples taken while the accelerometer reads gravity count: a pad
+    /// in motion can have a quiet gyro for a moment and still not be at rest.
+    fn observe(&mut self, raw_dps: [f32; 3], gravity_ok: bool, at_us: u64) {
+        if !gravity_ok {
+            self.reset_window();
+            return;
+        }
+        let since = *self.since_us.get_or_insert(at_us);
+        for (axis, rate) in raw_dps.iter().enumerate() {
+            self.min[axis] = self.min[axis].min(*rate);
+            self.max[axis] = self.max[axis].max(*rate);
+            self.sum[axis] += f64::from(*rate);
+        }
+        self.count += 1;
+
+        let spread = (0..3)
+            .map(|axis| self.max[axis] - self.min[axis])
+            .fold(0.0f32, f32::max);
+        if spread > STILL_SPREAD_DPS {
+            // Moved. Start over from here rather than waiting the window out.
+            self.reset_window();
+            return;
+        }
+        if (at_us.saturating_sub(since)) as f64 >= STILL_WINDOW_S * 1e6 && self.count > 0 {
+            let mean = [
+                (self.sum[0] / f64::from(self.count)) as f32,
+                (self.sum[1] / f64::from(self.count)) as f32,
+                (self.sum[2] / f64::from(self.count)) as f32,
+            ];
+            // Blend with what is already known rather than jumping: two still windows a minute
+            // apart disagreeing by a tenth of a degree per second should not make the picture
+            // twitch each time.
+            self.value = Some(match self.value {
+                Some(old) => [
+                    0.5 * (old[0] + mean[0]),
+                    0.5 * (old[1] + mean[1]),
+                    0.5 * (old[2] + mean[2]),
+                ],
+                None => mean,
+            });
+            self.reset_window();
+        }
+    }
+
+    fn reset_window(&mut self) {
+        self.since_us = None;
+        self.min = [f32::INFINITY; 3];
+        self.max = [f32::NEG_INFINITY; 3];
+        self.sum = [0.0; 3];
+        self.count = 0;
+    }
+}
+
+impl Imu {
+    pub fn new(device: proto::PadImuDevice) -> Self {
+        Self {
+            device,
+            samples: 0,
+            socket_dropped: 0,
+            last_us: None,
+            rate_hz: None,
+            accel_g: [0.0; 3],
+            gyro_dps: [0.0; 3],
+            bias: Bias::new(),
+            q: [1.0, 0.0, 0.0, 0.0],
+            seeded: false,
+        }
+    }
+
+    pub fn device(&self) -> &proto::PadImuDevice {
+        &self.device
+    }
+
+    pub fn samples(&self) -> u64 {
+        self.samples
+    }
+
+    pub fn socket_dropped(&self) -> u64 {
+        self.socket_dropped
+    }
+
+    pub fn rate_hz(&self) -> Option<f32> {
+        self.rate_hz
+    }
+
+    /// The newest acceleration, g.
+    pub fn accel_g(&self) -> [f32; 3] {
+        self.accel_g
+    }
+
+    /// The newest angular rate with the bias removed, °/s.
+    pub fn gyro_dps(&self) -> [f32; 3] {
+        self.gyro_dps
+    }
+
+    /// The gyro bias in use, °/s — `None` while it is still being learned.
+    pub fn bias_dps(&self) -> Option<[f32; 3]> {
+        self.bias.value
+    }
+
+    /// Take one sample.
+    pub fn absorb(&mut self, sample: &proto::PadImuSample) {
+        self.samples += 1;
+        self.socket_dropped += sample.socket_dropped;
+
+        let accel_scale = scale(self.device.accel_per_g);
+        let gyro_scale = scale(self.device.gyro_per_dps);
+        let accel = [
+            sample.accel[0] as f32 * accel_scale,
+            sample.accel[1] as f32 * accel_scale,
+            sample.accel[2] as f32 * accel_scale,
+        ];
+        let raw_gyro = [
+            sample.gyro[0] as f32 * gyro_scale,
+            sample.gyro[1] as f32 * gyro_scale,
+            sample.gyro[2] as f32 * gyro_scale,
+        ];
+        self.accel_g = accel;
+
+        let magnitude = norm(accel);
+        let gravity_ok = GRAVITY_BAND.contains(&magnitude);
+        self.bias.observe(raw_gyro, gravity_ok, sample.at_us);
+        let bias = self.bias.value.unwrap_or([0.0; 3]);
+        let gyro = [
+            raw_gyro[0] - bias[0],
+            raw_gyro[1] - bias[1],
+            raw_gyro[2] - bias[2],
+        ];
+        self.gyro_dps = gyro;
+
+        // The interval, from the kernel's clock: a gap too long to trust is measured (for the
+        // rate) but not integrated.
+        let dt = match self.last_us {
+            Some(last) if sample.at_us > last => (sample.at_us - last) as f32 * 1e-6,
+            _ => 0.0,
+        };
+        self.last_us = Some(sample.at_us);
+        if dt > 0.0 && dt <= MAX_DT_S {
+            let hz = 1.0 / dt;
+            self.rate_hz = Some(match self.rate_hz {
+                Some(rate) => rate + 0.02 * (hz - rate),
+                None => hz,
+            });
+        }
+
+        if !self.seeded {
+            if gravity_ok {
+                self.q = from_gravity(accel);
+                self.seeded = true;
+            }
+            return;
+        }
+        if dt <= 0.0 || dt > MAX_DT_S {
+            return;
+        }
+
+        // Gyro: rotate the body by ω·dt, in the body frame.
+        let rad = std::f32::consts::PI / 180.0;
+        let step = [gyro[0] * rad * dt, gyro[1] * rad * dt, gyro[2] * rad * dt];
+        self.q = mul(self.q, from_rotvec(step));
+
+        // Gravity: nudge the body so that where it thinks "up" is moves onto where the
+        // accelerometer says it is. With `q ← q ⊗ δ`, the new prediction is `δᵀ·predicted`, so δ
+        // has to carry *measured* onto *predicted* — hence the order of the cross product; the
+        // other way round runs away rather than converging. Applied a fraction at a time, and
+        // skipped while the pad is being moved, when the accelerometer is not measuring gravity.
+        if gravity_ok {
+            let measured = normalized(accel);
+            let predicted = rotate(conj(self.q), [0.0, 0.0, 1.0]);
+            let error = cross(measured, predicted);
+            let k = GRAVITY_GAIN * dt;
+            self.q = mul(self.q, from_rotvec([error[0] * k, error[1] * k, error[2] * k]));
+        }
+        self.q = normalized4(self.q);
+    }
+
+    /// Pitch, roll and yaw of the body in the world, degrees.
+    ///
+    /// Aerospace order — yaw about Z, then pitch about the pad's Y (nose up positive), then roll
+    /// about its X (left side up positive) — read off the rotation matrix. Yaw is the gyro's word
+    /// alone and drifts; the other two are held by gravity.
+    pub fn euler_deg(&self) -> [f32; 3] {
+        let m = matrix(self.q);
+        // m carries body axes as columns in world coordinates: m[i][j] = row i, column j.
+        let pitch = (-m[2][0]).clamp(-1.0, 1.0).asin();
+        let roll = m[2][1].atan2(m[2][2]);
+        let yaw = m[1][0].atan2(m[0][0]);
+        let deg = 180.0 / std::f32::consts::PI;
+        [pitch * deg, roll * deg, yaw * deg]
+    }
+
+    /// Draw the pad's attitude into `area`, two pixels per cell.
+    ///
+    /// A wireframe of a pad — a flat slab, two grips toward the player, the two sticks, a marker on
+    /// the front edge — posed by the orientation and seen from a fixed three-quarter camera. Cheap
+    /// on purpose: a dozen segments, no depth sorting. The eye resolves a wireframe pad without it.
+    pub fn draw(&self, area: Rect, buf: &mut Buffer) {
+        let (w, h) = (usize::from(area.width), usize::from(area.height) * 2);
+        if w < 6 || h < 6 {
+            return;
+        }
+        let mut canvas = Canvas::new(w, h);
+        let rotation = matrix(self.q);
+
+        // World → screen: yaw the camera for a three-quarter view, then look down at it. The
+        // result is in body millimetres until it is fitted below.
+        let (az_sin, az_cos) = CAMERA_AZIMUTH.sin_cos();
+        let (el_sin, el_cos) = CAMERA_ELEVATION.sin_cos();
+        let project = |p: [f32; 3]| -> (f32, f32) {
+            let world = rotate_matrix(rotation, p);
+            let x = world[0] * az_cos - world[1] * az_sin;
+            let y = world[0] * az_sin + world[1] * az_cos;
+            let up = world[2] * el_cos + y * el_sin;
+            (x, -up)
+        };
+
+        // Fit the whole pad, whatever its attitude, into the canvas with a pixel of margin. Fitted
+        // per frame rather than to a fixed extent: a pad on its edge is tall and thin, a pad flat
+        // is wide and short, and a fixed scale that framed both would draw each at half size.
+        // The pad's own centre stays put, so tilting reads as tilting and not as sliding.
+        let ends: Vec<((f32, f32), (f32, f32))> = PAD_WIREFRAME
+            .iter()
+            .map(|s| (project(s.from), project(s.to)))
+            .collect();
+        let (mut min_x, mut max_x, mut min_y, mut max_y) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+        for (a, b) in &ends {
+            for p in [a, b] {
+                min_x = min_x.min(p.0);
+                max_x = max_x.max(p.0);
+                min_y = min_y.min(p.1);
+                max_y = max_y.max(p.1);
+            }
+        }
+        let extent_x = (max_x - min_x).max(1.0);
+        let extent_y = (max_y - min_y).max(1.0);
+        let scale = ((w as f32 - 2.0) / extent_x).min((h as f32 - 2.0) / extent_y);
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        let (mid_x, mid_y) = ((min_x + max_x) / 2.0, (min_y + max_y) / 2.0);
+        let place = |p: (f32, f32)| ((p.0 - mid_x) * scale + cx, (p.1 - mid_y) * scale + cy);
+
+        for (segment, (a, b)) in PAD_WIREFRAME.iter().zip(ends) {
+            canvas.line(place(a), place(b), segment.colour());
+        }
+        canvas.blit(area, buf);
+    }
+}
+
+/// Camera yaw, radians: a three-quarter view, so both the front edge and a grip are visible.
+const CAMERA_AZIMUTH: f32 = -0.55;
+/// Camera elevation above the pad's plane, radians.
+const CAMERA_ELEVATION: f32 = 0.55;
+
+/// One segment of the drawn pad, in the body frame: millimetres, +X front, +Y left, +Z up.
+struct Segment {
+    from: [f32; 3],
+    to: [f32; 3],
+    part: Part,
+}
+
+#[derive(Clone, Copy)]
+enum Part {
+    Body,
+    Grip,
+    Stick,
+    Front,
+}
+
+impl Segment {
+    const fn new(from: [f32; 3], to: [f32; 3], part: Part) -> Self {
+        Self { from, to, part }
+    }
+
+    fn colour(&self) -> Color {
+        match self.part {
+            Part::Body => Color::Cyan,
+            Part::Grip => Color::Rgb(0, 140, 160),
+            Part::Stick => Color::White,
+            Part::Front => Color::Yellow,
+        }
+    }
+}
+
+/// The pad, in as few lines as still read as a pad: the top face of a slab 50 mm deep by 150
+/// wide, its front edge given thickness, two grips reaching back toward the player, the two
+/// sticks standing proud, and a bar along the front edge so that "which way is it facing" never
+/// has to be inferred from the grips alone. Every line dropped from a fuller model — the bottom
+/// face, the grips' far edges — was one that turned the picture into hatching at terminal
+/// resolution without adding a degree of freedom the eye could read.
+const PAD_WIREFRAME: &[Segment] = &{
+    const B: Part = Part::Body;
+    const G: Part = Part::Grip;
+    const S: Part = Part::Stick;
+    const F: Part = Part::Front;
+    [
+        // Top face.
+        Segment::new([25.0, 75.0, 10.0], [25.0, -75.0, 10.0], B),
+        Segment::new([25.0, -75.0, 10.0], [-25.0, -75.0, 10.0], B),
+        Segment::new([-25.0, -75.0, 10.0], [-25.0, 75.0, 10.0], B),
+        Segment::new([-25.0, 75.0, 10.0], [25.0, 75.0, 10.0], B),
+        // Thickness, on the front edge only.
+        Segment::new([25.0, 75.0, 10.0], [25.0, 75.0, -10.0], B),
+        Segment::new([25.0, -75.0, 10.0], [25.0, -75.0, -10.0], B),
+        Segment::new([25.0, 75.0, -10.0], [25.0, -75.0, -10.0], B),
+        // Grips: the outer edge of each, back and down from the rear corners, closed at the end.
+        Segment::new([-25.0, 70.0, 10.0], [-70.0, 55.0, -20.0], G),
+        Segment::new([-25.0, 40.0, 10.0], [-70.0, 35.0, -20.0], G),
+        Segment::new([-70.0, 55.0, -20.0], [-70.0, 35.0, -20.0], G),
+        Segment::new([-25.0, -70.0, 10.0], [-70.0, -55.0, -20.0], G),
+        Segment::new([-25.0, -40.0, 10.0], [-70.0, -35.0, -20.0], G),
+        Segment::new([-70.0, -55.0, -20.0], [-70.0, -35.0, -20.0], G),
+        // Sticks: the Pro Controller's left stick sits forward-left, the right one back-right.
+        Segment::new([8.0, 45.0, 10.0], [8.0, 45.0, 26.0], S),
+        Segment::new([-10.0, -30.0, 10.0], [-10.0, -30.0, 26.0], S),
+        // Front bar, along the top of the front edge, with a nose at its middle.
+        Segment::new([25.0, 60.0, 14.0], [25.0, -60.0, 14.0], F),
+        Segment::new([25.0, 0.0, 14.0], [45.0, 0.0, 14.0], F),
+    ]
+};
+
+/// A half-block pixel canvas: one colour per pixel, two pixels per terminal row.
+struct Canvas {
+    w: usize,
+    h: usize,
+    pixels: Vec<Option<Color>>,
+}
+
+impl Canvas {
+    fn new(w: usize, h: usize) -> Self {
+        Self {
+            w,
+            h,
+            pixels: vec![None; w * h],
+        }
+    }
+
+    fn set(&mut self, x: i32, y: i32, colour: Color) {
+        if x < 0 || y < 0 {
+            return;
+        }
+        let (x, y) = (x as usize, y as usize);
+        if x < self.w && y < self.h {
+            self.pixels[y * self.w + x] = Some(colour);
+        }
+    }
+
+    /// Bresenham, on rounded endpoints. Clipped per pixel: a segment that leaves the canvas is
+    /// drawn as far as it goes rather than dropped.
+    fn line(&mut self, a: (f32, f32), b: (f32, f32), colour: Color) {
+        let (mut x0, mut y0) = (a.0.round() as i32, a.1.round() as i32);
+        let (x1, y1) = (b.0.round() as i32, b.1.round() as i32);
+        let dx = (x1 - x0).abs();
+        let dy = -(y1 - y0).abs();
+        let sx = if x0 < x1 { 1 } else { -1 };
+        let sy = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+        loop {
+            self.set(x0, y0, colour);
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+            let e2 = 2 * err;
+            if e2 >= dy {
+                err += dy;
+                x0 += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
+    fn blit(&self, area: Rect, buf: &mut Buffer) {
+        for row in 0..usize::from(area.height) {
+            for col in 0..self.w {
+                let top = self.pixels[(row * 2) * self.w + col];
+                let bottom = self.pixels.get((row * 2 + 1) * self.w + col).copied().flatten();
+                let Some(cell) = buf.cell_mut((area.x + col as u16, area.y + row as u16)) else {
+                    continue;
+                };
+                match (top, bottom) {
+                    (Some(t), Some(b)) => {
+                        cell.set_symbol("▀").set_fg(t).set_bg(b);
+                    }
+                    (Some(t), None) => {
+                        cell.set_symbol("▀").set_fg(t);
+                    }
+                    (None, Some(b)) => {
+                        cell.set_symbol("▄").set_fg(b);
+                    }
+                    (None, None) => {}
+                }
+            }
+        }
+    }
+}
+
+// ── quaternion arithmetic, w first ───────────────────────────────────────────────────────
+
+/// Units per physical unit → physical units per raw unit. A driver that declared no resolution
+/// leaves the numbers raw, which is at least not wrong.
+fn scale(per_unit: i32) -> f32 {
+    if per_unit > 0 {
+        1.0 / per_unit as f32
+    } else {
+        1.0
+    }
+}
+
+fn norm(v: [f32; 3]) -> f32 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+fn normalized(v: [f32; 3]) -> [f32; 3] {
+    let n = norm(v);
+    if n < 1e-9 {
+        return [0.0, 0.0, 1.0];
+    }
+    [v[0] / n, v[1] / n, v[2] / n]
+}
+
+fn normalized4(q: [f32; 4]) -> [f32; 4] {
+    let n = (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]).sqrt();
+    if n < 1e-9 {
+        return [1.0, 0.0, 0.0, 0.0];
+    }
+    [q[0] / n, q[1] / n, q[2] / n, q[3] / n]
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn mul(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
+    [
+        a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3],
+        a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2],
+        a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1],
+        a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0],
+    ]
+}
+
+fn conj(q: [f32; 4]) -> [f32; 4] {
+    [q[0], -q[1], -q[2], -q[3]]
+}
+
+/// The rotation of a small rotation vector (axis × angle, radians).
+fn from_rotvec(r: [f32; 3]) -> [f32; 4] {
+    let angle = norm(r);
+    if angle < 1e-9 {
+        return [1.0, 0.0, 0.0, 0.0];
+    }
+    let (s, c) = (angle / 2.0).sin_cos();
+    [c, r[0] / angle * s, r[1] / angle * s, r[2] / angle * s]
+}
+
+/// Rotate a vector by a quaternion.
+fn rotate(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
+    let p = mul(mul(q, [0.0, v[0], v[1], v[2]]), conj(q));
+    [p[1], p[2], p[3]]
+}
+
+fn rotate_matrix(m: [[f32; 3]; 3], v: [f32; 3]) -> [f32; 3] {
+    [
+        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+    ]
+}
+
+/// The rotation matrix of a unit quaternion, body axes as columns.
+fn matrix(q: [f32; 4]) -> [[f32; 3]; 3] {
+    let [w, x, y, z] = q;
+    [
+        [
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - z * w),
+            2.0 * (x * z + y * w),
+        ],
+        [
+            2.0 * (x * y + z * w),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - x * w),
+        ],
+        [
+            2.0 * (x * z - y * w),
+            2.0 * (y * z + x * w),
+            1.0 - 2.0 * (x * x + y * y),
+        ],
+    ]
+}
+
+/// The body → world rotation that carries the measured up (the accelerometer at rest) onto the
+/// world's up, with no yaw. The seed, and what the filter would converge to if the gyro said
+/// nothing.
+fn from_gravity(accel: [f32; 3]) -> [f32; 4] {
+    let up_body = normalized(accel);
+    let up_world = [0.0, 0.0, 1.0];
+    let axis = cross(up_body, up_world);
+    let s = norm(axis);
+    let c = up_body[2];
+    if s < 1e-6 {
+        return if c > 0.0 {
+            [1.0, 0.0, 0.0, 0.0]
+        } else {
+            [0.0, 1.0, 0.0, 0.0] // upside down: any horizontal axis will do
+        };
+    }
+    let angle = s.atan2(c);
+    from_rotvec([
+        axis[0] / s * angle,
+        axis[1] / s * angle,
+        axis[2] / s * angle,
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn a_device() -> proto::PadImuDevice {
+        proto::PadImuDevice {
+            name: "Nintendo Switch Pro Controller IMU".to_owned(),
+            node: "/dev/input/event5".to_owned(),
+            accel_per_g: 4096,
+            gyro_per_dps: 14247,
+            accel_max: 32767,
+            gyro_max: 32_767_000,
+        }
+    }
+
+    /// One sample, in physical units, `at_us` on the clock.
+    fn sample(seq: u64, at_us: u64, accel_g: [f32; 3], gyro_dps: [f32; 3]) -> proto::PadImuSample {
+        proto::PadImuSample {
+            seq,
+            at_us,
+            accel: [
+                (accel_g[0] * 4096.0) as i32,
+                (accel_g[1] * 4096.0) as i32,
+                (accel_g[2] * 4096.0) as i32,
+            ],
+            gyro: [
+                (gyro_dps[0] * 14247.0) as i32,
+                (gyro_dps[1] * 14247.0) as i32,
+                (gyro_dps[2] * 14247.0) as i32,
+            ],
+            socket_dropped: 0,
+        }
+    }
+
+    /// Feed `seconds` of a steady reading at 200 Hz.
+    fn steady(imu: &mut Imu, seconds: f32, accel_g: [f32; 3], gyro_dps: [f32; 3]) {
+        let n = (seconds * 200.0) as u64;
+        let start = imu.last_us.unwrap_or(0);
+        for i in 1..=n {
+            imu.absorb(&sample(i, start + i * 5_000, accel_g, gyro_dps));
+        }
+    }
+
+    /// Flat on the table: level, and the clone's 12 °/s of Z bias is learned rather than
+    /// integrated — the drawn pad must not spin while the real one lies still.
+    #[test]
+    fn a_pad_at_rest_reads_level_and_learns_its_bias() {
+        let mut imu = Imu::new(a_device());
+        steady(&mut imu, 3.0, [0.0, 0.0, 1.0], [1.8, -0.6, 12.0]);
+
+        let bias = imu.bias_dps().expect("three seconds still is a bias");
+        assert!((bias[2] - 12.0).abs() < 0.1, "{bias:?}");
+        let [pitch, roll, yaw] = imu.euler_deg();
+        assert!(pitch.abs() < 0.5 && roll.abs() < 0.5, "level: {pitch} {roll}");
+        // Yaw drifted for the half second before the bias was known and not after.
+        assert!(yaw.abs() < 12.0 * 0.6, "yaw stopped drifting: {yaw}");
+        let rate = imu.rate_hz().expect("a rate");
+        assert!((rate - 200.0).abs() < 2.0, "{rate}");
+    }
+
+    /// Nose up: gravity moves toward −X on the body, and the filter reads that as positive pitch.
+    /// The same rotation seeded from gravity and reached by integrating the gyro must agree.
+    #[test]
+    fn a_tilt_reads_as_pitch_whether_seeded_or_integrated() {
+        let tilt = 30.0f32.to_radians();
+        let tilted = [-tilt.sin(), 0.0, tilt.cos()];
+
+        let mut seeded = Imu::new(a_device());
+        steady(&mut seeded, 0.1, tilted, [0.0; 3]);
+        let [pitch, roll, _] = seeded.euler_deg();
+        assert!((pitch - 30.0).abs() < 1.0, "seeded pitch {pitch}");
+        assert!(roll.abs() < 1.0, "seeded roll {roll}");
+
+        // Level first, learn the (zero) bias, then pitch up at 60 °/s for half a second with the
+        // accelerometer saying "moving" so only the gyro speaks.
+        let mut turned = Imu::new(a_device());
+        steady(&mut turned, 2.0, [0.0, 0.0, 1.0], [0.0; 3]);
+        steady(&mut turned, 0.5, [0.0, 0.0, 1.5], [0.0, 60.0, 0.0]);
+        let [pitch, _, _] = turned.euler_deg();
+        assert!((pitch - 30.0).abs() < 1.5, "integrated pitch {pitch}");
+
+        // And once it is still again, gravity agrees and holds it there.
+        steady(&mut turned, 2.0, tilted, [0.0; 3]);
+        let [pitch, _, _] = turned.euler_deg();
+        assert!((pitch - 30.0).abs() < 1.0, "held pitch {pitch}");
+    }
+
+    /// A pad being waved has an accelerometer full of hand: it must not pull the orientation, and
+    /// it must not be mistaken for stillness by the bias learner.
+    #[test]
+    fn motion_neither_corrects_the_attitude_nor_teaches_a_bias() {
+        let mut imu = Imu::new(a_device());
+        steady(&mut imu, 0.1, [0.0, 0.0, 1.0], [0.0; 3]);
+        assert!(imu.bias_dps().is_none());
+        // Quiet gyro, but two g on the accelerometer: not at rest.
+        steady(&mut imu, 2.0, [0.0, 0.0, 2.0], [5.0, 0.0, 0.0]);
+        assert!(imu.bias_dps().is_none(), "a swinging pad taught a bias");
+        let [pitch, roll, _] = imu.euler_deg();
+        // Integrated 5 °/s of roll for two seconds with nothing to say otherwise.
+        assert!((roll - 10.0).abs() < 1.0, "roll {roll}");
+        assert!(pitch.abs() < 1.0, "pitch {pitch}");
+    }
+
+    /// A gap the integrator will not bridge is measured, not integrated.
+    #[test]
+    fn a_long_gap_is_not_integrated() {
+        let mut imu = Imu::new(a_device());
+        steady(&mut imu, 2.0, [0.0, 0.0, 1.0], [0.0; 3]);
+        let before = imu.euler_deg();
+        let last = imu.last_us.unwrap();
+        imu.absorb(&sample(9_999, last + 3_000_000, [0.0, 0.0, 1.0], [90.0, 0.0, 0.0]));
+        let after = imu.euler_deg();
+        assert!((after[1] - before[1]).abs() < 0.5, "{before:?} → {after:?}");
+    }
+
+    /// The wireframe lands on the canvas: something is drawn, in the pad's colours, and a level
+    /// pad and a rolled pad are different pictures.
+    #[test]
+    fn the_pad_is_drawn_and_moves_with_the_attitude() {
+        fn picture(imu: &Imu) -> Vec<String> {
+            let area = Rect::new(0, 0, 40, 10);
+            let mut buf = Buffer::empty(area);
+            imu.draw(area, &mut buf);
+            (0..10)
+                .map(|y| (0..40).map(|x| buf[(x, y)].symbol()).collect())
+                .collect()
+        }
+
+        let mut level = Imu::new(a_device());
+        steady(&mut level, 0.1, [0.0, 0.0, 1.0], [0.0; 3]);
+        let flat = picture(&level);
+        let inked = flat.iter().flat_map(|r| r.chars()).filter(|c| *c != ' ').count();
+        assert!(inked > 60, "a wireframe is more than a few pixels: {inked}");
+
+        let mut rolled = Imu::new(a_device());
+        steady(&mut rolled, 0.1, [0.0, 0.7, 0.7], [0.0; 3]);
+        assert_ne!(flat, picture(&rolled), "a rolled pad is a different picture");
+    }
+}
+
+#[cfg(test)]
+mod probe {
+    use super::*;
+
+    /// Print the wireframe for a few attitudes. Not an assertion — a way to look at the picture
+    /// without a pad in hand: `cargo test -p robotctl pad_imu::probe -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "visual probe, run manually with --ignored --nocapture"]
+    fn show_me_the_pad() {
+        for (name, accel) in [
+            ("flat", [0.0, 0.0, 1.0]),
+            ("nose up 30°", [-0.5, 0.0, 0.866]),
+            ("rolled left 45°", [0.0, -0.707, 0.707]),
+            ("on its front edge", [1.0, 0.0, 0.0]),
+        ] {
+            let device = proto::PadImuDevice {
+                name: String::new(),
+                node: String::new(),
+                accel_per_g: 4096,
+                gyro_per_dps: 14247,
+                accel_max: 32767,
+                gyro_max: 32_767_000,
+            };
+            let mut imu = Imu::new(device);
+            imu.absorb(&proto::PadImuSample {
+                seq: 1,
+                at_us: 1_000_000,
+                accel: [
+                    (accel[0] * 4096.0) as i32,
+                    (accel[1] * 4096.0) as i32,
+                    (accel[2] * 4096.0) as i32,
+                ],
+                gyro: [0; 3],
+                socket_dropped: 0,
+            });
+            let area = Rect::new(0, 0, 44, 10);
+            let mut buf = Buffer::empty(area);
+            imu.draw(area, &mut buf);
+            println!("── {name} · euler {:?}", imu.euler_deg());
+            for y in 0..10 {
+                let row: String = (0..44).map(|x| buf[(x, y)].symbol()).collect();
+                println!("│{row}│");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Pro Controller clones carry a six-axis IMU that hid-nintendo exposes as a
second evdev node (INPUT_PROP_ACCELEROMETER, same HID parent). This wires it
through and draws it.

- duck-ipc-proto (API v27): PadReport::ImuAttached / Imu(PadImuBatch) /
  ImuDetached. Raw kernel units plus the driver's resolutions (4096/g,
  14247 per deg/s). A pad without an IMU never sends them.
- padd tap: finds the accelerometer sibling through sysfs, reads it on a
  second thread with the tap's lifecycle (open only while subscribed). One
  report per kernel read; IMU drops counted apart from stick-report drops.
- robotctl monitor: the pad block grows a panel only while an IMU is attached.
  pad_imu.rs runs a complementary filter (gyro integration pulled toward
  gravity, yaw gyro-only) and learns the gyro rest bias from half a second of
  stillness (the clone reads 12 deg/s on a table). Wireframe pad in half-block
  pixels at a fixed zoom, yellow bar on the front edge. Repaints capped at 30/s.

Validated on graphite 2026-09-09: attitude tracks the pad in hand, axes as
guessed (+X front, +Y left, +Z up). Cost: padd 1.6% idle, 6.0% with a monitor
open (was 8.2% before batching); bluetoothd 0%. Xbox pad unchanged.
Tests: 50 proto, 16 padd, 158 robotctl; clippy clean; cargo board builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)