### PR TITLE
systemd was not supervising the 3A engine at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,17 @@ jobs:
       # other script here, and was missing from this list while being the one file that runs on
       # every board on every update — the argument this comment opens with, applied to itself.
       #
+      # `setup-rkaiq.sh` runs from `hooks/preinstall` on every update too, and it writes a systemd
+      # drop-in that decides whether the 3A engine is supervised at all. Its sibling
+      # `setup-gstreamer.sh` has been linted here since the beginning; this one had not been.
+      # `setup-npu.sh` is the remaining unlinted installer and does not pass yet, so it is not
+      # here.
+      #
       # POSIX sh, not bash: the script is piped to `sh` by the documented one-liner, and
       # a bashism would work on a dev box and fail on the board.
       - name: Lint the installer
         run: |
-          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-login.sh scripts/setup-quiet-boot.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh scripts/seed-policies.sh; do
+          for script in scripts/install.sh scripts/setup-board.sh scripts/setup-gstreamer.sh scripts/setup-rkaiq.sh scripts/setup-login.sh scripts/setup-quiet-boot.sh scripts/migrate-network.sh scripts/provision.sh scripts/provision-board.sh scripts/ci-release-notes.sh scripts/robot-rescue scripts/dev-push.sh scripts/pad-link-test.sh scripts/pad-stack-report.sh scripts/seed-policies.sh; do
             sh -n "$script"
             shellcheck --shell=sh "$script"
             # The one-liner is only correct if the file is executable and self-contained.

--- a/docs/project/media-bringup.md
+++ b/docs/project/media-bringup.md
@@ -387,6 +387,58 @@ order is the whole trick:
 sudo systemctl stop mediad && sudo systemctl restart rkaiq_3A && sleep 2 && sudo systemctl start mediad
 ```
 
+### Nothing was supervising the engine
+
+The vendor unit is `Type=forking` over `/etc/init.d/rkaiq_3A.sh`, whose `start_3A` is
+
+```sh
+/usr/bin/rkaiq_3A_server 2>&1 | logger -t rkaiq &
+```
+
+— a pipeline, backgrounded, and then the script exits. systemd's forking heuristic expects one
+forked child and finds nothing it can claim, so on a board with the engine running:
+
+```
+$ systemctl is-active rkaiq_3A
+active
+$ systemctl show rkaiq_3A -p MainPID
+MainPID=0
+```
+
+Both processes are reparented to init, though they do stay in the unit's cgroup, which is the one
+thing keeping `systemctl stop` honest — the final cgroup kill is what collects them, not the unit's
+own `ExecStop`. What is left broken:
+
+- **The unit reads `active` whether the engine is alive or dead**, and nothing restarts it when it
+  segfaults — which is the failure this platform actually has, the day the shim stops matching the
+  kernel.
+- **`stop_3A` is `killall rkaiq_3A_server`**, so the unit's stop reaches any engine on the box rather
+  than the one it started.
+- **`reload` is `stop_3A; start_3A` inside the unit**, so it never reaches the cgroup kill and leaks
+  the `logger` from the previous run every time.
+
+So the drop-in runs the engine directly: `ExecStart` cleared and set to `rkaiq_3A_server`, `ExecStop`
+cleared so the vendor `killall` never runs, and the engine's output to the journal under its own unit
+instead of through a `logger` process — `journalctl -u rkaiq_3A` rather than `journalctl -t rkaiq`.
+`Type=simple` is right because the engine does not daemonise, and the evidence is that `logger`: it
+was alive alongside the server, which only holds if the server keeps the write end of that pipe open
+in the foreground.
+
+**`Restart=` needs a cap here, and the cap is the interesting half.** The `ExecStartPost` above
+bounces `mediad` on every start, and with `Type=simple` it fires as soon as the process is spawned —
+before a segfault at startup is known. Uncapped, a board with a mismatched shim would bounce the
+camera stream every few seconds for ever, which is worse than an engine that simply stays dead. So
+`StartLimitBurst=3` in three minutes: `mediad` is bounced three times, then systemd gives up and
+leaves the unit `failed` — which is at least a state `systemctl status` can report, where `active`
+with `MainPID=0` was not. `on-failure` rather than `always`, because the segfault exits non-zero and
+a clean exit from this engine has never been observed.
+
+**A failed engine is still not visible in `robotctl health`.** `configd::units::MANAGED` is the seven
+units a daemon release ships and `install.sh` manages, and the 3A engine is a vendor unit this
+project provisions rather than ships, so it is deliberately not among them. Now that the unit can
+reach `failed` at all, putting it there is worth considering — a green picture is a real symptom with
+no reading on that report — but it means widening what that list claims to cover.
+
 ### rkaiq's auto-exposure fires once, and only if it caught the stream
 
 `scripts/setup-rkaiq.sh` first shipped leaving rkaiq's AE **enabled**, on this reasoning: the

--- a/scripts/setup-rkaiq.sh
+++ b/scripts/setup-rkaiq.sh
@@ -276,21 +276,72 @@ chmod 755 "$PIN"
 say "wiring the shim and the pin into rkaiq_3A.service"
 mkdir -p "$DROP_IN_DIR"
 cat > "${DROP_IN_DIR}/robot.conf" <<DROPIN
-# Installed by scripts/setup-rkaiq.sh. All three lines are load-bearing.
+# Installed by scripts/setup-rkaiq.sh. Every line is load-bearing.
 #
 # LD_PRELOAD is what keeps the engine from segfaulting on this kernel, and the pin is what keeps it
 # from programming the ISP with the sensor's boot resolution.
 #
-# **The third is an ordering invariant, and it was learned the hard way.** The engine attaches to the
-# ISP and then waits for a *stream start* event — and it misses one that already happened. Restart it
-# while \`mediad\` is streaming (which every \`robotctl update apply\` did, because the pre-install hook
-# runs this script) and it sits on "wait stream start event..." for ever: no stats loop, no auto
-# exposure, no white balance, and a green picture that a reboot fixes only because the reboot happens
-# to order the two correctly. So whenever the engine starts, the camera stream is bounced behind it.
+# **The ExecStartPost is an ordering invariant, and it was learned the hard way.** The engine
+# attaches to the ISP and then waits for a *stream start* event — and it misses one that already
+# happened. Restart it while \`mediad\` is streaming (which every \`robotctl update apply\` did, because
+# the pre-install hook runs this script) and it sits on "wait stream start event..." for ever: no
+# stats loop, no auto exposure, no white balance, and a green picture that a reboot fixes only
+# because the reboot happens to order the two correctly. So whenever the engine starts, the camera
+# stream is bounced behind it.
 #
 # \`try-restart\`, so a board with no \`mediad\` running is left alone, and \`--no-block\`, because a unit
 # waiting on another unit's job inside its own start transaction is how you deadlock systemd.
+#
+# ── Why this unit is run directly rather than through its init script ─────────
+#
+# **The vendor unit is \`Type=forking\` over \`/etc/init.d/rkaiq_3A.sh\`, and systemd cannot supervise
+# what that script starts.** The script's \`start_3A\` is \`rkaiq_3A_server 2>&1 | logger -t rkaiq &\` —
+# a *pipeline*, backgrounded, and then the script exits. systemd's forking heuristic expects one
+# forked child and finds none it can claim, so \`systemctl show rkaiq_3A -p MainPID\` answers
+# \`MainPID=0\`: both processes end up reparented to init (they do stay in the unit's cgroup, which is
+# what keeps \`systemctl stop\` honest — the cgroup kill collects them, not the unit's own
+# \`ExecStop\`). What that leaves broken is the unit reading \`active\` whether the engine is alive or
+# dead with nothing to restart it when it segfaults, a \`stop\` of \`killall rkaiq_3A_server\` that
+# reaches any engine on the box rather than this unit's, and a \`reload\` of stop-then-start inside
+# the unit that never reaches the cgroup kill and so leaks the previous run's \`logger\` every time.
+#
+# So: \`ExecStart\` is cleared and set to the engine itself, and the engine writes to the journal
+# under this unit instead of through a \`logger\` process. systemd then knows the PID, kills the
+# whole cgroup on stop, and can restart a dead engine. \`ExecStop\` is cleared too, or the vendor's
+# \`killall\` would run on every stop and reach any engine on the box, not just this unit's.
+#
+# **The engine does not daemonise, which is what makes \`Type=simple\` right.** Measured on a board:
+# the \`logger\` from the init script's pipeline was still alive alongside the server, which can only
+# be true of a server holding the write end of that pipe in the foreground. A daemonising one would
+# have exited its first process and closed the pipe. The report at the end of this script checks
+# \`MainPID\` after a restart, so if that is ever wrong on some board, it says so there.
+#
+# ── Why the restart is capped ─────────────────────────────────────────────────
+#
+# \`Restart=\` and the \`ExecStartPost\` above are a loop waiting to happen: the known failure is a
+# segfault at startup when the shim does not match the kernel, and with \`Type=simple\` the
+# ExecStartPost fires as soon as the process is spawned — before the segfault is known. Uncapped,
+# a board with a mismatched shim would bounce \`mediad\` every few seconds for ever, which is worse
+# than the engine simply staying dead. \`StartLimitBurst\` is what makes \`Restart=\` safe here: three
+# attempts, then systemd gives up and leaves the unit failed, so \`mediad\` is bounced three times
+# and not indefinitely.
+#
+# \`on-failure\` rather than \`always\` because the segfault is the failure that has been observed and
+# it exits non-zero; a clean exit from this engine has never been seen, and \`always\` would add a
+# \`mediad\` bounce to a case nobody has characterised.
+[Unit]
+StartLimitIntervalSec=180
+StartLimitBurst=3
+
 [Service]
+Type=simple
+ExecStart=
+ExecStart=/usr/bin/rkaiq_3A_server
+ExecStop=
+StandardOutput=journal
+StandardError=journal
+Restart=on-failure
+RestartSec=10s
 Environment=LD_PRELOAD=${SHIM_SO}
 ExecStartPre=${PIN}
 ExecStartPost=-/bin/systemctl --no-block try-restart mediad.service
@@ -314,14 +365,28 @@ if [ -e /dev/video8 ] && [ -e /dev/video9 ]; then
     # The engine either survives its own startup or segfaults in it, and which one it did is the
     # single fact worth reporting. A second is enough for the latter.
     sleep 1
+    # And whether systemd is *holding* it, which is the premise of the drop-in's `Type=simple`:
+    # a `MainPID` of 0 beside a running engine is the vendor unit's supervision hole reappearing,
+    # and it would mean nothing restarts the engine and `systemctl stop` leaves it behind.
+    main_pid=$(systemctl show rkaiq_3A -p MainPID --value 2>/dev/null || echo 0)
     if pgrep rkaiq_3A_server >/dev/null 2>&1; then
-        say "rkaiq_3A_server is running, and the camera stream has been bounced behind it so the
-  engine sees it start — that is the ExecStartPost in the drop-in above, not something to do by
-  hand. \`journalctl -fu rkaiq_3A\` should say 'wait stream start event success'."
+        if [ "${main_pid:-0}" -gt 0 ] 2>/dev/null; then
+            say "rkaiq_3A_server is running as PID ${main_pid}, tracked by systemd, and the camera
+  stream has been bounced behind it so the engine sees it start — that is the ExecStartPost in the
+  drop-in above, not something to do by hand. \`journalctl -fu rkaiq_3A\` should say 'wait stream
+  start event success'."
+        else
+            warn "rkaiq_3A_server is running, but systemd is not tracking it (MainPID=${main_pid}).
+  The drop-in's Type=simple assumes the engine stays in the foreground, and on this board it
+  apparently does not. Nothing will restart it if it dies, and \`systemctl stop\` will leave it
+  running. Report this with:
+    systemctl cat rkaiq_3A; systemctl show rkaiq_3A -p MainPID -p Type"
+        fi
     else
         warn "rkaiq_3A_server is not running. The camera still works, with no 3A:
-    journalctl -t rkaiq -b --no-pager | tail -40
-  A segfault here means the shim did not match this kernel (${SHIM_SRC})."
+    journalctl -u rkaiq_3A -b --no-pager | tail -40
+  A segfault here means the shim did not match this kernel (${SHIM_SRC}). Three attempts, then
+  systemd stops trying — \`systemctl reset-failed rkaiq_3A\` after a fix, or just re-run this."
     fi
 else
     say "the ISP nodes are not present yet, so nothing to start.


### PR DESCRIPTION
`rkaiq_3A.service` is a vendor unit, `Type=forking` over an init script whose `start_3A` is `rkaiq_3A_server 2>&1 | logger -t rkaiq &` — a pipeline, backgrounded, and then the script exits. systemd's forking heuristic finds no child it can claim, so on a board with the engine running and healthy:

```
$ systemctl is-active rkaiq_3A
active
$ systemctl show rkaiq_3A -p MainPID
MainPID=0
```

The processes do stay in the unit's cgroup, which is the one thing keeping `systemctl stop` honest — the final cgroup kill collects them, not the unit's own `ExecStop`. What that leaves broken:

- The unit reads `active` whether the engine is alive or dead, and nothing restarts it when it segfaults — the failure this platform actually has, the day the shim stops matching the kernel.
- The unit's `stop` is `killall rkaiq_3A_server`, so it reaches any engine on the box rather than the one it started.
- `reload` is stop-then-start inside the unit, so it never reaches the cgroup kill and leaks the previous run's `logger` every time.

## What the drop-in does now

`ExecStart` cleared and set to the engine itself, `ExecStop` cleared so the vendor `killall` never runs, and output to the journal under the unit instead of through a `logger` process — so `journalctl -u rkaiq_3A`, where this script's advice used to say `-t rkaiq`. systemd then knows the PID, kills the whole cgroup on stop, and can restart a dead engine.

`Type=simple` because the engine does not daemonise. The evidence is the `logger` itself: it was alive alongside the server on a board, which only holds if the server keeps the write end of that pipe open in the foreground. The script's report now checks `MainPID` after its own restart, so a board where that assumption turns out wrong says so where somebody is already looking.

## The cap is the interesting half

The drop-in's existing `ExecStartPost` bounces `mediad` on every start — the stream-start ordering invariant — and with `Type=simple` it fires as soon as the process is spawned, before a segfault at startup is known. Uncapped, a board with a mismatched shim would bounce the camera stream every few seconds for ever, which is worse than an engine that simply stays dead.

`StartLimitBurst=3` in three minutes bounds it: `mediad` is bounced three times, then systemd gives up and leaves the unit `failed` — at least a state `systemctl status` can report, where `active` with `MainPID=0` was not. `on-failure` rather than `always`, because the segfault exits non-zero and a clean exit from this engine has never been observed.

A failed engine is still invisible to `robotctl health`: `configd::units::MANAGED` is the seven units a release ships and `install.sh` manages, and this is a vendor unit we provision rather than ship. Now that it can reach `failed` at all, adding it is worth considering — a green picture has no reading on that report — but it widens what that list claims to cover, so it is not in this PR.

## Also

`setup-rkaiq.sh` joins CI's shellcheck list. It runs from `hooks/preinstall` on every update on every board and writes the drop-in that decides whether the engine is supervised; its sibling `setup-gstreamer.sh` has been linted there from the start. `setup-npu.sh` is the remaining unlinted installer and does not pass yet, so it is left out.

## Verification

`shellcheck --shell=sh`, `sh -n` and the `test -x` that CI's loop applies all pass, and the drop-in was rendered from the heredoc to confirm the generated unit file. The fix lands on a board through an ordinary update — the pre-install hook rewrites `robot.conf`, `daemon-reload` picks it up, and the script's closing `systemctl restart rkaiq_3A` makes the transition, killing the old untracked pair through the cgroup they are still in.

## Testing it on a board, without waiting for a release

The script needs `rkaiq-modinfo-shim.c` beside it or it refuses to run, so both files go over. From a checkout, without switching branches:

```bash
git fetch origin rkaiq-supervision
```

```bash
git show origin/rkaiq-supervision:scripts/setup-rkaiq.sh > /tmp/rk.sh
```

```bash
git show origin/rkaiq-supervision:scripts/rkaiq-modinfo-shim.c > /tmp/rk.c
```

```bash
scp /tmp/rk.sh "pierre@$(duckctl ip):setup-rkaiq.sh"
```

```bash
scp /tmp/rk.c "pierre@$(duckctl ip):rkaiq-modinfo-shim.c"
```

Then take a shell on the robot; everything below runs there, and `sudo` wants a password.

```bash
duckctl ssh
```

**The bug, before anything changes.** `Type=forking` with `MainPID=0` is the whole report, and both processes answer to init:

```bash
systemctl show rkaiq_3A -p Type -p MainPID -p NRestarts
```

```bash
ps -eo pid,ppid,comm | grep -E 'rkaiq|logger'
```

**Apply it.** Idempotent — the debs are installed and the shim is unchanged, so this rewrites the drop-in, reloads, restarts the engine and bounces `mediad` behind it. Its closing report says whether systemd is holding the engine:

```bash
sudo sh ~/setup-rkaiq.sh
```

**What should be different.** `Type=simple`, a real `MainPID`, no `logger` process at all, and the engine's own `DBG:` lines now under the unit ending in `wait stream start event success`:

```bash
systemctl show rkaiq_3A -p Type -p MainPID -p NRestarts
```

```bash
pgrep -a logger
```

```bash
journalctl -u rkaiq_3A -b --no-pager | tail -20
```

**That the engine still does its job** — video, and not green. From the laptop:

```bash
duckctl open
```

**That supervision now works**, which is the new behaviour and the thing worth actually testing. Kill the engine outright, wait about fifteen seconds for `RestartSec`, and ask again — `NRestarts=1` with a new PID, where before nothing would have noticed. The video drops for a moment, which is the `ExecStartPost` bouncing the stream on purpose:

```bash
sudo systemctl kill -s SIGKILL rkaiq_3A
```

```bash
systemctl show rkaiq_3A -p MainPID -p NRestarts
```

**That the cap holds.** Kill it four times inside three minutes and systemd stops trying rather than bouncing `mediad` for ever:

```bash
systemctl is-failed rkaiq_3A
```

```bash
sudo systemctl reset-failed rkaiq_3A
```

```bash
sudo systemctl start rkaiq_3A
```

**That a stop leaves nothing behind:**

```bash
sudo systemctl stop rkaiq_3A
```

```bash
pgrep -a rkaiq_3A_server
```

```bash
sudo systemctl start rkaiq_3A
```

To put the released behaviour back, run the release's own copy — it rewrites the drop-in from the version installed on the board:

```bash
sudo sh /opt/robot/daemon/current/scripts/setup-rkaiq.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
