### PR TITLE
configure: the right daemon, and the right thing to do to it

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -1,7 +1,10 @@
 # robotd — per-robot parameters.
 #
-# Installed to /etc/robot/robotd.toml. Read once at startup, not watched: changing
-# anything here needs `systemctl restart robotd`. Live reload is deferred
+# Installed to /etc/robot/robotd.toml. Mostly read once at startup and not watched, so
+# mostly a change needs a restart — of the daemon that reads the section, which is not
+# always robotd: [media] and [detect] are mediad's and [head_imu] is tofd's. The two
+# exceptions: padd re-reads [imu_head] a second after the file changes, and robotd
+# re-reads [policy] when asked. `robotctl configure` knows which is which and offers it
 # (docs/design/robotd-design.md §4.2).
 #
 # It lives here, and not under /opt/robot/daemon/releases/<ver>/, on purpose: this is

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -777,9 +777,19 @@ single last-writer slot would lose.
 
 ### 4.2 Params
 
-A TOML file read at startup, **not watched** — live reload comes later. It lives outside
+A TOML file read at startup and, for the most part, **not watched**. It lives outside
 `releases/<ver>/` so it survives update *and* rollback, next to the updater's own config at
 `/etc/robot/robotd.toml`.
+
+Two parts of it are watched, and both are exceptions earned by what a restart would cost rather
+than steps towards watching the whole file. `padd` stats the file once a second and re-reads
+`[pad]` and `[imu_head]` when the mtime moves: a binding is changed from a phone, and restarting
+`padd` to apply it would drop the pad session and let `robotd`'s deadman zero a walking robot.
+`robotd` re-reads `[policy]` — all of it but `mode` and `enabled` — when asked to, which is how
+`robotctl policy add` lands a skill without taking motor control away from a standing robot.
+Re-reading `[safety]` or `[control]` under a running loop is a different and much larger promise,
+and it is still not made. `robotctl configure` knows which of the three answers a key wants, and
+a key that says nothing fails a test in `robotctl`.
 
 Belonging to the board rather than the release is what makes a hand-edited policy path stick: the
 defaults point inside `releases/<ver>/`, so an ordinary update keeps a policy alongside the

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -138,8 +138,10 @@ Three properties worth trusting:
 - **It cannot write a file robotd refuses to start on.** Every save is validated through the
   daemon's own loader first, atomically (temp file + rename), and rejected with the reason.
 
-The daemons read the file once at startup, so saving offers a restart — of the ones that read
-what you changed: `[media]` is `mediad`, everything else is `robotd`. `sudo`, because the file
+Saving offers what the change actually needs, from the daemon that actually reads it: a restart
+for most keys (`[media]` and `[detect]` are `mediad`'s, `[head_imu]` is `tofd`'s), a `robotd`
+*reload* for `[policy]` — the motors stay powered — and nothing at all for `[pad]` and
+`[imu_head]`, which `padd` picks up within a second. `sudo`, because the file
 is root-owned — without it the editor opens read-only and says so on the first write.
 `--file` points it elsewhere for a bench copy. The shipped `deploy/robotd.toml` stays the
 reference for *why* each knob exists; this is for flipping them.

--- a/robotctl/src/configure.rs
+++ b/robotctl/src/configure.rs
@@ -52,15 +52,27 @@ pub use robotd_params::edit::{Edit, Model, Row, bind_pad, pad_bindings, render, 
 /// tee. Being wrong here is an edit that appears to do nothing until the next reboot — which is
 /// exactly what the restart offer exists to prevent, so it is derived from the keys that changed
 /// rather than assumed.
-fn unit_for(section: &str) -> &'static str {
-    match section {
+///
+/// **Every section is listed, and there is no fallback.** `[head_imu]` shipped reading as `robotd`
+/// because a `_ => "robotd"` arm answered for it: enabling the head IMU restarted the daemon that
+/// does not read the key and left `tofd` on the old value, so the switch did nothing and said
+/// nothing. A section with no arm here now fails `every_registry_section_names_its_daemon` rather
+/// than picking up whichever daemon the catch-all happened to name.
+fn unit_for(section: &str) -> Option<&'static str> {
+    Some(match section {
         "media" | "detect" => "mediad",
         // `padd` reads the bindings, and `robotd` never sees them. Offering a robotd restart for
         // a button change would drop motor control — putting a standing robot on the floor — to
         // apply a setting it does not read.
         "pad" | "imu_head" => "padd",
-        _ => "robotd",
-    }
+        // `tofd` reads `[head_imu]` out of robotd's file — see `tof/src/config.rs` for why it
+        // reads that file rather than one of its own. Not to be confused with `imu_head` above,
+        // which is the *controller's* IMU steering the head.
+        "head_imu" => "tofd",
+        "bus" | "control" | "update_gate" | "policy" | "safety" | "chorale" | "theremin"
+        | "audio" => "robotd",
+        _ => return None,
+    })
 }
 
 /// The units a set of `section.key` names requires restarting, in start order, without duplicates.
@@ -70,7 +82,12 @@ fn units_for_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Vec<&'static str> 
     let mut units: Vec<&'static str> = Vec::new();
     for key in keys {
         let (section, _) = key.split_once('.').expect("registry keys are section.key");
-        let unit = unit_for(section);
+        // Unreachable for a registry key: the test above keeps `unit_for` exhaustive. Offering
+        // nothing beats offering the wrong daemon — the exit path then prints the file it wrote
+        // instead of restarting something that never reads it.
+        let Some(unit) = unit_for(section) else {
+            continue;
+        };
         if !units.contains(&unit) {
             units.push(unit);
         }
@@ -657,6 +674,50 @@ mod tests {
 
         // Nothing pending is nothing to restart, and the caller must not offer one.
         assert!(units_for(&model("")).is_empty());
+    }
+
+    /// `[head_imu]` is `tofd`'s, and it read as `robotd`'s on the board.
+    ///
+    /// Turning the head IMU on through this editor restarted `robotd` — which never looks at the
+    /// key — and left `tofd` running on the value it loaded at boot. The switch was on in the
+    /// file, off in the daemon, and the only sign was a startup line nobody re-reads. Regression
+    /// test rather than an assertion folded into the case above, because the two IMU sections are
+    /// a name apart: `imu_head` is the controller's, and it really is `padd`'s.
+    #[test]
+    fn the_head_imu_switch_restarts_tofd_and_not_robotd() {
+        let mut m = model("");
+        m.edit(entry("head_imu.enabled"), "true").expect("valid");
+        assert_eq!(units_for(&m), vec!["tofd"]);
+
+        let mut m = model("");
+        m.edit(entry("imu_head.enabled"), "true").expect("valid");
+        assert_eq!(
+            units_for(&m),
+            vec!["padd"],
+            "the controller's IMU is padd's"
+        );
+    }
+
+    /// Every section in the registry names the daemon that reads it.
+    ///
+    /// What went wrong with `[head_imu]` was not a wrong answer, it was a default one: a
+    /// catch-all arm answered `robotd` for a section nobody had mapped, so adding a section was
+    /// enough to ship a restart offer that restarts the wrong daemon. There is no catch-all now,
+    /// and this fails for the next section added without an arm — at `cargo test`, not on a
+    /// board, and not as a switch that silently does nothing.
+    #[test]
+    fn every_registry_section_names_its_daemon() {
+        let mut unmapped: Vec<&str> = robotd_params::registry::REGISTRY
+            .iter()
+            .filter_map(|e| e.key.split_once('.').map(|(section, _)| section))
+            .filter(|section| unit_for(section).is_none())
+            .collect();
+        unmapped.sort_unstable();
+        unmapped.dedup();
+        assert!(
+            unmapped.is_empty(),
+            "no daemon named for {unmapped:?} — add an arm to `unit_for`"
+        );
     }
 
     /// The whole first screen renders without panicking, features first — the same

--- a/robotctl/src/configure.rs
+++ b/robotctl/src/configure.rs
@@ -27,13 +27,21 @@
 //! unit a change needs restarted, restarting it, printing a divergence list, and the full-screen
 //! editor.
 //!
-//! ## Restart
+//! ## Making a change take
 //!
-//! The daemons read the file **once at startup** (`robotd-params` docs) — so every change
-//! requires a restart, and the exit flow offers one whenever anything was written. *Which*
-//! daemon is derived from the keys that changed, not assumed: `[media]` is `mediad` reading the
-//! same file, and a "restart robotd" offer over a video setting is an edit that reads as having
-//! done nothing at all. [`unit_for`] is that mapping and [`units_for`] applies it.
+//! Mostly the daemons read the file **once at startup** (`robotd-params` docs), so mostly a
+//! change needs a restart — and *which* daemon is derived from the keys that changed rather than
+//! assumed: `[media]` is `mediad` reading the same file, and a "restart robotd" offer over a
+//! video setting is an edit that reads as having done nothing at all.
+//!
+//! Mostly, not always, and the exceptions are where offering a restart is worst. `padd` re-reads
+//! `[pad]` and `[imu_head]` a second after the file changes, so a restart there drops the pad
+//! session — and robotd's deadman with it — to apply what would have applied by itself. `robotd`
+//! re-reads `[policy]` on a call, so a restart there takes motor control away from a standing
+//! robot to change a number it would have taken standing up.
+//!
+//! [`Apply`] is what a key needs, [`apply_for`] is the mapping, and [`Plan`] is that answer for a
+//! set of keys — what to restart, what to reload, and what needs nothing at all.
 //!
 //! The file is root-owned; run as `sudo robotctl configure` to actually write.
 
@@ -44,73 +52,152 @@ use std::path::Path;
 // of `robotctl` reaches for `configure::Model` and should not have to know it moved.
 pub use robotd_params::edit::{Edit, Model, Row, bind_pad, pad_bindings, render, sections};
 
-/// Which daemon reads a section, and so which unit a change to it needs restarted.
+/// What a written key needs before the daemon that reads it is running on it.
+///
+/// Every variant names that daemon, because every message the exit flow prints names it: an offer
+/// that says "restart" without saying *what* is how `[head_imu]` came to restart `robotd`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Apply {
+    /// Read once at startup. The unit has to go down and come back, and everything it was doing
+    /// stops for as long as that takes.
+    Restart(&'static str),
+    /// A running daemon will re-read it on a call. Cheaper than a restart in the way that
+    /// matters: the motors stay powered.
+    Reload(&'static str),
+    /// The daemon re-reads the file by itself. Nothing to do but say so.
+    Live(&'static str),
+}
+
+impl Apply {
+    /// The daemon, whatever the answer was.
+    fn unit(self) -> &'static str {
+        match self {
+            Self::Restart(unit) | Self::Reload(unit) | Self::Live(unit) => unit,
+        }
+    }
+}
+
+/// What a change to `section.key` needs, and from which daemon.
 ///
 /// `robotd` parses this file for itself; `[media]` and `[detect]` are `mediad` reading the same
 /// file, because a per-board setting belongs in the per-board config rather than on a unit file the
 /// release installer rewrites — and because the camera frames `[detect]` is about are on `mediad`'s
 /// tee. Being wrong here is an edit that appears to do nothing until the next reboot — which is
-/// exactly what the restart offer exists to prevent, so it is derived from the keys that changed
-/// rather than assumed.
+/// exactly what the offer exists to prevent, so it is derived from the keys that changed rather
+/// than assumed.
 ///
 /// **Every section is listed, and there is no fallback.** `[head_imu]` shipped reading as `robotd`
 /// because a `_ => "robotd"` arm answered for it: enabling the head IMU restarted the daemon that
 /// does not read the key and left `tofd` on the old value, so the switch did nothing and said
-/// nothing. A section with no arm here now fails `every_registry_section_names_its_daemon` rather
+/// nothing. A section with no arm here now fails `every_registry_key_says_how_it_applies` rather
 /// than picking up whichever daemon the catch-all happened to name.
-fn unit_for(section: &str) -> Option<&'static str> {
+///
+/// Keyed by the whole `section.key` rather than the section because `[policy]` is not of one
+/// mind: the daemon re-reads that section on a call, all of it but the two keys below.
+fn apply_for(key: &str) -> Option<Apply> {
+    let (section, name) = key.split_once('.')?;
     Some(match section {
-        "media" | "detect" => "mediad",
-        // `padd` reads the bindings, and `robotd` never sees them. Offering a robotd restart for
-        // a button change would drop motor control — putting a standing robot on the floor — to
-        // apply a setting it does not read.
-        "pad" | "imu_head" => "padd",
+        "media" | "detect" => Apply::Restart("mediad"),
+        // `padd` stats the file once a second and re-reads both of its sections when the mtime
+        // moves — `padd/src/main.rs`, where the reload is a line above `tap.imu_control()` and
+        // says why it is on every tick. So there is nothing to offer, and offering a restart
+        // anyway is not free: the pad session goes with it, and robotd's deadman zeroes the
+        // velocity of whatever was walking. `robotctl pad bind` has always said the true thing —
+        // "padd picks this up within a second".
+        //
+        // `imu_head` is the *controller's* IMU steering the head. Not `head_imu` below.
+        "pad" | "imu_head" => Apply::Live("padd"),
         // `tofd` reads `[head_imu]` out of robotd's file — see `tof/src/config.rs` for why it
-        // reads that file rather than one of its own. Not to be confused with `imu_head` above,
-        // which is the *controller's* IMU steering the head.
-        "head_imu" => "tofd",
+        // reads that file rather than one of its own — and reads it once, at startup.
+        "head_imu" => Apply::Restart("tofd"),
+        // `[policy]` is the one section a running daemon takes back: `PolicyChange::Reload`
+        // re-reads it whole and rebuilds the controller from it, which is how `robotctl policy
+        // add` lands a skill without a restart. Two keys are not in that promise:
+        //
+        // - `mode` is deliberately kept across a reload, because `robot.setMode` does not write
+        //   config and adopting the file's mode would undo a live switch as a side effect.
+        // - `enabled` is read once into `RobotState`, and the reload call is *refused* while it
+        //   is false — so the one direction anybody cares about, off to on, cannot be a reload.
+        "policy" if name != "mode" && name != "enabled" => Apply::Reload("robotd"),
         "bus" | "control" | "update_gate" | "policy" | "safety" | "chorale" | "theremin"
-        | "audio" => "robotd",
+        | "audio" => Apply::Restart("robotd"),
         _ => return None,
     })
 }
 
-/// The units a set of `section.key` names requires restarting, in start order, without duplicates.
-fn units_for_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Vec<&'static str> {
-    // `robotd` first, because `mediad.service` is `After=robotd.service`: restarting in the
-    // other order means mediad reconnects to a robotd that is about to go away.
-    let mut units: Vec<&'static str> = Vec::new();
+/// What a set of written keys needs, with each daemon named once.
+///
+/// Three lists rather than one, because the three answers read differently on the way out: a
+/// restart is a question, a reload is a lighter question, and `live` is an answer — the operator
+/// is told it already applies and asked nothing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Plan {
+    /// Units to restart, in start order.
+    pub restart: Vec<&'static str>,
+    /// Units to ask for a re-read.
+    pub reload: Vec<&'static str>,
+    /// Units that have it already, or will within a second.
+    pub live: Vec<&'static str>,
+}
+
+impl Plan {
+    /// Is there nothing to ask the operator?
+    ///
+    /// True for no edits at all *and* for edits that are already live — the difference is
+    /// `live`, and the caller says the two things differently.
+    pub fn is_quiet(&self) -> bool {
+        self.restart.is_empty() && self.reload.is_empty()
+    }
+}
+
+/// What a set of `section.key` names needs, in the order the exit flow acts on it.
+fn plan_for_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Plan {
+    let mut plan = Plan::default();
     for key in keys {
-        let (section, _) = key.split_once('.').expect("registry keys are section.key");
-        // Unreachable for a registry key: the test above keeps `unit_for` exhaustive. Offering
-        // nothing beats offering the wrong daemon — the exit path then prints the file it wrote
-        // instead of restarting something that never reads it.
-        let Some(unit) = unit_for(section) else {
+        // Unreachable for a registry key: `every_registry_key_says_how_it_applies` keeps
+        // `apply_for` exhaustive. Saying nothing beats naming the wrong daemon — the exit path
+        // then prints the file it wrote instead of restarting something that never reads it.
+        let Some(apply) = apply_for(key) else {
             continue;
         };
-        if !units.contains(&unit) {
-            units.push(unit);
+        let list = match apply {
+            Apply::Restart(_) => &mut plan.restart,
+            Apply::Reload(_) => &mut plan.reload,
+            Apply::Live(_) => &mut plan.live,
+        };
+        if !list.contains(&apply.unit()) {
+            list.push(apply.unit());
         }
     }
-    units.sort_unstable_by_key(|unit| *unit != "robotd");
-    units
+    // A daemon that is going down anyway reads the whole file coming back up, so the weaker
+    // answers for it are absorbed rather than listed. `[policy] mode` with `[policy] gain` is
+    // exactly that shape: mode needs the restart, gain would have been a reload, and offering
+    // "restart robotd, then reload robotd" would disturb a walking robot a second time to apply
+    // what it already applied.
+    plan.reload.retain(|unit| !plan.restart.contains(unit));
+    plan.live
+        .retain(|unit| !plan.restart.contains(unit) && !plan.reload.contains(unit));
+    // `robotd` first, because `mediad.service` is `After=robotd.service`: restarting in the
+    // other order means mediad reconnects to a robotd that is about to go away.
+    plan.restart.sort_unstable_by_key(|unit| *unit != "robotd");
+    plan
 }
 
-/// The units the pending edits require restarting, in start order, without duplicates.
+/// What the pending edits need.
 ///
-/// Empty is a real answer — no edits, nothing to restart — and the caller must not offer a
-/// restart for it. Read *before* a save, which clears the pending map.
-pub fn units_for(model: &Model) -> Vec<&'static str> {
-    units_for_keys(model.pending.keys().copied())
+/// A quiet plan is a real answer — no edits, or edits nobody has to do anything about — and the
+/// caller must not offer a restart for it. Read *before* a save, which clears the pending map.
+pub fn plan_for(model: &Model) -> Plan {
+    plan_for_keys(model.pending.keys().copied())
 }
 
-/// The daemons that read the keys somebody just changed.
+/// What the keys somebody just changed need.
 ///
-/// The same mapping as [`units_for`], from what a save recorded rather than from what is still
+/// The same mapping as [`plan_for`], from what a save recorded rather than from what is still
 /// pending — which is what the exit flow has to work from, because the save already cleared the
 /// other one.
-pub fn units_to_restart(edited: &[String]) -> Vec<&'static str> {
-    units_for_keys(edited.iter().map(String::as_str))
+pub fn plan_for_written(edited: &[String]) -> Plan {
+    plan_for_keys(edited.iter().map(String::as_str))
 }
 
 /// Restart units, reporting rather than hiding the outcome.
@@ -248,13 +335,17 @@ enum Focus {
     },
     /// Deciding what to do with the pending edits on the way out.
     Confirm,
-    /// Everything written; offering the restart every change requires — of the daemons that
-    /// actually read what changed, which is not always `robotd`.
-    Restart { units: Vec<&'static str> },
+    /// Everything written; offering what the change actually needs — of the daemons that
+    /// actually read what changed, which is not always `robotd` and is not always a restart.
+    /// Never reached for a [`Plan::is_quiet`] plan: there is nothing to ask.
+    Apply { plan: Plan },
 }
 
 /// Run the editor. Returns once the user has left, with everything saved or discarded.
-pub fn run(path: &Path) -> Result<(), String> {
+///
+/// `robot_socket` is only reached for a `[policy]` change, and only if the operator accepts the
+/// reload — the editor is useful on a board where nothing is running.
+pub fn run(path: &Path, robot_socket: &Path) -> Result<(), String> {
     // An interactive editor and nothing else: piped in or out, there is no sensible
     // behaviour to fall back to, and ratatui would panic trying to open the terminal.
     if !crate::monitor::stdout_is_a_terminal() {
@@ -364,11 +455,16 @@ pub fn run(path: &Path) -> Result<(), String> {
                 KeyCode::Char('y') | KeyCode::Enter => {
                     // Read before the save, which clears `pending` — after it there is nothing
                     // left to say which daemons were affected.
-                    let units = units_for(&model);
+                    let plan = plan_for(&model);
                     match model.save() {
                         Ok(()) => {
                             saved = true;
-                            focus = Focus::Restart { units };
+                            if plan.is_quiet() {
+                                // `padd` has it, or will within a second. Asking would be
+                                // asking somebody to authorise a pad restart for nothing.
+                                break Ok(true);
+                            }
+                            focus = Focus::Apply { plan };
                         }
                         Err(e) => {
                             status = Some(e);
@@ -380,10 +476,12 @@ pub fn run(path: &Path) -> Result<(), String> {
                 KeyCode::Esc => focus = Focus::List,
                 _ => {}
             },
-            Focus::Restart { .. } => match key.code {
+            Focus::Apply { .. } => match key.code {
                 // The restart itself happens after `ratatui::restore`, outside the alternate
                 // screen, so systemctl's output is visible.
                 KeyCode::Char('y') | KeyCode::Enter => break Ok(true),
+                // Back to `List` so the tail below finds no plan to act on — declining has to
+                // leave the same trace as never having been asked.
                 KeyCode::Char('n') | KeyCode::Esc | KeyCode::Char('q') => {
                     focus = Focus::List;
                     break Ok(saved);
@@ -392,9 +490,10 @@ pub fn run(path: &Path) -> Result<(), String> {
             },
         }
     };
-    let restart_wanted = match &focus {
-        Focus::Restart { units } => units.clone(),
-        _ => Vec::new(),
+    // What the operator agreed to on the way out — nothing, unless they were asked and said yes.
+    let agreed = match &focus {
+        Focus::Apply { plan } => plan.clone(),
+        _ => Plan::default(),
     };
     // What was *written*, not what is pending: the save already happened inside the loop above and
     // cleared the pending map, which is why reading it here restarted nothing at all.
@@ -402,17 +501,62 @@ pub fn run(path: &Path) -> Result<(), String> {
     ratatui::restore();
 
     let saved = outcome?;
-    if !restart_wanted.is_empty() {
-        let names = restart_wanted.join(" and ");
+    if !saved {
+        return Ok(());
+    }
+
+    if !agreed.restart.is_empty() {
+        let names = agreed.restart.join(" and ");
         println!("restarting {names}…");
-        restart_units(&restart_wanted)?;
+        restart_units(&agreed.restart)?;
         println!("{names} restarted");
-    } else if saved {
-        let names = units_to_restart(&edited).join(" and ");
-        println!(
-            "written to {} — changes apply on the next `systemctl restart {names}`",
-            path.display()
-        );
+    }
+    for unit in &agreed.reload {
+        // `robotd` is the only unit that can be here — `[policy]` is the one section a running
+        // daemon takes back, and `reload_policies` is that one call — so the name is read off
+        // the plan for the message and asserted rather than dispatched on.
+        debug_assert_eq!(*unit, "robotd", "robotd owns the only reloadable section");
+        println!("asking {unit} to re-read the config…");
+        match crate::reload_policies(robot_socket) {
+            Ok(true) => println!("{unit} is running on the new values"),
+            Ok(false) => println!(
+                "{unit} declined — policies are off on this robot, which takes a restart:\n  \
+                 sudo systemctl restart {unit}"
+            ),
+            Err(e) => {
+                println!("{unit} did not answer ({e}) — it will read the file at its next start")
+            }
+        }
+    }
+    if agreed.is_quiet() {
+        // Declined, or never asked. Say where the change is and what it is waiting on, since
+        // the two answers are different and only one of them is a thing to do.
+        let plan = plan_for_written(&edited);
+        println!("written to {}", path.display());
+        if !plan.restart.is_empty() {
+            println!(
+                "  applies on:  sudo systemctl restart {}",
+                plan.restart.join(" ")
+            );
+        }
+        if !plan.reload.is_empty() {
+            // No command to name: the reload is a call this editor makes, and `robotctl policy`
+            // makes it as a side effect of its own writes. What is worth saying is that nothing
+            // is running on the new value yet.
+            println!(
+                "  {} has it at its next start — nothing is running on it yet",
+                plan.reload.join(" and ")
+            );
+        }
+        if !plan.live.is_empty() {
+            let names = plan.live.join(" and ");
+            let reads = if plan.live.len() == 1 {
+                "picks"
+            } else {
+                "pick"
+            };
+            println!("  {names} {reads} this up within a second — nothing to restart");
+        }
     }
     Ok(())
 }
@@ -574,16 +718,28 @@ fn draw(
                 Line::from("y save · n discard · ESC back"),
             ]
         }
-        // Which daemons, by name: `[media]` is read by `mediad`, and "restart it" over a
-        // change that needs the *other* daemon is how an edit reads as having done nothing.
-        Focus::Restart { units } => {
-            let names = units.join(" and ");
-            let reads = if units.len() == 1 { "reads" } else { "read" };
+        // Which daemons, by name, and what they actually need: `[media]` is read by `mediad`,
+        // and "restart it" over a change that needs the *other* daemon is how an edit reads as
+        // having done nothing. A reload is offered where one exists, because it keeps the motors
+        // powered — it can still ramp a walking robot home, which is why it says so.
+        Focus::Apply { plan } => {
+            let mut what: Vec<String> = Vec::new();
+            if !plan.restart.is_empty() {
+                what.push(format!("restart {}", plan.restart.join(" and ")));
+            }
+            if !plan.reload.is_empty() {
+                what.push(format!("reload {}", plan.reload.join(" and ")));
+            }
+            let reason = if plan.restart.is_empty() {
+                "re-reads [policy] without dropping the motors — a walking robot ramps home first"
+            } else if plan.reload.is_empty() {
+                "reads the config once at startup"
+            } else {
+                "reads some of this at startup and the rest on a call"
+            };
             vec![
-                Line::from(format!(
-                    "written. {names} {reads} the config once at startup —"
-                )),
-                Line::from(format!("restart {names} now? y restart · n later")),
+                Line::from(format!("written. {reason} —")),
+                Line::from(format!("{} now? y do it · n later", what.join(", then "))),
             ]
         }
         Focus::List => {
@@ -659,21 +815,22 @@ mod tests {
     fn the_restart_offer_names_the_daemon_that_reads_the_change() {
         let mut m = model("");
         m.edit(entry("media.quality"), "360p30").expect("valid");
-        assert_eq!(units_for(&m), vec!["mediad"]);
+        assert_eq!(plan_for(&m).restart, vec!["mediad"]);
 
         let mut m = model("");
         m.edit(entry("control.hz"), "60").expect("valid");
-        assert_eq!(units_for(&m), vec!["robotd"]);
+        assert_eq!(plan_for(&m).restart, vec!["robotd"]);
 
         // Both, and robotd first: mediad.service is After=robotd.service, so the other order
         // reconnects mediad to a robotd that is about to go away.
         let mut m = model("");
         m.edit(entry("media.camera"), "false").expect("valid");
         m.edit(entry("audio.enabled"), "false").expect("valid");
-        assert_eq!(units_for(&m), vec!["robotd", "mediad"]);
+        assert_eq!(plan_for(&m).restart, vec!["robotd", "mediad"]);
 
-        // Nothing pending is nothing to restart, and the caller must not offer one.
-        assert!(units_for(&model("")).is_empty());
+        // Nothing pending is nothing to ask about, and the caller must not offer anything.
+        assert!(plan_for(&model("")).is_quiet());
+        assert!(plan_for(&model("")).live.is_empty());
     }
 
     /// `[head_imu]` is `tofd`'s, and it read as `robotd`'s on the board.
@@ -682,41 +839,170 @@ mod tests {
     /// key — and left `tofd` running on the value it loaded at boot. The switch was on in the
     /// file, off in the daemon, and the only sign was a startup line nobody re-reads. Regression
     /// test rather than an assertion folded into the case above, because the two IMU sections are
-    /// a name apart: `imu_head` is the controller's, and it really is `padd`'s.
+    /// a name apart: `imu_head` is the controller's, and `padd` re-reads it by itself.
     #[test]
     fn the_head_imu_switch_restarts_tofd_and_not_robotd() {
         let mut m = model("");
         m.edit(entry("head_imu.enabled"), "true").expect("valid");
-        assert_eq!(units_for(&m), vec!["tofd"]);
+        let plan = plan_for(&m);
+        assert_eq!(plan.restart, vec!["tofd"]);
+        assert!(plan.live.is_empty());
 
         let mut m = model("");
         m.edit(entry("imu_head.enabled"), "true").expect("valid");
+        let plan = plan_for(&m);
         assert_eq!(
-            units_for(&m),
+            plan.live,
             vec!["padd"],
-            "the controller's IMU is padd's"
+            "the controller's IMU is padd's, and padd re-reads it"
         );
+        assert!(plan.restart.is_empty(), "and it needs no restart");
     }
 
-    /// Every section in the registry names the daemon that reads it.
+    /// `[pad]` and `[imu_head]` are live: padd re-reads them, so there is nothing to offer.
+    ///
+    /// The inverse of the `[head_imu]` bug and the same mistake — a mapping that does not
+    /// describe the daemon. `padd` stats the file every second and re-reads both sections when
+    /// the mtime moves, which is why `robotctl pad bind` prints "padd picks this up within a
+    /// second" rather than offering anything. Restarting it to apply what applies by itself
+    /// takes the pad session down, and robotd's deadman then zeroes the velocity of whatever was
+    /// walking — a real cost, paid for nothing.
+    #[test]
+    fn the_pad_sections_need_no_restart_at_all() {
+        for key in [
+            "pad.a",
+            "pad.dpad_down",
+            "imu_head.enabled",
+            "imu_head.gain",
+        ] {
+            let mut m = model("");
+            let value = match key {
+                "imu_head.enabled" => "true",
+                "imu_head.gain" => "0.5",
+                _ => "walk",
+            };
+            m.edit(entry(key), value).expect("valid");
+            let plan = plan_for(&m);
+            assert!(plan.is_quiet(), "{key} must not ask for anything: {plan:?}");
+            assert_eq!(plan.live, vec!["padd"], "{key}");
+        }
+
+        // Paired with a restart it stays quiet about padd and loud about the other one: the
+        // offer is for the daemon that needs it, and padd is neither restarted nor mentioned in
+        // it.
+        let mut m = model("");
+        m.edit(entry("pad.a"), "walk").expect("valid");
+        m.edit(entry("safety.deadman_ms"), "800").expect("valid");
+        let plan = plan_for(&m);
+        assert_eq!(plan.restart, vec!["robotd"]);
+        assert_eq!(plan.live, vec!["padd"]);
+    }
+
+    /// `[policy]` reloads instead of restarting — except the two keys a reload does not carry.
+    ///
+    /// `PolicyChange::Reload` re-reads that section whole and rebuilds the controller from it,
+    /// which is how `robotctl policy add` lands a skill on a running robot. Restarting robotd
+    /// for `action_scale` takes motor control away from a standing robot to change a number it
+    /// would have taken standing up. `mode` is deliberately kept across a reload and `enabled`
+    /// is read once at startup — with the reload call *refused* while it is false, so off to on
+    /// cannot be one.
+    #[test]
+    fn the_policy_section_reloads_but_its_two_startup_keys_do_not() {
+        let mut m = model("");
+        m.edit(entry("policy.action_scale"), "0.4").expect("valid");
+        let plan = plan_for(&m);
+        assert_eq!(plan.reload, vec!["robotd"]);
+        assert!(plan.restart.is_empty(), "the motors stay powered");
+
+        let mut m = model("");
+        m.edit(entry("policy.enabled"), "true").expect("valid");
+        assert_eq!(
+            plan_for(&m).restart,
+            vec!["robotd"],
+            "a reload is refused while policies are off"
+        );
+
+        let mut m = model("");
+        m.edit(entry("policy.mode"), "roller").expect("valid");
+        assert_eq!(
+            plan_for(&m).restart,
+            vec!["robotd"],
+            "a reload keeps the running mode, so the file's would be ignored"
+        );
+
+        // One section, both answers, and the restart absorbs the reload. "restart robotd, then
+        // reload robotd" would ramp a walking robot home a second time to apply what coming back
+        // up already applied.
+        let mut m = model("");
+        m.edit(entry("policy.mode"), "roller").expect("valid");
+        m.edit(entry("policy.gain"), "300").expect("valid");
+        let plan = plan_for(&m);
+        assert_eq!(plan.restart, vec!["robotd"]);
+        assert!(plan.reload.is_empty(), "the restart is the reload");
+    }
+
+    /// Every key in the registry says how it applies.
     ///
     /// What went wrong with `[head_imu]` was not a wrong answer, it was a default one: a
     /// catch-all arm answered `robotd` for a section nobody had mapped, so adding a section was
     /// enough to ship a restart offer that restarts the wrong daemon. There is no catch-all now,
-    /// and this fails for the next section added without an arm — at `cargo test`, not on a
-    /// board, and not as a switch that silently does nothing.
+    /// and this fails for the next key added without an arm — at `cargo test`, not on a board,
+    /// and not as a switch that silently does nothing.
     #[test]
-    fn every_registry_section_names_its_daemon() {
-        let mut unmapped: Vec<&str> = robotd_params::registry::REGISTRY
+    fn every_registry_key_says_how_it_applies() {
+        let unmapped: Vec<&str> = robotd_params::registry::REGISTRY
             .iter()
-            .filter_map(|e| e.key.split_once('.').map(|(section, _)| section))
-            .filter(|section| unit_for(section).is_none())
+            .map(|e| e.key)
+            .filter(|key| apply_for(key).is_none())
             .collect();
-        unmapped.sort_unstable();
-        unmapped.dedup();
         assert!(
             unmapped.is_empty(),
-            "no daemon named for {unmapped:?} — add an arm to `unit_for`"
+            "nothing says how {unmapped:?} applies — add an arm to `apply_for`"
+        );
+    }
+
+    /// The offer says which daemon and which of the three answers, in words.
+    ///
+    /// The screen is the whole user interface to this mapping: an operator who reads "restart
+    /// robotd" over a `[media]` change learns the wrong thing about their robot, and one who is
+    /// asked to restart `padd` for a binding pays for nothing. Rendered rather than asserted on
+    /// the `Plan`, because what went wrong on the board was what the screen *said*.
+    #[test]
+    fn the_offer_says_which_daemon_and_what_it_needs() {
+        let screen_for = |focus: &Focus| {
+            let m = model("");
+            let rows = m.rows();
+            let items = layout_items(&m);
+            let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 24))
+                .expect("terminal");
+            terminal
+                .draw(|frame| draw(frame, &m, &rows, &items, 1, focus, None))
+                .expect("draws");
+            format!("{:?}", terminal.backend().buffer())
+        };
+
+        let restart = screen_for(&Focus::Apply {
+            plan: plan_for_keys(["head_imu.enabled"].into_iter()),
+        });
+        assert!(restart.contains("restart tofd"), "{restart}");
+        assert!(restart.contains("once at startup"), "{restart}");
+
+        // A reload names itself as one, and says the thing an operator standing over the robot
+        // wants to know: the motors stay powered, and a walking robot ramps home first.
+        let reload = screen_for(&Focus::Apply {
+            plan: plan_for_keys(["policy.gain"].into_iter()),
+        });
+        assert!(reload.contains("reload robotd"), "{reload}");
+        assert!(!reload.contains("restart"), "{reload}");
+        assert!(reload.contains("ramps home"), "{reload}");
+
+        // Both, in the order they are done.
+        let both = screen_for(&Focus::Apply {
+            plan: plan_for_keys(["media.quality", "policy.gain"].into_iter()),
+        });
+        assert!(
+            both.contains("restart mediad, then reload robotd"),
+            "{both}"
         );
     }
 
@@ -794,9 +1080,9 @@ mod tests {
     /// A save records what it wrote, because that is what decides the restart.
     ///
     /// The bug this pins: `save` clears `pending`, and the restart decision is made after the
-    /// editor closes — so reading `pending` there found an empty map, `units_to_restart` returned
-    /// nothing, and turning the detector off looked like it had no effect at all. Twice, on a
-    /// robot, before anybody suspected the editor rather than the daemon.
+    /// editor closes — so reading `pending` there found an empty map, the plan came back empty,
+    /// and turning the detector off looked like it had no effect at all. Twice, on a robot,
+    /// before anybody suspected the editor rather than the daemon.
     #[test]
     fn a_save_remembers_what_it_wrote_so_the_right_daemon_restarts() {
         let dir = tempfile::tempdir().unwrap();
@@ -811,34 +1097,40 @@ mod tests {
 
         assert!(m.pending.is_empty(), "a save clears what is pending");
         assert_eq!(m.written(), ["detect.enabled".to_owned()]);
-        assert_eq!(units_to_restart(m.written()), vec!["mediad"]);
+        assert_eq!(plan_for_written(m.written()).restart, vec!["mediad"]);
 
         // A second save adds to the record rather than replacing it: somebody who changes the
         // detector and then the gait wants both daemons restarted.
         m.edit(entry("policy.mode"), "roller").expect("edits");
         m.save().expect("saves");
-        assert_eq!(units_to_restart(m.written()), vec!["robotd", "mediad"]);
+        assert_eq!(
+            plan_for_written(m.written()).restart,
+            vec!["robotd", "mediad"]
+        );
     }
 
     /// wrong daemon is how somebody edits a value three times and swears it does nothing.
     #[test]
     fn the_section_decides_which_daemon_restarts() {
         let detect = vec!["detect.enabled".to_owned()];
-        assert_eq!(units_to_restart(&detect), vec!["mediad"]);
+        assert_eq!(plan_for_written(&detect).restart, vec!["mediad"]);
 
         let policy = vec!["policy.mode".to_owned()];
-        assert_eq!(units_to_restart(&policy), vec!["robotd"]);
+        assert_eq!(plan_for_written(&policy).restart, vec!["robotd"]);
 
         // Both, in the order they are least disruptive to restart: the control loop first, then the
         // camera — a robot that is standing up should not be waiting on a WebRTC teardown.
         let both = vec!["detect.hz".to_owned(), "audio.enabled".to_owned()];
-        assert_eq!(units_to_restart(&both), vec!["robotd", "mediad"]);
+        assert_eq!(plan_for_written(&both).restart, vec!["robotd", "mediad"]);
 
-        // A button change restarts the daemon that reads it. Offering `robotd` here would drop
-        // motor control — a standing robot on the floor — to apply a setting it never sees.
+        // A button change restarts nothing: `padd` reads it back off the file by itself, and
+        // offering `robotd` here would drop motor control — a standing robot on the floor — to
+        // apply a setting it never sees.
         let pad = vec!["pad.x".to_owned()];
-        assert_eq!(units_to_restart(&pad), vec!["padd"]);
+        let plan = plan_for_written(&pad);
+        assert!(plan.is_quiet());
+        assert_eq!(plan.live, vec!["padd"]);
 
-        assert!(units_to_restart(&[]).is_empty());
+        assert_eq!(plan_for_written(&[]), Plan::default());
     }
 }

--- a/robotctl/src/main.rs
+++ b/robotctl/src/main.rs
@@ -3475,6 +3475,24 @@ fn skill_encoding_refusal(name: &str, encoding: Option<&str>) -> Option<String> 
     }
 }
 
+/// Ask `robotd` to re-read `[policy]`, and say whether it took it.
+///
+/// `false` is a running daemon that declined — policies are off on this robot, which is the one
+/// thing in that section a reload cannot change — and an `Err` is one that could not be reached
+/// at all. Neither is a failure worth an exit code: the config is written either way, and the
+/// next start picks it up. Shared with `configure`, which offers this instead of a restart for
+/// the same keys.
+pub(crate) fn reload_policies(robot_socket: &Path) -> Result<bool, String> {
+    (|| -> Result<bool, Failure> {
+        let mut client = Client::connect_to("robotd", robot_socket)?;
+        client.hello()?;
+        let result: proto::IntentResult =
+            decode(&result_of(client.call(&proto::Call::RobotReloadPolicies)?)?)?;
+        Ok(result.accepted)
+    })()
+    .map_err(|e| e.message)
+}
+
 /// Tell `robotd` to re-read its skills, and say whether it did.
 ///
 /// A skill written into config is not one the robot has until the loop resolves it again, and
@@ -3482,14 +3500,7 @@ fn skill_encoding_refusal(name: &str, encoding: Option<&str>) -> Option<String> 
 /// the whole point of the command is that trying one is cheap. An unreachable robot is not a
 /// failure here: the config is written either way, and the next start picks it up.
 fn report_reload(robot_socket: &Path) {
-    let reloaded = (|| -> Result<bool, Failure> {
-        let mut client = Client::connect_to("robotd", robot_socket)?;
-        client.hello()?;
-        let result: proto::IntentResult =
-            decode(&result_of(client.call(&proto::Call::RobotReloadPolicies)?)?)?;
-        Ok(result.accepted)
-    })();
-    match reloaded {
+    match reload_policies(robot_socket) {
         Ok(true) => println!("  the robot is re-reading its skills"),
         Ok(false) | Err(_) => {
             println!("  robotd did not pick it up — it will at the next start");
@@ -4466,7 +4477,7 @@ fn run(cli: Cli) -> Result<(), Failure> {
             let result = if list {
                 configure::list(&file, json)
             } else {
-                configure::run(&file)
+                configure::run(&file, &cli.robot_socket)
             };
             return result.map_err(|e| Failure::new(exit::FAILED, e));
         }


### PR DESCRIPTION
Turning the head IMU on through `robotctl configure` offers a restart, takes it, and restarts `robotd` — which does not read the key. `tofd`, which does, keeps running on the value it loaded at boot. The switch is `true` in the file and off in the daemon, and the only sign is a startup line nobody re-reads after setting it:

```
robotd.toml written 08:06:27   [head_imu] enabled = true
tofd active since   08:05:36   "the head IMU is off; set [head_imu] enabled = true to read it"
```

Found on a board while trying to measure what the head-IMU thread costs: `ps -L -o pcpu,comm -p $(pgrep tofd)` had no `head-imu` line, an hour after the switch was set.

## Not a missing arm, a default one

`unit_for` mapped `media`/`detect` to `mediad` and `pad`/`imu_head` to `padd`, then `_ => "robotd"`. `head_imu` had no arm, so the catch-all answered for it. Adding `"head_imu" => "tofd"` fixes this section and leaves the next one to be found the same way — on a board, as a setting that silently does nothing — so the match is exhaustive instead and a section with no arm fails a test.

Each section's owner was checked against the source rather than assumed: `bus`, `control`, `update_gate`, `policy`, `safety`, `chorale`, `theremin` and `audio` are read in `robotd/src/main.rs`; `media` and `detect` in `mediad/src/main.rs:240`; `pad` and `imu_head` in `padd/src/main.rs:285`; `head_imu` in `tof/src/main.rs:243`. No section is read by two daemons, and `btd`, `configd` and `updaterd` do not depend on `robotd-params` at all.

## Two traps, now in comments

`imu_head` is the *controller's* IMU steering the head, and really is `padd`'s. It is one line above `head_imu`, the BMI088, and a name apart from it.

`tofd` reads `[head_imu]` out of `robotd`'s file rather than one of its own — `tof/src/config.rs` says why — which is what puts a `tofd` key in this editor at all.

## The mapping was answering the wrong question

Naming the right daemon is half of it. The other half, which that audit turned up: the editor assumed *every* change needs a restart, and two daemons already re-read this file.

**`padd` re-reads `[pad]` and `[imu_head]` by itself** — it stats the file once a second and reloads when the mtime moves (`padd/src/main.rs:277`, `:470`), which is why `tap.imu_control()` is called every tick rather than at startup. So the editor was offering a `padd` restart to apply what applies on its own, and that restart is not free: the pad session goes with it, and `robotd`'s deadman then zeroes the velocity of whatever was walking. `docs/robot/cheatsheet.md` already said "`padd` picks the change up within a second; no restart", and `robotctl pad bind` prints "padd picks this up within a second". The editor was the one disagreeing — the same way it disagreed about `[head_imu]`.

**`robotd` re-reads `[policy]` on a call.** `PolicyChange::Reload` reads that section whole and rebuilds the controller from it (`robotd/src/main.rs:1566`), which is how `robotctl policy add` lands a skill on a running robot. Restarting `robotd` to change `action_scale` takes motor control away from a standing robot to apply a number it would have taken standing up. Two keys are outside that promise and stay restarts:

- `mode` is deliberately kept across a reload, so that adopting the file's mode does not undo a live `robot.setMode`.
- `enabled` is read once into `RobotState` and the reload call is *refused* while it is false — so the one direction anybody cares about, off to on, cannot be a reload.

## What replaces `unit_for`

`apply_for(key)` answers `Apply::Restart(unit)`, `Apply::Reload(unit)` or `Apply::Live(unit)`. Keyed by the whole `section.key`, because `[policy]` is not of one mind. `Plan` is that answer for a set of keys — three lists, because the three read differently on the way out: a restart is a question, a reload is a lighter one, and `Live` is an answer.

A unit that is going down absorbs its own weaker answers. `[policy] mode` together with `[policy] gain` would otherwise offer "restart robotd, then reload robotd", ramping a walking robot home a second time to apply what coming back up already applied.

A plan with nothing to ask skips the exit screen entirely rather than asking the operator to authorise a pad restart for nothing.

`configure::run` now takes the robot socket to make the reload call, sharing `reload_policies` with `robotctl policy` rather than growing a second copy of it. It is only reached for a `[policy]` change the operator accepted — the editor still works on a board where nothing is running.

## Docs

`deploy/robotd.toml` and `docs/design/robotd-design.md` §4.2 both said the file is read once at startup and not watched, which has not been true since `padd` started polling it. Both now name the two exceptions, and say that `[safety]` or `[control]` under a running loop is still not a promise. `docs/robot/cheatsheet.md` had the `tofd` restart and the `padd` no-restart right already; its one paragraph about what saving offers is updated to match.

## Tests

- `the_head_imu_switch_restarts_tofd_and_not_robotd` — both IMU sections, so the pair cannot drift into each other again.
- `the_pad_sections_need_no_restart_at_all` — including a `pad` + `safety` edit, where the offer must be loud about `robotd` and silent about `padd`.
- `the_policy_section_reloads_but_its_two_startup_keys_do_not` — and the mixed case, where the restart absorbs the reload.
- `every_registry_key_says_how_it_applies` — the one that fails for the next key added without an arm, at `cargo test` rather than on a board.
- `the_offer_says_which_daemon_and_what_it_needs` — rendered through `TestBackend`, because what went wrong on the board was what the screen *said*.

`cargo test -p robotctl`: 159 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
