### PR TITLE
Take apt off the boot path

### DIFF
--- a/.github/workflows/_build-release.yml
+++ b/.github/workflows/_build-release.yml
@@ -175,6 +175,7 @@ jobs:
             --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
             --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
             --include "scripts/setup-login.sh=scripts/setup-login.sh" \
+            --include "scripts/setup-quiet-boot.sh=scripts/setup-quiet-boot.sh" \
             --include "scripts/seed-policies.sh=scripts/seed-policies.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh scripts/seed-policies.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/setup-quiet-boot.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh scripts/seed-policies.sh; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -161,6 +161,7 @@ jobs:
             --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
             --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
             --include "scripts/setup-login.sh=scripts/setup-login.sh" \
+            --include "scripts/setup-quiet-boot.sh=scripts/setup-quiet-boot.sh" \
             --include "scripts/seed-policies.sh=scripts/seed-policies.sh" \
             --include "scripts/robot-rescue=scripts/robot-rescue" \
             --include "scripts/robot-boot-check=scripts/robot-boot-check" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ hooks/          preinstall · postinstall — what runs inside an update, from t
 scripts/        provision-board.sh · dev-push.sh + dev-build.Dockerfile (from your machine) ·
                 provision.sh → setup-board.sh → setup-gstreamer.sh · setup-rkaiq.sh ·
                 migrate-network.sh · install.sh (on the board) ·
+                setup-login.sh · setup-quiet-boot.sh (install.sh and postinstall both run these) ·
                 robot-boot-check · robot-rescue (recovery, installed to /usr/local/sbin) ·
                 pad-link-test.sh · pad-stack-report.sh (gamepad radio, on the board) ·
                 board-test.sh · systemd-test.sh (CI) · cross-sysroot.sh (cross-builds) ·

--- a/hooks/postinstall
+++ b/hooks/postinstall
@@ -62,6 +62,16 @@ if [ -f "$script" ]; then
         || echo "postinstall: the login-shell files did not install; they are cosmetic" >&2
 fi
 
+# Apt off the boot path: Armbian's `@reboot` simulated upgrade and the stock apt-daily timers. Here
+# rather than in setup-board.sh alone because every board in the field was provisioned with them
+# running, and this hook is what reaches those boards. Never fatal — a slower boot is not worth a
+# rollback.
+script=scripts/setup-quiet-boot.sh
+if [ -f "$script" ]; then
+    sh "$script" \
+        || echo "postinstall: could not take apt off the boot path; boot stays slower than it needs to be" >&2
+fi
+
 # The robot's voice bank, rendered from the SoC serial by the release's own generator.
 # Idempotent — a marker records the seed and bank version, and a current bank is a no-op —
 # so this runs on every install and only actually renders on the first one (or when the

--- a/scripts/board-test.sh
+++ b/scripts/board-test.sh
@@ -771,6 +771,16 @@ sed "s|\"ORG/duck-daemon\"|\"pollen-robotics/microduck\"|" \
     /bin/deploy/updater.toml > /etc/robot/updater.toml
 cp /bin/deploy/robotd.toml /etc/robot/robotd.toml
 
+# What Armbian ships in /etc/cron.d: a simulated `apt-get upgrade` at every boot, whose only
+# reader is the login banner and which holds one core for seconds while robotd is starting.
+# setup-quiet-boot.sh is meant to empty it, and the assertion below is on what the file contains, not
+# on its absence — the package that owns it would recreate a deleted one.
+mkdir -p /etc/cron.d
+cat > /etc/cron.d/armbian-updates <<"CRON"
+@reboot root /usr/lib/armbian/armbian-apt-updates
+@daily root /usr/lib/armbian/armbian-apt-updates
+CRON
+
 # ── install.sh, the provisioning path ──
 #
 # The bootstrap download self-skips because a release is already live, which is the branch a
@@ -847,6 +857,22 @@ echo "    [ok] the login banner is installed and reports a rolled-back update"
 # updated had it.
 test -f /etc/profile.d/robot-name-prompt.sh \
     || { echo "    [FAIL] the prompt snippet was not installed"; exit 1; }
+
+# Apt off the boot path. The cron file must still exist, hold no live job, and both stock apt
+# timers must be masked — masked, not disabled, because an upgrade of apt itself re-enables a disabled
+# timer and leaves a mask alone.
+test -f /etc/cron.d/armbian-updates \
+    || { echo "    [FAIL] setup-quiet-boot deleted the Armbian cron file instead of emptying it"; exit 1; }
+if grep -Eq "^[[:space:]]*[^#[:space:]]" /etc/cron.d/armbian-updates; then
+    echo "    [FAIL] /etc/cron.d/armbian-updates still runs armbian-apt-updates at boot"
+    cat /etc/cron.d/armbian-updates
+    exit 1
+fi
+for unit in apt-daily.timer apt-daily-upgrade.timer; do
+    grep -q "^mask ${unit}$" /stub/systemctl.log \
+        || { echo "    [FAIL] install.sh did not mask ${unit}"; exit 1; }
+done
+echo "    [ok] install.sh takes the Armbian update count and the apt-daily timers off the boot path"
 test -f /etc/bash_completion.d/robotctl \
     || { echo "    [FAIL] the robotctl completions were not installed"; exit 1; }
 
@@ -1010,6 +1036,12 @@ rm -f /etc/systemd/journald.conf.d/10-robot.conf /usr/local/bin/robotctl
 # And the login-shell files, for the opposite reason: the hook is supposed to put these back, and
 # leaving the ones install.sh wrote in place would make that assertion vacuous.
 rm -f /etc/profile.d/robot-name-prompt.sh /etc/bash_completion.d/robotctl /etc/update-motd.d/40-robot
+# And the Armbian boot-time apt job put back, for the same reason: a board in the field has it, and
+# the hook is the only thing that reaches that board.
+cat > /etc/cron.d/armbian-updates <<"CRON"
+@reboot root /usr/lib/armbian/armbian-apt-updates
+@daily root /usr/lib/armbian/armbian-apt-updates
+CRON
 ( cd "$REL" && PATH="/stub:$PATH" sh "$REL"/hooks/postinstall > /tmp/hook.log 2>&1 ) || {
     echo "    [FAIL] hooks/postinstall exited non-zero, which fails an update"
     cat /tmp/hook.log
@@ -1067,6 +1099,17 @@ for f in /etc/profile.d/robot-name-prompt.sh /etc/bash_completion.d/robotctl /et
         || { echo "    [FAIL] postinstall alone did not install ${f}"; exit 1; }
 done
 echo "    [ok] postinstall alone installs the login-shell files"
+
+# Apt off the boot path, from the hook alone: the whole fleet was provisioned with the Armbian
+# `@reboot` simulated upgrade running, and an update is the only path that fixes those boards.
+if grep -Eq "^[[:space:]]*[^#[:space:]]" /etc/cron.d/armbian-updates; then
+    echo "    [FAIL] postinstall alone left armbian-apt-updates running at boot"; exit 1
+fi
+for unit in apt-daily.timer apt-daily-upgrade.timer; do
+    grep -q "^mask ${unit}$" /stub/systemctl.log \
+        || { echo "    [FAIL] postinstall alone did not mask ${unit}"; exit 1; }
+done
+echo "    [ok] postinstall alone takes apt off the boot path"
 
 # What the hook does NOT place, which is now a short list and worth naming exactly: the journald
 # drop-in and the robotctl symlink. Both were deleted above and the hook restored neither, so a

--- a/scripts/dev-push.sh
+++ b/scripts/dev-push.sh
@@ -379,6 +379,7 @@ cargo run -p xtask -- package \
     --include "scripts/setup-rkaiq.sh=scripts/setup-rkaiq.sh" \
     --include "scripts/rkaiq-modinfo-shim.c=scripts/rkaiq-modinfo-shim.c" \
     --include "scripts/setup-login.sh=scripts/setup-login.sh" \
+    --include "scripts/setup-quiet-boot.sh=scripts/setup-quiet-boot.sh" \
     --include "scripts/seed-policies.sh=scripts/seed-policies.sh" \
     --include "scripts/robot-rescue=scripts/robot-rescue" \
     --include "scripts/robot-boot-check=scripts/robot-boot-check" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -738,6 +738,18 @@ install_units() {
   robot. The next update installs it."
     fi
 
+    # Apt off the boot path: Armbian's `@reboot` update count and the stock apt-daily timers, which
+    # together pin a core for seconds while robotd is starting and produce nothing a robot reads.
+    # Same shape as setup-login.sh above, for the same §9.1 reason: the hook runs it too.
+    setup_quiet_boot="${INSTALL_DIR}/current/scripts/setup-quiet-boot.sh"
+    if [ -f "$setup_quiet_boot" ]; then
+        sh "$setup_quiet_boot" || warn "could not take apt off the boot path; boot is slower and
+  noisier than it needs to be, and the robot is unaffected."
+    else
+        warn "the release carries no scripts/setup-quiet-boot.sh; Armbian keeps running a simulated
+  apt upgrade at every boot. The next update installs it."
+    fi
+
     systemctl daemon-reload
     enable_unit updaterd.service
     enable_unit robotd.service

--- a/scripts/setup-quiet-boot.sh
+++ b/scripts/setup-quiet-boot.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Take apt off the boot path.
+#
+# Every boot of a stock Armbian image runs `/usr/lib/armbian/armbian-apt-updates` from an `@reboot`
+# line in `/etc/cron.d/armbian-updates`. That script's whole job is a *simulated* upgrade —
+# `apt-get upgrade -s -qq` — whose output is counted into `/var/cache/apt/archives/updates.number`
+# so the login banner can say "3 updates available". On a Zero 3W that simulation pins one of the
+# four cores for several seconds, exactly while robotd is bringing up its control loop, and the
+# number it produces is read by nothing on a robot: the daemon does not update through apt, and
+# the operator does not `apt upgrade` a robot from the motd.
+#
+# The same reasoning removes the stock `apt-daily` and `apt-daily-upgrade` timers, which are the
+# other unattended apt work a board does: a real `apt-get update` shortly after every boot, and —
+# with `unattended-upgrades` present, which it is on the Ubuntu-based images — package upgrades
+# nobody asked for. A kernel or a userspace library swapping under a robot between two reboots is
+# how `setup-rkaiq.sh`'s shim stops matching, and it is not something a fleet of ducks should do on
+# its own. Releases reach a robot through `updaterd`; apt is for a human at a shell.
+#
+# Nothing here touches `apt` itself. `apt-get update`/`install` by hand keep working, and so does
+# `setup-board.sh`, which calls them.
+#
+# Idempotent, never fatal, and run on every install and every update, so a board provisioned
+# before this was written gets it at its next update (`docs/design/updater-design.md` §9.1).
+# `install.sh` and `hooks/postinstall` both call it; a failure there is a warning, because a
+# noisy boot is not worth rolling an update back for.
+set -eu
+
+say() { printf 'setup-quiet-boot: %s\n' "$*"; }
+warn() { printf 'setup-quiet-boot: warning: %s\n' "$*" >&2; }
+
+# Overridable so the board test can exercise this against a fixture rather than the host's
+# real crontab.
+ARMBIAN_CRON="${ARMBIAN_CRON:-/etc/cron.d/armbian-updates}"
+
+# The cron file is rewritten rather than deleted, and kept as a file with only comments in it.
+# It is a conffile of Armbian's bsp package: dpkg keeps a locally modified conffile across a
+# package upgrade, so this survives one, whereas a package postinst is free to recreate a file
+# it finds missing. An empty file would work too, but one that says why it is empty is what the
+# next person to open it needs.
+disable_armbian_update_check() {
+    if [ ! -f "$ARMBIAN_CRON" ]; then
+        say "no ${ARMBIAN_CRON}; nothing runs apt at boot from cron"
+        return 0
+    fi
+    # Anything that is not a comment or blank is a live crontab line.
+    if ! grep -Eq '^[[:space:]]*[^#[:space:]]' "$ARMBIAN_CRON"; then
+        say "${ARMBIAN_CRON} already holds no job"
+        return 0
+    fi
+    say "disabling Armbian's boot-time update count in ${ARMBIAN_CRON}"
+    cat > "$ARMBIAN_CRON" <<'EOF'
+# Emptied by the robot daemon installer (scripts/setup-quiet-boot.sh).
+#
+# Armbian ships two lines here that run /usr/lib/armbian/armbian-apt-updates at every boot and
+# once a day. That is a simulated `apt-get upgrade` whose only reader is the login banner, and it
+# holds one core for several seconds during boot on this board. The robot updates through
+# updaterd, not apt, so the count it produces is read by nothing here.
+#
+# Kept as a file, rather than deleted, so the package that owns it does not put its version back.
+EOF
+    chmod 644 "$ARMBIAN_CRON"
+}
+
+# The stock apt timers. Masked rather than disabled: `apt` re-enables them on its own upgrade,
+# and a mask is the one state a package postinst does not undo.
+mask_apt_timers() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        say "no systemctl; skipping the apt timers"
+        return 0
+    fi
+    for unit in apt-daily.timer apt-daily-upgrade.timer; do
+        if [ "$(systemctl is-enabled "$unit" 2>/dev/null)" = masked ]; then
+            say "${unit} already masked"
+            continue
+        fi
+        say "masking ${unit}"
+        # `disable --now` first so a timer already armed for later today does not fire once
+        # more before the mask lands; each step tolerated on its own, because an image that
+        # never had the unit reports an error here that means nothing.
+        systemctl disable --now "$unit" >/dev/null 2>&1 || true
+        systemctl mask "$unit" >/dev/null 2>&1 \
+            || warn "could not mask ${unit}; it keeps running apt in the background"
+    done
+}
+
+disable_armbian_update_check
+mask_apt_timers


### PR DESCRIPTION
Every boot of the Armbian image runs /usr/lib/armbian/armbian-apt-updates from an `@reboot` line in /etc/cron.d/armbian-updates: a simulated `apt-get upgrade -s -qq` that pins one core for several seconds while robotd is starting, to produce an update count that only the stock login banner reads. The robot updates through updaterd, so nothing on it reads that number.

scripts/setup-quiet-boot.sh empties that cron file (kept as a file so the package that owns it does not put its lines back) and masks apt-daily.timer and apt-daily-upgrade.timer, the other unattended apt work a board does — including, on the Ubuntu-based images, unattended package upgrades nobody asked for. `apt-get` by hand is untouched.

Run by install.sh and by hooks/postinstall, so every board already in the field gets it at its next update (updater-design.md §9.1); packaged by both workflows and dev-push.sh, which the xtask guards insisted on. board-test.sh asserts the cron file is emptied and both timers masked, from install.sh and from the hook alone.