### PR TITLE
The servos report velocity and load every tick, and the wire dropped both

### DIFF
--- a/duck-control/src/io.rs
+++ b/duck-control/src/io.rs
@@ -256,6 +256,21 @@ impl FakeIo {
         self.sensors.imu = imu;
     }
 
+    /// Joint velocities the next [`RobotIo::read`] will report.
+    ///
+    /// Unlike positions these are never derived from what was written — a fake that echoed
+    /// its own targets back as velocity would make any test of the velocity path pass
+    /// vacuously.
+    pub fn set_velocities(&mut self, velocities: [f64; NUM_JOINTS]) {
+        self.sensors.velocities = velocities;
+    }
+
+    /// Present current per joint, mA. Same rule as [`Self::set_velocities`]: nothing derives
+    /// this, so a test has to state what the servos are supposed to be reporting.
+    pub fn set_currents_ma(&mut self, currents_ma: [f64; NUM_JOINTS]) {
+        self.sensors.currents_ma = currents_ma;
+    }
+
     pub fn positions(&self) -> [f64; NUM_JOINTS] {
         self.sensors.positions
     }

--- a/duck-ipc-proto/src/lib.rs
+++ b/duck-ipc-proto/src/lib.rs
@@ -326,7 +326,15 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// A new variant on a tagged enum is what a robotctl built before it cannot decode, which is the
 /// one reason this is a bump rather than a note: the tap is still `padd`'s own socket, and every
 /// other client is untouched.
-pub const API_VERSION: u32 = 27;
+///
+/// # v28 — measured joint velocity and load, on the state stream
+///
+/// [`RobotState::velocities`] and [`RobotState::currents_ma`]: the two blocks the control loop has
+/// read beside position on every tick and never published. Neither is recoverable from outside
+/// the daemon — differencing `joints` across a decimated subscription is not a velocity, and
+/// present current is the only measure of external force this robot has. Additive, on the rule
+/// `odom` set: absent from a daemon predating it, and absent stays distinguishable from zero.
+pub const API_VERSION: u32 = 28;
 
 /// The observation width every policy this robot family runs is built against.
 ///
@@ -3368,6 +3376,34 @@ pub struct RobotState {
     pub joints: Vec<f64>,
     /// What was commanded, so a viewer can show tracking error rather than guessing at it.
     pub targets: Vec<f64>,
+    /// Measured joint velocities, rad/s, indexed as [`JOINT_NAMES`].
+    ///
+    /// Read in the same twelve-byte block as [`Self::joints`] — `present_pwm`,
+    /// `present_current`, `present_velocity`, `present_position` are contiguous at register 124,
+    /// so the control loop already has this every tick at no extra bus cost. It stopped at the
+    /// wire only because nothing had asked for it.
+    ///
+    /// Differencing [`Self::joints`] between frames is not the same thing: a subscriber
+    /// decimated to 10 Hz differences across five ticks, and any dropped frame silently
+    /// becomes a velocity spike.
+    ///
+    /// `default` so a frame from a `robotd` predating this field still parses, on the same rule
+    /// as [`Self::odom`]. Empty means *not reported*, which is not the same as a robot at rest —
+    /// a client must not render it as zero velocity. (v28)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub velocities: Vec<f64>,
+    /// Present current magnitude per joint, mA, indexed as [`JOINT_NAMES`].
+    ///
+    /// Sign is dropped by the control loop, which is deliberate there and worth repeating here:
+    /// direction is inferable from [`Self::velocities`], and what a consumer wants is load.
+    ///
+    /// This is the robot's only measure of external force. A joint holding a squat, a foot
+    /// taking weight, a hand pressing on the beak and a servo about to latch its overload
+    /// shutdown are all visible here and nowhere else on this wire.
+    ///
+    /// Same `default` rule as [`Self::velocities`]: empty is *not reported*, not zero load. (v28)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub currents_ma: Vec<f64>,
     /// Where contact odometry believes the robot is. `default` so a frame from
     /// a `robotd` predating the estimator still parses — zeros, like a robot
     /// that has not moved.
@@ -5687,6 +5723,8 @@ mod tests {
             },
             joints: vec![0.0; 15],
             targets: vec![0.0; 15],
+            velocities: vec![0.0; 15],
+            currents_ma: vec![0.0; 15],
             odom: OdomState::default(),
             theremin: None,
             chorale: None,
@@ -5748,6 +5786,8 @@ mod tests {
             },
             joints: vec![0.0; 15],
             targets: vec![0.0; 15],
+            velocities: vec![0.0; 15],
+            currents_ma: vec![0.0; 15],
             odom: OdomState::default(),
             theremin: None,
             chorale: None,
@@ -5763,6 +5803,98 @@ mod tests {
         let back: Request = serde_json::from_str(&line).unwrap();
         assert!(back.is_notification(), "state carries no id");
         assert_eq!(back.as_state().unwrap(), state);
+    }
+
+    /// Velocity and load must reach the wire under the names the docs promise, and must
+    /// survive a round trip. They are the only measurements of joint motion and external
+    /// force this protocol carries; a rename here is silent in Rust and leaves every
+    /// consumer reading nothing.
+    #[test]
+    fn velocity_and_load_ride_under_their_documented_names() {
+        let mut state = a_state();
+        // Distinguishable, and distinguishable *from each other* — a swap of the two blocks
+        // would otherwise round-trip happily.
+        state.velocities = (0..15).map(|i| i as f64 * 0.1).collect();
+        state.currents_ma = (0..15).map(|i| 100.0 + i as f64).collect();
+
+        let line = serde_json::to_string(&Request::notify_state(&state)).unwrap();
+        assert!(line.contains(r#""velocities":"#), "{line}");
+        assert!(line.contains(r#""currents_ma":"#), "{line}");
+
+        let back = serde_json::from_str::<Request>(&line)
+            .unwrap()
+            .as_state()
+            .unwrap()
+            .clone();
+        // Compared approximately, on this protocol's own rule that exact equality is not a
+        // comparison to offer about a measurement (see `SafetyState`, which drops `Eq` for
+        // exactly this reason). A JSON round trip is not bit-exact for every f64.
+        let close = |a: &[f64], b: &[f64], what: &str| {
+            assert_eq!(a.len(), b.len(), "{what}: length");
+            for (i, (x, y)) in a.iter().zip(b).enumerate() {
+                assert!((x - y).abs() < 1e-9, "{what}[{i}]: {x} vs {y}");
+            }
+        };
+        close(&back.velocities, &state.velocities, "velocities");
+        close(&back.currents_ma, &state.currents_ma, "currents_ma");
+    }
+
+    /// A `robotd` predating these fields sends a frame without them, and a client must be able
+    /// to tell *not reported* from *reported as zero*. A robot at rest and a robot that cannot
+    /// tell you what it is doing look nothing alike, and rendering one as the other is how a
+    /// dashboard says "no load" about a servo cooking itself.
+    ///
+    /// The same rule `odom` established, applied to two more blocks.
+    #[test]
+    fn an_older_frame_reports_no_velocity_rather_than_zero() {
+        let line = serde_json::to_string(&Request::notify_state(&a_state())).unwrap();
+        assert!(
+            !line.contains("velocities") && !line.contains("currents_ma"),
+            "empty blocks must not be serialised at all: {line}"
+        );
+
+        let back = serde_json::from_str::<Request>(&line)
+            .unwrap()
+            .as_state()
+            .unwrap()
+            .clone();
+        assert!(back.velocities.is_empty(), "absent is not a vec of zeros");
+        assert!(back.currents_ma.is_empty(), "absent is not a vec of zeros");
+    }
+
+    /// A minimal frame: everything present, nothing interesting.
+    fn a_state() -> RobotState {
+        RobotState {
+            t: 1.5,
+            movement: MoveState {
+                requested: [0.0; 3],
+                applied: [0.0; 3],
+                limited_by: Vec::new(),
+            },
+            head: [0.0; 4],
+            policy: "stand".into(),
+            safety: SafetyState {
+                fallen: false,
+                limp: false,
+                gravity: [0.0, 0.0, -1.0],
+                gain: Some(200),
+            },
+            control_loop: LoopState {
+                hz: 49.8,
+                missed: 0,
+            },
+            joints: vec![0.0; 15],
+            targets: vec![0.0; 15],
+            velocities: Vec::new(),
+            currents_ma: Vec::new(),
+            odom: OdomState::default(),
+            theremin: None,
+            chorale: None,
+            t_ns: 0,
+            imu: None,
+            frames: None,
+            skeleton: Vec::new(),
+        }
     }
 
     /// An unlimited command must not carry an empty array — a consumer checking

--- a/robotctl/src/monitor.rs
+++ b/robotctl/src/monitor.rs
@@ -4492,6 +4492,9 @@ mod tests {
             },
             joints: vec![0.0; proto::JOINT_NAMES.len()],
             targets: vec![0.0; proto::JOINT_NAMES.len()],
+            // Not reported, as from a daemon predating them; the monitor draws neither.
+            velocities: Vec::new(),
+            currents_ma: Vec::new(),
             odom: proto::OdomState::default(),
             theremin: None,
             chorale: None,

--- a/robotd/src/main.rs
+++ b/robotd/src/main.rs
@@ -3073,6 +3073,8 @@ async fn control_loop<T: RobotIo>(
                 },
                 joints: sensors.positions.to_vec(),
                 targets: targets.to_vec(),
+                velocities: sensors.velocities.to_vec(),
+                currents_ma: sensors.currents_ma.to_vec(),
                 odom: proto::OdomState {
                     position: odometry.position(),
                     yaw: odometry.yaw(),
@@ -6474,6 +6476,74 @@ mod tests {
         );
         assert_eq!(frame.policy, "held", "no policy was loaded");
         assert_eq!(frame.joints.len(), NUM_JOINTS);
+    }
+
+    /// Measured velocity and load must reach the state stream.
+    ///
+    /// They arrive in the same twelve-byte block as position (`bus.rs`, register 124), so the
+    /// loop has had them all along and only ever published position. A client outside the
+    /// daemon cannot recover either one: differencing `joints` across frames is wrong for any
+    /// subscriber that asked for a decimated rate, and load has no substitute at all.
+    ///
+    /// The fake reports values that are distinguishable from each other and from the joint
+    /// angles, so a block landing in the wrong field fails here rather than on a robot.
+    #[tokio::test]
+    async fn the_state_stream_carries_measured_velocity_and_load() {
+        let params = Params {
+            policy: params::PolicyParams {
+                enabled: false,
+                ..params::PolicyParams::default()
+            },
+            ..Params::default()
+        };
+        let s = Arc::new(RobotState::new(
+            &params,
+            &PathBuf::from("/nonexistent/robotd.toml"),
+            false,
+            false,
+        ));
+        let mut states = s.state_tx.subscribe();
+
+        let mut io = FakeIo::at(DEFAULT_POSITION);
+        let velocities = std::array::from_fn(|i| (i as f64 + 1.0) * 0.01);
+        let currents = std::array::from_fn(|i| 100.0 + i as f64);
+        io.set_velocities(velocities);
+        io.set_currents_ma(currents);
+
+        let loop_state = Arc::clone(&s);
+        let handle = tokio::spawn(control_loop(
+            io,
+            loop_state,
+            Arc::new(Intents::new()),
+            params,
+            PathBuf::from("/nonexistent/robotd.toml"),
+            Duration::from_millis(2),
+            noop_poweroff(),
+        ));
+
+        let frame = tokio::time::timeout(Duration::from_secs(5), states.recv())
+            .await
+            .expect("a frame within five seconds")
+            .expect("the stream stayed open");
+
+        s.shutdown.store(true, Ordering::Relaxed);
+        handle.await.unwrap();
+
+        assert_eq!(
+            frame.velocities.len(),
+            duck_control::NUM_JOINTS,
+            "one velocity per joint, mouth included, indexed as JOINT_NAMES"
+        );
+        assert_eq!(
+            frame.currents_ma.len(),
+            duck_control::NUM_JOINTS,
+            "one current per joint"
+        );
+        assert_eq!(frame.velocities, velocities.to_vec(), "velocity block");
+        assert_eq!(frame.currents_ma, currents.to_vec(), "load block");
+        // ...and not confused with each other, or with the angles the robot is holding.
+        assert_ne!(frame.velocities, frame.currents_ma);
+        assert_ne!(frame.velocities, frame.joints);
     }
 
     /// Assembling a frame allocates, on the thread that should not be visiting the


### PR DESCRIPTION
`bus.rs` reads one contiguous twelve-byte block per tick at register 124 — `present_pwm`, `present_current`, `present_velocity`, `present_position` — and unpacks all four into `Sensors`. Only position has ever reached `robot.state`. The other two are measured, paid for, and discarded at the socket.

Neither is recoverable from outside the daemon. Differencing `joints` between frames is not velocity: subscribers are decimated per connection, so a client at 10 Hz differences across five ticks, and any dropped frame becomes a spike. Load has no substitute at all — present current is the robot's only measure of external force: a foot taking weight, a hand pressing the beak, a servo on its way to an overload shutdown.

## The change

`RobotState` gains `velocities` (rad/s) and `currents_ma`, indexed as `JOINT_NAMES`, filled from the `Sensors` the loop already holds. Both ride as `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, on the rule `odom` set: a frame from an older `robotd` still parses, and *absent* stays distinguishable from *zero* — a robot at rest and a robot that cannot say what it is doing must not render alike. `API_VERSION` goes 27 → 28 with an entry in the history, as v24 and v25 did for additive fields on the state stream.

`FakeIo` gains `set_velocities` / `set_currents_ma` beside `set_imu`. Positions are echoed from what was written, and deriving these the same way would make any test of the new path pass vacuously. `robotctl`'s monitor fixture names every field of the frame, so it gains the two, empty: the monitor draws neither.

## Cost

Measured on a frame assembled the way the loop assembles it, with the IMU, frames and skeleton present: 3042 B → 3346 B standing (+304 B, +10 %) and 3422 B walking (+380 B, +12 %); the spread is the digits a velocity carries once it is counts × 0.229 rpm. That is +15 to +19 KB/s at 50 Hz and +3 to +4 KB/s at a 10 Hz dashboard. The loop already skips frame assembly when nobody is subscribed, so a robot with no client pays nothing.

## Validation

Three tests: the blocks land under their documented names and survive a round trip; an older frame reports empty rather than zeros; and the control loop, driven by `FakeIo` with values distinguishable from each other and from the joint angles, puts both on the stream. duck-ipc-proto 50 → 52, robotd 150 → 151, the workspace 1363 → 1366, 0 failed. `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` under `-D warnings` are clean, and `cargo llvm-cov` reports 72.17 % of lines on this branch against 72.11 % on `main` and the floor of 72.

What it does not show: everything here runs against `FakeIo`, so it covers the plumbing from `Sensors` to the wire and nothing below it. The unpack in `bus.rs` is untouched, and whether an XL330 reports a sensible current under load is a bench question — I have no hardware.

## Out of scope

`robotctl monitor` still displays neither field. And `serde_json` round-trips some f64 on this wire inexactly (`1.4000000000000001` comes back `1.4`), which affects `joints`, `targets` and `gravity` today and is about 1e-16 against a sensor resolution near 1e-3; the round-trip test compares approximately, on the rule `SafetyState` states when it drops `Eq`. Both belong in their own change, if you want them at all.
