### PR TITLE
Imu head control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
+name = "pad-imu"
+version = "0.11.0"
+dependencies = [
+ "duck-ipc-proto",
+]
+
+[[package]]
 name = "padd"
 version = "0.11.0"
 dependencies = [
@@ -3243,6 +3250,7 @@ dependencies = [
  "evdev",
  "gilrs",
  "libc",
+ "pad-imu",
  "robotd-params",
  "serde",
  "serde_json",
@@ -3805,6 +3813,7 @@ dependencies = [
  "duck-ipc-proto",
  "kinematics",
  "libc",
+ "pad-imu",
  "ratatui",
  "robotd-params",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # docs/design/architecture.md §1. `robotd`, `btd` and `mediad` are all siblings now.
 [workspace]
 resolver = "3"
-members = ["btd", "configd", "duck-control", "duck-detect", "duck-ether", "duck-ipc-proto", "duckctl", "kinematics", "mediad", "odometry", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
+members = ["btd", "configd", "duck-control", "duck-detect", "duck-ether", "duck-ipc-proto", "duckctl", "kinematics", "mediad", "odometry", "pad-imu", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
 
 # Everything except `duckctl`, and that exception is the whole reason this key exists.
 #
@@ -18,7 +18,7 @@ members = ["btd", "configd", "duck-control", "duck-detect", "duck-ether", "duck-
 # writing down. One list here, and a new daemon is picked up by both without anybody remembering.
 #
 # `--workspace` is unaffected, so CI still lints and tests `duckctl` exactly as before.
-default-members = ["btd", "configd", "duck-control", "duck-detect", "duck-ipc-proto", "kinematics", "mediad", "odometry", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
+default-members = ["btd", "configd", "duck-control", "duck-detect", "duck-ipc-proto", "kinematics", "mediad", "odometry", "pad-imu", "padd", "pet-detect", "sounds", "tof", "updater", "robotctl", "robotd", "robotd-params", "test-support", "xtask"]
 
 # ONNX Runtime, which robotd dlopens to run a policy. One source of truth: `xtask package`
 # bakes these into the release's preinstall hook, and a test asserts scripts/setup-board.sh

--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -422,3 +422,19 @@ mode = "walk"
 #
 # gcc is webrtcsink's own default, so this line changes nothing; it is here to be found.
 # congestion_control = "gcc"
+
+# ── Controller-IMU head control ─────────────────────────────────────────────────────────────
+#
+# Read by `padd`, not by `robotd`. Some pads carry an inertial unit — the "Pro Controller" Switch
+# clones do, an Xbox pad does not. With this on and such a pad connected, Y stops meaning "the
+# sticks pose the head" and means "the pad's tilt poses the head": the sticks keep driving, and
+# turning the pad in your hands turns the robot's head. Y again holds the head where it is, still
+# driving. A third press hands the head back to the pad from where the pad is *now* — its yaw is
+# a gyro's word alone and drifts, and re-centring on every re-entry is how you beat that without
+# a magnetometer. Off, or on a pad with no IMU, Y is what it always was.
+# [imu_head]
+# enabled = false
+
+# Head radians per pad radian. 1 follows the pad exactly; more turns a small wrist movement into
+# a large head movement. The head's own travel limit still applies.
+# gain = 1.0

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -480,7 +480,7 @@ mapping is the prototype's, so muscle memory carries over:
 | left stick | drive: forward/back and strafe · head: head yaw and pitch · body pose: up and crouch |
 | right stick | drive: turn · head: neck pitch and head roll · body pose: pitch and roll |
 | **Start** | first press: torque on and a 2 s ramp to the home pose, then hold. Second press: the policy drives. After that it toggles the policy |
-| **Y** / triangle | head mode: sticks pose the head (body holds still) |
+| **Y** / triangle | head mode: sticks pose the head (body holds still). With `[imu_head] enabled` and a pad that has an IMU: the pad's tilt poses the head and the sticks keep driving — see below |
 | **B** / circle | body-pose mode: sticks lean and crouch the standing robot |
 | **A** / cross | ground pick |
 | **X** / square | roulade — one forward roll; hold to chain rolls |
@@ -491,6 +491,20 @@ mapping is the prototype's, so muscle memory carries over:
 | **DPad-Right** | reboot every servo: the way back from a tripped overload without pulling the battery. Torque off, then Start |
 | **Select** | torque off (`robot.relax`): the emergency release. The robot drops, so hold it. Then Start stands it up again |
 | **Select**, held 2 s | power off (the press has already cut torque) |
+
+**Drive the head with the pad itself.** A Pro Controller carries an IMU, and with
+
+```bash
+sudo robotctl configure      # Controller-IMU head control → enabled
+```
+
+Y changes meaning on such a pad: the first press hands the head to the pad — tilt it and the head
+tilts, turn it and the head turns — while the sticks go on driving the body. Press Y again and the
+head holds where it is, sticks still driving. Press it a third time and the pad drives the head again
+**from wherever the pad is now**: its yaw is a gyro's word alone and drifts, and re-centring on every
+re-entry is how you beat the drift without a magnetometer. `gain` in the same section is head
+radians per pad radian, 1 by default. On an Xbox pad, or with the switch off, Y is the stick head
+mode above. `padd` picks the change up within a second; no restart.
 
 There is no stop button: release the sticks and the robot stands, and `robotd`'s deadman stops it
 if `padd` dies. On a roller robot (`mode = "roller"` in `robotd.toml`) the sticks take the roller

--- a/docs/robot/pair-a-gamepad.md
+++ b/docs/robot/pair-a-gamepad.md
@@ -69,7 +69,14 @@ that appears only when the pad has one: a wireframe pad posed like the real one,
 from gravity, yaw from the gyro alone (it drifts — nothing on a pad observes heading), and the
 gyro's rest bias, which the clone needs learned before the picture stops turning on its own. Set
 the pad down for half a second and the panel says `settled`. The stream costs nothing while the
-monitor is not open: `padd` reads the IMU node only while somebody is subscribed to the tap.
+monitor is not open: `padd` reads the IMU node only while somebody is subscribed to the tap — or
+while it is steering the head from it, below.
+
+The same attitude can drive the robot's head. `sudo robotctl configure`, section *Controller-IMU
+head control*, `enabled`: Y then hands the head to the pad's tilt while the sticks keep driving,
+Y again holds the head, and a third Y re-centres on the pad's current attitude and follows again —
+the [cheat sheet](cheatsheet.md#gamepad-configd) has the full cycle. The picture in the monitor and
+the head use one filter, so where the drawn pad points is where the head goes.
 
 `paired but NOT trusted` is the state worth knowing. It works now and does not reconnect after a
 reboot, because approving a reconnection needs an agent and at boot there is none. Re-run `pad pair`

--- a/pad-imu/Cargo.toml
+++ b/pad-imu/Cargo.toml
@@ -1,0 +1,14 @@
+# A gamepad's inertial unit, read into an attitude.
+#
+# One filter for two programs: `padd` poses the robot's head from it, `robotctl monitor` draws
+# the pad from it. Its own crate so neither depends on the other, and so the head and the
+# picture cannot disagree about which way the pad is tilted. Depends on the wire types only.
+[package]
+name = "pad-imu"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+duck-ipc-proto = { path = "../duck-ipc-proto" }

--- a/pad-imu/src/lib.rs
+++ b/pad-imu/src/lib.rs
@@ -1,47 +1,45 @@
-//! The pad's inertial unit, as the monitor reads it and draws it.
+//! A gamepad's inertial unit, read into an attitude.
 //!
 //! Some pads carry a six-axis IMU. The "Pro Controller" Switch clones do, and `padd`'s tap hands
 //! its samples out as [`proto::PadReport::Imu`] — raw kernel units at several hundred a second.
-//! This module turns that stream into something a person can read at a glance: the pad's attitude,
-//! drawn as a wireframe that tilts and turns with the pad in your hands, next to the numbers.
+//! This crate turns that stream into an orientation two programs need the same way: `padd`, to
+//! pose the robot's head from the pad in your hands, and `robotctl monitor`, to draw the pad
+//! tilting on screen. One filter, so the head and the picture cannot disagree.
 //!
 //! ## What it computes
 //!
 //! **Orientation**, as a quaternion from the pad's body frame to the world, by integrating the
 //! gyro and pulling the result back toward the accelerometer's gravity — the smallest useful
 //! complementary filter. Gravity fixes pitch and roll; yaw comes from the gyro alone and drifts,
-//! which is honest: nothing on a pad can observe heading.
+//! which is honest: nothing on a pad can observe heading. Whoever uses yaw has to re-zero it now
+//! and then, and [`relative`] is how.
 //!
 //! **Gyro bias**, because the clone's gyro is not calibrated. At rest on a table its Z rate reads
-//! about 12 °/s, and integrated as-is the drawn pad would spin a full turn every thirty seconds
-//! while lying still. So the rate is watched for stillness — a short window in which the three
-//! rates barely move and the accelerometer reads one g — and the mean over such a window is taken
-//! as the bias. Until the first still window the raw rate is used and the view says the bias is
-//! still being learned.
+//! about 12 °/s, and integrated as-is the attitude would turn a full circle every thirty seconds
+//! while the pad lay still. So the rate is watched for stillness — a short window in which the
+//! three rates barely move and the accelerometer reads one g — and the mean over such a window is
+//! taken as the bias. Until the first still window the raw rate is used and [`Imu::bias_dps`] says
+//! so.
 //!
 //! ## Axes
 //!
 //! `hid-nintendo` reports the accelerometer on `ABS_X/Y/Z` and the gyro on `ABS_RX/RY/RZ`, with
-//! `+Z` up when the pad lies flat: the clone reads about `+1 g` there at rest. The body frame drawn
-//! here takes **+X as the pad's front** — the edge with the triggers, away from the player — and
-//! **+Y as the pad's left**, which follows from a right-handed frame with Z up. The wireframe puts
-//! a marker on the front edge so a wrong guess about X is visible the first time the pad tilts.
+//! `+Z` up when the pad lies flat: the clone reads about `+1 g` there at rest. The body frame is
+//! **+X the pad's front** — the edge with the triggers, away from the player — and **+Y the pad's
+//! left**, which follows from a right-handed frame with Z up. Confirmed against the drawn pad on
+//! the robot, 2026-09-09.
 //!
 //! ## What it costs
 //!
-//! The filter is a few dozen multiplications per sample. The drawing is a dozen line segments
-//! rasterised into half-block pixels, redrawn at the monitor's own pace rather than the IMU's —
-//! six hundred samples a second is a rate for a filter, not for a terminal.
+//! A few dozen multiplications per sample. Six hundred a second are a rounding error next to
+//! reading them off the kernel.
 
 use duck_ipc_proto as proto;
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::Color;
 
 /// How hard the accelerometer pulls the orientation back toward gravity, per second.
 ///
 /// Two: a tilt error decays with a half-second time constant, which is slow enough that shaking
-/// the pad does not make the picture flinch and fast enough that it is level a second after being
+/// the pad does not make the attitude flinch and fast enough that it is level a second after being
 /// set down.
 const GRAVITY_GAIN: f32 = 2.0;
 
@@ -62,8 +60,8 @@ const STILL_SPREAD_DPS: f32 = 3.0;
 
 /// Longest gap between two samples the integrator will bridge, seconds.
 ///
-/// Beyond it the pad was silent — a dropped batch, a paused terminal — and integrating one stale
-/// rate over the whole gap would throw the picture. The sample is taken; the interval is not.
+/// Beyond it the pad was silent — a dropped batch, a paused reader — and integrating one stale
+/// rate over the whole gap would throw the attitude. The sample is taken; the interval is not.
 const MAX_DT_S: f32 = 0.05;
 
 /// One pad IMU, as accumulated from the tap.
@@ -139,7 +137,7 @@ impl Bias {
                 (self.sum[2] / f64::from(self.count)) as f32,
             ];
             // Blend with what is already known rather than jumping: two still windows a minute
-            // apart disagreeing by a tenth of a degree per second should not make the picture
+            // apart disagreeing by a tenth of a degree per second should not make the attitude
             // twitch each time.
             self.value = Some(match self.value {
                 Some(old) => [
@@ -291,223 +289,68 @@ impl Imu {
         self.q = normalized4(self.q);
     }
 
-    /// Pitch, roll and yaw of the body in the world, degrees.
-    ///
-    /// Aerospace order — yaw about Z, then pitch about the pad's Y (nose up positive), then roll
-    /// about its X (left side up positive) — read off the rotation matrix. Yaw is the gyro's word
-    /// alone and drifts; the other two are held by gravity.
+    /// Pitch, roll and yaw of the body in the world, degrees — [`euler_deg`] of the attitude.
+    /// Yaw is the gyro's word alone and drifts; the other two are held by gravity.
     pub fn euler_deg(&self) -> [f32; 3] {
-        let m = matrix(self.q);
-        // m carries body axes as columns in world coordinates: m[i][j] = row i, column j.
-        let pitch = (-m[2][0]).clamp(-1.0, 1.0).asin();
-        let roll = m[2][1].atan2(m[2][2]);
-        let yaw = m[1][0].atan2(m[0][0]);
-        let deg = 180.0 / std::f32::consts::PI;
-        [pitch * deg, roll * deg, yaw * deg]
+        euler_deg(self.q)
     }
 
-    /// Draw the pad's attitude into `area`, two pixels per cell.
-    ///
-    /// A wireframe of a pad — a flat slab, two grips toward the player, the two sticks, a marker on
-    /// the front edge — posed by the orientation and seen from a fixed three-quarter camera. Cheap
-    /// on purpose: a dozen segments, no depth sorting. The eye resolves a wireframe pad without it.
-    pub fn draw(&self, area: Rect, buf: &mut Buffer) {
-        let (w, h) = (usize::from(area.width), usize::from(area.height) * 2);
-        if w < 6 || h < 6 {
-            return;
-        }
-        let mut canvas = Canvas::new(w, h);
-        let rotation = matrix(self.q);
-
-        // World → screen: yaw the camera for a three-quarter view, then look down at it. The
-        // result is in body millimetres until it is scaled below.
-        let (az_sin, az_cos) = CAMERA_AZIMUTH.sin_cos();
-        let (el_sin, el_cos) = CAMERA_ELEVATION.sin_cos();
-        let project = |p: [f32; 3]| -> (f32, f32) {
-            let world = rotate_matrix(rotation, p);
-            let x = world[0] * az_cos - world[1] * az_sin;
-            let y = world[0] * az_sin + world[1] * az_cos;
-            let up = world[2] * el_cos + y * el_sin;
-            (x, -up)
-        };
-
-        // One zoom for every attitude: the pad's bounding sphere is what has to fit, so a pad on
-        // its edge and a pad lying flat are drawn at the same scale and tilting reads as tilting,
-        // not as the picture breathing. The body origin sits at the canvas centre. Framed at 80% of
-        // the sphere rather than all of it: only a grip tip pointing straight at the camera's edge
-        // ever reaches the last 20%, and framing for that moment shrinks every other one.
-        let radius = PAD_WIREFRAME
-            .iter()
-            .flat_map(|s| [s.from, s.to])
-            .map(norm)
-            .fold(1.0f32, f32::max)
-            * 0.8;
-        let scale = ((w as f32 - 2.0) / (2.0 * radius)).min((h as f32 - 2.0) / (2.0 * radius));
-        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
-        let place = |p: (f32, f32)| (p.0 * scale + cx, p.1 * scale + cy);
-
-        for segment in PAD_WIREFRAME {
-            canvas.line(
-                place(project(segment.from)),
-                place(project(segment.to)),
-                segment.colour(),
-            );
-        }
-        canvas.blit(area, buf);
-    }
-}
-
-/// Camera yaw, radians: a three-quarter view, so both the front edge and a grip are visible.
-const CAMERA_AZIMUTH: f32 = -0.55;
-/// Camera elevation above the pad's plane, radians.
-const CAMERA_ELEVATION: f32 = 0.55;
-
-/// One segment of the drawn pad, in the body frame: millimetres, +X front, +Y left, +Z up.
-struct Segment {
-    from: [f32; 3],
-    to: [f32; 3],
-    part: Part,
-}
-
-#[derive(Clone, Copy)]
-enum Part {
-    Body,
-    Grip,
-    Stick,
-    Front,
-}
-
-impl Segment {
-    const fn new(from: [f32; 3], to: [f32; 3], part: Part) -> Self {
-        Self { from, to, part }
-    }
-
-    fn colour(&self) -> Color {
-        match self.part {
-            Part::Body => Color::Cyan,
-            Part::Grip => Color::Rgb(0, 140, 160),
-            Part::Stick => Color::White,
-            Part::Front => Color::Yellow,
-        }
-    }
-}
-
-/// The pad, in as few lines as still read as a pad: the top face of a slab 50 mm deep by 150
-/// wide, its front edge given thickness, two grips reaching back toward the player, the two
-/// sticks standing proud, and a bar along the front edge so that "which way is it facing" never
-/// has to be inferred from the grips alone. Every line dropped from a fuller model — the bottom
-/// face, the grips' far edges — was one that turned the picture into hatching at terminal
-/// resolution without adding a degree of freedom the eye could read.
-const PAD_WIREFRAME: &[Segment] = &{
-    const B: Part = Part::Body;
-    const G: Part = Part::Grip;
-    const S: Part = Part::Stick;
-    const F: Part = Part::Front;
-    [
-        // Top face.
-        Segment::new([25.0, 75.0, 10.0], [25.0, -75.0, 10.0], B),
-        Segment::new([25.0, -75.0, 10.0], [-25.0, -75.0, 10.0], B),
-        Segment::new([-25.0, -75.0, 10.0], [-25.0, 75.0, 10.0], B),
-        Segment::new([-25.0, 75.0, 10.0], [25.0, 75.0, 10.0], B),
-        // Thickness, on the front edge only.
-        Segment::new([25.0, 75.0, 10.0], [25.0, 75.0, -10.0], B),
-        Segment::new([25.0, -75.0, 10.0], [25.0, -75.0, -10.0], B),
-        Segment::new([25.0, 75.0, -10.0], [25.0, -75.0, -10.0], B),
-        // Grips: the outer edge of each, back and down from the rear corners, closed at the end.
-        Segment::new([-25.0, 70.0, 10.0], [-70.0, 55.0, -20.0], G),
-        Segment::new([-25.0, 40.0, 10.0], [-70.0, 35.0, -20.0], G),
-        Segment::new([-70.0, 55.0, -20.0], [-70.0, 35.0, -20.0], G),
-        Segment::new([-25.0, -70.0, 10.0], [-70.0, -55.0, -20.0], G),
-        Segment::new([-25.0, -40.0, 10.0], [-70.0, -35.0, -20.0], G),
-        Segment::new([-70.0, -55.0, -20.0], [-70.0, -35.0, -20.0], G),
-        // Sticks: the Pro Controller's left stick sits forward-left, the right one back-right.
-        Segment::new([8.0, 45.0, 10.0], [8.0, 45.0, 26.0], S),
-        Segment::new([-10.0, -30.0, 10.0], [-10.0, -30.0, 26.0], S),
-        // Front bar, along the top of the front edge, with a nose at its middle.
-        Segment::new([25.0, 60.0, 14.0], [25.0, -60.0, 14.0], F),
-        Segment::new([25.0, 0.0, 14.0], [45.0, 0.0, 14.0], F),
-    ]
-};
-
-/// A half-block pixel canvas: one colour per pixel, two pixels per terminal row.
-struct Canvas {
-    w: usize,
-    h: usize,
-    pixels: Vec<Option<Color>>,
-}
-
-impl Canvas {
-    fn new(w: usize, h: usize) -> Self {
-        Self {
-            w,
-            h,
-            pixels: vec![None; w * h],
-        }
-    }
-
-    fn set(&mut self, x: i32, y: i32, colour: Color) {
-        if x < 0 || y < 0 {
-            return;
-        }
-        let (x, y) = (x as usize, y as usize);
-        if x < self.w && y < self.h {
-            self.pixels[y * self.w + x] = Some(colour);
-        }
-    }
-
-    /// Bresenham, on rounded endpoints. Clipped per pixel: a segment that leaves the canvas is
-    /// drawn as far as it goes rather than dropped.
-    fn line(&mut self, a: (f32, f32), b: (f32, f32), colour: Color) {
-        let (mut x0, mut y0) = (a.0.round() as i32, a.1.round() as i32);
-        let (x1, y1) = (b.0.round() as i32, b.1.round() as i32);
-        let dx = (x1 - x0).abs();
-        let dy = -(y1 - y0).abs();
-        let sx = if x0 < x1 { 1 } else { -1 };
-        let sy = if y0 < y1 { 1 } else { -1 };
-        let mut err = dx + dy;
-        loop {
-            self.set(x0, y0, colour);
-            if x0 == x1 && y0 == y1 {
-                break;
-            }
-            let e2 = 2 * err;
-            if e2 >= dy {
-                err += dy;
-                x0 += sx;
-            }
-            if e2 <= dx {
-                err += dx;
-                y0 += sy;
-            }
-        }
-    }
-
-    fn blit(&self, area: Rect, buf: &mut Buffer) {
-        for row in 0..usize::from(area.height) {
-            for col in 0..self.w {
-                let top = self.pixels[(row * 2) * self.w + col];
-                let bottom = self.pixels.get((row * 2 + 1) * self.w + col).copied().flatten();
-                let Some(cell) = buf.cell_mut((area.x + col as u16, area.y + row as u16)) else {
-                    continue;
-                };
-                match (top, bottom) {
-                    (Some(t), Some(b)) => {
-                        cell.set_symbol("▀").set_fg(t).set_bg(b);
-                    }
-                    (Some(t), None) => {
-                        cell.set_symbol("▀").set_fg(t);
-                    }
-                    (None, Some(b)) => {
-                        cell.set_symbol("▄").set_fg(b);
-                    }
-                    (None, None) => {}
-                }
-            }
-        }
+    /// The attitude itself, body → world, `w` first. `None` until the first sample with a
+    /// believable gravity has seeded it — before that there is no attitude, only a default.
+    pub fn quaternion(&self) -> Option<[f32; 4]> {
+        self.seeded.then_some(self.q)
     }
 }
 
 // ── quaternion arithmetic, w first ───────────────────────────────────────────────────────
+
+/// The rotation from `reference` to `now`, in the body frame of `reference`: what a pad has done
+/// since the moment `reference` was taken. This is how a consumer of yaw beats the drift — take a
+/// fresh reference when the person says "this is centre", and read everything after it relative.
+pub fn relative(reference: [f32; 4], now: [f32; 4]) -> [f32; 4] {
+    normalized4(mul(conj(reference), now))
+}
+
+/// Pitch, roll and yaw of a body → world rotation, degrees.
+///
+/// Aerospace order — yaw about Z, then pitch about the body's Y (nose up positive), then roll
+/// about its X (left side up positive) — read off the rotation matrix.
+pub fn euler_deg(q: [f32; 4]) -> [f32; 3] {
+    let m = matrix(q);
+    // m carries body axes as columns in world coordinates: m[i][j] = row i, column j.
+    let pitch = (-m[2][0]).clamp(-1.0, 1.0).asin();
+    let roll = m[2][1].atan2(m[2][2]);
+    let yaw = m[1][0].atan2(m[0][0]);
+    let deg = 180.0 / std::f32::consts::PI;
+    [pitch * deg, roll * deg, yaw * deg]
+}
+
+/// The rotation matrix of a unit quaternion, body axes as columns.
+pub fn matrix(q: [f32; 4]) -> [[f32; 3]; 3] {
+    let [w, x, y, z] = q;
+    [
+        [
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - z * w),
+            2.0 * (x * z + y * w),
+        ],
+        [
+            2.0 * (x * y + z * w),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - x * w),
+        ],
+        [
+            2.0 * (x * z - y * w),
+            2.0 * (y * z + x * w),
+            1.0 - 2.0 * (x * x + y * y),
+        ],
+    ]
+}
+
+/// Euclidean length of a vector.
+pub fn norm(v: [f32; 3]) -> f32 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
 
 /// Units per physical unit → physical units per raw unit. A driver that declared no resolution
 /// leaves the numbers raw, which is at least not wrong.
@@ -517,10 +360,6 @@ fn scale(per_unit: i32) -> f32 {
     } else {
         1.0
     }
-}
-
-fn norm(v: [f32; 3]) -> f32 {
-    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
 }
 
 fn normalized(v: [f32; 3]) -> [f32; 3] {
@@ -574,36 +413,6 @@ fn from_rotvec(r: [f32; 3]) -> [f32; 4] {
 fn rotate(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
     let p = mul(mul(q, [0.0, v[0], v[1], v[2]]), conj(q));
     [p[1], p[2], p[3]]
-}
-
-fn rotate_matrix(m: [[f32; 3]; 3], v: [f32; 3]) -> [f32; 3] {
-    [
-        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
-        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
-        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
-    ]
-}
-
-/// The rotation matrix of a unit quaternion, body axes as columns.
-fn matrix(q: [f32; 4]) -> [[f32; 3]; 3] {
-    let [w, x, y, z] = q;
-    [
-        [
-            1.0 - 2.0 * (y * y + z * z),
-            2.0 * (x * y - z * w),
-            2.0 * (x * z + y * w),
-        ],
-        [
-            2.0 * (x * y + z * w),
-            1.0 - 2.0 * (x * x + z * z),
-            2.0 * (y * z - x * w),
-        ],
-        [
-            2.0 * (x * z - y * w),
-            2.0 * (y * z + x * w),
-            1.0 - 2.0 * (x * x + y * y),
-        ],
-    ]
 }
 
 /// The body → world rotation that carries the measured up (the accelerometer at rest) onto the
@@ -680,10 +489,11 @@ mod tests {
     }
 
     /// Flat on the table: level, and the clone's 12 °/s of Z bias is learned rather than
-    /// integrated — the drawn pad must not spin while the real one lies still.
+    /// integrated — the attitude must not spin while the real pad lies still.
     #[test]
     fn a_pad_at_rest_reads_level_and_learns_its_bias() {
         let mut imu = Imu::new(a_device());
+        assert!(imu.quaternion().is_none(), "no attitude before a sample");
         steady(&mut imu, 3.0, [0.0, 0.0, 1.0], [1.8, -0.6, 12.0]);
 
         let bias = imu.bias_dps().expect("three seconds still is a bias");
@@ -694,6 +504,7 @@ mod tests {
         assert!(yaw.abs() < 12.0 * 0.6, "yaw stopped drifting: {yaw}");
         let rate = imu.rate_hz().expect("a rate");
         assert!((rate - 200.0).abs() < 2.0, "{rate}");
+        assert!(imu.quaternion().is_some());
     }
 
     /// Nose up: gravity moves toward −X on the body, and the filter reads that as positive pitch.
@@ -756,76 +567,26 @@ mod tests {
         assert!((after[1] - before[1]).abs() < 0.5, "{before:?} → {after:?}");
     }
 
-    /// The wireframe lands on the canvas: something is drawn, in the pad's colours, and a level
-    /// pad and a rolled pad are different pictures.
+    /// Re-zeroing: the attitude relative to a reference taken a moment ago is what the pad did
+    /// since — a yaw the gyro has drifted by is gone the moment a new reference is taken, and a
+    /// turn made after it reads in full.
     #[test]
-    fn the_pad_is_drawn_and_moves_with_the_attitude() {
-        fn picture(imu: &Imu) -> Vec<String> {
-            let area = Rect::new(0, 0, 40, 10);
-            let mut buf = Buffer::empty(area);
-            imu.draw(area, &mut buf);
-            (0..10)
-                .map(|y| (0..40).map(|x| buf[(x, y)].symbol()).collect())
-                .collect()
-        }
+    fn a_relative_attitude_starts_from_zero_and_reads_the_turn_since() {
+        let mut imu = Imu::new(a_device());
+        steady(&mut imu, 2.0, [0.0, 0.0, 1.0], [0.0; 3]);
+        // Drift: 40 °/s of yaw for a second, unlearned because the pad is "moving".
+        steady(&mut imu, 1.0, [0.0, 0.0, 1.4], [0.0, 0.0, 40.0]);
+        let drifted = imu.quaternion().unwrap();
+        assert!(euler_deg(drifted)[2].abs() > 30.0, "{:?}", euler_deg(drifted));
 
-        let mut level = Imu::new(a_device());
-        steady(&mut level, 0.1, [0.0, 0.0, 1.0], [0.0; 3]);
-        let flat = picture(&level);
-        let inked = flat.iter().flat_map(|r| r.chars()).filter(|c| *c != ' ').count();
-        assert!(inked > 30, "a wireframe is more than a few pixels: {inked}");
+        let reference = drifted;
+        let zeroed = euler_deg(relative(reference, imu.quaternion().unwrap()));
+        assert!(zeroed.iter().all(|a| a.abs() < 0.01), "{zeroed:?}");
 
-        let mut rolled = Imu::new(a_device());
-        steady(&mut rolled, 0.1, [0.0, 0.7, 0.7], [0.0; 3]);
-        assert_ne!(flat, picture(&rolled), "a rolled pad is a different picture");
-    }
-}
-
-#[cfg(test)]
-mod probe {
-    use super::*;
-
-    /// Print the wireframe for a few attitudes. Not an assertion — a way to look at the picture
-    /// without a pad in hand: `cargo test -p robotctl pad_imu::probe -- --ignored --nocapture`.
-    #[test]
-    #[ignore = "visual probe, run manually with --ignored --nocapture"]
-    fn show_me_the_pad() {
-        for (name, accel) in [
-            ("flat", [0.0, 0.0, 1.0]),
-            ("nose up 30°", [-0.5, 0.0, 0.866]),
-            ("rolled left 45°", [0.0, -0.707, 0.707]),
-            ("on its front edge", [1.0, 0.0, 0.0]),
-        ] {
-            let device = proto::PadImuDevice {
-                name: String::new(),
-                node: String::new(),
-                accel_per_g: 4096,
-                gyro_per_dps: 14247,
-                accel_max: 32767,
-                gyro_max: 32_767_000,
-            };
-            let mut imu = Imu::new(device);
-            imu.absorb(&proto::PadImuBatch {
-                samples: vec![proto::PadImuSample {
-                    seq: 1,
-                    at_us: 1_000_000,
-                    accel: [
-                        (accel[0] * 4096.0) as i32,
-                        (accel[1] * 4096.0) as i32,
-                        (accel[2] * 4096.0) as i32,
-                    ],
-                    gyro: [0; 3],
-                }],
-                socket_dropped: 0,
-            });
-            let area = Rect::new(0, 0, 44, 10);
-            let mut buf = Buffer::empty(area);
-            imu.draw(area, &mut buf);
-            println!("── {name} · euler {:?}", imu.euler_deg());
-            for y in 0..10 {
-                let row: String = (0..44).map(|x| buf[(x, y)].symbol()).collect();
-                println!("│{row}│");
-            }
-        }
+        // Turn left 20° (about +Z) after the reference, and that is all that shows.
+        steady(&mut imu, 0.5, [0.0, 0.0, 1.4], [0.0, 0.0, 40.0]);
+        let since = euler_deg(relative(reference, imu.quaternion().unwrap()));
+        assert!((since[2] - 20.0).abs() < 1.0, "{since:?}");
+        assert!(since[0].abs() < 1.0 && since[1].abs() < 1.0, "{since:?}");
     }
 }

--- a/padd/Cargo.toml
+++ b/padd/Cargo.toml
@@ -24,6 +24,9 @@ duck-ipc-proto = { path = "../duck-ipc-proto" }
 # up. Pure serde and toml, and read once at startup: this daemon still holds no privileged access
 # and still knows nothing about what a skill *is*, only that a button names one.
 robotd-params = { path = "../robotd-params" }
+# The pad's IMU as an attitude — the same filter `robotctl monitor` draws from, so the head goes
+# where the picture says the pad is.
+pad-imu = { path = "../pad-imu" }
 clap = { workspace = true, features = ["derive"] }
 gilrs = "0.11"
 # Only to serialise the tap's own lines; the wire types themselves live in duck-ipc-proto.

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -110,6 +110,16 @@ mod tap {
         pub fn watch(&self, _pad: &gilrs::Gamepad<'_>) {}
 
         pub fn idle(&self) {}
+
+        pub fn imu_control(&self, _on: bool) {}
+
+        pub fn has_imu(&self) -> bool {
+            false
+        }
+
+        pub fn attitude(&self) -> Option<[f32; 4]> {
+            None
+        }
     }
 }
 
@@ -213,22 +223,24 @@ enum Mode {
 /// How often to look for a rewritten config. See the loop.
 const BINDINGS_POLL: Duration = Duration::from_secs(1);
 
-/// The button bindings, or the mapping the prototype had.
+/// The button bindings and the IMU head switch, or the defaults.
 ///
 /// A file that will not parse is never a reason to leave somebody without a pad: the defaults
 /// are a working robot, and the reason is logged. That matters more here than elsewhere because
 /// this is re-read while running — a half-saved file caught mid-write must not take the buttons
 /// away, and the next read a second later gets the finished one.
-fn read_bindings(path: &Path) -> robotd_params::PadParams {
+fn read_bindings(path: &Path) -> (robotd_params::PadParams, robotd_params::ImuHeadParams) {
     match robotd_params::Params::load(path, false) {
         Ok(params) => {
             let pad = params.pad;
+            let imu_head = params.imu_head;
             tracing::info!(
                 a = %pad.a, x = %pad.x, lb = %pad.lb, rb = %pad.rb,
                 dpad_down = %pad.dpad_down,
+                imu_head = imu_head.enabled, imu_head_gain = imu_head.gain,
                 "button bindings"
             );
-            pad
+            (pad, imu_head)
         }
         Err(e) => {
             tracing::warn!(
@@ -236,8 +248,56 @@ fn read_bindings(path: &Path) -> robotd_params::PadParams {
                 path = %path.display(),
                 "cannot read the button bindings; using the default mapping"
             );
-            robotd_params::PadParams::default()
+            (
+                robotd_params::PadParams::default(),
+                robotd_params::ImuHeadParams::default(),
+            )
         }
+    }
+}
+
+/// Where the pad's IMU stands in relation to the head. See `[imu_head]` in `robotd-params`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ImuHead {
+    /// Y means what it always did.
+    Off,
+    /// The head follows the pad's attitude relative to `reference`, the attitude at the press
+    /// that started this. The sticks keep driving.
+    Following { reference: [f32; 4] },
+    /// The head stays where the last pose left it; nothing is sent for it. The sticks drive.
+    Holding,
+}
+
+impl ImuHead {
+    /// Y was pressed with an IMU pad and the feature on. Off or holding → follow **from here**,
+    /// which is what beats the gyro's yaw drift: every re-entry makes the pad's current attitude
+    /// the new centre. Following → hold.
+    fn on_y(self, attitude: [f32; 4]) -> Self {
+        match self {
+            Self::Off | Self::Holding => Self::Following {
+                reference: attitude,
+            },
+            Self::Following { .. } => Self::Holding,
+        }
+    }
+}
+
+/// The head pose for a pad attitude relative to its reference.
+///
+/// `relative` is body → world of the pad now, in the frame of the reference — [`pad_imu::relative`].
+/// Its pitch, roll and yaw become the head's, scaled by `gain` and clamped to `max_head`, with the
+/// same signs the stick mapping uses: nose-up on the pad is a negative `head_pitch` (the joint axis
+/// is inverted relative to "look up", verified on hardware for the sticks), pad yaw to the left is
+/// positive `head_yaw`, and the pad rolling right (left side up) is positive `head_roll`. The neck
+/// stays at zero: one pitch joint is enough to follow a wrist.
+fn head_from_pad(relative: [f32; 4], gain: f64, max_head: f64) -> proto::HeadParams {
+    let [pitch, roll, yaw] = pad_imu::euler_deg(relative);
+    let angle = |degrees: f32| (f64::from(degrees).to_radians() * gain).clamp(-max_head, max_head);
+    proto::HeadParams {
+        neck_pitch: 0.0,
+        head_pitch: -angle(pitch),
+        head_yaw: angle(yaw),
+        head_roll: angle(roll),
     }
 }
 
@@ -317,7 +377,7 @@ fn main() -> std::process::ExitCode {
     // The button bindings, read once like every other daemon reads its config. A file that will
     // not parse is not a reason to leave somebody without a pad: the mapping the prototype had is
     // the fallback, and the reason is logged.
-    let mut bindings = read_bindings(&args.config);
+    let (mut bindings, mut imu_head_cfg) = read_bindings(&args.config);
     // When the file was last written, so a change is picked up without a restart. `padd` holds
     // no motor control and no session state — the whole of it is this table — so re-reading is a
     // swap between two ticks rather than anything to sequence.
@@ -325,6 +385,9 @@ fn main() -> std::process::ExitCode {
     let mut bindings_checked = Instant::now();
 
     let mut mode = Mode::Drive;
+    // IMU head control, when `[imu_head]` is on and the pad has one. Off whenever the pad is
+    // gone: a reference taken against one pad means nothing to the next.
+    let mut imu_head = ImuHead::Off;
     // Whether a pad was there last tick, so appearing and disappearing are each logged once.
     let mut driving = false;
     let mut select_held_since: Option<Instant> = None;
@@ -355,7 +418,7 @@ fn main() -> std::process::ExitCode {
             let now = config_mtime(&args.config);
             if now != bindings_at {
                 bindings_at = now;
-                bindings = read_bindings(&args.config);
+                (bindings, imu_head_cfg) = read_bindings(&args.config);
                 tracing::warn!("button bindings reloaded");
             }
         }
@@ -409,6 +472,7 @@ fn main() -> std::process::ExitCode {
                 tracing::warn!("pad gone — sending nothing; robotd's deadman holds the robot");
                 driving = false;
             }
+            imu_head = ImuHead::Off;
             if let Some(tap) = tap.as_ref() {
                 tap.idle();
             }
@@ -426,15 +490,62 @@ fn main() -> std::process::ExitCode {
         // enough that a tap following the old one would report the rest of the session as silence.
         if let Some(tap) = tap.as_ref() {
             tap.watch(&pad);
+            // Every tick, like the bindings: switching the feature on in the config has to start
+            // the IMU reader without a restart, and off has to let it go.
+            tap.imu_control(imu_head_cfg.enabled);
+        }
+
+        // The pad's attitude this tick, when the feature is on and the pad has an IMU that has
+        // said something believable. `None` is every other case, and Y then means the sticks.
+        let attitude = if imu_head_cfg.enabled {
+            tap.as_ref().and_then(|tap| tap.attitude())
+        } else {
+            None
+        };
+        if attitude.is_none() && imu_head != ImuHead::Off {
+            // The feature went off, or the IMU went away under us. Not silent: a head that stops
+            // following mid-turn wants a line in the journal saying why.
+            tracing::info!("IMU head control off — no attitude to follow");
+            imu_head = ImuHead::Off;
         }
 
         if toggle_head {
-            mode = if mode == Mode::Head {
-                Mode::Drive
-            } else {
-                Mode::Head
-            };
-            tracing::info!(?mode, "mode");
+            match attitude {
+                Some(attitude) => {
+                    // Y is the IMU's. The sticks never pose the head while this is possible: two
+                    // sources for one joint set is a head that shakes.
+                    if mode == Mode::Head {
+                        mode = Mode::Drive;
+                    }
+                    imu_head = imu_head.on_y(attitude);
+                    match imu_head {
+                        ImuHead::Following { .. } => tracing::info!(
+                            "IMU head control: following the pad from here — sticks keep driving"
+                        ),
+                        ImuHead::Holding => {
+                            tracing::info!("IMU head control: holding the head where it is")
+                        }
+                        ImuHead::Off => {}
+                    }
+                }
+                None => {
+                    if imu_head_cfg.enabled
+                        && tap.as_ref().is_some_and(|tap| tap.has_imu())
+                    {
+                        // The IMU is there and has not spoken yet — a second after connecting,
+                        // typically. Saying so beats silently doing the other thing.
+                        tracing::warn!(
+                            "the pad's IMU has no attitude yet; Y is stick head mode this once"
+                        );
+                    }
+                    mode = if mode == Mode::Head {
+                        Mode::Drive
+                    } else {
+                        Mode::Head
+                    };
+                    tracing::info!(?mode, "mode");
+                }
+            }
         }
         if toggle_body {
             let leaving = mode == Mode::BodyPose;
@@ -742,6 +853,19 @@ fn main() -> std::process::ExitCode {
                     active: true,
                 }));
             }
+        }
+
+        // IMU head control rides in the same frame as the drive: the pad's tilt and the sticks
+        // describe one instant. Only while driving — body-pose mode owns the whole robot for as
+        // long as it lasts, and stick head mode cannot coexist with this (see the Y handling).
+        if mode == Mode::Drive
+            && let (ImuHead::Following { reference }, Some(now)) = (imu_head, attitude)
+        {
+            frame.push(proto::Call::RobotHead(head_from_pad(
+                pad_imu::relative(reference, now),
+                imu_head_cfg.gain,
+                args.max_head,
+            )));
         }
 
         if let Err(e) = continuous.send(&mut stream, &frame, tick) {
@@ -1079,4 +1203,54 @@ mod tests {
             "the default still parses"
         );
     }
+
+    /// Y, with an IMU pad: the first press follows from where the pad is, the second holds, the
+    /// third follows again **from where the pad is now** — the new reference is what beats the
+    /// gyro's yaw drift, so a re-entry after a minute of drift starts the head at centre.
+    #[test]
+    fn y_cycles_follow_hold_follow_and_re_centres_each_time() {
+        let level = [1.0, 0.0, 0.0, 0.0];
+        // Yawed 30° by the time of the third press — drift, or a turn; the pad cannot tell.
+        let yawed = [(15.0f32.to_radians()).cos(), 0.0, 0.0, (15.0f32.to_radians()).sin()];
+
+        let following = ImuHead::Off.on_y(level);
+        assert_eq!(following, ImuHead::Following { reference: level });
+        let holding = following.on_y(yawed);
+        assert_eq!(holding, ImuHead::Holding, "the second press holds, whatever the pad did");
+        let again = holding.on_y(yawed);
+        assert_eq!(
+            again,
+            ImuHead::Following { reference: yawed },
+            "the third follows from the pad's attitude now, not the first one"
+        );
+        // And that reference reads as centre.
+        let head = head_from_pad(pad_imu::relative(yawed, yawed), 1.0, 2.5);
+        assert!(head.head_yaw.abs() < 1e-4 && head.head_pitch.abs() < 1e-4, "{head:?}");
+    }
+
+    /// The pad's tilt becomes the head's pose with the stick mapping's signs: nose up looks up
+    /// (negative head_pitch), yaw left looks left (positive head_yaw). Gain scales, the travel
+    /// limit clamps, the neck stays put.
+    #[test]
+    fn the_head_follows_the_pad_with_the_sticks_signs_gain_and_limit() {
+        let half = 15.0f32.to_radians();
+        // 30° nose up: a rotation about +Y.
+        let nose_up = [half.cos(), 0.0, half.sin(), 0.0];
+        let head = head_from_pad(nose_up, 1.0, 2.5);
+        assert!((head.head_pitch - (-30.0f64.to_radians())).abs() < 0.01, "{head:?}");
+        assert!(head.head_yaw.abs() < 0.01 && head.head_roll.abs() < 0.01, "{head:?}");
+        assert_eq!(head.neck_pitch, 0.0);
+
+        // 30° yaw left: about +Z.
+        let left = [half.cos(), 0.0, 0.0, half.sin()];
+        let head = head_from_pad(left, 1.0, 2.5);
+        assert!((head.head_yaw - 30.0f64.to_radians()).abs() < 0.01, "{head:?}");
+
+        // Gain 2 doubles it; a limit of 0.5 rad clamps it.
+        let head = head_from_pad(left, 2.0, 2.5);
+        assert!((head.head_yaw - 60.0f64.to_radians()).abs() < 0.01, "{head:?}");
+        let head = head_from_pad(left, 2.0, 0.5);
+        assert!((head.head_yaw - 0.5).abs() < 1e-6, "{head:?}");
+    }
+
 }

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -285,19 +285,21 @@ impl ImuHead {
 /// The head pose for a pad attitude relative to its reference.
 ///
 /// `relative` is body → world of the pad now, in the frame of the reference — [`pad_imu::relative`].
-/// Its pitch, roll and yaw become the head's, scaled by `gain` and clamped to `max_head`, with the
-/// same signs the stick mapping uses: nose-up on the pad is a negative `head_pitch` (the joint axis
-/// is inverted relative to "look up", verified on hardware for the sticks), pad yaw to the left is
-/// positive `head_yaw`, and the pad rolling right (left side up) is positive `head_roll`. The neck
-/// stays at zero: one pitch joint is enough to follow a wrist.
+/// Its pitch, roll and yaw become the head's, scaled by `gain` and clamped to `max_head`. The signs
+/// are the ones that made the head copy the pad on the robot (2026-09-09): pad nose-up is a
+/// positive `head_pitch`, pad yaw to the left a positive `head_yaw`, and the pad rolling right
+/// (left side up) a negative `head_roll`. Pitch and roll came out opposite to the stick mapping's
+/// guess, which is worth knowing: the sticks' signs describe "stick up looks up", not the joint
+/// axes, and the pad frame is the joints'. The neck stays at zero: one pitch joint is enough to
+/// follow a wrist.
 fn head_from_pad(relative: [f32; 4], gain: f64, max_head: f64) -> proto::HeadParams {
     let [pitch, roll, yaw] = pad_imu::euler_deg(relative);
     let angle = |degrees: f32| (f64::from(degrees).to_radians() * gain).clamp(-max_head, max_head);
     proto::HeadParams {
         neck_pitch: 0.0,
-        head_pitch: -angle(pitch),
+        head_pitch: angle(pitch),
         head_yaw: angle(yaw),
-        head_roll: angle(roll),
+        head_roll: -angle(roll),
     }
 }
 
@@ -1228,18 +1230,23 @@ mod tests {
         assert!(head.head_yaw.abs() < 1e-4 && head.head_pitch.abs() < 1e-4, "{head:?}");
     }
 
-    /// The pad's tilt becomes the head's pose with the stick mapping's signs: nose up looks up
-    /// (negative head_pitch), yaw left looks left (positive head_yaw). Gain scales, the travel
-    /// limit clamps, the neck stays put.
+    /// The pad's tilt becomes the head's pose with the signs verified on the robot: nose up is a
+    /// positive head_pitch, yaw left a positive head_yaw, rolled right a negative head_roll. Gain
+    /// scales, the travel limit clamps, the neck stays put.
     #[test]
     fn the_head_follows_the_pad_with_the_sticks_signs_gain_and_limit() {
         let half = 15.0f32.to_radians();
         // 30° nose up: a rotation about +Y.
         let nose_up = [half.cos(), 0.0, half.sin(), 0.0];
         let head = head_from_pad(nose_up, 1.0, 2.5);
-        assert!((head.head_pitch - (-30.0f64.to_radians())).abs() < 0.01, "{head:?}");
+        assert!((head.head_pitch - 30.0f64.to_radians()).abs() < 0.01, "{head:?}");
         assert!(head.head_yaw.abs() < 0.01 && head.head_roll.abs() < 0.01, "{head:?}");
         assert_eq!(head.neck_pitch, 0.0);
+
+        // 30° rolled right (left side up): about +X. The head rolls the other sign.
+        let rolled = [half.cos(), half.sin(), 0.0, 0.0];
+        let head = head_from_pad(rolled, 1.0, 2.5);
+        assert!((head.head_roll - (-30.0f64.to_radians())).abs() < 0.01, "{head:?}");
 
         // 30° yaw left: about +Z.
         let left = [half.cos(), 0.0, 0.0, half.sin()];

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -48,7 +48,18 @@
 //!
 //! Unlike a stick it is never silent: the clone streams several hundred samples a second whether
 //! or not anyone touches it. That is why a sample is six integers rather than an event list, why it
-//! has its own drop counter, and why the IMU is not opened at all unless someone is watching.
+//! has its own drop counter, and why the IMU is not opened at all unless someone is watching —
+//! or unless `padd` itself is, which is the second reader below.
+//!
+//! ## The IMU as a control, not only a stream
+//!
+//! With `[imu_head] enabled`, `padd` poses the robot's head from the pad's tilt. The attitude that
+//! needs comes from the same node the tap streams, so rather than a second reader on the same
+//! device this reader runs a `pad_imu::Imu` filter over every batch it reads and the main loop asks
+//! for the attitude ([`Tap::attitude`]). [`Tap::imu_control`] is the main loop saying "keep the
+//! IMU open for me": the node then stays open with or without a subscriber, and closes again when
+//! the feature goes off. One reader, one filter, and `robotctl monitor` draws the same attitude
+//! `padd` steers by.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::fs::PermissionsExt;
@@ -108,6 +119,10 @@ struct Shared {
     state: Mutex<State>,
     /// Signalled whenever the reader might have work: a pad appeared, or someone subscribed.
     wake: Condvar,
+    /// The IMU's attitude, kept by the IMU reader for the main loop. `None` while no IMU is
+    /// open. Its own lock, not `state`'s: the main loop reads it fifty times a second and must not
+    /// queue behind a subscriber's send.
+    attitude: Mutex<Option<pad_imu::Imu>>,
 }
 
 struct State {
@@ -116,6 +131,9 @@ struct State {
     /// The pad's IMU node, when the pad has one — see [`imu_sibling`]. Resolved once per pad node
     /// rather than per tick, because it is a walk through sysfs.
     wanted_imu: Option<PathBuf>,
+    /// Does `padd` itself want the IMU read, for head control? A second reason to hold the node
+    /// open, beside a subscriber.
+    control: bool,
     subscribers: Vec<Subscriber>,
     /// The `Attached` report for the device currently open.
     ///
@@ -170,11 +188,13 @@ impl Tap {
             state: Mutex::new(State {
                 wanted: None,
                 wanted_imu: None,
+                control: false,
                 subscribers: Vec::new(),
                 attached: None,
                 imu_attached: None,
             }),
             wake: Condvar::new(),
+            attitude: Mutex::new(None),
         });
 
         let accepting = Arc::clone(&shared);
@@ -219,6 +239,34 @@ impl Tap {
     /// No pad. The readers close their devices and say so to whoever is watching.
     pub fn idle(&self) {
         self.want(None, None);
+    }
+
+    /// Keep the pad's IMU open for `padd`'s own use, or stop. Safe to call every tick.
+    pub fn imu_control(&self, on: bool) {
+        let mut state = self.shared.lock();
+        if state.control == on {
+            return;
+        }
+        state.control = on;
+        drop(state);
+        self.shared.wake.notify_all();
+    }
+
+    /// Does the connected pad have an IMU at all? True as soon as the node is known, before it is
+    /// open — the question "can Y mean IMU head control on this pad" needs answering on the press.
+    pub fn has_imu(&self) -> bool {
+        self.shared.lock().wanted_imu.is_some()
+    }
+
+    /// The pad's attitude, body → world, `w` first. `None` while no IMU is open or before its
+    /// first believable sample.
+    pub fn attitude(&self) -> Option<[f32; 4]> {
+        self.shared
+            .attitude
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .as_ref()
+            .and_then(pad_imu::Imu::quaternion)
     }
 
     fn want(&self, node: Option<PathBuf>, imu: Option<PathBuf>) {
@@ -330,12 +378,13 @@ impl Shared {
         None
     }
 
-    /// The IMU reader's [`Self::wait_for_work`]: a pad with an IMU, and somebody to read it for.
+    /// The IMU reader's [`Self::wait_for_work`]: a pad with an IMU, and somebody to read it for —
+    /// a subscriber, or `padd` itself.
     fn wait_for_imu_work(&self) -> PathBuf {
         let mut state = self.lock();
         loop {
             if let Some(node) = state.wanted_imu.clone()
-                && !state.subscribers.is_empty()
+                && (!state.subscribers.is_empty() || state.control)
             {
                 return node;
             }
@@ -349,7 +398,7 @@ impl Shared {
     /// The IMU reader's [`Self::done_with`].
     fn done_with_imu(&self, node: &Path) -> Option<&'static str> {
         let state = self.lock();
-        if state.subscribers.is_empty() {
+        if state.subscribers.is_empty() && !state.control {
             return Some("nobody is watching any more");
         }
         if state.wanted_imu.as_deref() != Some(node) {
@@ -359,6 +408,7 @@ impl Shared {
     }
 
     fn attach_imu(&self, device: proto::PadImuDevice) {
+        *self.attitude_slot() = Some(pad_imu::Imu::new(device.clone()));
         let report = Arc::new(proto::PadReport::ImuAttached {
             device: Box::new(device),
         });
@@ -368,17 +418,26 @@ impl Shared {
     }
 
     fn detach_imu(&self, why: String) {
+        *self.attitude_slot() = None;
         let mut state = self.lock();
         state.imu_attached = None;
         state.send(&Arc::new(proto::PadReport::ImuDetached { why }));
     }
 
+    /// One batch: into the filter first, then out to whoever is watching.
     fn samples(&self, samples: Vec<proto::PadImuSample>) {
-        self.lock()
-            .send(&Arc::new(proto::PadReport::Imu(proto::PadImuBatch {
-                samples,
-                socket_dropped: 0,
-            })));
+        let batch = proto::PadImuBatch {
+            samples,
+            socket_dropped: 0,
+        };
+        if let Some(imu) = self.attitude_slot().as_mut() {
+            imu.absorb(&batch);
+        }
+        self.lock().send(&Arc::new(proto::PadReport::Imu(batch)));
+    }
+
+    fn attitude_slot(&self) -> MutexGuard<'_, Option<pad_imu::Imu>> {
+        self.attitude.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     fn attach(&self, device: proto::PadInputDevice) {
@@ -936,11 +995,13 @@ mod tests {
             state: Mutex::new(State {
                 wanted: None,
                 wanted_imu: None,
+                control: false,
                 subscribers: Vec::new(),
                 attached: None,
                 imu_attached: None,
             }),
             wake: Condvar::new(),
+            attitude: Mutex::new(None),
         })
     }
 
@@ -1077,6 +1138,52 @@ mod tests {
         assert_eq!(dropped.samples.load(Ordering::Relaxed), 25);
         assert_eq!(dropped.frames.load(Ordering::Relaxed), 0);
         drop(reports);
+    }
+
+    /// `padd` wanting the attitude is reason enough to hold the IMU open, with nobody subscribed —
+    /// and the attitude it reads is the filter's, fed from the same batches the subscribers get.
+    #[test]
+    fn head_control_holds_the_imu_open_and_reads_the_filter() {
+        let shared = a_shared();
+        let node = Path::new("/dev/input/event5");
+        shared.lock().wanted_imu = Some(node.to_path_buf());
+        assert_eq!(
+            shared.done_with_imu(node),
+            Some("nobody is watching any more"),
+            "no subscriber, no control: let go"
+        );
+
+        shared.lock().control = true;
+        assert_eq!(shared.done_with_imu(node), None, "control alone holds it");
+
+        shared.attach_imu(proto::PadImuDevice {
+            name: "Nintendo Switch Pro Controller IMU".to_owned(),
+            node: node.display().to_string(),
+            accel_per_g: 4096,
+            gyro_per_dps: 14247,
+            accel_max: 32767,
+            gyro_max: 32_767_000,
+        });
+        let read = |shared: &Shared| {
+            shared
+                .attitude_slot()
+                .as_ref()
+                .and_then(pad_imu::Imu::quaternion)
+        };
+        assert!(read(&shared).is_none(), "no sample yet, no attitude");
+        // Flat on the table, one sample: seeded level.
+        shared.samples(vec![proto::PadImuSample {
+            seq: 1,
+            at_us: 1_000_000,
+            accel: [0, 0, 4096],
+            gyro: [0, 0, 0],
+        }]);
+        let q = read(&shared).expect("an attitude after a believable sample");
+        let euler = pad_imu::euler_deg(q);
+        assert!(euler.iter().all(|a| a.abs() < 0.5), "{euler:?}");
+
+        shared.detach_imu("the pad changed".to_owned());
+        assert!(read(&shared).is_none(), "gone with the node");
     }
 
     /// A subscriber arriving while an IMU is open is told about it, as it is told about the pad.

--- a/robotctl/Cargo.toml
+++ b/robotctl/Cargo.toml
@@ -27,6 +27,7 @@ libc = "0.2.189"
 # Pure geometry (the ToF reprojection the monitor overlays) — deliberately NOT the `tof`
 # crate, whose vendored C driver would drag a cross C toolchain into every robotctl build.
 kinematics = { path = "../kinematics" }
+pad-imu = { path = "../pad-imu" }
 # `robotctl configure`'s schema, defaults and validation — the same crate `robotd` parses
 # its config with, which is what makes the editor unable to disagree with the daemon. Pure
 # serde + toml, so the recovery-path rule above still holds.

--- a/robotctl/src/configure.rs
+++ b/robotctl/src/configure.rs
@@ -58,7 +58,7 @@ fn unit_for(section: &str) -> &'static str {
         // `padd` reads the bindings, and `robotd` never sees them. Offering a robotd restart for
         // a button change would drop motor control — putting a standing robot on the floor — to
         // apply a setting it does not read.
-        "pad" => "padd",
+        "pad" | "imu_head" => "padd",
         _ => "robotd",
     }
 }

--- a/robotctl/src/imu_view.rs
+++ b/robotctl/src/imu_view.rs
@@ -1,0 +1,293 @@
+//! The pad's IMU, drawn: a wireframe pad posed like the real one.
+//!
+//! The attitude comes from the `pad-imu` crate — the same filter `padd` poses the head with — and
+//! this module only draws it. A dozen line segments rasterised into half-block pixels, redrawn at
+//! the monitor's own pace rather than the IMU's: six hundred samples a second is a rate for a
+//! filter, not for a terminal. The wireframe puts a marker on the front edge so a wrong guess
+//! about the body frame is visible the first time the pad tilts.
+
+use pad_imu::Imu;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+/// Camera yaw, radians: a three-quarter view, so both the front edge and a grip are visible.
+const CAMERA_AZIMUTH: f32 = -0.55;
+/// Camera elevation above the pad's plane, radians.
+const CAMERA_ELEVATION: f32 = 0.55;
+
+/// Draw the pad's attitude into `area`, two pixels per cell.
+///
+/// A wireframe of a pad — a flat slab, two grips toward the player, the two sticks, a marker on
+/// the front edge — posed by the orientation and seen from a fixed three-quarter camera. Cheap on
+/// purpose: a dozen segments, no depth sorting. The eye resolves a wireframe pad without it.
+pub fn draw(imu: &Imu, area: Rect, buf: &mut Buffer) {
+    let (w, h) = (usize::from(area.width), usize::from(area.height) * 2);
+    if w < 6 || h < 6 {
+        return;
+    }
+    let mut canvas = Canvas::new(w, h);
+    let rotation = pad_imu::matrix(imu.quaternion().unwrap_or([1.0, 0.0, 0.0, 0.0]));
+
+    // World → screen: yaw the camera for a three-quarter view, then look down at it. The result
+    // is in body millimetres until it is scaled below.
+    let (az_sin, az_cos) = CAMERA_AZIMUTH.sin_cos();
+    let (el_sin, el_cos) = CAMERA_ELEVATION.sin_cos();
+    let project = |p: [f32; 3]| -> (f32, f32) {
+        let world = rotate_matrix(rotation, p);
+        let x = world[0] * az_cos - world[1] * az_sin;
+        let y = world[0] * az_sin + world[1] * az_cos;
+        let up = world[2] * el_cos + y * el_sin;
+        (x, -up)
+    };
+
+    // One zoom for every attitude: the pad's bounding sphere is what has to fit, so a pad on its
+    // edge and a pad lying flat are drawn at the same scale and tilting reads as tilting, not as
+    // the picture breathing. The body origin sits at the canvas centre. Framed at 80% of the
+    // sphere rather than all of it: only a grip tip pointing straight at the camera's edge ever
+    // reaches the last 20%, and framing for that moment shrinks every other one.
+    let radius = PAD_WIREFRAME
+        .iter()
+        .flat_map(|s| [s.from, s.to])
+        .map(pad_imu::norm)
+        .fold(1.0f32, f32::max)
+        * 0.8;
+    let scale = ((w as f32 - 2.0) / (2.0 * radius)).min((h as f32 - 2.0) / (2.0 * radius));
+    let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+    let place = |p: (f32, f32)| (p.0 * scale + cx, p.1 * scale + cy);
+
+    for segment in PAD_WIREFRAME {
+        canvas.line(
+            place(project(segment.from)),
+            place(project(segment.to)),
+            segment.colour(),
+        );
+    }
+    canvas.blit(area, buf);
+}
+
+/// One segment of the drawn pad, in the body frame: millimetres, +X front, +Y left, +Z up.
+struct Segment {
+    from: [f32; 3],
+    to: [f32; 3],
+    part: Part,
+}
+
+#[derive(Clone, Copy)]
+enum Part {
+    Body,
+    Grip,
+    Stick,
+    Front,
+}
+
+impl Segment {
+    const fn new(from: [f32; 3], to: [f32; 3], part: Part) -> Self {
+        Self { from, to, part }
+    }
+
+    fn colour(&self) -> Color {
+        match self.part {
+            Part::Body => Color::Cyan,
+            Part::Grip => Color::Rgb(0, 140, 160),
+            Part::Stick => Color::White,
+            Part::Front => Color::Yellow,
+        }
+    }
+}
+
+/// The pad, in as few lines as still read as a pad: the top face of a slab 50 mm deep by 150
+/// wide, its front edge given thickness, two grips reaching back toward the player, the two
+/// sticks standing proud, and a bar along the front edge so that "which way is it facing" never
+/// has to be inferred from the grips alone. Every line dropped from a fuller model — the bottom
+/// face, the grips' far edges — was one that turned the picture into hatching at terminal
+/// resolution without adding a degree of freedom the eye could read.
+const PAD_WIREFRAME: &[Segment] = &{
+    const B: Part = Part::Body;
+    const G: Part = Part::Grip;
+    const S: Part = Part::Stick;
+    const F: Part = Part::Front;
+    [
+        // Top face.
+        Segment::new([25.0, 75.0, 10.0], [25.0, -75.0, 10.0], B),
+        Segment::new([25.0, -75.0, 10.0], [-25.0, -75.0, 10.0], B),
+        Segment::new([-25.0, -75.0, 10.0], [-25.0, 75.0, 10.0], B),
+        Segment::new([-25.0, 75.0, 10.0], [25.0, 75.0, 10.0], B),
+        // Thickness, on the front edge only.
+        Segment::new([25.0, 75.0, 10.0], [25.0, 75.0, -10.0], B),
+        Segment::new([25.0, -75.0, 10.0], [25.0, -75.0, -10.0], B),
+        Segment::new([25.0, 75.0, -10.0], [25.0, -75.0, -10.0], B),
+        // Grips: the outer edge of each, back and down from the rear corners, closed at the end.
+        Segment::new([-25.0, 70.0, 10.0], [-70.0, 55.0, -20.0], G),
+        Segment::new([-25.0, 40.0, 10.0], [-70.0, 35.0, -20.0], G),
+        Segment::new([-70.0, 55.0, -20.0], [-70.0, 35.0, -20.0], G),
+        Segment::new([-25.0, -70.0, 10.0], [-70.0, -55.0, -20.0], G),
+        Segment::new([-25.0, -40.0, 10.0], [-70.0, -35.0, -20.0], G),
+        Segment::new([-70.0, -55.0, -20.0], [-70.0, -35.0, -20.0], G),
+        // Sticks: the Pro Controller's left stick sits forward-left, the right one back-right.
+        Segment::new([8.0, 45.0, 10.0], [8.0, 45.0, 26.0], S),
+        Segment::new([-10.0, -30.0, 10.0], [-10.0, -30.0, 26.0], S),
+        // Front bar, along the top of the front edge, with a nose at its middle.
+        Segment::new([25.0, 60.0, 14.0], [25.0, -60.0, 14.0], F),
+        Segment::new([25.0, 0.0, 14.0], [45.0, 0.0, 14.0], F),
+    ]
+};
+
+/// A half-block pixel canvas: one colour per pixel, two pixels per terminal row.
+struct Canvas {
+    w: usize,
+    h: usize,
+    pixels: Vec<Option<Color>>,
+}
+
+impl Canvas {
+    fn new(w: usize, h: usize) -> Self {
+        Self {
+            w,
+            h,
+            pixels: vec![None; w * h],
+        }
+    }
+
+    fn set(&mut self, x: i32, y: i32, colour: Color) {
+        if x < 0 || y < 0 {
+            return;
+        }
+        let (x, y) = (x as usize, y as usize);
+        if x < self.w && y < self.h {
+            self.pixels[y * self.w + x] = Some(colour);
+        }
+    }
+
+    /// Bresenham, on rounded endpoints. Clipped per pixel: a segment that leaves the canvas is
+    /// drawn as far as it goes rather than dropped.
+    fn line(&mut self, a: (f32, f32), b: (f32, f32), colour: Color) {
+        let (mut x0, mut y0) = (a.0.round() as i32, a.1.round() as i32);
+        let (x1, y1) = (b.0.round() as i32, b.1.round() as i32);
+        let dx = (x1 - x0).abs();
+        let dy = -(y1 - y0).abs();
+        let sx = if x0 < x1 { 1 } else { -1 };
+        let sy = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+        loop {
+            self.set(x0, y0, colour);
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+            let e2 = 2 * err;
+            if e2 >= dy {
+                err += dy;
+                x0 += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
+    fn blit(&self, area: Rect, buf: &mut Buffer) {
+        for row in 0..usize::from(area.height) {
+            for col in 0..self.w {
+                let top = self.pixels[(row * 2) * self.w + col];
+                let bottom = self
+                    .pixels
+                    .get((row * 2 + 1) * self.w + col)
+                    .copied()
+                    .flatten();
+                let Some(cell) = buf.cell_mut((area.x + col as u16, area.y + row as u16)) else {
+                    continue;
+                };
+                match (top, bottom) {
+                    (Some(t), Some(b)) => {
+                        cell.set_symbol("▀").set_fg(t).set_bg(b);
+                    }
+                    (Some(t), None) => {
+                        cell.set_symbol("▀").set_fg(t);
+                    }
+                    (None, Some(b)) => {
+                        cell.set_symbol("▄").set_fg(b);
+                    }
+                    (None, None) => {}
+                }
+            }
+        }
+    }
+}
+
+fn rotate_matrix(m: [[f32; 3]; 3], v: [f32; 3]) -> [f32; 3] {
+    [
+        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use duck_ipc_proto as proto;
+
+    fn an_imu(accel_g: [f32; 3]) -> Imu {
+        let mut imu = Imu::new(proto::PadImuDevice {
+            name: String::new(),
+            node: String::new(),
+            accel_per_g: 4096,
+            gyro_per_dps: 14247,
+            accel_max: 32767,
+            gyro_max: 32_767_000,
+        });
+        imu.absorb(&proto::PadImuBatch {
+            samples: vec![proto::PadImuSample {
+                seq: 1,
+                at_us: 1_000_000,
+                accel: [
+                    (accel_g[0] * 4096.0) as i32,
+                    (accel_g[1] * 4096.0) as i32,
+                    (accel_g[2] * 4096.0) as i32,
+                ],
+                gyro: [0; 3],
+            }],
+            socket_dropped: 0,
+        });
+        imu
+    }
+
+    fn picture(imu: &Imu, w: u16, h: u16) -> Vec<String> {
+        let area = Rect::new(0, 0, w, h);
+        let mut buf = Buffer::empty(area);
+        draw(imu, area, &mut buf);
+        (0..h)
+            .map(|y| (0..w).map(|x| buf[(x, y)].symbol()).collect())
+            .collect()
+    }
+
+    /// The wireframe lands on the canvas: something is drawn, and a level pad and a rolled pad
+    /// are different pictures.
+    #[test]
+    fn the_pad_is_drawn_and_moves_with_the_attitude() {
+        let flat = picture(&an_imu([0.0, 0.0, 1.0]), 40, 10);
+        let inked = flat.iter().flat_map(|r| r.chars()).filter(|c| *c != ' ').count();
+        assert!(inked > 30, "a wireframe is more than a few pixels: {inked}");
+        assert_ne!(flat, picture(&an_imu([0.0, 0.7, 0.7]), 40, 10));
+    }
+
+    /// Print the wireframe for a few attitudes. Not an assertion — a way to look at the picture
+    /// without a pad in hand: `cargo test -p robotctl imu_view -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "visual probe, run manually with --ignored --nocapture"]
+    fn show_me_the_pad() {
+        for (name, accel) in [
+            ("flat", [0.0, 0.0, 1.0]),
+            ("nose up 30°", [-0.5, 0.0, 0.866]),
+            ("rolled left 45°", [0.0, -0.707, 0.707]),
+            ("on its front edge", [1.0, 0.0, 0.0]),
+        ] {
+            let imu = an_imu(accel);
+            println!("── {name} · euler {:?}", imu.euler_deg());
+            for row in picture(&imu, 44, 10) {
+                println!("│{row}│");
+            }
+        }
+    }
+}

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -43,7 +43,7 @@ use robotd_params::Slot;
 mod configure;
 mod duck;
 mod monitor;
-mod pad_imu;
+mod imu_view;
 mod path_map;
 mod show;
 

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -31,7 +31,7 @@ use ratatui::widgets::{
     Block, Cell, Paragraph, RenderDirection, Row, Sparkline, Table, TableState,
 };
 
-use crate::{Client, Failure, duck, exit, pad_imu, path_map};
+use crate::{Client, Failure, duck, exit, imu_view, path_map};
 
 /// Tracking error at the edge of a deviation bar, radians.
 ///
@@ -1171,7 +1171,7 @@ fn render_imu(imu: &pad_imu::Imu, frame: &mut ratatui::Frame, area: ratatui::lay
         Constraint::Min(0),
     ])
     .areas::<2>(inner);
-    imu.draw(picture, frame.buffer_mut());
+    imu_view::draw(imu, picture, frame.buffer_mut());
 
     let [pitch, roll, yaw] = imu.euler_deg();
     let a = imu.accel_g();

--- a/robotd-params/src/edit.rs
+++ b/robotd-params/src/edit.rs
@@ -1051,7 +1051,8 @@ mod tests {
                 "media",
                 // Last, and the editor shows sections in this order: the pad is what a robot's
                 // buttons do, which is the thing somebody browses for rather than tunes.
-                "pad"
+                "pad",
+                "imu_head"
             ]
         );
     }

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -65,6 +65,38 @@ pub struct Params {
     pub detect: DetectParams,
     /// Which pad button runs which skill. `padd` reads this, not `robotd`.
     pub pad: PadParams,
+    /// Posing the head from the pad's own IMU. `padd` reads this too.
+    pub imu_head: ImuHeadParams,
+}
+
+/// Controller-IMU head control: pose the head by tilting the pad.
+///
+/// Some pads carry an inertial unit — the "Pro Controller" Switch clones do; an Xbox pad does not.
+/// With this on and such a pad connected, **Y** stops meaning "the sticks pose the head" and
+/// means "the pad's tilt poses the head": the sticks keep driving, and turning the pad in your
+/// hands turns the robot's head. Press Y again and the head holds where it is, still driving.
+/// Press it a third time and the pad drives the head again **from where the pad is now** — the
+/// pad's yaw comes from a gyro and drifts, and re-centring on every re-entry is how a person
+/// beats the drift without a magnetometer.
+///
+/// Off, or on a pad with no IMU, Y is what it always was. Nothing else about the pad changes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ImuHeadParams {
+    /// Whether Y engages IMU head control on a pad that has an IMU.
+    pub enabled: bool,
+    /// Head radians per pad radian. One is "the head turns as far as the pad did"; more makes a
+    /// small wrist movement a large head movement. The head's own travel limit still applies.
+    pub gain: f64,
+}
+
+impl Default for ImuHeadParams {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            gain: 1.0,
+        }
+    }
 }
 
 /// Which pad button runs which skill.

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -435,6 +435,19 @@ pub const REGISTRY: &[Entry] = &[
     feature("pad.lb", Kind::Text, "Skill on the left bumper"),
     feature("pad.rb", Kind::Text, "Skill on the right bumper"),
     feature("pad.dpad_down", Kind::Text, "Skill on D-pad down"),
+    // ── [imu_head] ───────────────────────────────────────────────────────────
+    //
+    // Controller-IMU head control. Read by `padd`, like `[pad]`.
+    feature(
+        "imu_head.enabled",
+        Kind::Bool,
+        "Y poses the head from the pad's own IMU (Pro Controller) — sticks keep driving; Y again holds, again re-centres",
+    ),
+    entry(
+        "imu_head.gain",
+        Kind::Float,
+        "Head radians per pad radian — 1 follows the pad exactly, more amplifies the wrist",
+    ),
 ];
 
 /// The registry entry for a key, if it is one.
@@ -630,6 +643,7 @@ mod tests {
                 "pad.lb",
                 "pad.rb",
                 "pad.dpad_down",
+                "imu_head.enabled",
             ]
         );
     }


### PR DESCRIPTION
Controller-IMU head control. With [imu_head] enabled (sudo robotctl configure,
front page) and a pad that has an IMU, Y hands the head to the pad's tilt while
the sticks keep driving; Y again holds the head; a third Y re-centres on the
pad's current attitude and follows again, which is what beats the gyro's yaw
drift. Off, or on an Xbox pad, Y is the stick head mode it always was.

- pad-imu: new crate holding the attitude filter, shared by padd and robotctl
  so the head goes where the drawn pad points.
- padd: the tap keeps the IMU open for the main loop when the feature is on
  (Tap::imu_control / attitude); robot.head rides in the same frame as
  robot.move; config re-read within a second, no restart.
- robotd-params: [imu_head] enabled + gain, registered, ordered after [pad],
  restart offer maps to padd, documented in deploy/robotd.toml.

Validated on graphite 2026-09-09; pitch and roll signs corrected on hardware
(the stick mapping's signs are not the joint axes). Tests: 88 robotd-params,
19 padd, 5 pad-imu, 154 robotctl; clippy clean; cargo board builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)