### PR TITLE
padd: Select stops on release, and a two-second hold is the whole shu…

### DIFF
--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -489,8 +489,8 @@ mapping is the prototype's, so muscle memory carries over:
 | **RT / LT** | mouth (either trigger) — RT also quacks; LT rides the "wheee" while held |
 | **DPad-Up**, held 3 s | switch drive mode, walk ⇄ roller |
 | **DPad-Right** | reboot every servo: the way back from a tripped overload without pulling the battery. Torque off, then Start |
-| **Select** | torque off (`robot.relax`): the emergency release. The robot drops, so hold it. Then Start stands it up again |
-| **Select**, held 2 s | power off (the press has already cut torque) |
+| **Select**, short press | torque off (`robot.relax`) **on release**: the emergency stop. The robot drops, so hold it. Then Start stands it up again |
+| **Select**, held 2 s | sit down, torque off, power off — the release afterwards does nothing more |
 
 **Drive the head with the pad itself.** A Pro Controller carries an IMU, and with
 

--- a/duckctl/src/main.rs
+++ b/duckctl/src/main.rs
@@ -446,7 +446,9 @@ fn deliver(command: &Command, address: &str) -> Result<(), Box<dyn std::error::E
             }
             #[cfg(not(unix))]
             {
-                let status = ssh.status().map_err(|e| format!("could not run ssh: {e}"))?;
+                let status = ssh
+                    .status()
+                    .map_err(|e| format!("could not run ssh: {e}"))?;
                 std::process::exit(status.code().unwrap_or(1));
             }
         }
@@ -860,7 +862,11 @@ enum Command {
         #[arg(long, value_name = "USER")]
         user: Option<String>,
         /// A command to run on the robot instead of opening a shell. Put it after `--`.
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true, value_name = "COMMAND")]
+        #[arg(
+            trailing_var_arg = true,
+            allow_hyphen_values = true,
+            value_name = "COMMAND"
+        )]
         command: Vec<String>,
     },
     /// Open the robot's console in a browser.

--- a/pad-imu/src/lib.rs
+++ b/pad-imu/src/lib.rs
@@ -284,7 +284,10 @@ impl Imu {
             let predicted = rotate(conj(self.q), [0.0, 0.0, 1.0]);
             let error = cross(measured, predicted);
             let k = GRAVITY_GAIN * dt;
-            self.q = mul(self.q, from_rotvec([error[0] * k, error[1] * k, error[2] * k]));
+            self.q = mul(
+                self.q,
+                from_rotvec([error[0] * k, error[1] * k, error[2] * k]),
+            );
         }
         self.q = normalized4(self.q);
     }
@@ -499,7 +502,10 @@ mod tests {
         let bias = imu.bias_dps().expect("three seconds still is a bias");
         assert!((bias[2] - 12.0).abs() < 0.1, "{bias:?}");
         let [pitch, roll, yaw] = imu.euler_deg();
-        assert!(pitch.abs() < 0.5 && roll.abs() < 0.5, "level: {pitch} {roll}");
+        assert!(
+            pitch.abs() < 0.5 && roll.abs() < 0.5,
+            "level: {pitch} {roll}"
+        );
         // Yaw drifted for the half second before the bias was known and not after.
         assert!(yaw.abs() < 12.0 * 0.6, "yaw stopped drifting: {yaw}");
         let rate = imu.rate_hz().expect("a rate");
@@ -577,7 +583,11 @@ mod tests {
         // Drift: 40 °/s of yaw for a second, unlearned because the pad is "moving".
         steady(&mut imu, 1.0, [0.0, 0.0, 1.4], [0.0, 0.0, 40.0]);
         let drifted = imu.quaternion().unwrap();
-        assert!(euler_deg(drifted)[2].abs() > 30.0, "{:?}", euler_deg(drifted));
+        assert!(
+            euler_deg(drifted)[2].abs() > 30.0,
+            "{:?}",
+            euler_deg(drifted)
+        );
 
         let reference = drifted;
         let zeroed = euler_deg(relative(reference, imu.quaternion().unwrap()));

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -589,9 +589,7 @@ fn main() -> std::process::ExitCode {
                     }
                 }
                 None => {
-                    if imu_head_cfg.enabled
-                        && tap.as_ref().is_some_and(|tap| tap.has_imu())
-                    {
+                    if imu_head_cfg.enabled && tap.as_ref().is_some_and(|tap| tap.has_imu()) {
                         // The IMU is there and has not spoken yet — a second after connecting,
                         // typically. Saying so beats silently doing the other thing.
                         tracing::warn!(
@@ -1269,12 +1267,21 @@ mod tests {
     fn y_cycles_follow_hold_follow_and_re_centres_each_time() {
         let level = [1.0, 0.0, 0.0, 0.0];
         // Yawed 30° by the time of the third press — drift, or a turn; the pad cannot tell.
-        let yawed = [(15.0f32.to_radians()).cos(), 0.0, 0.0, (15.0f32.to_radians()).sin()];
+        let yawed = [
+            (15.0f32.to_radians()).cos(),
+            0.0,
+            0.0,
+            (15.0f32.to_radians()).sin(),
+        ];
 
         let following = ImuHead::Off.on_y(level);
         assert_eq!(following, ImuHead::Following { reference: level });
         let holding = following.on_y(yawed);
-        assert_eq!(holding, ImuHead::Holding, "the second press holds, whatever the pad did");
+        assert_eq!(
+            holding,
+            ImuHead::Holding,
+            "the second press holds, whatever the pad did"
+        );
         let again = holding.on_y(yawed);
         assert_eq!(
             again,
@@ -1283,7 +1290,10 @@ mod tests {
         );
         // And that reference reads as centre.
         let head = head_from_pad(pad_imu::relative(yawed, yawed), 1.0, 2.5);
-        assert!(head.head_yaw.abs() < 1e-4 && head.head_pitch.abs() < 1e-4, "{head:?}");
+        assert!(
+            head.head_yaw.abs() < 1e-4 && head.head_pitch.abs() < 1e-4,
+            "{head:?}"
+        );
     }
 
     /// The pad's tilt becomes the head's pose with the signs verified on the robot: nose up is a
@@ -1295,27 +1305,41 @@ mod tests {
         // 30° nose up: a rotation about +Y.
         let nose_up = [half.cos(), 0.0, half.sin(), 0.0];
         let head = head_from_pad(nose_up, 1.0, 2.5);
-        assert!((head.head_pitch - 30.0f64.to_radians()).abs() < 0.01, "{head:?}");
-        assert!(head.head_yaw.abs() < 0.01 && head.head_roll.abs() < 0.01, "{head:?}");
+        assert!(
+            (head.head_pitch - 30.0f64.to_radians()).abs() < 0.01,
+            "{head:?}"
+        );
+        assert!(
+            head.head_yaw.abs() < 0.01 && head.head_roll.abs() < 0.01,
+            "{head:?}"
+        );
         assert_eq!(head.neck_pitch, 0.0);
 
         // 30° rolled right (left side up): about +X. The head rolls the other sign.
         let rolled = [half.cos(), half.sin(), 0.0, 0.0];
         let head = head_from_pad(rolled, 1.0, 2.5);
-        assert!((head.head_roll - (-30.0f64.to_radians())).abs() < 0.01, "{head:?}");
+        assert!(
+            (head.head_roll - (-30.0f64.to_radians())).abs() < 0.01,
+            "{head:?}"
+        );
 
         // 30° yaw left: about +Z.
         let left = [half.cos(), 0.0, 0.0, half.sin()];
         let head = head_from_pad(left, 1.0, 2.5);
-        assert!((head.head_yaw - 30.0f64.to_radians()).abs() < 0.01, "{head:?}");
+        assert!(
+            (head.head_yaw - 30.0f64.to_radians()).abs() < 0.01,
+            "{head:?}"
+        );
 
         // Gain 2 doubles it; a limit of 0.5 rad clamps it.
         let head = head_from_pad(left, 2.0, 2.5);
-        assert!((head.head_yaw - 60.0f64.to_radians()).abs() < 0.01, "{head:?}");
+        assert!(
+            (head.head_yaw - 60.0f64.to_radians()).abs() < 0.01,
+            "{head:?}"
+        );
         let head = head_from_pad(left, 2.0, 0.5);
         assert!((head.head_yaw - 0.5).abs() < 1e-6, "{head:?}");
     }
-
 
     /// Select is read on release. A short press is the stop, on the release; a hold reaching two
     /// seconds is the shutdown, once, and the release after it is not a stop as well — the robot
@@ -1346,5 +1370,4 @@ mod tests {
         assert_eq!(select.tick(true, false, at(6_000)), SelectAction::Nothing);
         assert_eq!(select.tick(false, true, at(6_100)), SelectAction::Relax);
     }
-
 }

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -32,7 +32,8 @@
 //! LB / RB      left / right kick
 //! DPad-Down    sit ↔ stand
 //! RT / LT      mouth (either trigger; the max wins) · RT quacks · LT rides the wheee
-//! Select, 2 s  sit down, then power off
+//! Select       torque off, on release — the emergency stop
+//! Select, 2 s  sit down, torque off, then power off — the release does nothing more
 //! ```
 //!
 //! Head and body-pose mode both zero the velocity while active, as the prototype does — a
@@ -190,6 +191,58 @@ const IDLE_POLL: Duration = Duration::from_millis(500);
 
 /// Select held this long sits the robot down and powers it off.
 const SHUTDOWN_HOLD: Duration = Duration::from_secs(2);
+
+/// The Select button, which does one of two things depending on how long it was held — and so
+/// has to wait for the release to know which.
+///
+/// A short press is the emergency stop: `robot.relax`, torque off, the robot drops. Held for
+/// [`SHUTDOWN_HOLD`] it is the shutdown sequence instead: sit down, torque off, power off. The two
+/// cannot both fire — a robot that has already gone limp cannot sit — so the stop is sent **on
+/// release**, and only if the hold never reached the shutdown. The cost is that the stop lands
+/// when the thumb comes off rather than when it goes down, which for a button somebody presses
+/// and lets go of is the same instant.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SelectButton {
+    /// When the current hold began. `None` between presses.
+    held_since: Option<Instant>,
+    /// The shutdown was sent for this hold, so its release is not a stop.
+    shutdown_sent: bool,
+}
+
+/// What Select asks for this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectAction {
+    Nothing,
+    /// Held long enough: sit, torque off, power off. Once per hold.
+    Shutdown,
+    /// Let go before that: torque off now.
+    Relax,
+}
+
+impl SelectButton {
+    /// One tick: is the button down now, and did it come up since the last tick.
+    ///
+    /// `released` is the edge from the event queue, because a press and release inside one tick
+    /// leaves `pressed` false on both sides and would otherwise be a stop nobody saw.
+    fn tick(&mut self, pressed: bool, released: bool, now: Instant) -> SelectAction {
+        if pressed {
+            let since = *self.held_since.get_or_insert(now);
+            if now.duration_since(since) >= SHUTDOWN_HOLD && !self.shutdown_sent {
+                self.shutdown_sent = true;
+                return SelectAction::Shutdown;
+            }
+            return SelectAction::Nothing;
+        }
+        let was_shutdown = self.shutdown_sent;
+        self.held_since = None;
+        self.shutdown_sent = false;
+        if released && !was_shutdown {
+            return SelectAction::Relax;
+        }
+        // A release after the shutdown, or a tick with nothing to say.
+        SelectAction::Nothing
+    }
+}
 
 /// D-pad up held this long switches drive mode, walk ⇄ roller.
 ///
@@ -372,7 +425,7 @@ fn main() -> std::process::ExitCode {
         roller,
         "driving — Start once stands up, Start again toggles the policy, Y head mode, B body pose, \
          A ground pick, LB/RB kicks, DPad-Down sit, triggers mouth, DPad-Right reboot servos, \
-         DPad-Up (3s) walk/roller, Select torque off, Select (2s) shutdown"
+         DPad-Up (3s) walk/roller, Select (release) torque off, Select (2s) sit and shutdown"
     );
 
     let period = Duration::from_secs_f64(1.0 / args.hz as f64);
@@ -392,10 +445,9 @@ fn main() -> std::process::ExitCode {
     let mut imu_head = ImuHead::Off;
     // Whether a pad was there last tick, so appearing and disappearing are each logged once.
     let mut driving = false;
-    let mut select_held_since: Option<Instant> = None;
+    let mut select = SelectButton::default();
     let mut dpad_up_held_since: Option<Instant> = None;
     let mut mode_switch_sent = false;
-    let mut shutdown_sent = false;
     // Trigger levels last tick, for the sound edges: RT quacks on its rising edge, LT
     // starts the wheee ride. The prototype's threshold.
     let mut prev_rt = 0.0f64;
@@ -434,8 +486,14 @@ fn main() -> std::process::ExitCode {
         // a flag apiece, because what each one runs is config now and this loop no longer knows.
         let mut pressed: Vec<&'static str> = Vec::new();
         let mut relax = false;
+        let mut select_released = false;
         let mut reboot_motors = false;
         while let Some(event) = gilrs.next_event() {
+            // Select is the one button read on its release: a short press stops, a long hold shuts
+            // down, and which it was is only known when the thumb comes off.
+            if let gilrs::EventType::ButtonReleased(Button::Select, _) = event.event {
+                select_released = true;
+            }
             if let gilrs::EventType::ButtonPressed(button, _) = event.event {
                 match button {
                     Button::Start => toggle_enable = true,
@@ -452,8 +510,8 @@ fn main() -> std::process::ExitCode {
                     Button::LeftTrigger => pressed.push("lb"),
                     Button::RightTrigger => pressed.push("rb"),
                     Button::DPadDown => pressed.push("dpad_down"),
-                    // Emergency release: torque off. Held on, it is still the shutdown below.
-                    Button::Select => relax = true,
+                    // Select is handled on release — see `SelectButton`.
+                    Button::Select => {}
                     // Reboot the servos: the way back from a tripped overload without pulling
                     // the battery.
                     Button::DPadRight => reboot_motors = true,
@@ -650,8 +708,24 @@ fn main() -> std::process::ExitCode {
             return std::process::ExitCode::FAILURE;
         }
 
+        // Select: a short press is the emergency stop, on release; held two seconds it is the
+        // shutdown sequence — sit down, torque off, power off — sent once per hold, and the
+        // release after it does nothing. The robot owns the sequence from there.
+        match select.tick(pad.is_pressed(Button::Select), select_released, tick) {
+            SelectAction::Nothing => {}
+            SelectAction::Relax => relax = true,
+            SelectAction::Shutdown => {
+                up = false;
+                tracing::warn!("Select held — asking the robot to sit, torque off and power off");
+                if let Err(e) = request(&mut stream, &mut next_id, &proto::Call::RobotShutdown) {
+                    tracing::error!(error = %e, "shutdown request failed");
+                    return std::process::ExitCode::FAILURE;
+                }
+            }
+        }
+
         if relax {
-            tracing::warn!("Select — robot.relax: torque off");
+            tracing::warn!("Select released — robot.relax: torque off");
             // Torque off leaves the robot limp, so the next Start stands it up again rather
             // than toggling the policy on a robot that is lying on the floor.
             up = false;
@@ -673,24 +747,6 @@ fn main() -> std::process::ExitCode {
                 tracing::error!(error = %e, "reboot request failed");
                 return std::process::ExitCode::FAILURE;
             }
-        }
-
-        // Select held two seconds: sit down, then power off. Sent once per hold — the
-        // robot owns the sequence from there, and a second request would be a no-op anyway.
-        if pad.is_pressed(Button::Select) {
-            let held = select_held_since.get_or_insert(tick);
-            if tick.duration_since(*held) >= SHUTDOWN_HOLD && !shutdown_sent {
-                shutdown_sent = true;
-                up = false;
-                tracing::warn!("Select held — asking the robot to sit and power off");
-                if let Err(e) = request(&mut stream, &mut next_id, &proto::Call::RobotShutdown) {
-                    tracing::error!(error = %e, "shutdown request failed");
-                    return std::process::ExitCode::FAILURE;
-                }
-            }
-        } else {
-            select_held_since = None;
-            shutdown_sent = false;
         }
 
         // D-pad up held three seconds: switch drive mode, which is what somebody who has just
@@ -1258,6 +1314,37 @@ mod tests {
         assert!((head.head_yaw - 60.0f64.to_radians()).abs() < 0.01, "{head:?}");
         let head = head_from_pad(left, 2.0, 0.5);
         assert!((head.head_yaw - 0.5).abs() < 1e-6, "{head:?}");
+    }
+
+
+    /// Select is read on release. A short press is the stop, on the release; a hold reaching two
+    /// seconds is the shutdown, once, and the release after it is not a stop as well — the robot
+    /// is sitting down and must not be dropped mid-way.
+    #[test]
+    fn select_stops_on_a_short_release_and_shuts_down_on_a_long_hold() {
+        let t0 = Instant::now();
+        let at = |ms: u64| t0 + Duration::from_millis(ms);
+        let mut select = SelectButton::default();
+
+        // Short press: down for 300 ms, then up.
+        assert_eq!(select.tick(true, false, at(0)), SelectAction::Nothing);
+        assert_eq!(select.tick(true, false, at(300)), SelectAction::Nothing);
+        assert_eq!(select.tick(false, true, at(320)), SelectAction::Relax);
+        assert_eq!(select.tick(false, false, at(340)), SelectAction::Nothing);
+
+        // Press and release inside one tick: the state never read as down, the edge did.
+        assert_eq!(select.tick(false, true, at(1_000)), SelectAction::Relax);
+
+        // Long hold: the shutdown fires at two seconds, once, and the release is silent.
+        assert_eq!(select.tick(true, false, at(2_000)), SelectAction::Nothing);
+        assert_eq!(select.tick(true, false, at(3_990)), SelectAction::Nothing);
+        assert_eq!(select.tick(true, false, at(4_000)), SelectAction::Shutdown);
+        assert_eq!(select.tick(true, false, at(4_020)), SelectAction::Nothing);
+        assert_eq!(select.tick(false, true, at(5_000)), SelectAction::Nothing);
+
+        // And the next short press is a stop again.
+        assert_eq!(select.tick(true, false, at(6_000)), SelectAction::Nothing);
+        assert_eq!(select.tick(false, true, at(6_100)), SelectAction::Relax);
     }
 
 }

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -293,8 +293,9 @@ impl Tap {
 fn imu_sibling(sysfs: &Path, dev: &Path, node: &Path) -> Option<PathBuf> {
     let event = node.file_name()?.to_owned();
     let class = sysfs.join("class/input");
-    let hid_parent =
-        |event: &std::ffi::OsStr| std::fs::canonicalize(class.join(event).join("device/device")).ok();
+    let hid_parent = |event: &std::ffi::OsStr| {
+        std::fs::canonicalize(class.join(event).join("device/device")).ok()
+    };
     let parent = hid_parent(&event)?;
 
     let mut candidates: Vec<PathBuf> = std::fs::read_dir(&class)
@@ -1201,7 +1202,10 @@ mod tests {
         });
 
         let (reports, _dropped) = shared.subscribe();
-        assert!(matches!(&*reports.try_recv().unwrap(), proto::PadReport::Attached { .. }));
+        assert!(matches!(
+            &*reports.try_recv().unwrap(),
+            proto::PadReport::Attached { .. }
+        ));
         assert!(matches!(
             &*reports.try_recv().unwrap(),
             proto::PadReport::ImuAttached { .. }

--- a/robotctl/src/imu_view.rs
+++ b/robotctl/src/imu_view.rs
@@ -267,7 +267,11 @@ mod tests {
     #[test]
     fn the_pad_is_drawn_and_moves_with_the_attitude() {
         let flat = picture(&an_imu([0.0, 0.0, 1.0]), 40, 10);
-        let inked = flat.iter().flat_map(|r| r.chars()).filter(|c| *c != ' ').count();
+        let inked = flat
+            .iter()
+            .flat_map(|r| r.chars())
+            .filter(|c| *c != ' ')
+            .count();
         assert!(inked > 30, "a wireframe is more than a few pixels: {inked}");
         assert_ne!(flat, picture(&an_imu([0.0, 0.7, 0.7]), 40, 10));
     }

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -42,8 +42,8 @@ use robotd_params::Slot;
 
 mod configure;
 mod duck;
-mod monitor;
 mod imu_view;
+mod monitor;
 mod path_map;
 mod show;
 

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -1166,11 +1166,9 @@ fn render_imu(imu: &pad_imu::Imu, frame: &mut ratatui::Frame, area: ratatui::lay
     // The picture gets the left half of the width, capped where a wider one stops adding detail;
     // the words take the rest. The picture is the one that earns its place, so it is sized first.
     let picture_width = (inner.width / 2).clamp(12, 48);
-    let [picture, words] = Layout::horizontal([
-        Constraint::Length(picture_width),
-        Constraint::Min(0),
-    ])
-    .areas::<2>(inner);
+    let [picture, words] =
+        Layout::horizontal([Constraint::Length(picture_width), Constraint::Min(0)])
+            .areas::<2>(inner);
     imu_view::draw(imu, picture, frame.buffer_mut());
 
     let [pitch, roll, yaw] = imu.euler_deg();
@@ -1585,7 +1583,12 @@ impl View {
         if !self.show_pad {
             return 0;
         }
-        PAD_HEIGHT + if self.pad.imu.is_some() { IMU_HEIGHT } else { 0 }
+        PAD_HEIGHT
+            + if self.pad.imu.is_some() {
+                IMU_HEIGHT
+            } else {
+                0
+            }
     }
 
     /// Carve the robot view's column off the right, when it is wanted and fits.
@@ -2480,7 +2483,11 @@ impl View {
 
         // Fixed rows, in the order the questions arrive: is it arriving, has it been arriving, and
         // what it is saying — and, when the pad has one, where the pad is in space.
-        let imu_height = if self.pad.imu.is_some() { IMU_HEIGHT } else { 0 };
+        let imu_height = if self.pad.imu.is_some() {
+            IMU_HEIGHT
+        } else {
+            0
+        };
         let [cadence, gaps, axes, held, imu] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Length(1),
@@ -3834,7 +3841,10 @@ mod tests {
     fn the_pad_block_grows_an_imu_panel_only_when_the_pad_has_one() {
         let mut view = watching_a_pad();
         let without = render_to(&mut view, 100, 40);
-        assert!(!without.contains("front edge"), "no IMU, no panel:\n{without}");
+        assert!(
+            !without.contains("front edge"),
+            "no IMU, no panel:\n{without}"
+        );
         assert!(!without.contains("· IMU"), "{without}");
 
         feed(
@@ -3865,7 +3875,10 @@ mod tests {
             "the panel names the unit:\n{with}"
         );
         assert!(with.contains("pitch"), "and reads its attitude:\n{with}");
-        assert!(with.contains("settled"), "a second still learns the bias:\n{with}");
+        assert!(
+            with.contains("settled"),
+            "a second still learns the bias:\n{with}"
+        );
         assert!(
             with.contains('▀') || with.contains('▄'),
             "and draws the pad:\n{with}"
@@ -3878,7 +3891,10 @@ mod tests {
             })),
         );
         let gone = render_to(&mut view, 100, 40);
-        assert!(!gone.contains("· IMU"), "and it goes when the IMU does:\n{gone}");
+        assert!(
+            !gone.contains("· IMU"),
+            "and it goes when the IMU does:\n{gone}"
+        );
     }
 
     /// Six hundred samples a second must not become six hundred repaints a second.
@@ -3907,7 +3923,10 @@ mod tests {
                 .unwrap_or_else(|_| panic!("an update is not a failure"))
             })
             .count();
-        assert!(repaints <= 2, "a burst of samples earned {repaints} repaints");
+        assert!(
+            repaints <= 2,
+            "a burst of samples earned {repaints} repaints"
+        );
     }
 
     /// Stopping `tofd` must be an ordinary thing to do. The subscribe reports why


### PR DESCRIPTION
…tdown again

The emergency stop on Select's press cut torque at once, so the two-second hold that followed asked a limp robot to sit down before powering off. The two cannot both fire, and which one was meant is only known when the thumb comes off -- so the stop is now sent on release, and only when the hold never reached the shutdown. A hold that does reach it sits the robot, cuts torque and powers off, and its release does nothing more. A press and release inside one tick is still a stop: the release edge is read from the event queue, not from the held state.

Closes #246.