### PR TITLE
Prepare release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "btd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bluer",
  "clap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "configd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "duck-control"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "duck-ipc-proto",
  "libloading 0.8.9",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "duck-detect"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "duck-ether"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "duck-ipc-proto",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "duck-ipc-proto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "libc",
  "semver",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "duckctl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "btd",
  "btleplug",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "kinematics"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "roxmltree",
  "serde",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "mediad"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "odometry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "duck-ipc-proto",
  "kinematics",
@@ -3236,14 +3236,14 @@ checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "pad-imu"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "duck-ipc-proto",
 ]
 
 [[package]]
 name = "padd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "duck-ipc-proto",
@@ -3351,7 +3351,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pet-detect"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "robotctl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "robotd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "clap",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "robotd-params"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "duck-ipc-proto",
  "kinematics",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "sounds"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "minisign",
@@ -4703,7 +4703,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tof"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bmi088",
@@ -5121,7 +5121,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5764,7 +5764,7 @@ checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xtask"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "minisign",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ repo    = "pollen-robotics/microduck-gst-plugins"
 version = "v3"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 # 1.89 for `std::fs::File::try_lock`, which is how the single-flight update lock works
 # without a dependency (updater/src/journal.rs). Edition 2024 needs 1.85, so this covers


### PR DESCRIPTION
Bumps the workspace version to 0.12.0, which is what `xtask package` checks the tag against.

101 commits since `daemon-v0.11.0`. `API_VERSION` goes 23 → 27, so a client built against 0.11.0 will
see routes and enum variants it does not know.

**A duck in MuJoCo.** `robotd --sim` is the same daemon with its body in the twin, and `scripts/duck-sim`
brings one up in a command — `boot N` gives each duck a container you log into and its own overlay of the
body, all in one world, and `duck-ether` puts them in a room together so they sing. `tofd --sim` reads
depth off the simulated body. A Mac builds the workspace and runs the twin (the viewer needs `mjpython`,
and the container half says so first).

**What a map needs from the robot** (API v24–v26). `RobotState` and `TofFrame` carry the same
`CLOCK_MONOTONIC` instant, so a sample from `robotd` and a frame from `tofd` go on one axis without
guessing the offset between two daemons' start times; `media.video` adds the monotonic and wall clocks
read together, so RTP timestamps join that axis too. `RobotState` gains the trunk IMU, the camera and ToF
sensor poses, and the whole skeleton's pose this tick, with `robot.model` answering the static geometry
they are stated in — so a mapper or a viewer carries no copy of the kinematics. The camera publishes its
intrinsics, and the alpha family's calibration is the full 62° field rather than a 39° crop.

**A Space runs a model on a duck's camera.** The robot dials a Hugging Face Space and pushes H.264,
because a relay candidate is what §6 has not got. Two Spaces speak one protocol over one client: a vision
demo that receives frames rather than pulling them, and a policy shop that puts a policy from the Hub onto
a duck in one click. An idle page costs the Space nothing.

**The head IMU, off until something reads it.** The BMI088 ships disabled and `tofd` starts its thread
only when a subscriber asks, a sample is two I²C reads rather than three, and the spec says what the head
sensors cost when nobody is looking. The theremin ships off too, like the chorale.

**The pad.** A classic (BR/EDR) gamepad is paired before it is connected, through the kernel's `hidp`
rather than bluetoothd, and a pad presenting as two devices is one candidate. The pad's own six-axis IMU
is tapped by `padd` and drawn live in `robotctl monitor` (API v27); Y hands the head to the pad's tilt.
Select stops on release, and a two-second hold is the whole shutdown again.

**`robotctl configure` names the right daemon and does the right thing to it.** `[head_imu]` restarts
`tofd`, not `robotd` — the switch used to read `true` in the file and off in the daemon. The section →
owner match is exhaustive now, and a section with no arm fails a test. Per key: `padd` re-reads `[pad]`
and `[imu_head]` by itself, `robotd` re-reads `[policy]` on a call, and only what genuinely needs one
gets offered a restart.

**Reaching a daemon that stopped talking.** `duckctl logs` is a daemon's last words over the radio
(`system.logs`, API v26, and it says where the daemon restarted). `duckctl ssh` is the address and the
login as one step. `btd` sizes a reply for the link and stops calling a full queue a disconnect.

**Fixes.** A non-finite command target is dropped instead of poisoning the command filters; an empty ToF
band is no hand even when `min_zones` is 0; a factory-fresh servo is adopted as the one joint that stopped
answering; the Hugging Face login comes from `hf-robot-account` on crates.io rather than being carried
here; an ordinary dropped bus read logs once a minute, not once a second.

Once CI is green here, `daemon-staging-v0.12.0` builds the candidate for a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
