### PR TITLE
The test pattern runs small, and the key that picks it says what it does

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -401,10 +401,16 @@ mode = "walk"
 # only supported way to change one was a systemd drop-in, and nobody reaches for a drop-in to
 # answer "why is the video soft?".
 
-# Stream the head camera. Off streams a test pattern instead, which is what a board with no
-# camera wants — the pipeline still starts, so the WebRTC *control* channel still exists. It is
-# bundled with the video track, so a pipeline that will not start costs both.
-# camera = true
+# Where the video comes from: "camera" or "test".
+#
+# "test" streams a test pattern, which is what a board with no camera wants — the pipeline still
+# starts, so the WebRTC *control* channel still exists. It is bundled with the video track, so a
+# pipeline that will not start costs both. A name rather than a boolean because "camera = false"
+# does not mean "no video", it means "synthetic video", and nothing in the old key said so.
+#
+# The pattern ignores `quality` and runs at 256x144@5: it exists to make the session reachable,
+# and drawing a 720p30 one in software cost five times what the camera it stands in for does.
+# source = "camera"
 
 # Frame size and rate, as one name: 1080p30, 720p30, 720p15 or 360p30.
 #

--- a/docs/project/idle-cpu.md
+++ b/docs/project/idle-cpu.md
@@ -20,7 +20,8 @@ pattern has been measured on a board**; the last section says what the rest woul
 ### `mediad` copied every frame
 
 The appsink callback copied every buffer off the tee into a slot readers took the latest of.
-At 720p30 — the shipped quality, and `media.camera` defaults on — a UYVY frame is 1 280 × 720 × 2
+At 720p30 — the shipped quality, and `media.source` defaults to the camera — a UYVY frame is
+1 280 × 720 × 2
 = 1.84 MB. The readers are auto-exposure at 2 Hz and the duck detector at 2 Hz when enabled, so
 twenty-eight of every thirty copies were made for nobody: 55 MB/s of memcpy and a 1.8 MB
 allocation thirty times a second, from boot.
@@ -31,7 +32,7 @@ exposure loop steering on half-second-old luma hunts rather than settles.
 
 ### The test pattern was drawn at the camera's resolution
 
-A board with `[media] camera = false` streams `videotestsrc` instead, so that a robot with no
+A board with `[media] source = "test"` streams `videotestsrc` instead, so that a robot with no
 camera still has a session — signalling, negotiation, the datachannel, the control API, all of
 which ride the video track. It ran at `[media] quality`, the same rung a camera streams at.
 

--- a/docs/project/idle-cpu.md
+++ b/docs/project/idle-cpu.md
@@ -4,14 +4,15 @@ A duck sitting on a desk with no pad connected, no viewer, and nothing driving i
 five daemons. This is what they were each doing in that state, what was changed, and — for the
 two candidates that were not — the numbers that say why.
 
-Everything here is arithmetic on the code or a measurement on this machine. **Nothing in it has
-been measured on a board**, and the last section says what that would take.
+Everything here was arithmetic on the code or a measurement on this machine. **Only the test
+pattern has been measured on a board**; the last section says what the rest would take.
 
 ## What was costing something
 
 | | idle before | idle after |
 |---|---|---|
 | `mediad` raw branch | 1.84 MB copied 30×/s | copied when a reader asks — ~2×/s |
+| `mediad` test pattern | 720p30 drawn by the CPU — 29.4% of a core | 256x144@5 — 0.7% of the pixel rate |
 | `tofd` frame poll | ~100 I²C reads/s | ~45 |
 | `padd`, pad connected, sticks centred | 50–100 msg/s | 10 |
 | `pet-detect`, when enabled | ~400 FFTs/s + 4 forward passes/s | none until the room makes a sound |
@@ -27,6 +28,30 @@ allocation thirty times a second, from boot.
 A reader now asks and the callback answers the *next* frame. Answering with the last one instead
 would be cheaper again and would put the reader's own polling period into the measurement — an
 exposure loop steering on half-second-old luma hunts rather than settles.
+
+### The test pattern was drawn at the camera's resolution
+
+A board with `[media] camera = false` streams `videotestsrc` instead, so that a robot with no
+camera still has a session — signalling, negotiation, the datachannel, the control API, all of
+which ride the video track. It ran at `[media] quality`, the same rung a camera streams at.
+
+The difference is where the pixels come from. A camera's frames arrive off the ISP in hardware and
+cost `v4l2src` almost nothing to hand on; a test pattern's are drawn by this process, one packed
+UYVY frame at a time. Two boards, same model, both idle with nothing connected:
+
+| source | idle `mediad` |
+|---|---|
+| `Camera`, rkisp | 6.1% |
+| `Test`, 720p30 | **29.4%** |
+
+Five times the cost of the thing it stands in for, to synthesise 1.84 MB thirty times a second for
+a tee whose readers had all said no — `camera.json` on that board read `"frames":23142` against
+`"consumers":0`.
+
+The pattern now runs at `TEST_PATTERN_GEOMETRY` — 256x144 at 5 fps, 16:9 and 8-aligned like every
+`Quality` rung, 73 KB a frame. That is 0.7% of the pixel rate, and it is not a compromise: nothing
+in what the pattern is *for* wants resolution. `media.video` reports the small geometry, because
+that is what the robot is producing.
 
 ### `tofd` polled a 15 Hz sensor 100 times a second
 
@@ -110,7 +135,12 @@ measurement on a developer's machine. The four changes want confirming where the
 is:
 
 - `mediad`, `tofd` and `padd` CPU before and after, from `dev-push.sh` and `top -H`. The camera
-  one should be the visible change.
+  one should be the visible change. What exists so far is `mediad` idle on 0.12.0 — 6.1% with a
+  camera, 29.4% with the 720p test pattern — which is an after-figure for the raw branch with no
+  before-figure beside it, and nothing at all for `tofd` or `padd`.
+- The test pattern at 256x144@5 on the board that measured 29.4% at 720p30. The arithmetic says
+  0.7% of the pixel rate; what it actually leaves is `videotestsrc`'s per-frame overhead, which
+  no longer scales with the picture.
 - SoC temperature at idle over ten minutes, which is the number the whole exercise is for. The
   `videoflip` episode took this board to 97 °C and throttled it to 408 MHz, so idle headroom is
   what decides whether a duck walks well while it is also looking at something.

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -153,7 +153,8 @@ sudo robotctl configure
 ```
 
 Set `media.quality` — `1080p30`, `720p30`, `720p15` or `360p30` — and take the restart it
-offers. `media.camera` off streams a test pattern instead, which is what a board with no camera
+offers. `media.source` set to `test` streams a test pattern instead, which is what a board with
+no camera
 wants: the WebRTC *control* channel rides on the video track, so a pipeline that cannot start
 costs both. The pattern ignores `media.quality` and runs at 256x144@5 — it is there to make the
 session exist, and drawing a 720p one costs five times the CPU a real camera does.

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -155,7 +155,9 @@ sudo robotctl configure
 Set `media.quality` — `1080p30`, `720p30`, `720p15` or `360p30` — and take the restart it
 offers. `media.camera` off streams a test pattern instead, which is what a board with no camera
 wants: the WebRTC *control* channel rides on the video track, so a pipeline that cannot start
-costs both. `media.bitrate` follows the quality unless you set it; the unit is bits per second.
+costs both. The pattern ignores `media.quality` and runs at 256x144@5 — it is there to make the
+session exist, and drawing a 720p one costs five times the CPU a real camera does.
+`media.bitrate` follows the quality unless you set it; the unit is bits per second.
 
 `media.congestion_control` is the other knob in that section, and it is the one that moves CPU:
 `disabled` drops the bandwidth estimator, which is the largest single consumer in `mediad` (7.6% of

--- a/mediad/src/config.rs
+++ b/mediad/src/config.rs
@@ -45,7 +45,7 @@ pub fn load(path: &Path, explicit: bool) -> Params {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use robotd_params::MediaParams;
+    use robotd_params::{MediaParams, MediaSource};
 
     fn write(dir: &Path, text: &str) -> PathBuf {
         let path = dir.join("robotd.toml");
@@ -62,7 +62,11 @@ mod tests {
         assert_eq!(media.quality.size(), (640, 360));
         assert_eq!(media.quality.fps(), 30);
         assert_eq!(media.bitrate_resolved(), media.quality.default_bitrate());
-        assert!(media.camera, "untouched keys keep their defaults");
+        assert_eq!(
+            media.source,
+            MediaSource::Camera,
+            "untouched keys keep their defaults"
+        );
     }
 
     /// A robot with no file at the default path streams its camera, and says nothing about it.
@@ -71,7 +75,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let media = load(&dir.path().join("absent.toml"), false).media;
         assert_eq!(media.quality, MediaParams::default().quality);
-        assert!(media.camera);
+        assert_eq!(media.source, MediaSource::Camera);
     }
 
     /// The claim the doc comment makes, pinned: a params file `robotd` will not start on still
@@ -82,7 +86,7 @@ mod tests {
         let path = write(dir.path(), "[media\nquality = ");
         let media = load(&path, true).media;
         assert_eq!(media.quality, MediaParams::default().quality);
-        assert!(media.camera);
+        assert_eq!(media.source, MediaSource::Camera);
     }
 
     /// A `[media]` section from a build that had a key this one does not is ignored key by key,

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -132,7 +132,7 @@ struct Args {
     /// renders at — because the frames arrive raw and length-prefixed with no handshake, and a
     /// mismatch is a picture nobody can read rather than an error the pipeline can recover from.
     /// `mediad` says so and refuses the frame if the sizes disagree.
-    /// Takes precedence over `[media] camera`, which is a fact about a robot and not about this.
+    /// Takes precedence over `[media] source`, which is a fact about a robot and not about this.
     #[arg(long)]
     sim_camera: Option<String>,
 
@@ -243,7 +243,7 @@ fn main() -> ExitCode {
     // streams at; a test pattern ignores it and runs at `TEST_PATTERN_GEOMETRY`, so a log line
     // reporting the rung on a board with no camera named a resolution nothing was producing.
     //
-    // `--sim-camera` wins over `[media] camera`, exactly as the source selection further down
+    // `--sim-camera` wins over `[media] source`, exactly as the source selection further down
     // does: a simulated camera is a camera, and it renders the configured rung.
     let (width, height, fps) = if args.sim_camera.is_some() {
         (
@@ -255,7 +255,7 @@ fn main() -> ExitCode {
         media.geometry()
     };
     tracing::info!(
-        camera = media.camera,
+        source = media.source.label(),
         quality = media.quality.label(),
         width,
         height,
@@ -372,16 +372,20 @@ fn main() -> ExitCode {
             }
         }
 
-        let source = if let Some(addr) = args.sim_camera.clone() {
-            mediad::pipeline::Source::Sim(addr)
-        } else if media.camera {
-            mediad::pipeline::Source::Camera(mediad::pipeline::Camera {
-                device: args.camera_device.clone(),
-                exposure: args.exposure,
-                analogue_gain: args.analogue_gain,
-            })
-        } else {
-            mediad::pipeline::Source::Test
+        // Matched rather than tested, so a source added to `MediaSource` fails the build here
+        // instead of quietly arriving as a test pattern.
+        let source = match args.sim_camera.clone() {
+            Some(addr) => mediad::pipeline::Source::Sim(addr),
+            None => match media.source {
+                robotd_params::MediaSource::Camera => {
+                    mediad::pipeline::Source::Camera(mediad::pipeline::Camera {
+                        device: args.camera_device.clone(),
+                        exposure: args.exposure,
+                        analogue_gain: args.analogue_gain,
+                    })
+                }
+                robotd_params::MediaSource::Test => mediad::pipeline::Source::Test,
+            },
         };
 
         // Frame size and rate are still pinned rather than negotiated — both branches of the tee

--- a/mediad/src/main.rs
+++ b/mediad/src/main.rs
@@ -238,12 +238,28 @@ fn main() -> ExitCode {
         .unwrap_or_else(mediad::config::default_path);
     let params = mediad::config::load(&config, explicit);
     let (media, detect) = (params.media, params.detect);
+
+    // **What will actually run, not what is configured.** `[media] quality` is the rung a camera
+    // streams at; a test pattern ignores it and runs at `TEST_PATTERN_GEOMETRY`, so a log line
+    // reporting the rung on a board with no camera named a resolution nothing was producing.
+    //
+    // `--sim-camera` wins over `[media] camera`, exactly as the source selection further down
+    // does: a simulated camera is a camera, and it renders the configured rung.
+    let (width, height, fps) = if args.sim_camera.is_some() {
+        (
+            media.quality.width(),
+            media.quality.height(),
+            media.quality.fps(),
+        )
+    } else {
+        media.geometry()
+    };
     tracing::info!(
         camera = media.camera,
         quality = media.quality.label(),
-        width = media.quality.width(),
-        height = media.quality.height(),
-        fps = media.quality.fps(),
+        width,
+        height,
+        fps,
         bitrate = media.bitrate_resolved(),
         congestion_control = media.congestion_control.nick(),
         "streaming"
@@ -378,9 +394,9 @@ fn main() -> ExitCode {
             port: args.port,
             bitrate: media.bitrate_resolved(),
             congestion_control: media.congestion_control,
-            width: media.quality.width(),
-            height: media.quality.height(),
-            fps: media.quality.fps(),
+            width,
+            height,
+            fps,
             rotation,
         };
 
@@ -477,13 +493,13 @@ fn main() -> ExitCode {
         let intrinsics = if args.sim_camera.is_some() {
             // The MuJoCo twin renders a known field of view, so publish its exact geometry — twin
             // recordings then self-describe (no `--calib` needed on the duckslam side).
-            mediad::camera::Intrinsics::sim(media.quality.width(), media.quality.height())
+            mediad::camera::Intrinsics::sim(width, height)
         } else {
             mediad::camera::Intrinsics::published(
                 media.intrinsics.as_ref(),
                 mediad::pipeline::sensor_mode(),
-                media.quality.width(),
-                media.quality.height(),
+                width,
+                height,
             )
         };
         match &intrinsics {
@@ -502,8 +518,8 @@ fn main() -> ExitCode {
         }
 
         let video = mediad::session::Video {
-            width: media.quality.width(),
-            height: media.quality.height(),
+            width,
+            height,
             rotate,
             intrinsics,
         };

--- a/mediad/src/pipeline.rs
+++ b/mediad/src/pipeline.rs
@@ -69,6 +69,12 @@
 //! without the capture path existing. The camera arrives as a different source element behind the
 //! same encoder, and `media-bringup.md` records why capture cannot simply be `v4l2src`.
 //!
+//! **It runs at `robotd_params::TEST_PATTERN_GEOMETRY` rather than `[media] quality`**, and that is
+//! a CPU decision. A camera's frames come off the ISP in hardware; a test pattern's are drawn by
+//! this process, so at the configured rung an idle board with no camera burned 29.4% of a core
+//! against a real camera's 6.1% — synthesising 1.84 MB of UYVY thirty times a second for a tee
+//! whose readers had all said no. The session it exists to provide needs none of those pixels.
+//!
 //! ## What is not verified
 //!
 //! **Nothing in a signal handler here may panic.** These closures are invoked from C, so a panic

--- a/robotctl/src/configure.rs
+++ b/robotctl/src/configure.rs
@@ -824,7 +824,7 @@ mod tests {
         // Both, and robotd first: mediad.service is After=robotd.service, so the other order
         // reconnects mediad to a robotd that is about to go away.
         let mut m = model("");
-        m.edit(entry("media.camera"), "false").expect("valid");
+        m.edit(entry("media.source"), "test").expect("valid");
         m.edit(entry("audio.enabled"), "false").expect("valid");
         assert_eq!(plan_for(&m).restart, vec!["robotd", "mediad"]);
 

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -329,6 +329,20 @@ impl CongestionControl {
     }
 }
 
+/// What a test pattern runs at, whatever `[media] quality` says — width, height, frames a second.
+///
+/// **A test pattern is not video anybody watches.** It exists so a board with no camera still has
+/// a whole session — signalling, negotiation, the datachannel, the control API — and none of that
+/// needs the rung a camera streams at. Running it at the configured rung instead is what an idle
+/// radxa-zero3 was measured doing: **29.4% of a core against the real camera's 6.1%** on the same
+/// board, with nothing connected. A camera's frames arrive off the ISP in hardware, while a test
+/// pattern is drawn by the CPU — at 720p30, 1.84 MB of packed UYVY thirty times a second, every
+/// frame discarded unread. This is 73 KB five times a second: 0.7% of that pixel rate.
+///
+/// 16:9 with both axes a multiple of 8, for [`Quality::size`]'s reason. Five frames a second is
+/// still a live stream — enough to prove the path end to end, which is all it is for.
+pub const TEST_PATTERN_GEOMETRY: (u32, u32, u32) = (256, 144, 5);
+
 /// `[media]` — what `mediad` streams.
 ///
 /// **These were command-line flags in `mediad.service`, and that is why this section exists.**
@@ -350,6 +364,9 @@ impl CongestionControl {
 pub struct MediaParams {
     /// Stream the head camera. `false` streams a test pattern instead, which is what a board
     /// with no camera wants: the pipeline starts, so the WebRTC control channel exists.
+    ///
+    /// The pattern ignores `quality` and runs at [`TEST_PATTERN_GEOMETRY`], because it is there to
+    /// make the session exist rather than to be watched.
     pub camera: bool,
     /// Frame size and rate, as one name. [`Quality`] says why it is one key and not four.
     pub quality: Quality,
@@ -496,6 +513,23 @@ impl MediaParams {
     pub fn bitrate_resolved(&self) -> u32 {
         self.bitrate
             .unwrap_or_else(|| self.quality.default_bitrate())
+    }
+
+    /// Frame size and rate the pipeline will actually run at — width, height, frames a second.
+    ///
+    /// [`Quality`], except for the test pattern, which gets [`TEST_PATTERN_GEOMETRY`] instead.
+    /// A simulated camera is a camera: `--sim-camera` renders the configured rung, and `mediad`
+    /// applies that precedence where it picks the source.
+    pub fn geometry(&self) -> (u32, u32, u32) {
+        if self.camera {
+            (
+                self.quality.width(),
+                self.quality.height(),
+                self.quality.fps(),
+            )
+        } else {
+            TEST_PATTERN_GEOMETRY
+        }
     }
 }
 
@@ -2803,6 +2837,57 @@ mod tests {
         }
         media.bitrate = Some(3_000_000);
         assert_eq!(media.bitrate_resolved(), 3_000_000);
+    }
+
+    /// **A camera runs at the configured rung and a test pattern does not**, which is the whole
+    /// of [`MediaParams::geometry`]. Every rung, so a `quality` edit cannot start reaching the
+    /// pattern by accident.
+    #[test]
+    fn only_a_camera_runs_at_the_configured_quality() {
+        let mut media = MediaParams::default();
+        for quality in Quality::ALL {
+            media.quality = quality;
+
+            media.camera = true;
+            assert_eq!(
+                media.geometry(),
+                (quality.width(), quality.height(), quality.fps()),
+                "a camera streams {}",
+                quality.label()
+            );
+
+            media.camera = false;
+            assert_eq!(
+                media.geometry(),
+                TEST_PATTERN_GEOMETRY,
+                "a test pattern ignores {}",
+                quality.label()
+            );
+        }
+    }
+
+    /// The pattern's geometry has to satisfy the same two constraints every [`Quality`] rung does
+    /// — 16:9, and both axes a multiple of 8 for the encoder's macroblocks — because it goes
+    /// through the same capsfilter and the same encoder. A rate of zero would be a still image.
+    #[test]
+    fn the_test_pattern_is_16_9_and_encodable() {
+        let (width, height, fps) = TEST_PATTERN_GEOMETRY;
+        assert_eq!(width % 8, 0, "width {width} is not a multiple of 8");
+        assert_eq!(height % 8, 0, "height {height} is not a multiple of 8");
+        assert_eq!(width * 9, height * 16, "{width}x{height} is not 16:9");
+        assert!(fps > 0, "a test pattern with no frame rate is a photograph");
+
+        // And it is worth having: a pattern as expensive as the rung it replaces would be this
+        // constant written the long way.
+        let (w, h, f) = MediaParams {
+            camera: true,
+            ..MediaParams::default()
+        }
+        .geometry();
+        assert!(
+            width * height * fps * 4 < w * h * f,
+            "{width}x{height}@{fps} is not materially cheaper than the default {w}x{h}@{f}"
+        );
     }
 
     /// A bitrate in the wrong unit is the mistake this band exists to catch: `2000` is somebody

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -329,6 +329,47 @@ impl CongestionControl {
     }
 }
 
+/// Where `mediad`'s video comes from.
+///
+/// **This was `camera: bool`, and the boolean was the problem.** `camera = false` does not mean
+/// "no video" — the WebRTC control channel rides the video track, so a pipeline that never starts
+/// costs a robot its control surface along with its picture (`remote-webrtc.md`). What it means is
+/// "a test pattern instead", and nothing in the key said so: a board set up with no camera streamed
+/// 720p30 of synthetic video, which is how the pattern came to cost five times what the camera it
+/// stands in for does. A name that says what you get is the fix for the next person reading it.
+///
+/// `--sim-camera` is not a value here. It carries an address, so it is a flag, and it overrides
+/// this the way it always has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MediaSource {
+    /// The head camera, at [`Quality`]. What every robot with a camera wants, and the default.
+    #[default]
+    Camera,
+    /// A test pattern at [`TEST_PATTERN_GEOMETRY`], for a board with no camera: the session
+    /// exists, so signalling, negotiation, the datachannel and the control API are all reachable.
+    Test,
+}
+
+/// Every source, in the order an editor cycles them — and the strings the file uses.
+///
+/// One list, for [`QUALITY_LABELS`]'s reason; [`tests::every_media_source_label_round_trips`]
+/// pins it to the enum in both directions.
+pub const MEDIA_SOURCE_LABELS: &[&str] = &["camera", "test"];
+
+impl MediaSource {
+    /// The sources, in [`MEDIA_SOURCE_LABELS`] order.
+    pub const ALL: [MediaSource; 2] = [MediaSource::Camera, MediaSource::Test];
+
+    /// The name this source has in the file.
+    pub fn label(self) -> &'static str {
+        match self {
+            MediaSource::Camera => "camera",
+            MediaSource::Test => "test",
+        }
+    }
+}
+
 /// What a test pattern runs at, whatever `[media] quality` says — width, height, frames a second.
 ///
 /// **A test pattern is not video anybody watches.** It exists so a board with no camera still has
@@ -362,12 +403,9 @@ pub const TEST_PATTERN_GEOMETRY: (u32, u32, u32) = (256, 144, 5);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct MediaParams {
-    /// Stream the head camera. `false` streams a test pattern instead, which is what a board
-    /// with no camera wants: the pipeline starts, so the WebRTC control channel exists.
-    ///
-    /// The pattern ignores `quality` and runs at [`TEST_PATTERN_GEOMETRY`], because it is there to
-    /// make the session exist rather than to be watched.
-    pub camera: bool,
+    /// Where the video comes from: the head camera, or a test pattern for a board without one.
+    /// [`MediaSource`] says why this is a name rather than a boolean.
+    pub source: MediaSource,
     /// Frame size and rate, as one name. [`Quality`] says why it is one key and not four.
     pub quality: Quality,
     /// Starting video bitrate, bits per second. Unset follows the quality —
@@ -449,12 +487,16 @@ impl CameraIntrinsics {
     }
 }
 
+// Derivable since `camera: bool` became `source: MediaSource`, and still written out: every line
+// of it is a decision with a reason beside it, and `#[derive(Default)]` would delete the reasons
+// while keeping the values. The next field added here should have to say what its default is for.
+#[allow(clippy::derivable_impls)]
 impl Default for MediaParams {
     fn default() -> Self {
         Self {
-            // On, because a robot with a camera is the case, and a board without one shows a
-            // test pattern rather than nothing only if somebody turns this off.
-            camera: true,
+            // The camera, because a robot with a camera is the case. A board without one shows a
+            // test pattern instead, and only if somebody names it.
+            source: MediaSource::Camera,
             quality: Quality::default(),
             bitrate: None,
             // Only a per-robot solve goes here; the family calibration is `mediad`'s fallback.
@@ -521,14 +563,13 @@ impl MediaParams {
     /// A simulated camera is a camera: `--sim-camera` renders the configured rung, and `mediad`
     /// applies that precedence where it picks the source.
     pub fn geometry(&self) -> (u32, u32, u32) {
-        if self.camera {
-            (
+        match self.source {
+            MediaSource::Camera => (
                 self.quality.width(),
                 self.quality.height(),
                 self.quality.fps(),
-            )
-        } else {
-            TEST_PATTERN_GEOMETRY
+            ),
+            MediaSource::Test => TEST_PATTERN_GEOMETRY,
         }
     }
 }
@@ -2805,6 +2846,42 @@ mod tests {
         }
     }
 
+    /// [`MEDIA_SOURCE_LABELS`] is what the registry offers and what the file may contain, and
+    /// [`MediaSource::ALL`] is what `mediad` can build. A name in one and not the other is either
+    /// a choice the editor writes and `mediad` cannot read, or a source nobody can select.
+    #[test]
+    fn every_media_source_label_round_trips() {
+        assert_eq!(MEDIA_SOURCE_LABELS.len(), MediaSource::ALL.len());
+        for (label, source) in MEDIA_SOURCE_LABELS.iter().zip(MediaSource::ALL) {
+            assert_eq!(*label, source.label());
+            let parsed: Params =
+                toml::from_str(&format!("[media]\nsource = \"{label}\"\n")).expect("parses");
+            assert_eq!(parsed.media.source, source);
+        }
+    }
+
+    /// **The key that was replaced must not come back as a silent default.** A robot carrying the
+    /// old `camera = false` gets the unknown-key warning and this build's default — the camera —
+    /// which is a board that starts using a camera it may not have. Better than refusing to boot
+    /// over an inert key (the `[chorale]` rule), and only defensible if the warning names it, so
+    /// this pins that the key is *ignored* rather than parsed into something.
+    #[test]
+    fn the_retired_camera_boolean_is_ignored_and_named() {
+        let (_, ignored) = without_unknown_keys("[media]\ncamera = false\n").unwrap();
+        assert_eq!(ignored, ["media.camera"]);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "[media]\ncamera = false\n");
+        let media = Params::load(&path, true)
+            .expect("an inert key must not stop the robot")
+            .media;
+        assert_eq!(
+            media.source,
+            MediaSource::Camera,
+            "the retired key must not still be steering the source"
+        );
+    }
+
     /// The labels are `webrtcsink`'s own property nicknames — the strings that get set on the
     /// element. `gcc`, not `googcc`: a nickname this file spelled its own way would be a config
     /// key that parses, validates, saves, and then silently leaves the element on its default.
@@ -2848,7 +2925,7 @@ mod tests {
         for quality in Quality::ALL {
             media.quality = quality;
 
-            media.camera = true;
+            media.source = MediaSource::Camera;
             assert_eq!(
                 media.geometry(),
                 (quality.width(), quality.height(), quality.fps()),
@@ -2856,7 +2933,7 @@ mod tests {
                 quality.label()
             );
 
-            media.camera = false;
+            media.source = MediaSource::Test;
             assert_eq!(
                 media.geometry(),
                 TEST_PATTERN_GEOMETRY,
@@ -2880,7 +2957,7 @@ mod tests {
         // And it is worth having: a pattern as expensive as the rung it replaces would be this
         // constant written the long way.
         let (w, h, f) = MediaParams {
-            camera: true,
+            source: MediaSource::Camera,
             ..MediaParams::default()
         }
         .geometry();
@@ -2910,7 +2987,11 @@ mod tests {
     #[test]
     fn the_defaults_are_what_mediad_streamed_before_the_section_existed() {
         let media = Params::default().media;
-        assert!(media.camera, "mediad.service carried --camera");
+        assert_eq!(
+            media.source,
+            MediaSource::Camera,
+            "mediad.service carried --camera"
+        );
         assert_eq!(media.quality.size(), (1280, 720));
         assert_eq!(media.quality.fps(), 30);
         assert_eq!(media.bitrate_resolved(), 2_000_000);
@@ -2947,7 +3028,7 @@ mod tests {
             from_file.update_gate.max_consecutive_errors,
             built_in.update_gate.max_consecutive_errors
         );
-        assert_eq!(from_file.media.camera, built_in.media.camera);
+        assert_eq!(from_file.media.source, built_in.media.source);
         assert_eq!(from_file.media.quality, built_in.media.quality);
         assert_eq!(
             from_file.media.bitrate_resolved(),

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -401,9 +401,9 @@ pub const REGISTRY: &[Entry] = &[
     ),
     // ── [media] ──────────────────────────────────────────────────────────────
     feature(
-        "media.camera",
-        Kind::Bool,
-        "Stream the head camera — off is a cheap test pattern, for a board with no camera",
+        "media.source",
+        Kind::Choice(crate::MEDIA_SOURCE_LABELS),
+        "Where video comes from: the head camera, or a cheap test pattern for a board without one",
     ),
     feature(
         "media.quality",
@@ -641,7 +641,7 @@ mod tests {
                 "audio.enabled",
                 "audio.greet",
                 "audio.pet_detect",
-                "media.camera",
+                "media.source",
                 "media.quality",
                 // The five one-shot buttons. Front-page keys because "what does this button do"
                 // is a question somebody asks holding the pad, not while reading tuning docs.

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -403,7 +403,7 @@ pub const REGISTRY: &[Entry] = &[
     feature(
         "media.camera",
         Kind::Bool,
-        "Stream the head camera — off is a test pattern, for a board with no camera",
+        "Stream the head camera — off is a cheap test pattern, for a board with no camera",
     ),
     feature(
         "media.quality",


### PR DESCRIPTION
Two changes, on a board with no camera.

## The pattern was drawn at the camera's resolution

`videotestsrc` ran at `[media] quality`, the rung a camera streams at. Two boards of the same model, both idle with nothing connected:

| source | idle `mediad` |
|---|---|
| `Camera`, rkisp | 6.1% |
| `Test`, 720p30 | **29.4%** |

A camera's frames come off the ISP in hardware; a test pattern's are drawn by this process, 1.84 MB of packed UYVY thirty times a second. On the board that measured 29.4%, `camera.json` read `"frames":23142` against `"consumers":0` — the raw branch already declines to copy a frame nobody asked for, but nothing asked whether the frame was worth drawing.

A test pattern now runs at `TEST_PATTERN_GEOMETRY`: 256x144 at 5 fps, 16:9 with both axes a multiple of 8 like every `Quality` rung, 73 KB a frame. Nothing in what the pattern is *for* — signalling, negotiation, the datachannel, the control API — wants resolution.

The resolved geometry is what gets logged and published, so `media.video` tells a peer what the robot is actually producing and the startup line stops naming a resolution nothing is emitting. `--sim-camera` keeps the configured rung.

`robotd_params` owns the rule rather than `mediad::pipeline`: `pipeline` is Linux-only for GStreamer, and what geometry a source runs at is answerable — and tested — on any host.

## `[media] camera` is now `[media] source`

`camera = false` does not mean "no video", it means "synthetic video", and a boolean named `camera` said none of that. A board in the fleet was configured `camera = false` because it was not using its camera, and that is how it came to spend every idle minute drawing 720p test frames.

`source = "camera"` or `source = "test"`, `Kind::Choice` in the registry so the editor cycles names, and `mediad` matching on it rather than testing equality — a third source added later fails the build instead of quietly arriving as a test pattern. `--sim-camera` stays a flag: it carries an address.

**Install consequence.** A `robotd.toml` carrying `camera = false` gets the unknown-key warning retired keys have had since the `[chorale]` incident — named in the journal, not fatal — and this build's default, which is the camera. A board deliberately set up without one starts using it again until somebody writes `source = "test"`. A test pins that the old key is ignored rather than parsed into something.

## Verification

`cargo test -p robotd-params -p mediad -p robotctl` and `cargo clippy` are clean on macOS. The Linux-only paths — `mediad::pipeline` and the `main` that wires them — have no aarch64 GStreamer sysroot on that host, so CI compiles them for the first time; the new logic was put in the portable crate for exactly that reason. Not yet measured on a board: the arithmetic says 0.7% of the pixel rate, and what will be left is `videotestsrc`'s per-frame overhead, which no longer scales with the picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)