### PR TITLE
tof: back off before reopening the head IMU after a read failure

### DIFF
--- a/tof/src/imu.rs
+++ b/tof/src/imu.rs
@@ -185,6 +185,12 @@ pub fn imu_loop(
                 sleep_unless_shutdown(period - elapsed, shutdown);
             }
         }
+
+        // A read failure fell straight back into `open_imu`: a chip that answers its ID but
+        // cannot stream was reopened in a tight loop, warning each time, on the bus the audio
+        // codec shares. Same backoff as the open-failure path above.
+        sleep_unless_shutdown(backoff, shutdown);
+        backoff = (backoff * 2).min(RETRY_MAX);
     }
 }
 


### PR DESCRIPTION
A read failure in the BMI088 loop fell straight back into `open_imu`: a chip that answers its ID but cannot stream was reopened in a tight loop, warning each time, on the I²C bus the audio codec shares. The open-failure path has always backed off; the read-failure path now waits on the same backoff, which is what the module docs already claimed.

No new arithmetic — the retry sequence is the one the open-failure path and the ToF loop already use — so no new unit test; the loop itself needs the chip. `cargo test -p tof`, `clippy -D warnings`, `fmt --check` all green.