### PR TITLE
Rename [imu_head] to [pad_imu_head_control]

### DIFF
--- a/deploy/robotd.toml
+++ b/deploy/robotd.toml
@@ -3,7 +3,7 @@
 # Installed to /etc/robot/robotd.toml. Mostly read once at startup and not watched, so
 # mostly a change needs a restart — of the daemon that reads the section, which is not
 # always robotd: [media] and [detect] are mediad's and [head_imu] is tofd's. The two
-# exceptions: padd re-reads [imu_head] a second after the file changes, and robotd
+# exceptions: padd re-reads [pad_imu_head_control] a second after the file changes, and robotd
 # re-reads [policy] when asked. `robotctl configure` knows which is which and offers it
 # (docs/design/robotd-design.md §4.2).
 #
@@ -453,7 +453,10 @@ mode = "walk"
 # driving. A third press hands the head back to the pad from where the pad is *now* — its yaw is
 # a gyro's word alone and drifts, and re-centring on every re-entry is how you beat that without
 # a magnetometer. Off, or on a pad with no IMU, Y is what it always was.
-# [imu_head]
+#
+# Not [head_imu], which is the IMU in the robot's head. This section was [imu_head] once; a file
+# still saying that loads, and `robotctl configure` renames it on its next save.
+# [pad_imu_head_control]
 # enabled = false
 
 # Head radians per pad radian. 1 follows the pad exactly; more turns a small wrist movement into

--- a/docs/design/robotd-design.md
+++ b/docs/design/robotd-design.md
@@ -783,7 +783,7 @@ A TOML file read at startup and, for the most part, **not watched**. It lives ou
 
 Two parts of it are watched, and both are exceptions earned by what a restart would cost rather
 than steps towards watching the whole file. `padd` stats the file once a second and re-reads
-`[pad]` and `[imu_head]` when the mtime moves: a binding is changed from a phone, and restarting
+`[pad]` and `[pad_imu_head_control]` when the mtime moves: a binding is changed from a phone, and restarting
 `padd` to apply it would drop the pad session and let `robotd`'s deadman zero a walking robot.
 `robotd` re-reads `[policy]` — all of it but `mode` and `enabled` — when asked to, which is how
 `robotctl policy add` lands a skill without taking motor control away from a standing robot.

--- a/docs/robot/cheatsheet.md
+++ b/docs/robot/cheatsheet.md
@@ -141,7 +141,7 @@ Three properties worth trusting:
 Saving offers what the change actually needs, from the daemon that actually reads it: a restart
 for most keys (`[media]` and `[detect]` are `mediad`'s, `[head_imu]` is `tofd`'s), a `robotd`
 *reload* for `[policy]` — the motors stay powered — and nothing at all for `[pad]` and
-`[imu_head]`, which `padd` picks up within a second. `sudo`, because the file
+`[pad_imu_head_control]`, which `padd` picks up within a second. `sudo`, because the file
 is root-owned — without it the editor opens read-only and says so on the first write.
 `--file` points it elsewhere for a bench copy. The shipped `deploy/robotd.toml` stays the
 reference for *why* each knob exists; this is for flipping them.
@@ -482,7 +482,7 @@ mapping is the prototype's, so muscle memory carries over:
 | left stick | drive: forward/back and strafe · head: head yaw and pitch · body pose: up and crouch |
 | right stick | drive: turn · head: neck pitch and head roll · body pose: pitch and roll |
 | **Start** | first press: torque on and a 2 s ramp to the home pose, then hold. Second press: the policy drives. After that it toggles the policy |
-| **Y** / triangle | head mode: sticks pose the head (body holds still). With `[imu_head] enabled` and a pad that has an IMU: the pad's tilt poses the head and the sticks keep driving — see below |
+| **Y** / triangle | head mode: sticks pose the head (body holds still). With `[pad_imu_head_control] enabled` and a pad that has an IMU: the pad's tilt poses the head and the sticks keep driving — see below |
 | **B** / circle | body-pose mode: sticks lean and crouch the standing robot |
 | **A** / cross | ground pick |
 | **X** / square | roulade — one forward roll; hold to chain rolls |

--- a/padd/src/main.rs
+++ b/padd/src/main.rs
@@ -282,15 +282,20 @@ const BINDINGS_POLL: Duration = Duration::from_secs(1);
 /// are a working robot, and the reason is logged. That matters more here than elsewhere because
 /// this is re-read while running — a half-saved file caught mid-write must not take the buttons
 /// away, and the next read a second later gets the finished one.
-fn read_bindings(path: &Path) -> (robotd_params::PadParams, robotd_params::ImuHeadParams) {
+fn read_bindings(
+    path: &Path,
+) -> (
+    robotd_params::PadParams,
+    robotd_params::PadImuHeadControlParams,
+) {
     match robotd_params::Params::load(path, false) {
         Ok(params) => {
             let pad = params.pad;
-            let imu_head = params.imu_head;
+            let imu_head = params.pad_imu_head_control;
             tracing::info!(
                 a = %pad.a, x = %pad.x, lb = %pad.lb, rb = %pad.rb,
                 dpad_down = %pad.dpad_down,
-                imu_head = imu_head.enabled, imu_head_gain = imu_head.gain,
+                pad_imu_head_control = imu_head.enabled, pad_imu_head_gain = imu_head.gain,
                 "button bindings"
             );
             (pad, imu_head)
@@ -303,15 +308,15 @@ fn read_bindings(path: &Path) -> (robotd_params::PadParams, robotd_params::ImuHe
             );
             (
                 robotd_params::PadParams::default(),
-                robotd_params::ImuHeadParams::default(),
+                robotd_params::PadImuHeadControlParams::default(),
             )
         }
     }
 }
 
-/// Where the pad's IMU stands in relation to the head. See `[imu_head]` in `robotd-params`.
+/// Where the pad's IMU stands in relation to the head. See `[pad_imu_head_control]` in `robotd-params`.
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum ImuHead {
+enum PadImuHead {
     /// Y means what it always did.
     Off,
     /// The head follows the pad's attitude relative to `reference`, the attitude at the press
@@ -321,7 +326,7 @@ enum ImuHead {
     Holding,
 }
 
-impl ImuHead {
+impl PadImuHead {
     /// Y was pressed with an IMU pad and the feature on. Off or holding → follow **from here**,
     /// which is what beats the gyro's yaw drift: every re-entry makes the pad's current attitude
     /// the new centre. Following → hold.
@@ -440,9 +445,9 @@ fn main() -> std::process::ExitCode {
     let mut bindings_checked = Instant::now();
 
     let mut mode = Mode::Drive;
-    // IMU head control, when `[imu_head]` is on and the pad has one. Off whenever the pad is
+    // IMU head control, when `[pad_imu_head_control]` is on and the pad has one. Off whenever the pad is
     // gone: a reference taken against one pad means nothing to the next.
-    let mut imu_head = ImuHead::Off;
+    let mut imu_head = PadImuHead::Off;
     // Whether a pad was there last tick, so appearing and disappearing are each logged once.
     let mut driving = false;
     let mut select = SelectButton::default();
@@ -532,7 +537,7 @@ fn main() -> std::process::ExitCode {
                 tracing::warn!("pad gone — sending nothing; robotd's deadman holds the robot");
                 driving = false;
             }
-            imu_head = ImuHead::Off;
+            imu_head = PadImuHead::Off;
             if let Some(tap) = tap.as_ref() {
                 tap.idle();
             }
@@ -562,11 +567,11 @@ fn main() -> std::process::ExitCode {
         } else {
             None
         };
-        if attitude.is_none() && imu_head != ImuHead::Off {
+        if attitude.is_none() && imu_head != PadImuHead::Off {
             // The feature went off, or the IMU went away under us. Not silent: a head that stops
             // following mid-turn wants a line in the journal saying why.
             tracing::info!("IMU head control off — no attitude to follow");
-            imu_head = ImuHead::Off;
+            imu_head = PadImuHead::Off;
         }
 
         if toggle_head {
@@ -579,13 +584,13 @@ fn main() -> std::process::ExitCode {
                     }
                     imu_head = imu_head.on_y(attitude);
                     match imu_head {
-                        ImuHead::Following { .. } => tracing::info!(
+                        PadImuHead::Following { .. } => tracing::info!(
                             "IMU head control: following the pad from here — sticks keep driving"
                         ),
-                        ImuHead::Holding => {
+                        PadImuHead::Holding => {
                             tracing::info!("IMU head control: holding the head where it is")
                         }
-                        ImuHead::Off => {}
+                        PadImuHead::Off => {}
                     }
                 }
                 None => {
@@ -915,7 +920,7 @@ fn main() -> std::process::ExitCode {
         // describe one instant. Only while driving — body-pose mode owns the whole robot for as
         // long as it lasts, and stick head mode cannot coexist with this (see the Y handling).
         if mode == Mode::Drive
-            && let (ImuHead::Following { reference }, Some(now)) = (imu_head, attitude)
+            && let (PadImuHead::Following { reference }, Some(now)) = (imu_head, attitude)
         {
             frame.push(proto::Call::RobotHead(head_from_pad(
                 pad_imu::relative(reference, now),
@@ -1274,18 +1279,18 @@ mod tests {
             (15.0f32.to_radians()).sin(),
         ];
 
-        let following = ImuHead::Off.on_y(level);
-        assert_eq!(following, ImuHead::Following { reference: level });
+        let following = PadImuHead::Off.on_y(level);
+        assert_eq!(following, PadImuHead::Following { reference: level });
         let holding = following.on_y(yawed);
         assert_eq!(
             holding,
-            ImuHead::Holding,
+            PadImuHead::Holding,
             "the second press holds, whatever the pad did"
         );
         let again = holding.on_y(yawed);
         assert_eq!(
             again,
-            ImuHead::Following { reference: yawed },
+            PadImuHead::Following { reference: yawed },
             "the third follows from the pad's attitude now, not the first one"
         );
         // And that reference reads as centre.

--- a/padd/src/tap.rs
+++ b/padd/src/tap.rs
@@ -53,7 +53,7 @@
 //!
 //! ## The IMU as a control, not only a stream
 //!
-//! With `[imu_head] enabled`, `padd` poses the robot's head from the pad's tilt. The attitude that
+//! With `[pad_imu_head_control] enabled`, `padd` poses the robot's head from the pad's tilt. The attitude that
 //! needs comes from the same node the tap streams, so rather than a second reader on the same
 //! device this reader runs a `pad_imu::Imu` filter over every batch it reads and the main loop asks
 //! for the attitude ([`Tap::attitude`]). [`Tap::imu_control`] is the main loop saying "keep the

--- a/robotctl/src/configure.rs
+++ b/robotctl/src/configure.rs
@@ -35,7 +35,7 @@
 //! video setting is an edit that reads as having done nothing at all.
 //!
 //! Mostly, not always, and the exceptions are where offering a restart is worst. `padd` re-reads
-//! `[pad]` and `[imu_head]` a second after the file changes, so a restart there drops the pad
+//! `[pad]` and `[pad_imu_head_control]` a second after the file changes, so a restart there drops the pad
 //! session — and robotd's deadman with it — to apply what would have applied by itself. `robotd`
 //! re-reads `[policy]` on a call, so a restart there takes motor control away from a standing
 //! robot to change a number it would have taken standing up.
@@ -105,8 +105,8 @@ fn apply_for(key: &str) -> Option<Apply> {
         // velocity of whatever was walking. `robotctl pad bind` has always said the true thing —
         // "padd picks this up within a second".
         //
-        // `imu_head` is the *controller's* IMU steering the head. Not `head_imu` below.
-        "pad" | "imu_head" => Apply::Live("padd"),
+        // `pad_imu_head_control` is the *controller's* IMU steering the head. Not `head_imu` below.
+        "pad" | "pad_imu_head_control" => Apply::Live("padd"),
         // `tofd` reads `[head_imu]` out of robotd's file — see `tof/src/config.rs` for why it
         // reads that file rather than one of its own — and reads it once, at startup.
         "head_imu" => Apply::Restart("tofd"),
@@ -839,7 +839,7 @@ mod tests {
     /// key — and left `tofd` running on the value it loaded at boot. The switch was on in the
     /// file, off in the daemon, and the only sign was a startup line nobody re-reads. Regression
     /// test rather than an assertion folded into the case above, because the two IMU sections are
-    /// a name apart: `imu_head` is the controller's, and `padd` re-reads it by itself.
+    /// a name apart (and now less so): `pad_imu_head_control` is the controller's, and `padd` re-reads it by itself.
     #[test]
     fn the_head_imu_switch_restarts_tofd_and_not_robotd() {
         let mut m = model("");
@@ -849,7 +849,8 @@ mod tests {
         assert!(plan.live.is_empty());
 
         let mut m = model("");
-        m.edit(entry("imu_head.enabled"), "true").expect("valid");
+        m.edit(entry("pad_imu_head_control.enabled"), "true")
+            .expect("valid");
         let plan = plan_for(&m);
         assert_eq!(
             plan.live,
@@ -859,7 +860,7 @@ mod tests {
         assert!(plan.restart.is_empty(), "and it needs no restart");
     }
 
-    /// `[pad]` and `[imu_head]` are live: padd re-reads them, so there is nothing to offer.
+    /// `[pad]` and `[pad_imu_head_control]` are live: padd re-reads them, so there is nothing to offer.
     ///
     /// The inverse of the `[head_imu]` bug and the same mistake — a mapping that does not
     /// describe the daemon. `padd` stats the file every second and re-reads both sections when
@@ -872,13 +873,13 @@ mod tests {
         for key in [
             "pad.a",
             "pad.dpad_down",
-            "imu_head.enabled",
-            "imu_head.gain",
+            "pad_imu_head_control.enabled",
+            "pad_imu_head_control.gain",
         ] {
             let mut m = model("");
             let value = match key {
-                "imu_head.enabled" => "true",
-                "imu_head.gain" => "0.5",
+                "pad_imu_head_control.enabled" => "true",
+                "pad_imu_head_control.gain" => "0.5",
                 _ => "walk",
             };
             m.edit(entry(key), value).expect("valid");

--- a/robotd-params/src/edit.rs
+++ b/robotd-params/src/edit.rs
@@ -32,7 +32,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::Params;
-use crate::registry::{Entry, Kind, REGISTRY};
+use crate::registry::{Entry, Kind, REGISTRY, RENAMED_SECTIONS};
 use toml_edit::DocumentMut;
 
 /// One key's place in the world: what the file says, what the default is.
@@ -112,9 +112,10 @@ impl Model {
         // The daemon's own parse first: a file robotd would refuse is not a file to edit
         // blind, and the error names the line.
         toml::from_str::<Params>(text).map_err(|e| format!("{}: {e}", path.display()))?;
-        let doc: DocumentMut = text
+        let mut doc: DocumentMut = text
             .parse()
             .map_err(|e| format!("{}: {e}", path.display()))?;
+        Self::migrate_renamed_sections(&mut doc);
         Ok(Self {
             path: path.to_path_buf(),
             doc,
@@ -122,6 +123,29 @@ impl Model {
             pending: BTreeMap::new(),
             written: Vec::new(),
         })
+    }
+
+    /// Sections that changed name, carried to the new one in the document itself.
+    ///
+    /// The loader accepts the old name through a serde alias, so a file written before the rename
+    /// keeps working untouched. This is the other half: an *editor* that then set a key under the new
+    /// name would leave the file with both sections, which the loader refuses as a duplicate — so the
+    /// old header is renamed here, once, and the next save writes the file under the new name only.
+    /// Nothing is written until something else is saved; a read-only browse changes no file.
+    ///
+    /// Called from [`Model::from_text`] and again in [`Model::save`], which re-reads the file
+    /// from disk before rendering and would otherwise write the old header straight back.
+    fn migrate_renamed_sections(doc: &mut DocumentMut) {
+        for (old, new) in RENAMED_SECTIONS {
+            if doc.contains_key(new) {
+                // Both present: the loader's duplicate-field error already named it. Not ours to
+                // guess which wins.
+                continue;
+            }
+            if let Some(item) = doc.remove(old) {
+                doc.insert(new, item);
+            }
+        }
     }
 
     /// Every key the daemon knows, in registry order, with pending edits shown as if applied.
@@ -441,8 +465,9 @@ impl Model {
     pub fn save(&mut self) -> Result<(), String> {
         let lock = lock(&self.path)?;
         if let Ok(fresh) = std::fs::read_to_string(&self.path)
-            && let Ok(doc) = fresh.parse::<DocumentMut>()
+            && let Ok(mut doc) = fresh.parse::<DocumentMut>()
         {
+            Self::migrate_renamed_sections(&mut doc);
             self.doc = doc;
         }
         let text = self.rendered();
@@ -1053,9 +1078,49 @@ mod tests {
                 // Last, and the editor shows sections in this order: the pad is what a robot's
                 // buttons do, which is the thing somebody browses for rather than tunes.
                 "pad",
-                "imu_head"
+                "pad_imu_head_control"
             ]
         );
+    }
+
+    /// A file written before `[imu_head]` became `[pad_imu_head_control]` loads (the alias), and
+    /// the editor carries the section to its new name so a save under the new key cannot leave two
+    /// sections the loader would refuse as duplicates. The value set under the old name is what the
+    /// new key reports.
+    #[test]
+    fn a_renamed_section_is_carried_to_its_new_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("robotd.toml");
+        std::fs::write(&config, "[imu_head]\nenabled = true\ngain = 0.5\n").expect("write");
+
+        let mut m = Model::load(&config).expect("loads through the alias");
+        let row = m
+            .rows()
+            .into_iter()
+            .find(|r| r.entry.key == "pad_imu_head_control.gain")
+            .expect("registry key");
+        assert_eq!(
+            row.set.as_deref(),
+            Some("0.5"),
+            "the old section's value shows under the new key"
+        );
+
+        m.edit(entry("pad_imu_head_control.enabled"), "false")
+            .expect("valid");
+        m.save().expect("saves");
+        let text = std::fs::read_to_string(&config).expect("read");
+        assert!(!text.contains("[imu_head]"), "old header gone:\n{text}");
+        assert!(
+            text.contains("[pad_imu_head_control]"),
+            "new header present:\n{text}"
+        );
+        assert!(
+            text.contains("gain = 0.5"),
+            "untouched key carried over:\n{text}"
+        );
+        let params: Params = toml::from_str(&text).expect("the daemon loads the result");
+        assert!(!params.pad_imu_head_control.enabled);
+        assert_eq!(params.pad_imu_head_control.gain, 0.5);
     }
 
     /// **Four processes write this file**, and two staging into the same `robotd.toml.new` at

--- a/robotd-params/src/lib.rs
+++ b/robotd-params/src/lib.rs
@@ -67,7 +67,13 @@ pub struct Params {
     /// Which pad button runs which skill. `padd` reads this, not `robotd`.
     pub pad: PadParams,
     /// Posing the head from the pad's own IMU. `padd` reads this too.
-    pub imu_head: ImuHeadParams,
+    ///
+    /// Named for what it is, in full, because `[head_imu]` is two sections up and is the IMU *in*
+    /// the robot's head: the two were `imu_head` and `head_imu` for a while, and that is a name
+    /// apart, not a difference. The alias keeps a file written under the old name loading; the
+    /// editor renames the section the next time it saves that file.
+    #[serde(alias = "imu_head")]
+    pub pad_imu_head_control: PadImuHeadControlParams,
 }
 
 /// Controller-IMU head control: pose the head by tilting the pad.
@@ -83,7 +89,7 @@ pub struct Params {
 /// Off, or on a pad with no IMU, Y is what it always was. Nothing else about the pad changes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
-pub struct ImuHeadParams {
+pub struct PadImuHeadControlParams {
     /// Whether Y engages IMU head control on a pad that has an IMU.
     pub enabled: bool,
     /// Head radians per pad radian. One is "the head turns as far as the pad did"; more makes a
@@ -91,7 +97,7 @@ pub struct ImuHeadParams {
     pub gain: f64,
 }
 
-impl Default for ImuHeadParams {
+impl Default for PadImuHeadControlParams {
     fn default() -> Self {
         Self {
             enabled: false,

--- a/robotd-params/src/registry.rs
+++ b/robotd-params/src/registry.rs
@@ -441,19 +441,33 @@ pub const REGISTRY: &[Entry] = &[
     feature("pad.lb", Kind::Text, "Skill on the left bumper"),
     feature("pad.rb", Kind::Text, "Skill on the right bumper"),
     feature("pad.dpad_down", Kind::Text, "Skill on D-pad down"),
-    // ── [imu_head] ───────────────────────────────────────────────────────────
+    // ── [pad_imu_head_control] ───────────────────────────────────────────────
     //
-    // Controller-IMU head control. Read by `padd`, like `[pad]`.
+    // Controller-IMU head control. Read by `padd`, like `[pad]`. Not `[head_imu]`, which is
+    // the IMU in the robot's head.
     feature(
-        "imu_head.enabled",
+        "pad_imu_head_control.enabled",
         Kind::Bool,
         "Y poses the head from the pad's own IMU (Pro Controller) — sticks keep driving; Y again holds, again re-centres",
     ),
     entry(
-        "imu_head.gain",
+        "pad_imu_head_control.gain",
         Kind::Float,
         "Head radians per pad radian — 1 follows the pad exactly, more amplifies the wrist",
     ),
+];
+
+/// Sections that changed name: `(old, new)`.
+///
+/// The loader takes the old name through a `#[serde(alias)]` on the field, so a file written
+/// before the rename keeps loading; the editor (`edit.rs`) carries the section to its new name so
+/// its next save cannot leave both in one file, which the loader refuses as a duplicate. Listed
+/// here, beside the registry, because the coverage test below has to know an alias is not a
+/// section of its own — serde names aliases in its "unknown field" message like any other field.
+pub const RENAMED_SECTIONS: &[(&str, &str)] = &[
+    // The pad's IMU steering the head, a letter-swap away from `head_imu` — the IMU *in* the
+    // head. Renamed 2026-09 for that reason alone.
+    ("imu_head", "pad_imu_head_control"),
 ];
 
 /// The registry entry for a key, if it is one.
@@ -518,6 +532,8 @@ mod tests {
             .skip(1)
             .step_by(2)
             .filter(|name| *name != "__no_such_section__")
+            // An old name is an alias for a section already in this list, not a section.
+            .filter(|name| !RENAMED_SECTIONS.iter().any(|(old, _)| old == name))
             .map(str::to_owned)
             .collect();
         // A sanity anchor so a serde message change cannot pass vacuously: the sections this
@@ -650,7 +666,7 @@ mod tests {
                 "pad.lb",
                 "pad.rb",
                 "pad.dpad_down",
-                "imu_head.enabled",
+                "pad_imu_head_control.enabled",
             ]
         );
     }


### PR DESCRIPTION
`imu_head` was the pad's IMU steering the robot's head; `head_imu` is the IMU in the robot's head. A letter-swap apart in `robotctl configure`, and read as the same thing. The section is now named for what it is in full, and so is its struct (`PadImuHeadControlParams`) and padd's state enum (`PadImuHead`).

A file that still says `[imu_head]` keeps loading through a serde alias on the field. The editor carries the section to its new name on load and again after `save()`'s re-read of the file — without that, setting a key under the new name would have left both sections in the file, which the loader refuses as a duplicate field. The rename table lives in `registry.rs` beside the registry, because the coverage test derives the section list from serde's unknown-field message, which names aliases too.